### PR TITLE
IContainerContext API cleanup

### DIFF
--- a/packages/loader/container-definitions/src/runtime.ts
+++ b/packages/loader/container-definitions/src/runtime.ts
@@ -9,7 +9,6 @@ import {
     IFluidConfiguration,
     IRequest,
     IResponse,
-    IFluidCodeDetails,
 } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
@@ -118,14 +117,11 @@ export interface IContainerContext extends IDisposable {
     readonly configuration: IFluidConfiguration;
     readonly clientId: string | undefined;
     readonly clientDetails: IClientDetails;
-    readonly codeDetails: IFluidCodeDetails;
     readonly storage: IDocumentStorageService | undefined | null;
     readonly connected: boolean;
-    readonly branch: string;
     readonly baseSnapshot: ISnapshotTree | undefined;
     readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
     readonly submitSignalFn: (contents: any) => void;
-    readonly snapshotFn: (message: string) => Promise<void>;
     readonly closeFn: (error?: ICriticalContainerError) => void;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly quorum: IQuorum;
@@ -133,7 +129,6 @@ export interface IContainerContext extends IDisposable {
     readonly loader: ILoader;
     readonly logger: ITelemetryLogger;
     readonly serviceConfiguration: IClientConfiguration | undefined;
-    readonly version: string;
     readonly previousRuntimeState: IRuntimeState;
 
     /**
@@ -142,8 +137,6 @@ export interface IContainerContext extends IDisposable {
     readonly scope: IFluidObject;
 
     raiseContainerWarning(warning: ContainerWarning): void;
-    requestSnapshot(tagMessage: string): Promise<void>;
-    reloadContext(): Promise<void>;
 
     /**
      * Get an absolute url for a provided container-relative request.
@@ -160,7 +153,6 @@ export interface IContainerContext extends IDisposable {
 
     getLoadedFromVersion(): IVersion | undefined;
 
-    createSummary(): ISummaryTree;
 }
 
 export const IRuntimeFactory: keyof IProvideRuntimeFactory = "IRuntimeFactory";

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1692,7 +1692,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             (warning: ContainerWarning) => this.raiseContainerWarning(warning),
             (type, contents, batch, metadata) => this.submitContainerMessage(type, contents, batch, metadata),
             (message) => this.submitSignal(message),
-            async (message) => this.snapshot(message),
             (error?: ICriticalContainerError) => this.close(error),
             Container.version,
             previousRuntimeState,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -62,7 +62,6 @@ export class ContainerContext implements IContainerContext {
         raiseContainerWarning: (warning: ContainerWarning) => void,
         submitFn: (type: MessageType, contents: any, batch: boolean, appData: any) => number,
         submitSignalFn: (contents: any) => void,
-        snapshotFn: (message: string) => Promise<void>,
         closeFn: (error?: ICriticalContainerError) => void,
         version: string,
         previousRuntimeState: IRuntimeState,
@@ -80,7 +79,6 @@ export class ContainerContext implements IContainerContext {
             raiseContainerWarning,
             submitFn,
             submitSignalFn,
-            snapshotFn,
             closeFn,
             version,
             previousRuntimeState);
@@ -191,7 +189,6 @@ export class ContainerContext implements IContainerContext {
         public readonly raiseContainerWarning: (warning: ContainerWarning) => void,
         public readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData: any) => number,
         public readonly submitSignalFn: (contents: any) => void,
-        public readonly snapshotFn: (message: string) => Promise<void>,
         public readonly closeFn: (error?: ICriticalContainerError) => void,
         public readonly version: string,
         public readonly previousRuntimeState: IRuntimeState,
@@ -261,10 +258,6 @@ export class ContainerContext implements IContainerContext {
 
     public async request(path: IRequest): Promise<IResponse> {
         return this.runtime.request(path);
-    }
-
-    public async requestSnapshot(tagMessage: string): Promise<void> {
-        return this.snapshotFn(tagMessage);
     }
 
     public registerTasks(tasks: string[]): any {

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -79,10 +79,8 @@ export interface IContainerRuntime extends
     readonly leader: boolean;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly storage: IDocumentStorageService;
-    readonly branch: string;
     readonly loader: ILoader;
     readonly flushMode: FlushMode;
-    readonly snapshotFn: (message: string) => Promise<void>;
     readonly scope: IFluidObject;
     /**
      * Indicates the attachment state of the container to a host service.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -548,14 +548,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this.context.storage!;
     }
 
-    public get branch(): string {
-        return this.context.branch;
-    }
-
-    public get snapshotFn(): (message: string) => Promise<void> {
-        return this.context.snapshotFn;
-    }
-
     public get reSubmitFn(): (
         type: ContainerMessageType,
         content: any,
@@ -949,10 +941,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
         const blobsTree = convertToSummaryTree(this.blobManager.snapshot(), false);
         addTreeToSummary(summaryTree, blobsTreeName, blobsTree);
-    }
-
-    public async requestSnapshot(tagMessage: string): Promise<void> {
-        return this.context.requestSnapshot(tagMessage);
     }
 
     public async stop(): Promise<IRuntimeState> {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -146,14 +146,6 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         return this._containerRuntime.leader;
     }
 
-    public get snapshotFn(): (message: string) => Promise<void> {
-        return this._containerRuntime.snapshotFn;
-    }
-
-    public get branch(): string {
-        return this._containerRuntime.branch;
-    }
-
     public get loader(): ILoader {
         return this._containerRuntime.loader;
     }
@@ -164,14 +156,6 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
     public get isLoaded(): boolean {
         return this.loaded;
-    }
-
-    /**
-     * @deprecated 0.17 Issue #1888 Rename IHostRuntime to IContainerRuntime and refactor usages
-     * Use containerRuntime instead of hostRuntime
-     */
-    public get hostRuntime(): IContainerRuntime {
-        return this._containerRuntime;
     }
 
     public get baseSnapshot(): ISnapshotTree | undefined {

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -258,7 +258,6 @@ IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegi
     readonly leader: boolean;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly storage: IDocumentStorageService;
-    readonly branch: string;
     readonly baseSnapshot: ISnapshotTree | undefined;
     readonly loader: ILoader;
     /**
@@ -267,12 +266,6 @@ IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegi
     readonly attachState: AttachState;
 
     readonly containerRuntime: IContainerRuntimeBase;
-    /**
-     * @deprecated 0.17 Issue #1888 Rename IHostRuntime to IContainerRuntime and refactor usages
-     * Use containerRuntime instead of hostRuntime
-     */
-    readonly hostRuntime: IContainerRuntimeBase;
-    readonly snapshotFn: (message: string) => Promise<void>;
 
     /**
      * @deprecated 0.16 Issue #1635, #3631


### PR DESCRIPTION
All of these are unused. Maybe some things are planned to be used soon - not sure, but ideally the smaller the surface - the better (in terms of allowing alternative implementations of loader layer).