### PR TITLE
Make the loader cache attached containers from "attached" event rather than exposing a public method

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -638,8 +638,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 throw new Error("Unable to parse Url");
             }
 
-            this.loader.cacheContainer(this, request, parsedUrl);
-
             const [, docId] = parsedUrl.id.split("/");
             this._id = decodeURI(docId);
 


### PR DESCRIPTION
Currently, the `Loader` exposes a method that allows the `Container` to manipulate the members of the `Loader`'s `Container` cache when a detached `Container` is attached.  In the interest of making the `Container` less dependent on the `Loader`, the `Loader` can observe the relevant `"attached"` event instead and add the `Container` to its own cache.  This has the added benefit of reducing `Loader`'s public surface and hiding access to its cache.