### PR TITLE
Turn on --preserveConstEnums for merge-tree

### DIFF
--- a/packages/dds/merge-tree/tsconfig.json
+++ b/packages/dds/merge-tree/tsconfig.json
@@ -6,7 +6,8 @@
     "compilerOptions": {
         "rootDir": "./src",
         "outDir": "./dist",
-        "composite": true
+        "composite": true,
+        "preserveConstEnums": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
Fix #5070.  Just turn on the switch for merge-tree to fix the immediate issue for now.
