### PR TITLE
Docs: Fix link to lambdas package

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -20,7 +20,7 @@ This directory contains our reference server implementation. [Routerlicious](./r
 
 [Historian](./historian) provides a REST API to git repositories. The API is similar to that exposed by GitHub but can be used in local development.
 
-[Lambdas](./lambdas) serverless lambda version of Fluid services
+[Lambdas](./routerlicious/packages/lambdas) reusable lambdas for serverless implementation, Routerlicious, and Tinylicious.
 
 [Routerlicious](./routerlicious) composed reference server implementation
 


### PR DESCRIPTION
@tanviraumi - In addition to fixing the broken link, I changed the text to indicate that the lambdas are reused by tinylicious and routerlicious.

(Suggested improvements warmly welcomed...)