### PR TITLE
Report  x-fluid-retries & sprequestguid for blob operations

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -346,6 +346,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         blob = await res.arrayBuffer();
                         event.end({
                             size: blob.byteLength,
+                            serverRetries: res.headers.get("x-fluid-retries") ?? undefined,
                             waitQueueLength: this.epochTracker.rateLimiter.waitQueueLength,
                         });
                         return blob;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -311,7 +311,11 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         },
                         "createBlob",
                     );
-                    event.end({ blobId: res.content.id });
+                    event.end({
+                        blobId: res.content.id,
+                        serverRetries: res.headers.get("x-fluid-retries") ?? undefined,
+                        sprequestguid: response.headers.get("sprequestguid") ?? undefined,
+                    });
                     return res;
                 },
             );
@@ -348,6 +352,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                             size: blob.byteLength,
                             serverRetries: res.headers.get("x-fluid-retries") ?? undefined,
                             waitQueueLength: this.epochTracker.rateLimiter.waitQueueLength,
+                            sprequestguid: res.headers.get("sprequestguid") ?? undefined,
                         });
                         return blob;
                     },


### PR DESCRIPTION
Issue #5084: ODSP driver: Blob upload events do not carry sprequestguid property
Issue #5193: ODSP driver: report x-fluid-retries to telemetry

Note that for failed reads/writes, we should get automatically sprequestguid  through centralized error reporting. The only place where it does not happen if read/write failed due to epoch check on client side. If that becomes a problem, we should address is separately, for all fetch calls that may fail client epoch check.