### PR TITLE
Improve close behavior for partitions and contexts

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -72,6 +72,10 @@ export class DocumentContextManager extends EventEmitter {
         for (const context of this.contexts) {
             context.close();
         }
+
+        this.contexts.clear();
+
+        this.removeAllListeners();
     }
 
     private updateCheckpoint() {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -48,5 +48,7 @@ export class Context extends EventEmitter implements IContext {
      */
     public close(): void {
         this.closed = true;
+
+        this.removeAllListeners();
     }
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -67,6 +67,8 @@ export class PartitionManager extends EventEmitter {
         }
 
         this.partitions.clear();
+
+        this.removeAllListeners();
     }
 
     private process(message: IQueuedMessage) {


### PR DESCRIPTION
- Ensure messages are not inserted into the partition queue after being closed
     - It may not be possible to get into this state but it feels safer with this check
- Remove listeners when closing things