### PR TITLE
Dev Container: Install dependencies for Puppeteer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /tmp/library-scripts \
     && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "${SOURCE_SOCKET}" "${TARGET_SOCKET}" "node" \
     && rm -rf /tmp/library-scripts/
 
-# Update package information before install dependencies
+# Update package information before installing
 RUN apt-get update
 
 # Install .so libraries required for Puppeteer tests

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,8 +23,32 @@ RUN mkdir /tmp/library-scripts \
     && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "${SOURCE_SOCKET}" "${TARGET_SOCKET}" "node" \
     && rm -rf /tmp/library-scripts/
 
+# Update package information before install dependencies
+RUN apt-get update
+
+# Install .so libraries required for Puppeteer tests
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+	    libpangocairo-1.0-0 \
+	    libxi6 \
+    	libatk-bridge2.0-0 \
+    	libgtk-3-0 \
+        libasound2 \
+        libatk1.0-0 \
+        libcups2 \
+        libnss3 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxrandr2 \
+        libxss1 \
+        libxtst6
+
 # Install additional desired packages here
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         vim
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,10 +29,10 @@ RUN apt-get update
 # Install .so libraries required for Puppeteer tests
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-	    libpangocairo-1.0-0 \
-	    libxi6 \
-    	libatk-bridge2.0-0 \
-    	libgtk-3-0 \
+        libpangocairo-1.0-0 \
+        libxi6 \
+        libatk-bridge2.0-0 \
+        libgtk-3-0 \
         libasound2 \
         libatk1.0-0 \
         libcups2 \


### PR DESCRIPTION
Installs required Debian packages for running Puppeteer tests (e.g., 'examples/data-objects/diceRoller')

Headless Chrome depends on some *.so files that are commonly omitted from headless Linux installations.