### PR TITLE
Add timeoutPromise to avoid timing issue causing leader test flakiness

### DIFF
--- a/packages/test/end-to-end-tests/src/test/leader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/leader.spec.ts
@@ -47,6 +47,11 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Currently, we load a container in write mode from the start. See issue #3304.
         // Once that is fix, this needs to change
         assert(container2.deltaManager.active);
+        if (!dataObject2.context.leader) {
+            await timeoutPromise((resolve) => {
+                dataObject2.context.once("leader", () => { resolve(); });
+            });
+        }
         assert(dataObject2.context.leader);
     });
 


### PR DESCRIPTION
e.g. https://dev.azure.com/fluidframework/public/_build/results?buildId=16377&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=5cfe65a4-d7cb-5934-e953-1c67617821f4&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c