### PR TITLE
Remove redundant assert from deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable no-null/no-null */
 
-import assert from "assert";
 import { RangeTracker } from "@fluidframework/common-utils";
 import { isSystemType } from "@fluidframework/protocol-base";
 import {
@@ -326,9 +325,6 @@ export class DeliLambda implements IPartitionLambda {
                     message.operation.referenceSequenceNumber = sequenceNumber;
                 }
             }
-            assert(
-                message.operation.referenceSequenceNumber >= this.minimumSequenceNumber,
-                `${message.operation.referenceSequenceNumber} >= ${this.minimumSequenceNumber}`);
 
             this.clientSeqManager.upsertClient(
                 message.clientId,


### PR DESCRIPTION
No need to assert as we are already nacking the client here (https://github.com/microsoft/FluidFramework/blob/b582d10944dc3c0841223c9c5337ea396768f7ec/server/routerlicious/packages/lambdas/src/deli/lambda.ts#L295)