### PR TITLE
FluidBuild: add ignoreDirs support for monorepos

### DIFF
--- a/tools/build-tools/.vscode/launch.json
+++ b/tools/build-tools/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program",
-            "program": "${workspaceFolder}\\dist\\fluidBuild.js",
+            "program": "${workspaceFolder}\\dist\\fluidBuild\\fluidBuild.js",
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ]

--- a/tools/build-tools/src/common/monoRepo.ts
+++ b/tools/build-tools/src/common/monoRepo.ts
@@ -15,7 +15,7 @@ export enum MonoRepoKind {
 export class MonoRepo {
     public readonly packages: Package[] = [];
     public readonly version: string;
-    constructor(public readonly kind: MonoRepoKind, public readonly repoPath: string) {
+    constructor(public readonly kind: MonoRepoKind, public readonly repoPath: string, ignoredDirs?: string[]) {
         const lernaPath = path.join(repoPath, "lerna.json");
         if (!existsSync(lernaPath)) {
             throw new Error(`ERROR: lerna.json not found in ${repoPath}`);
@@ -24,7 +24,7 @@ export class MonoRepo {
         for (const dir of lerna.packages as string[]) {
             // TODO: other glob pattern?
             const loadDir = dir.endsWith("/**") ? dir.substr(0, dir.length - 3) : dir;
-            this.packages.push(...Packages.loadDir(path.join(this.repoPath, loadDir), MonoRepoKind[kind], this));
+            this.packages.push(...Packages.loadDir(path.join(this.repoPath, loadDir), MonoRepoKind[kind], ignoredDirs, this));
         }
         this.version = lerna.version;
     }


### PR DESCRIPTION
So that we can skip build cra-demo once this is checked in.