### PR TITLE
Optimize the use of restWrapperP

### DIFF
--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -146,8 +146,8 @@ export class Historian implements IHistorian {
     // There are two scenarios in Historian call a REST, one the first time
     // you apply it. The other is to refresh the auth token after the permission
     // check fails.
-    private async loadOrCreateRestWrapper(isReset:boolean = false): Promise<RestWrapper> {
-        var isFirstCall:boolean = !this.restWrapper;
+    private async loadOrCreateRestWrapper(isReset: boolean = false): Promise<RestWrapper> {
+        const isFirstCall: boolean = !this.restWrapper;
         if (isFirstCall || isReset) {
             this.restWrapper = await this.restWrapperP;
             return this.restWrapper;

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -145,8 +145,10 @@ export class Historian implements IHistorian {
     }
 
     private async createRestWrapper(): Promise<RestWrapper> {
+        this.restWrapper = undefined;
         const queryString: { token?; disableCache?} = {};
         let cacheBust = false;
+
         if (this.disableCache && this.historianApi) {
             queryString.disableCache = this.disableCache;
         } else if (this.disableCache) {

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -28,6 +28,7 @@ export interface ICredentials {
  * Implementation of the IHistorian interface that calls out to a REST interface
  */
 export class Historian implements IHistorian {
+    // If the auth token need refresh after the permission check fails, it is recalled.
     private restWrapperP: Promise<RestWrapper>;
     private restWrapper: RestWrapper;
 


### PR DESCRIPTION
* in purpose

> we are using restWrapperP and waiting for it to resolve before every call. Given that the promise will only resolve once, it should not incur any additional latency

it is ref to #5116