### PR TITLE
Minimize involvement of Container in request headers

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -111,6 +111,9 @@ export interface IContainerLoadOptions {
      * Client details provided in the override will be merged over the default client.
      */
     clientDetailsOverride?: IClientDetails;
+    containerUrl: string;
+    docId: string;
+    resolvedUrl: IFluidResolvedUrl;
     /**
      * Control whether to load from snapshot or ops.  See IParsedUrl for detailed information.
      */
@@ -270,19 +273,16 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * Load an existing container.
      */
     public static async load(
-        docId: string,
         loader: Loader,
-        containerUrl: string,
-        resolvedUrl: IFluidResolvedUrl,
         loadOptions: IContainerLoadOptions,
     ): Promise<Container> {
         const container = new Container(
             loader,
             {
-                containerUrl,
+                containerUrl: loadOptions.containerUrl,
                 clientDetailsOverride: loadOptions.clientDetailsOverride,
-                id: docId,
-                resolvedUrl,
+                id: loadOptions.docId,
+                resolvedUrl: loadOptions.resolvedUrl,
                 canReconnect: loadOptions.canReconnect,
             });
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -281,7 +281,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             {
                 containerUrl,
                 clientDetailsOverride: loadOptions.clientDetailsOverride,
-                id: decodeURI(docId),
+                id: docId,
                 resolvedUrl,
                 canReconnect: loadOptions.canReconnect,
             });

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -102,10 +102,36 @@ interface ILocalSequencedClient extends ISequencedClient {
     shouldHaveLeft?: boolean;
 }
 
+export interface IContainerLoadOptions {
+    /**
+     * Disables the Container from reconnecting if false, allows reconnect otherwise.
+     */
+    canReconnect?: boolean;
+    /**
+     * Client details provided in the override will be merged over the default client.
+     */
+    clientDetailsOverride?: IClientDetails;
+    /**
+     * Control whether to load from snapshot or ops.  See IParsedUrl for detailed information.
+     */
+    version?: string | null | undefined;
+    /**
+     * Loads the Container in paused state if true, unpaused otherwise.
+     */
+    pause?: boolean;
+}
+
 export interface IContainerConfig {
     resolvedUrl?: IResolvedUrl;
     canReconnect?: boolean;
+    /**
+     * A url for the Container.  Critically, we expect Loader.resolve using this URL to resolve back to this Container
+     * for purposes of creating a separate Container instance for the summarizer to use.
+     */
     containerUrl?: string;
+    /**
+     * Client details provided in the override will be merged over the default client.
+     */
     clientDetailsOverride?: IClientDetails;
     id?: string;
 }
@@ -235,25 +261,6 @@ export class CollabWindowTracker {
         }
         this.updateSequenceNumberTimer = undefined;
     }
-}
-
-export interface IContainerLoadOptions {
-    /**
-     * Disables the Container from reconnecting if false, allows reconnect otherwise.
-     */
-    canReconnect?: boolean;
-    /**
-     * Client details provided in the override will be merged over the default client.
-     */
-    clientDetailsOverride?: IClientDetails;
-    /**
-     * Control whether to load from snapshot or ops.  See IParsedUrl for detailed information.
-     */
-    version?: string | null | undefined;
-    /**
-     * Loads the Container in paused state if true, unpaused otherwise.
-     */
-    pause?: boolean;
 }
 
 export class Container extends EventEmitterWithErrorHandling<IContainerEvents> implements IContainer {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -272,14 +272,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     public static async load(
         docId: string,
         loader: Loader,
-        request: IRequest,
+        containerUrl: string,
         resolvedUrl: IFluidResolvedUrl,
         loadOptions: IContainerLoadOptions,
     ): Promise<Container> {
         const container = new Container(
             loader,
             {
-                containerUrl: request.url,
+                containerUrl,
                 clientDetailsOverride: loadOptions.clientDetailsOverride,
                 id: decodeURI(docId),
                 resolvedUrl,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -238,9 +238,21 @@ export class CollabWindowTracker {
 }
 
 export interface IContainerLoadOptions {
+    /**
+     * Disables the Container from reconnecting if false, allows reconnect otherwise.
+     */
     canReconnect?: boolean;
+    /**
+     * Client details provided in the override will be merged over the default client.
+     */
     clientDetailsOverride?: IClientDetails;
+    /**
+     * Control whether to load from snapshot or ops.  See IParsedUrl for detailed information.
+     */
     version?: string | null | undefined;
+    /**
+     * Loads the Container in paused state if true, unpaused otherwise.
+     */
     pause?: boolean;
 }
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -316,7 +316,7 @@ export class Loader extends EventEmitter implements ILoader {
         });
     }
 
-    public async requestWorker(baseUrl: string, request: IRequest): Promise<IResponse> {
+    public async requestWorker(containerUrl: string, request: IRequest): Promise<IResponse> {
         // Currently the loader only supports web worker environment. Eventually we will
         // detect environment and bring appropriate loader (e.g., worker_thread for node).
         const supportedEnvironment = "webworker";
@@ -324,17 +324,17 @@ export class Loader extends EventEmitter implements ILoader {
 
         // If the loader does not support any other environment, request falls back to current loader.
         if (proxyLoaderFactory === undefined) {
-            const container = await this.resolve({ url: baseUrl, headers: request.headers });
+            const container = await this.resolve({ url: containerUrl, headers: request.headers });
             return container.request(request);
         } else {
-            const resolved = await this.services.urlResolver.resolve({ url: baseUrl, headers: request.headers });
+            const resolved = await this.services.urlResolver.resolve({ url: containerUrl, headers: request.headers });
             const resolvedAsFluid = resolved as IFluidResolvedUrl;
             const parsed = parseUrl(resolvedAsFluid.url);
             if (parsed === undefined) {
                 return Promise.reject(new Error(`Invalid URL ${resolvedAsFluid.url}`));
             }
             const { fromSequenceNumber } =
-                this.parseHeader(parsed, { url: baseUrl, headers: request.headers });
+                this.parseHeader(parsed, { url: containerUrl, headers: request.headers });
             const proxyLoader = await proxyLoaderFactory.createProxyLoader(
                 parsed.id,
                 this.services.options,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -464,7 +464,7 @@ export class Loader extends EventEmitter implements ILoader {
         return Container.load(
             docId,
             this,
-            request,
+            request.url,
             resolved,
             {
                 canReconnect: request.headers?.[LoaderHeader.reconnect],

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -463,13 +463,13 @@ export class Loader extends EventEmitter implements ILoader {
     ): Promise<Container> {
         const docId = decodeURI(encodedDocId);
         return Container.load(
-            docId,
             this,
-            request.url,
-            resolved,
             {
                 canReconnect: request.headers?.[LoaderHeader.reconnect],
                 clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
+                containerUrl: request.url,
+                docId,
+                resolvedUrl: resolved,
                 version: request.headers?.[LoaderHeader.version],
                 pause: request.headers?.[LoaderHeader.pause],
             },

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -59,7 +59,7 @@ export class RelativeLoader extends EventEmitter implements ILoader {
      */
     constructor(
         private readonly loader: ILoader,
-        private readonly baseRequest: () => IRequest | undefined,
+        private readonly containerUrl: () => string | undefined,
     ) {
         super();
     }
@@ -77,21 +77,21 @@ export class RelativeLoader extends EventEmitter implements ILoader {
     }
 
     public async request(request: IRequest): Promise<IResponse> {
-        const baseRequest = this.baseRequest();
+        const containerUrl = this.containerUrl();
         if (request.url.startsWith("/")) {
             if (this.needExecutionContext(request)) {
-                if (baseRequest === undefined) {
-                    throw new Error("Base Request is not provided");
+                if (containerUrl === undefined) {
+                    throw new Error("Container url is not provided");
                 }
-                return (this.loader as Loader).requestWorker(baseRequest.url, request);
+                return (this.loader as Loader).requestWorker(containerUrl, request);
             } else {
                 let container: IContainer;
                 if (canUseCache(request)) {
                     container = await this.containerDeferred.promise;
-                } else if (baseRequest === undefined) {
-                    throw new Error("Base Request is not provided");
+                } else if (containerUrl === undefined) {
+                    throw new Error("Container url is not provided");
                 } else {
-                    container = await this.loader.resolve({ url: baseRequest.url, headers: request.headers });
+                    container = await this.loader.resolve({ url: containerUrl, headers: request.headers });
                 }
                 return container.request(request);
             }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -457,10 +457,11 @@ export class Loader extends EventEmitter implements ILoader {
     }
 
     private async loadContainer(
-        docId: string,
+        encodedDocId: string,
         request: IRequest,
         resolved: IFluidResolvedUrl,
     ): Promise<Container> {
+        const docId = decodeURI(encodedDocId);
         return Container.load(
             docId,
             this,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -465,6 +465,13 @@ export class Loader extends EventEmitter implements ILoader {
             docId,
             this,
             request,
-            resolved);
+            resolved,
+            {
+                canReconnect: request.headers?.[LoaderHeader.reconnect],
+                clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
+                version: request.headers?.[LoaderHeader.version],
+                pause: request.headers?.[LoaderHeader.pause],
+            },
+        );
     }
 }

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -8,6 +8,7 @@ import { IRequest } from "@fluidframework/core-interfaces";
 import {
     IGenericError,
     ContainerErrorType,
+    LoaderHeader,
 } from "@fluidframework/container-definitions";
 import { Container, ConnectionState, Loader, ILoaderProps } from "@fluidframework/container-loader";
 import {
@@ -48,7 +49,14 @@ describe("Container", () => {
             "documentId",
             loader,
             testRequest,
-            testResolved);
+            testResolved,
+            {
+                canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
+                clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
+                version: testRequest.headers?.[LoaderHeader.version],
+                pause: testRequest.headers?.[LoaderHeader.pause],
+            },
+        );
     }
 
     it("Load container successfully", async () => {

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -46,13 +46,13 @@ describe("Container", () => {
         const testResolved = await loader.services.urlResolver.resolve(testRequest);
         ensureFluidResolvedUrl(testResolved);
         return Container.load(
-            "documentId",
             loader,
-            testRequest.url,
-            testResolved,
             {
                 canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                 clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
+                containerUrl: testRequest.url,
+                docId: "documentId",
+                resolvedUrl: testResolved,
                 version: testRequest.headers?.[LoaderHeader.version],
                 pause: testRequest.headers?.[LoaderHeader.pause],
             },

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -48,7 +48,7 @@ describe("Container", () => {
         return Container.load(
             "documentId",
             loader,
-            testRequest,
+            testRequest.url,
             testResolved,
             {
                 canReconnect: testRequest.headers?.[LoaderHeader.reconnect],

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -72,13 +72,13 @@ describe("Errors Types", () => {
 
         try {
             await Container.load(
-                "documentId",
                 loader,
-                testRequest.url,
-                testResolved,
                 {
                     canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                     clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
+                    containerUrl: testRequest.url,
+                    docId: "documentId",
+                    resolvedUrl: testResolved,
                     version: testRequest.headers?.[LoaderHeader.version],
                     pause: testRequest.headers?.[LoaderHeader.pause],
                 },

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import {
     ContainerErrorType,
+    LoaderHeader,
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { CreateContainerError } from "@fluidframework/container-utils";
@@ -74,7 +75,14 @@ describe("Errors Types", () => {
                 "documentId",
                 loader,
                 testRequest,
-                testResolved);
+                testResolved,
+                {
+                    canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
+                    clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
+                    version: testRequest.headers?.[LoaderHeader.version],
+                    pause: testRequest.headers?.[LoaderHeader.pause],
+                },
+            );
 
             assert.fail("Error expected");
         } catch (error) {

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -74,7 +74,7 @@ describe("Errors Types", () => {
             await Container.load(
                 "documentId",
                 loader,
-                testRequest,
+                testRequest.url,
                 testResolved,
                 {
                     canReconnect: testRequest.headers?.[LoaderHeader.reconnect],

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -34,14 +34,17 @@ class WorkerLoader implements ILoader, IFluidRunnable {
         console.log(`Request inside web worker`);
         console.log(request);
         const container = await Container.load(
-            decodeURI(this.id),
+            this.id,
             (this as unknown) as Loader,
-            request, // request.url, // To be used when taking the updated Container.load signature
+            request,
             this.resolved,
             // To be used when taking the updated Container.load signature
             // {
             //     canReconnect: request.headers?.[LoaderHeader.reconnect],
             //     clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
+            //     containerUrl: request.url,
+            //     docId: decodeURI(this.id),
+            //     resolvedUrl: this.resolved,
             //     version: request.headers?.[LoaderHeader.version],
             //     pause: request.headers?.[LoaderHeader.pause],
             // },

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -38,6 +38,13 @@ class WorkerLoader implements ILoader, IFluidRunnable {
             (this as unknown) as Loader,
             request,
             this.resolved,
+            // To be used when taking the updated Container.load signature
+            // {
+            //     canReconnect: request.headers?.[LoaderHeader.reconnect],
+            //     clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
+            //     version: request.headers?.[LoaderHeader.version],
+            //     pause: request.headers?.[LoaderHeader.pause],
+            // },
         );
         this.container = container;
 

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -34,7 +34,7 @@ class WorkerLoader implements ILoader, IFluidRunnable {
         console.log(`Request inside web worker`);
         console.log(request);
         const container = await Container.load(
-            this.id,
+            decodeURI(this.id),
             (this as unknown) as Loader,
             request, // request.url, // To be used when taking the updated Container.load signature
             this.resolved,

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -36,7 +36,7 @@ class WorkerLoader implements ILoader, IFluidRunnable {
         const container = await Container.load(
             this.id,
             (this as unknown) as Loader,
-            request,
+            request, // request.url, // To be used when taking the updated Container.load signature
             this.resolved,
             // To be used when taking the updated Container.load signature
             // {


### PR DESCRIPTION
This change proceeds with the effort to increase separation and layering between the `Loader` and `Container` (aligning with the pay-for-play idea of using `Container` without a `Loader`), by pulling `LoaderHeader` use out of the `Container`.  The `Container` then expects more-explicit options to be set upon it, rather than inferring from the headers of the `IRequest` it is given.  To further enforce this, `Container` no longer takes any `IRequest` arguments in its static `load` or `constructor`.

There is also a longer-term target of modifying the `attach` flow (which also takes an `IRequest` currently), to eventually allow us to remove direct usage of the `urlResolver` from the `Container`.  Although this change doesn't take dramatic steps in this direction, it does additionally serve as a prophylactic move to avoid new usages of the `urlResolver` from being introduced.