### PR TITLE
Enable strict null checks in lambdas-driver package

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -71,8 +71,8 @@ export class DocumentLambda implements IPartitionLambda {
         const routingKey = `${boxcar.tenantId}/${boxcar.documentId}`;
 
         // Create or update the DocumentPartition
-        let document: DocumentPartition;
-        if (!this.documents.has(routingKey)) {
+        let document = this.documents.get(routingKey);
+        if (!document) {
             // Create a new context and begin tracking it
             const documentContext = this.contextManager.createContext(message);
 
@@ -85,7 +85,6 @@ export class DocumentLambda implements IPartitionLambda {
                 this.documentLambdaServerConfiguration.partitionActivityTimeout);
             this.documents.set(routingKey, document);
         } else {
-            document = this.documents.get(routingKey);
             // SetHead assumes it will always receive increasing offsets. So we need to split the creation case
             // from the update case.
             document.context.setHead(message);

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -19,10 +19,10 @@ import { DocumentContext } from "./documentContext";
 export class DocumentPartition {
     private readonly q: AsyncQueue<IQueuedMessage>;
     private readonly lambdaP: Promise<IPartitionLambda>;
-    private lambda: IPartitionLambda;
+    private lambda: IPartitionLambda | undefined;
     private corrupt = false;
     private closed = false;
-    private activityTimeoutTime: number;
+    private activityTimeoutTime: number | undefined;
 
     constructor(
         factory: IPartitionLambdaFactory,
@@ -44,7 +44,8 @@ export class DocumentPartition {
                 // Winston.verbose(`${message.topic}:${message.partition}@${message.offset}`);
                 try {
                     if (!this.corrupt) {
-                        this.lambda.handler(message);
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        this.lambda!.handler(message);
                     } else {
                         // Until we can dead letter - simply checkpoint as handled
                         this.context.checkpoint(message);
@@ -117,7 +118,7 @@ export class DocumentPartition {
     }
 
     public isInactive(now: number = Date.now()) {
-        return !this.context.hasPendingWork() && now > this.activityTimeoutTime;
+        return !this.context.hasPendingWork() && this.activityTimeoutTime && now > this.activityTimeoutTime;
     }
 
     private updateActivityTime() {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -10,8 +10,8 @@ import { IConsumer, IQueuedMessage } from "@fluidframework/server-services-core"
 export class CheckpointManager {
     private checkpointing = false;
     private closed = false;
-    private commitedCheckpoint: IQueuedMessage;
-    private lastCheckpoint: IQueuedMessage;
+    private commitedCheckpoint: IQueuedMessage | undefined;
+    private lastCheckpoint: IQueuedMessage | undefined;
     private pendingCheckpoint: Deferred<void> | undefined;
     private error: any;
 
@@ -63,7 +63,7 @@ export class CheckpointManager {
 
                 // Trigger another checkpoint round if the offset has moved since the checkpoint finished and
                 // resolve any pending checkpoints to it.
-                if (this.lastCheckpoint !== this.commitedCheckpoint) {
+                if (this.lastCheckpoint && this.lastCheckpoint !== this.commitedCheckpoint) {
                     assert(this.pendingCheckpoint, "Differing offsets will always result in pendingCheckpoint");
                     const nextCheckpointP = this.checkpoint(this.lastCheckpoint);
                     this.pendingCheckpoint.resolve(nextCheckpointP);

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -26,7 +26,7 @@ import { Context } from "./context";
 export class Partition extends EventEmitter {
     private q: AsyncQueue<IQueuedMessage>;
     private readonly lambdaP: Promise<IPartitionLambda>;
-    private lambda: IPartitionLambda;
+    private lambda: IPartitionLambda | undefined;
     private readonly checkpointManager: CheckpointManager;
     private readonly context: Context;
     private closed = false;
@@ -55,7 +55,8 @@ export class Partition extends EventEmitter {
         this.q = queue(
             (message: IQueuedMessage, callback) => {
                 try {
-                    this.lambda.handler(message);
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this.lambda!.handler(message);
                     callback();
                 } catch (error) {
                     callback(error);

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -78,14 +78,14 @@ export class PartitionManager extends EventEmitter {
             return;
         }
 
-        if (!this.partitions.has(message.partition)) {
+        const partition = this.partitions.get(message.partition);
+        if (!partition) {
             this.emit(
                 "error",
                 `Received message for untracked partition ${message.topic}:${message.partition}@${message.offset}`);
             return;
         }
 
-        const partition = this.partitions.get(message.partition);
         partition.process(message);
     }
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -11,8 +11,8 @@ import * as winston from "winston";
 import { PartitionManager } from "./partitionManager";
 
 export class KafkaRunner implements IRunner {
-    private deferred: Deferred<void>;
-    private partitionManager: PartitionManager;
+    private deferred: Deferred<void> | undefined;
+    private partitionManager: PartitionManager | undefined;
 
     constructor(
         private readonly factory: IPartitionLambdaFactory,
@@ -22,37 +22,48 @@ export class KafkaRunner implements IRunner {
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public start(): Promise<void> {
-        this.deferred = new Deferred<void>();
+        if (this.deferred) {
+            throw new Error("Already started");
+        }
+
+        const deferred = new Deferred<void>();
+
+        this.deferred = deferred;
 
         process.on("warning", (msg) => {
             console.trace("Warning", msg);
         });
 
         this.factory.on("error", (error) => {
-            this.deferred.reject(error);
+            deferred.reject(error);
         });
 
         this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, winston);
         this.partitionManager.on("error", (error, errorData: IContextErrorData) => {
-            this.deferred.reject(error);
+            deferred.reject(error);
         });
 
-        return this.deferred.promise;
+        return deferred.promise;
     }
 
     /**
      * Signals to stop the service
      */
     public async stop(): Promise<void> {
+        if (!this.deferred) {
+            return;
+        }
+
         winston.info("Stop requested");
 
         // Stop listening for new updates
         await this.consumer.pause();
 
-        // Mark ourselves done once the topic manager has stopped processing
-        const stopP = this.partitionManager.stop();
-        this.deferred.resolve(stopP);
+        // Stop the partition manager
+        await this.partitionManager?.stop();
 
-        return this.deferred.promise;
+        // Mark ourselves done once the partition manager has stopped
+        this.deferred.resolve();
+        this.deferred = undefined;
     }
 }

--- a/server/routerlicious/packages/lambdas-driver/tsconfig.json
+++ b/server/routerlicious/packages/lambdas-driver/tsconfig.json
@@ -4,7 +4,6 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true


### PR DESCRIPTION
- Slight refactor to `KafkaRunner` to make `deferred` typing better and to enforce start/stop is called correctly
- Added non null assertions to `lambda.handler` calls because the queue is only active while the lambda exists

A part of #2358