### PR TITLE
Updates for the document lambda activity timeout system

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -20,7 +20,7 @@ const LastCheckpointedOffset: IQueuedMessage = {
  * from them.
  */
 export class DocumentContextManager extends EventEmitter {
-    private readonly contexts: DocumentContext[] = [];
+    private readonly contexts: Set<DocumentContext> = new Set();
 
     // Head and tail represent our processing position of the queue. Head is the latest message seen and
     // tail is the last message processed
@@ -42,10 +42,14 @@ export class DocumentContextManager extends EventEmitter {
 
         // Create the new context and register for listeners on it
         const context = new DocumentContext(head, () => this.tail);
-        this.contexts.push(context);
+        this.contexts.add(context);
         context.addListener("checkpoint", () => this.updateCheckpoint());
         context.addListener("error", (error, errorData: IContextErrorData) => this.emit("error", error, errorData));
         return context;
+    }
+
+    public removeContext(context: DocumentContext): void {
+        this.contexts.delete(context);
     }
 
     public setHead(head: IQueuedMessage) {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -82,5 +82,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 
     public close() {
         this.closed = true;
+
+        this.removeAllListeners();
     }
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -117,7 +117,7 @@ export class DocumentPartition {
     }
 
     public isInactive(now: number = Date.now()) {
-        return now > this.activityTimeoutTime;
+        return !this.context.hasPendingWork() && now > this.activityTimeoutTime;
     }
 
     private updateActivityTime() {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/index.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPartitionLambdaFactory, IPlugin } from "@fluidframework/server-services-core";
+import { DefaultServiceConfiguration, IPartitionLambdaFactory, IPlugin } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 import { DocumentLambdaFactory } from "./lambdaFactory";
 
@@ -18,5 +18,5 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
     // Factory used to create document lambda processors
     const factory = await plugin.create(config);
 
-    return new DocumentLambdaFactory(factory);
+    return new DocumentLambdaFactory(factory, DefaultServiceConfiguration.documentLambda);
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/lambdaFactory.ts
@@ -4,15 +4,19 @@
  */
 
 import { EventEmitter } from "events";
-import { IContext, IPartitionLambda, IPartitionLambdaFactory } from "@fluidframework/server-services-core";
+import {
+    IContext,
+    IDocumentLambdaServerConfiguration,
+    IPartitionLambda,
+    IPartitionLambdaFactory,
+} from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 import { DocumentLambda } from "./documentLambda";
 
 export class DocumentLambdaFactory extends EventEmitter implements IPartitionLambdaFactory {
     constructor(
         private readonly documentLambdaFactory: IPartitionLambdaFactory,
-        private readonly partitionActivityTimeout?: number,
-        private readonly partitionActivityCheckInterval?: number,
+        private readonly documentLambdaServerConfiguration: IDocumentLambdaServerConfiguration,
     ) {
         super();
 
@@ -27,8 +31,7 @@ export class DocumentLambdaFactory extends EventEmitter implements IPartitionLam
             this.documentLambdaFactory,
             config,
             context,
-            this.partitionActivityTimeout,
-            this.partitionActivityCheckInterval);
+            this.documentLambdaServerConfiguration);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/lambdaFactory.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/lambdaFactory.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IPartitionLambdaFactory, LambdaCloseType } from "@fluidframework/server-services-core";
+import { DefaultServiceConfiguration, IPartitionLambdaFactory, LambdaCloseType } from "@fluidframework/server-services-core";
 import { TestContext } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { Provider } from "nconf";
@@ -20,7 +20,7 @@ describe("document-router", () => {
         beforeEach(async () => {
             config = (new Provider({})).defaults({}).use("memory");
             documentFactory = create(config) as TestLambdaFactory;
-            factory = new DocumentLambdaFactory(documentFactory);
+            factory = new DocumentLambdaFactory(documentFactory, DefaultServiceConfiguration.documentLambda);
             testContext = new TestContext();
         });
 

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -29,6 +29,15 @@ export interface IScribeServerConfiguration {
     ignoreStorageException: boolean;
 }
 
+// Document lambda configuration
+export interface IDocumentLambdaServerConfiguration {
+    // Expire document partitions after this long of no activity
+    partitionActivityTimeout: number;
+
+    // How often to check the partitions for inacitivty
+    partitionActivityCheckInterval: number;
+}
+
 /**
  * Key value store of service configuration properties
  */
@@ -45,6 +54,9 @@ export interface IServerConfiguration {
 
     // Scribe lambda configuration
     scribe: IScribeServerConfiguration;
+
+    // Document lambda configuration
+    documentLambda: IDocumentLambdaServerConfiguration;
 
     // Enable adding a traces array to operation messages
     enableTraces: boolean;
@@ -69,5 +81,9 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         generateServiceSummary: true,
         clearCacheAfterServiceSummary: false,
         ignoreStorageException: false,
+    },
+    documentLambda: {
+        partitionActivityTimeout: 10 * 60 * 1000,
+        partitionActivityCheckInterval: 60 * 1000,
     },
 };


### PR DESCRIPTION
- Prevent closing inactive documents that still have pending work (they haven't checkpointed yet). If we close them while there is pending work, the partition will get stuck at an old checkpoint
- Remove contexts from the document context manager when closing a partition due to inactivity - This was leaking memory
- Add activity timeout configs to the server configuration instead of hard coding it