### PR TITLE
Issue #4519: Make Loader.resolve() return non-loaded container

### DIFF
--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -183,7 +183,7 @@ export interface ILoader extends IFluidRouter {
      * An analogy for this is resolve is a DNS resolve of a Fluid container. Request then executes
      * a request against the server found from the resolve step.
      */
-    resolve(request: IRequest): Promise<IContainer>;
+    resolve(request: IRequest, initialLoad?: boolean): Promise<IContainer>;
 
     /**
      * Creates a new container using the specified chaincode but in an unattached state. While unattached all

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -9,9 +9,9 @@ export class LoaderContainerTracker {
     private readonly containers = new Set<IContainer>();
 
     public add<LoaderType extends ILoader>(loader: LoaderType) {
-        const patch = <T, C extends IContainer>(fn: (...args: T[]) => Promise<C>) => {
+        const patch = <C extends IContainer>(fn: (...args: any[]) => Promise<C>) => {
             const boundFn = fn.bind(loader);
-            return async (...args: T[]) => {
+            return async (...args: any[]) => {
                 const container = await boundFn(...args);
                 this.containers.add(container);
                 return container;


### PR DESCRIPTION
Today, we return container only after we are done loading snapshot. That's too late for these scenarios:
- we hit 429 while downloading snapshot and keep retrying. There is nowhere to report progress or cancel as host does not have container yet
- People register for  various events (like "connected" and "disconnected") but never check initial state (Container.connected), assuming that is is always the same. Ideally initial state of container is always pre-defined, but we also notify users of it by calling appropriate handler on registration.
- We have no good point in time to bark on people (console.error or similar) if real shipping scenario did not register for all key handlers ("close", disconnect", etc.) - this shows up all the time, resulting in broken user experiences. Barking when we raised an error is a bit too late

This solution allows us to return shell container object (not hitting anything that can fail) much earlier, to give a chance for host to put all handlers, and then continue loading.

I did not make it a default path yet, as it would be great to prove it before making global change. Doing so in our repo requires changes in 4 test files, webpack loader, and I think one other place.