### PR TITLE
Only include README.md files in docs code reviews

### DIFF
--- a/.github/code_owners.yml
+++ b/.github/code_owners.yml
@@ -97,10 +97,9 @@ experimental/dds/tree/**:
 # docs
 docs/**:
 - tylerbutler
-"**/*.md":
+"**/README*.md":
 - tylerbutler
 
 # tools
 tools/**:
 - curtisman
-


### PR DESCRIPTION
With the current config, I'm getting looped in every time the BREAKING.md file gets modified.

I'd prefer to only exclude BREAKING.md, but I don't think that's possible based on my read of [the action code](https://github.com/shufo/auto-assign-reviewer-by-files/blob/master/index.js).