### PR TITLE
Ability to debug tests directly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -249,7 +249,20 @@
                 "<node_internals>/**/*.js"
             ],
             "preLaunchTask": "fluid-build $cwd -s tsc"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Current Test (JS)",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "args": [
+                "--no-timeouts",
+                "--exit",
+                "../../dist/test/${fileBasenameNoExtension}.js", ],
+            "cwd": "${fileDirname}",
+            "outFiles": ["${fileDirname}/../../dist/**/*.js"],
         }
-
     ]
 }


### PR DESCRIPTION
Existing "Debug Current Test" action quite often is very slow for me - might take 10-30 seconds before it hits first breakpoint.
I hear I'm not alone here - @chensixx experiences same (per Navin)
Also I could not make it work for newly added test - it would keep complaining that it can resolve some fluid package,
Deubgging ..js files works and is instant! Also does not spend extra couple seconds doing empty build.

Adding new config to do so, without touching old one.
