### PR TITLE
add data corruption error coercions

### DIFF
--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -21,6 +21,11 @@ export enum ContainerErrorType {
      * Data loss error detected by Container / DeltaManager. Likely points to storage issue.
      */
     dataCorruptionError = "dataCorruptionError",
+
+    /**
+     * Error encountered when processing an operation. May correlate with data corruption.
+     */
+    dataProcessingError = "dataProcessingError",
 }
 
 /**

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -46,7 +46,11 @@ import {
     createGenericNetworkError,
     getRetryDelayFromError,
 } from "@fluidframework/driver-utils";
-import { CreateContainerError, DataCorruptionError } from "@fluidframework/container-utils";
+import {
+    CreateContainerError,
+    CreateCorruptionError,
+    DataCorruptionError,
+} from "@fluidframework/container-utils";
 import { debug } from "./debug";
 import { DeltaQueue } from "./deltaQueue";
 import { logNetworkFailure, waitForConnectedState } from "./networkUtils";
@@ -396,7 +400,7 @@ export class DeltaManager
             });
 
         this._inbound.on("error", (error) => {
-            this.close(CreateContainerError(error));
+            this.close(CreateContainerError(CreateCorruptionError(error)));
         });
 
         // Outbound message queue. The outbound queue is represented as a queue of an array of ops. Ops contained

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -400,7 +400,7 @@ export class DeltaManager
             });
 
         this._inbound.on("error", (error) => {
-            this.close(CreateCorruptionError(error));
+            this.close(CreateCorruptionError(error, {}));
         });
 
         // Outbound message queue. The outbound queue is represented as a queue of an array of ops. Ops contained

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -400,7 +400,7 @@ export class DeltaManager
             });
 
         this._inbound.on("error", (error) => {
-            this.close(CreateContainerError(CreateCorruptionError(error)));
+            this.close(CreateCorruptionError(error));
         });
 
         // Outbound message queue. The outbound queue is represented as a queue of an array of ops. Ops contained

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -48,7 +48,7 @@ import {
 } from "@fluidframework/driver-utils";
 import {
     CreateContainerError,
-    CreateCorruptionError,
+    CreateProcessingError,
     DataCorruptionError,
 } from "@fluidframework/container-utils";
 import { debug } from "./debug";
@@ -400,7 +400,7 @@ export class DeltaManager
             });
 
         this._inbound.on("error", (error) => {
-            this.close(CreateCorruptionError(error, {}));
+            this.close(CreateProcessingError(error, {}));
         });
 
         // Outbound message queue. The outbound queue is represented as a queue of an array of ops. Ops contained

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -25,7 +25,7 @@ const isValidLoggingError = (error: any): error is LoggingError => {
     return typeof error?.errorType === "string" && error instanceof LoggingError;
 };
 
-const isRegularObject = (value: any): boolean => value !== null || Array.isArray(value) || typeof value !== "object";
+const isRegularObject = (value: any): boolean => value !== null && !Array.isArray(value) && typeof value === "object";
 
 function extractSafeLoggableProperties(error: any) {
     // Only get properties we know about.

--- a/packages/loader/container-utils/src/test/error.spec.ts
+++ b/packages/loader/container-utils/src/test/error.spec.ts
@@ -3,5 +3,112 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "assert";
+import { ContainerErrorType } from "@fluidframework/container-definitions";
+import { LoggingError } from "@fluidframework/telemetry-utils";
+import { DataCorruptionError, CreateCorruptionError } from "../error";
+
 describe("Errors", () => {
+    describe("DataCorruptionError coercion", () => {
+        it("Should skip coercion for matching types", () => {
+            const originalError = new DataCorruptionError(
+                "Example error message",
+                {},
+            );
+            const coercedError = CreateCorruptionError(originalError);
+
+            assert(coercedError === originalError);
+        });
+
+        it("Should not fail coercing malformed inputs", () => {
+            const originalMalformations = [
+                null,
+                undefined,
+                false,
+                true,
+                3.14,
+                Symbol("Unique"),
+                () => {},
+                [],
+            ];
+            const coercedErrors = originalMalformations.map((value) =>
+                CreateCorruptionError(value),
+            );
+
+            assert(
+                coercedErrors.every(
+                    (error) =>
+                        error.errorType ===
+                        ContainerErrorType.dataCorruptionError,
+                ),
+            );
+            assert(
+                coercedErrors.every(
+                    (error) => typeof error.message === "string",
+                ),
+            );
+            assert(
+                coercedErrors.reduce(
+                    (messages, error) => messages.add(error.message),
+                    new Set(),
+                ).size === 1,
+                "All malformed inputs should generate a common error.message",
+            );
+            assert(
+                !originalMalformations.some(
+                    (value) =>
+                        typeof value === "string" ||
+                        (typeof value === "object" &&
+                            !Array.isArray(value) &&
+                            value !== null),
+                ),
+                "Neither strings nor objects are considered malformed",
+            );
+        });
+
+        it("Should be coercible from a string message", () => {
+            const originalMessage = "Example of some thrown string";
+            const coercedError = CreateCorruptionError(originalMessage);
+
+            assert(coercedError.message === originalMessage);
+        });
+
+        it("Should be coercible from a property object", () => {
+            const originalProps = {
+                message: "Inherited error message",
+                errorType: "Overwritten error type",
+                otherProperty: "Presumed PII-full property",
+            };
+            const coercedError = CreateCorruptionError(originalProps);
+
+            assert(coercedError.message === originalProps.message);
+            assert(
+                coercedError.errorType ===
+                    ContainerErrorType.dataCorruptionError,
+            );
+            assert(coercedError.errorSubType === undefined);
+            assert((coercedError as any).otherProperty === undefined);
+        });
+
+        it("Should be coercible from a logging error", () => {
+            const originalError = new LoggingError("Inherited error message", {
+                errorType: "Demoted error type",
+                otherProperty: "Considered PII-free property",
+            });
+            const coercedError = CreateCorruptionError(originalError);
+
+            assert(coercedError.message === originalError.message);
+            assert(
+                coercedError.errorType ===
+                    ContainerErrorType.dataCorruptionError,
+            );
+            assert(
+                coercedError.errorSubType === (originalError as any).errorType,
+            );
+            assert(
+                (coercedError as any).otherProperty ===
+                    (originalError as any).otherProperty,
+            );
+        });
+    });
 });

--- a/packages/runtime/datastore/src/channelDeltaConnection.ts
+++ b/packages/runtime/datastore/src/channelDeltaConnection.ts
@@ -40,7 +40,14 @@ export class ChannelDeltaConnection implements IDeltaConnection {
         try {
             this.handler.process(message, local, localOpMetadata);
         } catch (error) {
-            throw CreateCorruptionError(error);
+            throw CreateCorruptionError(error, {
+                messageClientId: message.clientId,
+                sequenceNumber: message.sequenceNumber,
+                clientSequenceNumber: message.clientSequenceNumber,
+                referenceSequenceNumber: message.referenceSequenceNumber,
+                minimumSequenceNumber: message.minimumSequenceNumber,
+                messageTimestamp: message.timestamp,
+            });
         }
     }
 

--- a/packages/runtime/datastore/src/channelDeltaConnection.ts
+++ b/packages/runtime/datastore/src/channelDeltaConnection.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IDeltaConnection, IDeltaHandler } from "@fluidframework/datastore-definitions";
-import { CreateCorruptionError } from "@fluidframework/container-utils";
+import { CreateProcessingError } from "@fluidframework/container-utils";
 
 export class ChannelDeltaConnection implements IDeltaConnection {
     private _handler: IDeltaHandler | undefined;
@@ -38,9 +38,11 @@ export class ChannelDeltaConnection implements IDeltaConnection {
 
     public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
         try {
+            // catches as data processing error whether or not they come from async pending queues
             this.handler.process(message, local, localOpMetadata);
         } catch (error) {
-            throw CreateCorruptionError(error, {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw CreateProcessingError(error, {
                 messageClientId: message.clientId,
                 sequenceNumber: message.sequenceNumber,
                 clientSequenceNumber: message.clientSequenceNumber,

--- a/packages/runtime/datastore/src/channelDeltaConnection.ts
+++ b/packages/runtime/datastore/src/channelDeltaConnection.ts
@@ -6,6 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { IDocumentMessage, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IDeltaConnection, IDeltaHandler } from "@fluidframework/datastore-definitions";
+import { CreateCorruptionError } from "@fluidframework/container-utils";
 
 export class ChannelDeltaConnection implements IDeltaConnection {
     private _handler: IDeltaHandler | undefined;
@@ -36,7 +37,11 @@ export class ChannelDeltaConnection implements IDeltaConnection {
     }
 
     public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
-        this.handler.process(message, local, localOpMetadata);
+        try {
+            this.handler.process(message, local, localOpMetadata);
+        } catch (error) {
+            throw CreateCorruptionError(error);
+        }
     }
 
     public reSubmit(content: any, localOpMetadata: unknown) {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -19,6 +19,7 @@ import {
     AttachState,
     ILoaderOptions,
 } from "@fluidframework/container-definitions";
+import { CreateCorruptionError } from "@fluidframework/container-utils";
 import {
     assert,
     Deferred,
@@ -521,66 +522,70 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
-        this.verifyNotClosed();
-        switch (message.type) {
-            case DataStoreMessageType.Attach: {
-                const attachMessage = message.contents as IAttachMessage;
-                const id = attachMessage.id;
+        try {
+            this.verifyNotClosed();
+            switch (message.type) {
+                case DataStoreMessageType.Attach: {
+                    const attachMessage = message.contents as IAttachMessage;
+                    const id = attachMessage.id;
 
-                // If a non-local operation then go and create the object
-                // Otherwise mark it as officially attached.
-                if (local) {
-                    assert(this.pendingAttach.has(id), "Unexpected attach (local) channel OP");
-                    this.pendingAttach.delete(id);
-                } else {
-                    assert(!this.contexts.has(id), `Unexpected attach channel OP,
-                        is in pendingAttach set: ${this.pendingAttach.has(id)},
-                        is local channel contexts: ${this.contexts.get(id) instanceof LocalChannelContext}`);
-
-                    const flatBlobs = new Map<string, string>();
-                    const snapshotTree = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
-
-                    const remoteChannelContext = new RemoteChannelContext(
-                        this,
-                        this.dataStoreContext,
-                        this.dataStoreContext.storage,
-                        (content, localContentMetadata) => this.submitChannelOp(id, content, localContentMetadata),
-                        (address: string) => this.setChannelDirty(address),
-                        id,
-                        snapshotTree,
-                        this.sharedObjectRegistry,
-                        flatBlobs,
-                        this.dataStoreContext.getCreateChildSummarizerNodeFn(
-                            id,
-                            {
-                                type: CreateSummarizerNodeSource.FromAttach,
-                                sequenceNumber: message.sequenceNumber,
-                                snapshot: attachMessage.snapshot,
-                            },
-                        ),
-                        async () => this.getChannelInitialGCDetails(id),
-                        attachMessage.type);
-
-                    this.contexts.set(id, remoteChannelContext);
-                    if (this.contextsDeferred.has(id)) {
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        this.contextsDeferred.get(id)!.resolve(remoteChannelContext);
+                    // If a non-local operation then go and create the object
+                    // Otherwise mark it as officially attached.
+                    if (local) {
+                        assert(this.pendingAttach.has(id), "Unexpected attach (local) channel OP");
+                        this.pendingAttach.delete(id);
                     } else {
-                        const deferred = new Deferred<IChannelContext>();
-                        deferred.resolve(remoteChannelContext);
-                        this.contextsDeferred.set(id, deferred);
+                        assert(!this.contexts.has(id), `Unexpected attach channel OP,
+                            is in pendingAttach set: ${this.pendingAttach.has(id)},
+                            is local channel contexts: ${this.contexts.get(id) instanceof LocalChannelContext}`);
+
+                        const flatBlobs = new Map<string, string>();
+                        const snapshotTree = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
+
+                        const remoteChannelContext = new RemoteChannelContext(
+                            this,
+                            this.dataStoreContext,
+                            this.dataStoreContext.storage,
+                            (content, localContentMetadata) => this.submitChannelOp(id, content, localContentMetadata),
+                            (address: string) => this.setChannelDirty(address),
+                            id,
+                            snapshotTree,
+                            this.sharedObjectRegistry,
+                            flatBlobs,
+                            this.dataStoreContext.getCreateChildSummarizerNodeFn(
+                                id,
+                                {
+                                    type: CreateSummarizerNodeSource.FromAttach,
+                                    sequenceNumber: message.sequenceNumber,
+                                    snapshot: attachMessage.snapshot,
+                                },
+                            ),
+                            async () => this.getChannelInitialGCDetails(id),
+                            attachMessage.type);
+
+                        this.contexts.set(id, remoteChannelContext);
+                        if (this.contextsDeferred.has(id)) {
+                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                            this.contextsDeferred.get(id)!.resolve(remoteChannelContext);
+                        } else {
+                            const deferred = new Deferred<IChannelContext>();
+                            deferred.resolve(remoteChannelContext);
+                            this.contextsDeferred.set(id, deferred);
+                        }
                     }
+                    break;
                 }
-                break;
+
+                case DataStoreMessageType.ChannelOp:
+                    this.processChannelOp(message, local, localOpMetadata);
+                    break;
+                default:
             }
 
-            case DataStoreMessageType.ChannelOp:
-                this.processChannelOp(message, local, localOpMetadata);
-                break;
-            default:
+            this.emit("op", message);
+        } catch (error) {
+            throw CreateCorruptionError(error);
         }
-
-        this.emit("op", message);
     }
 
     public processSignal(message: IInboundSignalMessage, local: boolean) {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -19,7 +19,7 @@ import {
     AttachState,
     ILoaderOptions,
 } from "@fluidframework/container-definitions";
-import { CreateCorruptionError } from "@fluidframework/container-utils";
+import { CreateProcessingError } from "@fluidframework/container-utils";
 import {
     assert,
     Deferred,
@@ -525,6 +525,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         this.verifyNotClosed();
 
         try {
+            // catches as data processing error whether or not they come from async pending queues
             switch (message.type) {
                 case DataStoreMessageType.Attach: {
                     const attachMessage = message.contents as IAttachMessage;
@@ -585,7 +586,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
             this.emit("op", message);
         } catch (error) {
-            throw CreateCorruptionError(error, {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw CreateProcessingError(error, {
                 clientId: this.clientId,
                 messageClientId: message.clientId,
                 sequenceNumber: message.sequenceNumber,

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -522,8 +522,9 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
+        this.verifyNotClosed();
+
         try {
-            this.verifyNotClosed();
             switch (message.type) {
                 case DataStoreMessageType.Attach: {
                     const attachMessage = message.contents as IAttachMessage;
@@ -584,7 +585,15 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
             this.emit("op", message);
         } catch (error) {
-            throw CreateCorruptionError(error);
+            throw CreateCorruptionError(error, {
+                clientId: this.clientId,
+                messageClientId: message.clientId,
+                sequenceNumber: message.sequenceNumber,
+                clientSequenceNumber: message.clientSequenceNumber,
+                referenceSequenceNumber: message.referenceSequenceNumber,
+                minimumSequenceNumber: message.minimumSequenceNumber,
+                messageTimestamp: message.timestamp,
+            });
         }
     }
 


### PR DESCRIPTION
### Definitions (for the purpose of this discussion)
- Data corruption: a scenario in which participants of a session are unable to partially or fully leverage session data that is believed (i.e. code/protocol expectations rather than user/experience expectation) to be persisted
- Data loss: a scenario in which a user might expect data to be persisted but the protocol understands that persistence has not yet occurred (and may never occur)

### Objective
We want to rapidly expose signals that can be used in attempts to detect data corruption.

### Plan
The current indicator we are relying on is for "thrown" error values to have an `errorType` of "dataCorruptionError" -- this is built into the `DataCorruptionError` class.

While walking through the code with @anthony-murphy , he identified [3](https://github.com/microsoft/FluidFramework/pull/5144/files#diff-27ae7b1e16da168c508c887daa4cc945211fd4e7e2ccb0bf4f4973edb3c43a0aR41) [key](https://github.com/microsoft/FluidFramework/pull/5144/files#diff-5b145dfa0151b5be1f17d42f73c3aa248d3600b934665f3d22311345d32df4e4R524) [places](https://github.com/microsoft/FluidFramework/pull/5144/files#diff-01eeb7567dd98442afb9a308001150972f600ef3f04e17a71f88b34a0b8ee153R403) where we might be able to expose a "plurality" of corruption issues -- and we throw `DataCorruptionError` instances to do so.