### PR TITLE
include ContainerWarning.logged in interface

### DIFF
--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -46,7 +46,13 @@ export interface IErrorBase {
 /**
  * Represents warnings raised on container.
  */
-export type ContainerWarning = IErrorBase;
+export interface ContainerWarning extends IErrorBase {
+    /**
+     * Whether this error has already been logged. Used to avoid logging errors twice.
+     * Default is false.
+     */
+    logged?: boolean;
+}
 
 /**
  * Represents errors raised on container.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -830,7 +830,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     public raiseContainerWarning(warning: ContainerWarning) {
         // Some "warning" events come from outside the container and are logged
         // elsewhere (e.g. summarizing container). We shouldn't log these here.
-        if ((warning as any).logged !== true) {
+        if (warning.logged !== true) {
             this.logContainerError(warning);
         }
         this.emit("warning", warning);

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -21,7 +21,7 @@ import {
     IFluidHandle,
     IFluidLoadable,
 } from "@fluidframework/core-interfaces";
-import { IDeltaManager, IErrorBase } from "@fluidframework/container-definitions";
+import { ContainerWarning, IDeltaManager } from "@fluidframework/container-definitions";
 import { CreateContainerError } from "@fluidframework/container-utils";
 import {
     IDocumentMessage,
@@ -71,11 +71,8 @@ export interface ISummarizerInternalsProvider {
 
 const summarizingError = "summarizingError";
 
-export interface ISummarizingWarning extends IErrorBase {
+export interface ISummarizingWarning extends ContainerWarning {
     readonly errorType: "summarizingError";
-    /**
-     * Whether this error has already been logged. Used to avoid logging errors twice.
-     */
     readonly logged: boolean;
 }
 


### PR DESCRIPTION
This improves type safety and documentation of tracking if ContainerWarnings have already been logged.

Change to ContainerWarning type only adds an optional field, so it should be type wise non-breaking.

This does not change runtime behavior.