### PR TITLE
Remove manipulation of attach request headers from Container

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -36,7 +36,6 @@ import {
     IDocumentStorageService,
     IFluidResolvedUrl,
     IResolvedUrl,
-    DriverHeader,
 } from "@fluidframework/driver-definitions";
 import {
     BlobCacheStorageService,
@@ -602,13 +601,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             }
             assert(!!this.cachedAttachSummary,
                 "Summary should be there either by this attach call or previous attach call!!");
-
-            if (request.headers?.[DriverHeader.createNew] === undefined) {
-                request.headers = {
-                    ...request.headers,
-                    [DriverHeader.createNew]: {},
-                };
-            }
 
             const createNewResolvedUrl = await this.urlResolver.resolve(request);
             ensureFluidResolvedUrl(createNewResolvedUrl);


### PR DESCRIPTION
We're currently inconsistent in our `createNew` header typing (`true`, `{}`, `{ fileName: string }`).  Additionally, `Container` supplies `{}` as the `createNew` header if not provided during attach.  Experimenting with specifying typing as needed by ODSP (as it is the most strict), and removing header manipulation from `Container`.

I generally expect `Container` should not be manipulating the request (each service should be in control of its respective request format I think), so if unifying the typing here doesn't work out then perhaps the header typing should move into the individual drivers rather than the driver-definitions package.