### PR TITLE
Ignore: Testing references to "*" in the CI

### DIFF
--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.35.0",
     "@fluidframework/datastore-definitions": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/shared-object-base": "^0.35.0",
     "assert": "^2.0.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/core-interfaces": "^0.35.0",
     "@fluidframework/datastore-definitions": "^0.35.0",
     "@fluidframework/merge-tree": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/runtime-utils": "^0.35.0",
     "@fluidframework/shared-object-base": "^0.35.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/core-interfaces": "^0.35.0",
     "@fluidframework/datastore-definitions": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/shared-object-base": "^0.35.0",
     "assert": "^2.0.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/driver-utils": "^0.35.0",
     "@fluidframework/gitresources": "^0.1019.0-0",
     "@fluidframework/odsp-doclib-utils": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/telemetry-utils": "^0.35.0",
     "abort-controller": "^3.0.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/driver-definitions": "^0.35.0",
     "@fluidframework/driver-utils": "^0.35.0",
     "@fluidframework/gitresources": "^0.1019.0-0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/server-services-client": "^0.1019.0-0",
     "@fluidframework/telemetry-utils": "^0.35.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/core-interfaces": "^0.35.0",
     "@fluidframework/driver-definitions": "^0.35.0",
     "@fluidframework/driver-utils": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/telemetry-utils": "^0.35.0",
     "assert": "^2.0.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/core-interfaces": "^0.35.0",
     "@fluidframework/driver-definitions": "^0.35.0",
     "@fluidframework/gitresources": "^0.1019.0-0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/telemetry-utils": "^0.35.0",
     "assert": "^2.0.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/driver-definitions": "^0.35.0",
     "@fluidframework/driver-utils": "^0.35.0",
     "@fluidframework/garbage-collector": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/runtime-definitions": "^0.35.0",
     "@fluidframework/runtime-utils": "^0.35.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/driver-definitions": "^0.35.0",
     "@fluidframework/driver-utils": "^0.35.0",
     "@fluidframework/garbage-collector": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/runtime-definitions": "^0.35.0",
     "@fluidframework/runtime-utils": "^0.35.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/core-interfaces": "^0.35.0",
     "@fluidframework/datastore-definitions": "^0.35.0",
     "@fluidframework/garbage-collector": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "@fluidframework/runtime-definitions": "^0.35.0",
     "assert": "^2.0.0"

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/odsp-doclib-utils": "^0.35.0",
-    "@fluidframework/protocol-base": "^0.1019.0-0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
     "proper-lockfile": "^4.1.1"
   },

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/gitresources": "^0.1020.0",
-    "@fluidframework/protocol-base": "^0.1020.0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1020.0",
     "@fluidframework/server-services-client": "^0.1020.0",
     "@fluidframework/server-services-core": "^0.1020.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.27.0",
-    "@fluidframework/protocol-base": "^0.1020.0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1020.0",
     "@fluidframework/server-lambdas": "^0.1020.0",
     "@fluidframework/server-services-client": "^0.1020.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/gitresources": "^0.1020.0",
-    "@fluidframework/protocol-base": "^0.1020.0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1020.0",
     "@types/node": "^12.19.0",
     "axios": "^0.21.1",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/gitresources": "^0.1020.0",
-    "@fluidframework/protocol-base": "^0.1020.0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1020.0",
     "@fluidframework/server-services-client": "^0.1020.0",
     "@fluidframework/server-services-core": "^0.1020.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.27.0",
     "@fluidframework/gitresources": "^0.1020.0",
-    "@fluidframework/protocol-base": "^0.1020.0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1020.0",
     "@fluidframework/server-services-client": "^0.1020.0",
     "@fluidframework/server-services-core": "^0.1020.0",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.26.0",
     "@fluidframework/gitresources": "^0.1016.0",
-    "@fluidframework/protocol-base": "^0.1016.0",
+    "@fluidframework/protocol-base": "*",
     "@fluidframework/protocol-definitions": "^0.1016.0",
     "@fluidframework/server-lambdas": "^0.1017.1",
     "@fluidframework/server-local-server": "^0.1017.1",


### PR DESCRIPTION
Curious if instead of manually publishing a prerelease packages and referencing them with '^0.28.0-0' if we could instead target the prerelease packages with "*".

Both 'Lerna' and 'Fluid-Build --symlink:full' seem tolerant.  I suspect 'npm run bump-version' will also do the right thing.