### PR TITLE
Policy-Check: Add exemption for _package-lock.json

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
@@ -13,7 +13,7 @@ const urlPattern = /(https?[^"@]+)(\/@.+|\/[^/]+\/-\/.+tgz)/g;
 
 export const handler: Handler = {
     name: "package-lockfiles",
-    match: /^.*?package-lock\.json$/i,
+    match: /^.*?[^_]package-lock\.json$/i, // Ignore _package-lock.json
     handler: file => {
         let content = readFile(file);
         const matches = content.match(urlPattern);


### PR DESCRIPTION
See https://github.com/microsoft/FluidFramework/pull/5089 where I'm adding a file `_package-lock.json` which is for a package not to be installed by a user of this repo but rather our internal pipeline (after removing the `_` of course).