### PR TITLE
Add NackFutureMessages control message type

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -39,7 +39,7 @@ import {
     SequencedOperationType,
     IQueuedMessage,
     IUpdateDSNControlMessageContents,
-    INackFutureMessagesMessageContents,
+    INackFutureMessagesControlMessageContents,
 } from "@fluidframework/server-services-core";
 import { CheckpointContext } from "./checkpointContext";
 import { ClientSequenceNumberManager } from "./clientSeqManager";
@@ -105,7 +105,7 @@ export class DeliLambda implements IPartitionLambda {
     private canClose = false;
 
     // when set, all messages will be nacked based on the provided info
-    private nackFutureMessages: INackFutureMessagesMessageContents | undefined;
+    private nackFutureMessages: INackFutureMessagesControlMessageContents | undefined;
 
     constructor(
         private readonly context: IContext,
@@ -427,7 +427,7 @@ export class DeliLambda implements IPartitionLambda {
                 }
 
                 case ControlMessageType.NackFutureMessages: {
-                    this.nackFutureMessages = controlMessage.contents as INackFutureMessagesMessageContents;
+                    this.nackFutureMessages = controlMessage.contents as INackFutureMessagesControlMessageContents;
                     break;
                 }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -245,7 +245,8 @@ export class DeliLambda implements IPartitionLambda {
                 message,
                 this.nackFutureMessages.code,
                 this.nackFutureMessages.type,
-                this.nackFutureMessages.reason);
+                this.nackFutureMessages.message,
+                this.nackFutureMessages.retryAfter);
         }
 
         // Check incoming message order. Nack if there is any gap so that the client can resend.
@@ -602,7 +603,8 @@ export class DeliLambda implements IPartitionLambda {
         message: IRawOperationMessage,
         code: number,
         type: NackErrorType,
-        reason: string): ITicketedMessageOutput {
+        reason: string,
+        retryAfter?: number): ITicketedMessageOutput {
         const nackMessage: INackMessage = {
             clientId: message.clientId,
             documentId: this.documentId,
@@ -611,6 +613,7 @@ export class DeliLambda implements IPartitionLambda {
                     code,
                     type,
                     message: reason,
+                    retryAfter,
                 },
                 operation: message.operation,
                 sequenceNumber: this.minimumSequenceNumber,

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -38,6 +38,8 @@ import {
     RawOperationType,
     SequencedOperationType,
     IQueuedMessage,
+    IUpdateDSNControlMessageContents,
+    INackFutureMessagesMessageContents,
 } from "@fluidframework/server-services-core";
 import { CheckpointContext } from "./checkpointContext";
 import { ClientSequenceNumberManager } from "./clientSeqManager";
@@ -101,6 +103,9 @@ export class DeliLambda implements IPartitionLambda {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     private canClose = false;
+
+    // when set, all messages will be nacked based on the provided info
+    private nackFutureMessages: INackFutureMessagesMessageContents | undefined;
 
     constructor(
         private readonly context: IContext,
@@ -233,6 +238,15 @@ export class DeliLambda implements IPartitionLambda {
         // Update and retrieve the minimum sequence number
         const message = rawMessage as IRawOperationMessage;
         const systemContent = this.extractSystemContent(message);
+
+        // Check if we should nack all messages
+        if (this.nackFutureMessages) {
+            return this.createNackMessage(
+                message,
+                this.nackFutureMessages.code,
+                this.nackFutureMessages.type,
+                this.nackFutureMessages.reason);
+        }
 
         // Check incoming message order. Nack if there is any gap so that the client can resend.
         const messageOrder = this.checkOrder(message);
@@ -388,30 +402,37 @@ export class DeliLambda implements IPartitionLambda {
         } else if (message.operation.type === MessageType.Control) {
             sendType = SendType.Never;
             const controlMessage = systemContent as IControlMessage;
-            if (controlMessage.type === ControlMessageType.UpdateDSN) {
-                const messageMetaData = {
-                    documentId: this.documentId,
-                    tenantId: this.tenantId,
-                };
-                this.context.log.info(`Update DSN: ${JSON.stringify(controlMessage)}`, { messageMetaData });
-                // TODO: Make specific interface type for controlContents. The schema should be more clear
-                // as we introduce more of these.
-                const controlContent = controlMessage.contents as
-                    {
-                        durableSequenceNumber: number
-                        clearCache: boolean
+            switch (controlMessage.type) {
+                case ControlMessageType.UpdateDSN: {
+                    const messageMetaData = {
+                        documentId: this.documentId,
+                        tenantId: this.tenantId,
                     };
-                const dsn = controlContent.durableSequenceNumber;
-                if (dsn >= this.durableSequenceNumber) {
-                    // Deli cache is only cleared when no clients have joined since last noClient was sent to alfred.
-                    if (controlContent.clearCache && this.noActiveClients) {
-                        instruction = InstructionType.ClearCache;
-                        this.canClose = true;
-                        this.context.log.info(`Deli cache will be cleared`, { messageMetaData });
+                    this.context.log.info(`Update DSN: ${JSON.stringify(controlMessage)}`, { messageMetaData });
+
+                    const controlContents = controlMessage.contents as IUpdateDSNControlMessageContents;
+                    const dsn = controlContents.durableSequenceNumber;
+                    if (dsn >= this.durableSequenceNumber) {
+                        // Deli cache is only cleared when no clients have joined since last noClient was sent to alfred
+                        if (controlContents.clearCache && this.noActiveClients) {
+                            instruction = InstructionType.ClearCache;
+                            this.canClose = true;
+                            this.context.log.info(`Deli cache will be cleared`, { messageMetaData });
+                        }
+
+                        this.durableSequenceNumber = dsn;
                     }
 
-                    this.durableSequenceNumber = dsn;
+                    break;
                 }
+
+                case ControlMessageType.NackFutureMessages: {
+                    this.nackFutureMessages = controlMessage.contents as INackFutureMessagesMessageContents;
+                    break;
+                }
+
+                default:
+                // ignore unknown control messages
             }
         }
 

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -160,7 +160,7 @@ export interface IUpdateDSNControlMessageContents {
     clearCache: boolean;
 }
 
-export interface INackFutureMessagesMessageContents {
+export interface INackFutureMessagesControlMessageContents {
     code: number;
     type: NackErrorType;
     reason: string;

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IDocumentMessage, INack, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import {
+    IDocumentMessage,
+    INack,
+    ISequencedDocumentMessage,
+    NackErrorType,
+} from "@fluidframework/protocol-definitions";
 
 // String identifying the raw operation message
 export const RawOperationType: string = "RawOperation";
@@ -145,4 +150,18 @@ export interface IControlMessage {
 export enum ControlMessageType {
     // Instruction sent to update Durable sequence number
     UpdateDSN = "updateDSN",
+
+    // Instruction sent to have deli nack all future messages
+    NackFutureMessages = "nackFutureMessages",
+}
+
+export interface IUpdateDSNControlMessageContents {
+    durableSequenceNumber: number;
+    clearCache: boolean;
+}
+
+export interface INackFutureMessagesMessageContents {
+    code: number;
+    type: NackErrorType;
+    reason: string;
 }

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -6,8 +6,8 @@
 import {
     IDocumentMessage,
     INack,
+    INackContent,
     ISequencedDocumentMessage,
-    NackErrorType,
 } from "@fluidframework/protocol-definitions";
 
 // String identifying the raw operation message
@@ -160,8 +160,4 @@ export interface IUpdateDSNControlMessageContents {
     clearCache: boolean;
 }
 
-export interface INackFutureMessagesControlMessageContents {
-    code: number;
-    type: NackErrorType;
-    reason: string;
-}
+export type INackFutureMessagesControlMessageContents = INackContent;


### PR DESCRIPTION
This will allow other lambdas to tell deli to nack all future messages with the given nack code, error type, and reason.
This will be useful for scenarios when a document session is being shut down unexpectedly, such as a version restore.