### PR TITLE
Improve port usage for tinylicious and unit test

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3781,9 +3781,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.19.16",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
-					"integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+					"version": "12.20.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.0.tgz",
+					"integrity": "sha512-0/41wHcurotvSOTHQUFkgL702c3pyWR1mToSrrX3pGPvGfpHTv3Ksx0M4UVuU5VJfjVb62Eyr1eKO1tWNUCg2Q=="
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
@@ -4060,9 +4060,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.19.16",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
-					"integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+					"version": "12.20.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.0.tgz",
+					"integrity": "sha512-0/41wHcurotvSOTHQUFkgL702c3pyWR1mToSrrX3pGPvGfpHTv3Ksx0M4UVuU5VJfjVb62Eyr1eKO1tWNUCg2Q=="
 				}
 			}
 		},
@@ -27491,9 +27491,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.19.16",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
-					"integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+					"version": "12.20.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.0.tgz",
+					"integrity": "sha512-0/41wHcurotvSOTHQUFkgL702c3pyWR1mToSrrX3pGPvGfpHTv3Ksx0M4UVuU5VJfjVb62Eyr1eKO1tWNUCg2Q=="
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
@@ -29326,9 +29326,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.19.16",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
-							"integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+							"version": "12.20.0",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.0.tgz",
+							"integrity": "sha512-0/41wHcurotvSOTHQUFkgL702c3pyWR1mToSrrX3pGPvGfpHTv3Ksx0M4UVuU5VJfjVb62Eyr1eKO1tWNUCg2Q=="
 						}
 					}
 				},
@@ -29351,9 +29351,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.19.16",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
-							"integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+							"version": "12.20.0",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.0.tgz",
+							"integrity": "sha512-0/41wHcurotvSOTHQUFkgL702c3pyWR1mToSrrX3pGPvGfpHTv3Ksx0M4UVuU5VJfjVb62Eyr1eKO1tWNUCg2Q=="
 						},
 						"jwt-decode": {
 							"version": "3.1.2",
@@ -29378,9 +29378,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.19.16",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
-							"integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+							"version": "12.20.0",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.0.tgz",
+							"integrity": "sha512-0/41wHcurotvSOTHQUFkgL702c3pyWR1mToSrrX3pGPvGfpHTv3Ksx0M4UVuU5VJfjVb62Eyr1eKO1tWNUCg2Q=="
 						}
 					}
 				},

--- a/packages/test/end-to-end-tests/src/test/leader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/leader.spec.ts
@@ -99,6 +99,9 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // write something to get out of view only mode and take leadership
         dataObject1.root.set("blah", "blah");
 
+        // Make sure we reconnect as a writer and processed the op
+        await args.opProcessingController.process();
+
         const container2 = await args.loadTestContainer() as Container;
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
 

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -62,6 +62,7 @@
     "@fluidframework/test-runtime-utils": "^0.35.0",
     "@fluidframework/tinylicious-driver": "^0.35.0",
     "@fluidframework/tool-utils": "^0.35.0",
+    "axios": "^0.21.1",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -40,6 +40,7 @@
     "@fluidframework/server-services-shared": "^0.1017.1",
     "@fluidframework/server-services-utils": "^0.1016.0",
     "@fluidframework/server-test-utils": "^0.1017.1",
+    "axios": "^0.21.1",
     "body-parser": "^1.17.1",
     "bytes": "^3.0.0",
     "charwise": "^3.0.1",

--- a/server/tinylicious/src/index.ts
+++ b/server/tinylicious/src/index.ts
@@ -5,9 +5,20 @@
  */
 
 import * as path from "path";
+import http from "http";
+import Axios from "axios";
 import { runService } from "@fluidframework/server-services-utils";
 import { TinyliciousResourcesFactory } from "./resourcesFactory";
 import { TinyliciousRunnerFactory } from "./runnerFactory";
+
+// Each TCP connect has a delay to allow it to be reuse after close, and unit test make a lot of connection,
+// which might cause port exhaustion.
+
+// Tinylicious includes end points for ths historian for the client. But even we bundle all the service in
+// a monolithic process, it still uses sockets to communicate with the historian service.  For these call,
+// keep the TCP connection open so that they can be reused
+// TODO: Set this globally since the Historian use the global Axios default instance.  Make this encapsulated.
+Axios.defaults.httpAgent = new http.Agent({ keepAlive: true });
 
 runService(
     new TinyliciousResourcesFactory(),


### PR DESCRIPTION
TCP hangs on to a port after it close for a period of time to avoid message being delivered after. 
If we make a lot of HTTP request, that create a lot of TCP connection.  The unit test is an example.

Also within tinylicious, even though that it is monolithic, it is still a bundling of multiple microservices. So call to historian is still done thru HTTP request even though they are the same process.

To avoid port exhaustion, set the HTTP connection to keep alive so that it can be reused, instead of closing and creating a new one.

The change set those flag globally for the unit test and tinylicious.  We might want to consider making this more targeted and configurable in the future.

Related to issue #5098 

Note: I am able to run the mocha e2e test with --parallel --jobs 2 now.  Not enabling it because there are still instability.