### PR TITLE
First batch of change to enable e2e test to target ODSP

### DIFF
--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -42,7 +42,6 @@
     "axios": "^0.21.1",
     "debug": "^4.1.1",
     "isomorphic-ws": "^4.0.1",
-    "jwt-decode": "^2.2.0",
     "socket.io-client": "^2.1.1",
     "uuid": "^8.3.1",
     "ws": "^6.1.2"
@@ -53,7 +52,6 @@
     "@microsoft/api-extractor": "^7.7.2",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
-    "@types/jwt-decode": "^2.2.1",
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
     "@types/socket.io-client": "^1.4.32",

--- a/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -25,7 +25,7 @@ import { ITestDriver } from "@fluidframework/test-driver-definitions";
 describe(`Attach/Bind Api Tests For Attached Container`, () => {
     let driver: ITestDriver;
     before(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
 
     const codeDetails: IFluidCodeDetails = {

--- a/packages/test/end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/codePropsal.spec.ts
@@ -39,7 +39,7 @@ function isCodeProposalTestPackage(pkg: unknown): pkg is ICodeProposalTestPackag
 describe("CodeProposal.EndToEnd", () => {
     let driver: ITestDriver;
     before(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
 
     const packageV1: ICodeProposalTestPackage = {
@@ -99,7 +99,7 @@ describe("CodeProposal.EndToEnd", () => {
 
     async function loadContainer(documentId: string): Promise<IContainer> {
         const loader = createLoader();
-        return loader.resolve({ url: driver.createContainerUrl(documentId) });
+        return loader.resolve({ url: await driver.createContainerUrl(documentId) });
     }
 
     let containers: IContainer[];

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -27,8 +27,14 @@ const testRequest: IRequest = { url: id };
 describe("Container", () => {
     let driver: ITestDriver;
     const loaderContainerTracker = new LoaderContainerTracker();
-    beforeEach(()=>{
+    before(function() {
         driver = getFluidTestDriver() as unknown as ITestDriver;
+
+        // TODO: Convert these to mocked unit test. These are all API tests and doesn't
+        // need the service.  For new disable the tests other then local driver
+        if (driver.type !== "local") {
+            this.skip();
+        }
     });
     afterEach(() => {
         loaderContainerTracker.reset();

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -28,7 +28,7 @@ describe("Container", () => {
     let driver: ITestDriver;
     const loaderContainerTracker = new LoaderContainerTracker();
     beforeEach(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
     afterEach(() => {
         loaderContainerTracker.reset();

--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -105,7 +105,7 @@ describe("context reload (hot-swap)", function() {
             documentServiceFactory: driver.createDocumentServiceFactory(),
         });
         loaderContainerTracker.add(loader);
-        return loader.resolve({ url: driver.createContainerUrl(documentId) });
+        return loader.resolve({ url: await driver.createContainerUrl(documentId) });
     }
 
     const createRuntimeFactory = (dataStore): IRuntimeFactory => {
@@ -118,7 +118,7 @@ describe("context reload (hot-swap)", function() {
     };
     let driver: ITestDriver;
     before(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
 
     const tests = function() {
@@ -276,6 +276,7 @@ describe("context reload (hot-swap)", function() {
             describe("old loader, new runtime", () => {
                 beforeEach(async function() {
                     const documentId = createDocumentId();
+                    // TODO: this is not creating the old loader
                     container = await createContainer(
                         [
                             [codeDetails(V1), oldApi.createOldRuntimeFactory(oldApi.OldTestDataObjectV1)],

--- a/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -34,7 +34,7 @@ const detachedContainerRefSeqNumber = 0;
 describe(`Dehydrate Rehydrate Container Test`, () => {
     let driver: ITestDriver;
     before(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
 
     const codeDetails: IFluidCodeDetails = {

--- a/packages/test/end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/error.spec.ts
@@ -38,7 +38,7 @@ describe("Errors Types", () => {
     let driver: ITestDriver;
     const loaderContainerTracker = new LoaderContainerTracker();
     before(() => {
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
     afterEach(() => {
         loaderContainerTracker.reset();
@@ -48,7 +48,7 @@ describe("Errors Types", () => {
         const id = createDocumentId();
         // Setup
         urlResolver = driver.createUrlResolver();
-        testRequest = { url: driver.createContainerUrl(id) };
+        testRequest = { url: await driver.createContainerUrl(id) };
         testResolved =
             await urlResolver.resolve(testRequest) as IFluidResolvedUrl;
         documentServiceFactory = driver.createDocumentServiceFactory();

--- a/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/loaderTest.spec.ts
@@ -68,7 +68,7 @@ const testSharedDataObjectFactory2 = new DataObjectFactory(
 describe("Loader.request", () => {
     let driver: ITestDriver;
     before(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
 
     const codeDetails: IFluidCodeDetails = {

--- a/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/localLoader.spec.ts
@@ -89,7 +89,7 @@ const testDataObjectFactory = new DataObjectFactory(
 describe("LocalLoader", () => {
     let driver: ITestDriver;
     before(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
 
     const codeDetails: IFluidCodeDetails = {
@@ -113,7 +113,7 @@ describe("LocalLoader", () => {
             [[codeDetails, factory]],
             driver.createDocumentServiceFactory(),
             driver.createUrlResolver());
-        return loader.resolve({ url: driver.createContainerUrl(documentId) });
+        return loader.resolve({ url: await driver.createContainerUrl(documentId) });
     }
 
     describe("1 dataObject", () => {

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -196,7 +196,7 @@ export function createTestObjectProvider(
                 oldReset();
             };
         }
-        return oldProvider as ITestObjectProvider;
+        return oldProvider as unknown as  ITestObjectProvider;
     } else {
         return new newVer.TestObjectProvider(
             driver, containerFactoryFn as () => newVer.IRuntimeFactory);

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -177,9 +177,9 @@ export function createTestObjectProvider(
         throw new Error("Must provide a driver when using the current loader");
     }
     if (oldLoader) {
-        const oldProvider = new TestObjectProvider(
-            driver as any,
-            containerFactoryFn as () => IRuntimeFactory);
+        const oldProvider = new newVer.TestObjectProvider(
+            driver,
+            containerFactoryFn as () => newVer.IRuntimeFactory);
 
         // Remove once the older version support container tracking (for close)
         if (!(TestObjectProvider as any).patchLoader) {
@@ -188,6 +188,14 @@ export function createTestObjectProvider(
             oldProvider.makeTestLoader = (testContainerConfig?: unknown) => {
                 const testLoader = oldMakeTestLoader(testContainerConfig);
                 loaderContainerTracker.add(testLoader as any);
+
+                // Also patch the loader.resolve to deal with url being a Promise from
+                // the new ITestDriver.createcontainerUrl
+                const oldResolve = testLoader.resolve.bind(testLoader);
+                testLoader.resolve = async (request: newVer.IRequest) => {
+                    request.url = await ((request as any).url as Promise<string>);
+                    return oldResolve(request);
+                };
                 return testLoader;
             };
             const oldReset = oldProvider.reset.bind(oldProvider);

--- a/packages/test/end-to-end-tests/src/test/oldVersion2.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion2.ts
@@ -40,7 +40,7 @@ import {
     TestFluidObjectFactory,
 } from "old-test-utils2";
 
-import {v4 as uuid} from "uuid";
+import { v4 as uuid } from "uuid";
 import {
     createRuntimeFactory,
     DataObjectFactoryType,
@@ -81,10 +81,10 @@ export class LocalTestObjectProvider<TestContainerConfigType> {
 
     }
 
-    readonly driver: newVer.ITestDriver ={
+    readonly driver: newVer.ITestDriver = {
         type: "local",
         version: "0.33.0",
-        createContainerUrl: (testId)=>`http://localhost${testId}`,
+        createContainerUrl: async (testId)=>`http://localhost${testId}`,
         createCreateNewRequest: (testId)=>this.urlResolver.createCreateNewRequest(testId),
         createDocumentServiceFactory: ()=>this.documentServiceFactory as any as newVer.IDocumentServiceFactory,
         createUrlResolver: ()=>this.urlResolver,

--- a/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -30,7 +30,7 @@ import { bufferToString } from "@fluidframework/common-utils";
 describe("SharedString", () => {
     let driver: ITestDriver;
     before(()=>{
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
     });
     it("Failure to Load in Shared String", async ()=>{
         const stringId = "sharedStringKey";

--- a/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -20,7 +20,7 @@ import {
     IDocumentServiceFactory,
     IDocumentStorageService,
     LoaderCachingPolicy,
- } from "@fluidframework/driver-definitions";
+} from "@fluidframework/driver-definitions";
 import { NetworkErrorBasic } from "@fluidframework/driver-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ReferenceType, TextSegment } from "@fluidframework/merge-tree";
@@ -29,10 +29,10 @@ import { bufferToString } from "@fluidframework/common-utils";
 
 describe("SharedString", () => {
     let driver: ITestDriver;
-    before(()=>{
+    before(() => {
         driver = getFluidTestDriver() as unknown as ITestDriver;
     });
-    it("Failure to Load in Shared String", async ()=>{
+    it("Failure to Load in Shared String", async () => {
         const stringId = "sharedStringKey";
         const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
         const fluidExport: SupportedExportInterfaces = {
@@ -54,7 +54,7 @@ describe("SharedString", () => {
 
             const container = await loader.createDetachedContainer(codeDetails);
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
+            const sharedString = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
             assert(sharedString);
             sharedString.insertText(0, text);
 
@@ -72,9 +72,9 @@ describe("SharedString", () => {
                 codeLoader,
             });
 
-            const container = await loader.resolve(driver.createCreateNewRequest(documentId));
+            const container = await loader.resolve({ url: await driver.createContainerUrl(documentId) });
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
+            const sharedString = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
             assert(sharedString);
             assert.strictEqual(sharedString.getText(0), text);
         }
@@ -82,17 +82,17 @@ describe("SharedString", () => {
             const realSf: IDocumentServiceFactory = driver.createDocumentServiceFactory();
             const documentServiceFactory: IDocumentServiceFactory = {
                 ...realSf,
-                createDocumentService: async (resolvedUrl,logger) => {
+                createDocumentService: async (resolvedUrl, logger) => {
                     const realDs = await realSf.createDocumentService(resolvedUrl, logger);
                     const mockDs = Object.create(realDs) as IDocumentService;
-                    mockDs.connectToStorage = async ()=>{
+                    mockDs.connectToStorage = async () => {
                         const realStorage = await realDs.connectToStorage();
                         const mockstorage = Object.create(realStorage) as IDocumentStorageService;
                         (mockstorage as any).policies = {
                             ...realStorage.policies,
                             caching: LoaderCachingPolicy.NoCaching,
                         };
-                        mockstorage.readBlob = async (id)=>{
+                        mockstorage.readBlob = async (id) => {
                             const blob = await realStorage.readBlob(id);
                             const blobObj = JSON.parse(bufferToString(blob, "utf8"));
                             // throw when trying to load the header blob
@@ -121,17 +121,17 @@ describe("SharedString", () => {
                 codeLoader,
             });
 
-            const container = await loader.resolve(driver.createCreateNewRequest(documentId));
+            const container = await loader.resolve({ url: await driver.createContainerUrl(documentId) });
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
 
             try {
                 await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
                 assert.fail("expected failure");
-            } catch {}
+            } catch { }
         }
     });
 
-    it("Text operations successfully round trip on detached create", async ()=>{
+    it("Text operations successfully round trip on detached create", async () => {
         const stringId = "sharedStringKey";
         const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
         const fluidExport: SupportedExportInterfaces = {
@@ -154,7 +154,7 @@ describe("SharedString", () => {
 
             const container = await loader.createDetachedContainer(codeDetails);
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
+            const sharedString = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
             assert(sharedString);
 
             for (let i = 0; i < 10; i++) {
@@ -165,7 +165,7 @@ describe("SharedString", () => {
                     sharedString.createPositionReference(segInfo.segment, segInfo.offset, ReferenceType.SlideOnRemove),
                     new TextSegment(text));
 
-                sharedString.removeRange(0,5);
+                sharedString.removeRange(0, 5);
 
                 const length = sharedString.getLength();
                 sharedString.replaceText(length - 5, length, text);
@@ -186,9 +186,9 @@ describe("SharedString", () => {
                 codeLoader,
             });
 
-            const container = await loader.resolve(driver.createCreateNewRequest(documentId));
+            const container = await loader.resolve({ url: await driver.createContainerUrl(documentId) });
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-            const sharedString  = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
+            const sharedString = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
             assert(sharedString);
             assert.strictEqual(sharedString.getText(), initialText);
         }

--- a/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/upgradeManager.spec.ts
@@ -68,11 +68,11 @@ describe("UpgradeManager (hot-swap)", () => {
             options: { hotSwapContext: true },
         });
 
-        return loader.resolve({ url: driver.createContainerUrl(documentId) });
+        return loader.resolve({ url: await driver.createContainerUrl(documentId) });
     }
 
     beforeEach(async () => {
-        driver = getFluidTestDriver() as ITestDriver;
+        driver = getFluidTestDriver() as unknown as ITestDriver;
         opProcessingController = new OpProcessingController();
     });
 

--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -48,5 +48,5 @@ export interface ITestDriver{
      * type, this should only be done it absolutely necessary for complex scenarios
      * as the test may not  work against all supported servers if done.
      */
-    createContainerUrl(testId: string): string;
+    createContainerUrl(testId: string): Promise<string>;
 }

--- a/packages/test/test-drivers/README.md
+++ b/packages/test/test-drivers/README.md
@@ -14,7 +14,7 @@ If mocha tests wish to not run or only run on specific servers in a mocha test t
 
 ``` typescript
   before(function() {
-        const driver = getTestDriver();
+        const driver = getFluidTestDriver();
         if (driver.type !== "local") {
             this.skip();
         }

--- a/packages/test/test-drivers/src/localServerTestDriver.ts
+++ b/packages/test/test-drivers/src/localServerTestDriver.ts
@@ -29,7 +29,7 @@ export class LocalServerTestDriver implements ITestDriver {
         return createLocalResolverCreateNewRequest(testId);
     }
 
-    createContainerUrl(testId: string): string {
+    async createContainerUrl(testId: string): Promise<string> {
         return `http://localhost/${testId}`;
     }
 }

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -29,7 +29,7 @@ const passwordTokenConfig = (username, password): OdspTokenConfig => ({
     password,
 });
 
-interface IOdspTestLoginInfo {
+export interface IOdspTestLoginInfo {
     server: string;
     username: string;
     password: string;

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -1,10 +1,9 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*!
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
-import fs from "fs";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 import {
@@ -12,14 +11,15 @@ import {
     OdspDriverUrlResolver,
     createOdspCreateContainerRequest,
     OdspResourceTokenFetchOptions,
- } from "@fluidframework/odsp-driver";
+    IOdspResolvedUrl,
+} from "@fluidframework/odsp-driver";
 import {
     OdspTokenConfig,
     OdspTokenManager,
     odspTokensCache,
     getMicrosoftConfiguration,
 } from "@fluidframework/tool-utils";
-import { IClientConfig } from "@fluidframework/odsp-doclib-utils";
+import { getDriveItemByRootFileName, IClientConfig } from "@fluidframework/odsp-doclib-utils";
 import { ITestDriver } from "@fluidframework/test-driver-definitions";
 import { pkgVersion } from "./packageVersion";
 
@@ -29,66 +29,100 @@ const passwordTokenConfig = (username, password): OdspTokenConfig => ({
     password,
 });
 
-export interface IOdspConfig extends IClientConfig {
+interface IOdspTestLoginInfo {
     server: string;
-    driveId: string;
     username: string;
+    password: string;
+}
+export interface IOdspTestDriverConfig extends IClientConfig, IOdspTestLoginInfo {
+    driveId: string;
     directory: string;
 }
 
 export class OdspTestDriver implements ITestDriver {
     public static createFromEnv() {
-        const config = JSON.parse(fs.readFileSync("./odspConfig.json", "utf-8")) as IOdspConfig;
-        const password = process.env.fluid__odsp__password;
-        assert(password, "Missing password");
+        const config: IOdspTestDriverConfig = {
+            username: process.env.testuser!,
+            password: process.env.testpwd!,
+            server: process.env.testserver!,
+            directory: new Date().toISOString().replace(/:/g, "."),
+            ...getMicrosoftConfiguration(),
+            driveId: process.env.testDriveId!,
+        };
 
         if (process.env.BUILD_BUILD_ID !== undefined) {
             config.directory = `${process.env.BUILD_BUILD_ID}/${config.directory}`;
         }
 
-        return new OdspTestDriver(
-            {
-                ...config,
-                ... getMicrosoftConfiguration(),
-            },
-            password,
-        );
+        return new OdspTestDriver(config);
     }
 
     public readonly type = "odsp";
     public readonly version = pkgVersion;
     private readonly odspTokenManager = new OdspTokenManager(odspTokensCache);
-    constructor(
-        private readonly config: Readonly<IOdspConfig>,
-        private readonly password: string) { }
-    createContainerUrl(testId: string): string {
-        throw new Error("Method not implemented.");
+    private readonly urlResolver = new OdspDriverUrlResolver();
+    constructor(private readonly config: Readonly<IOdspTestDriverConfig>) { }
+
+    async createContainerUrl(testId: string): Promise<string> {
+        const siteUrl = `https://${this.config.server}`;
+        const driveItem = await getDriveItemByRootFileName(
+            this.config.server,
+            undefined,
+            `/${this.config.directory}/${testId}.fluid`,
+            {
+                accessToken: await this.getStorageToken({ siteUrl, refresh: false }),
+                refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: true }),
+            },
+            false,
+            this.config.driveId);
+        const resolvedUrl: IOdspResolvedUrl = {
+            type: "fluid",
+            siteUrl,
+            driveId: driveItem.drive,
+            itemId: driveItem.item,
+            url: "",
+            hashedDocumentId: "",
+            endpoints: {
+                snapshotStorageUrl: "",
+                attachmentGETStorageUrl: "",
+                attachmentPOSTStorageUrl: "",
+            },
+            tokens: {},
+            fileName: "",
+            summarizer: false,
+        };
+        return this.urlResolver.getAbsoluteUrl(resolvedUrl, "");
     }
 
     createDocumentServiceFactory(): IDocumentServiceFactory {
         return new OdspDocumentServiceFactory(
-            async (options: OdspResourceTokenFetchOptions) => {
-                const tokens = await this.odspTokenManager.getOdspTokens(
-                    this.config.server,
-                    this.config,
-                    passwordTokenConfig(this.config.username, this.password),
-                    options.refresh,
-                );
-                return tokens.accessToken;
-            },
-            async (options: OdspResourceTokenFetchOptions) => {
-                const tokens = await this.odspTokenManager.getPushTokens(
-                    this.config.server,
-                    this.config,
-                    passwordTokenConfig(this.config.username, this.password),
-                    options.refresh,
-                );
-                return tokens.accessToken;
-            },
+            this.getStorageToken.bind(this),
+            this.getPushToken.bind(this),
         );
     }
+
+    private async getStorageToken(options: OdspResourceTokenFetchOptions) {
+        // This function can handle token request for any multiple sites. Where the test driver is for a specific site.
+        const tokens = await this.odspTokenManager.getOdspTokens(
+            new URL(options.siteUrl).hostname,
+            this.config,
+            passwordTokenConfig(this.config.username, this.config.password),
+            options.refresh,
+        );
+        return tokens.accessToken;
+    }
+    private async getPushToken(options: OdspResourceTokenFetchOptions) {
+        const tokens = await this.odspTokenManager.getPushTokens(
+            new URL(options.siteUrl).hostname,
+            this.config,
+            passwordTokenConfig(this.config.username, this.config.password),
+            options.refresh,
+        );
+
+        return tokens.accessToken;
+    }
     createUrlResolver(): IUrlResolver {
-        return new OdspDriverUrlResolver();
+        return this.urlResolver;
     }
     createCreateNewRequest(testId: string): IRequest {
         return createOdspCreateContainerRequest(

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -75,7 +75,7 @@ export class RouterliciousTestDriver implements ITestDriver {
         return this.testIdPrefix + testId;
     }
 
-    createContainerUrl(testId: string): string {
+    async createContainerUrl(testId: string): Promise<string> {
         // eslint-disable-next-line max-len
         return `${this.serviceEndpoints.hostUrl}/${encodeURIComponent(this.tenantId)}/${encodeURIComponent(this.createDocumentId(testId))}`;
     }

--- a/packages/test/test-drivers/src/tinyliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/tinyliciousTestDriver.ts
@@ -27,7 +27,7 @@ export class TinyliciousTestDriver implements ITestDriver {
     createCreateNewRequest(testId: string): IRequest {
         return createTinyliciousCreateNewRequest(testId);
     }
-    createContainerUrl(testId: string): string {
+    async createContainerUrl(testId: string): Promise<string> {
         return `http://localhost:3000/${testId}`;
     }
 }

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -116,7 +116,7 @@ export class TestObjectProvider<TestContainerConfigType> {
      */
     public async loadTestContainer(testContainerConfig?: TestContainerConfigType) {
         const loader = this.makeTestLoader(testContainerConfig);
-        const container = await loader.resolve({ url: this.driver.createContainerUrl(this.documentId) });
+        const container = await loader.resolve({ url: await this.driver.createContainerUrl(this.documentId) });
         await waitContainerToCatchUp(container);
         this.opProcessingController.addDeltaManagers(container.deltaManager);
         return container;

--- a/packages/utils/odsp-doclib-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDrives.ts
@@ -56,7 +56,7 @@ export interface IOdspDriveItem {
 
 export async function getDriveItemByRootFileName(
     server: string,
-    account: string,
+    account: string | undefined,
     path: string,
     authRequestInfo: IOdspAuthRequestInfo,
     create: boolean,
@@ -124,7 +124,7 @@ export async function getChildrenByDriveItem(
     do {
         const response = await getAsync(url, authRequestInfo);
         if (response.status !== 200) {
-            throwOdspNetworkError("Unable to get children", response.status);
+            throwOdspNetworkError("Unable to get children", response.status, response);
         }
         const getChildrenResult = await response.json();
         children = children.concat(getChildrenResult.value);
@@ -142,19 +142,19 @@ async function getDriveItem(
     let response = await getAsync(getDriveItemUrl, authRequestInfo);
     if (response.status !== 200) {
         if (!create) {
-            throwOdspNetworkError("Unable to get drive/item id from path", response.status);
+            throwOdspNetworkError("Unable to get drive/item id from path", response.status, response);
         }
 
         // Try creating the file
         const contentUri = `${getDriveItemUrl}/content`;
         const createResultResponse = await putAsync(contentUri, authRequestInfo);
         if (createResultResponse.status !== 201) {
-            throwOdspNetworkError("Failed to create file.", createResultResponse.status);
+            throwOdspNetworkError("Failed to create file.", createResultResponse.status, createResultResponse);
         }
 
         response = await getAsync(getDriveItemUrl, authRequestInfo);
         if (response.status !== 200) {
-            throwOdspNetworkError("Unable to get drive/item id from path", response.status);
+            throwOdspNetworkError("Unable to get drive/item id from path", response.status, response);
         }
     }
     const getDriveItemResult = await response.json();
@@ -212,7 +212,7 @@ async function getDriveResponse(
     const getDriveUrl = `https://${server}${accountPath}/_api/v2.1/${routeTail}`;
     const response = await getAsync(getDriveUrl, authRequestInfo);
     if (response.status !== 200) {
-        throwOdspNetworkError(`Failed to get ${routeTail}.`, response.status);
+        throwOdspNetworkError(`Failed to get ${routeTail}.`, response.status, response);
     }
     return response;
 }

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -58,6 +58,7 @@
     "@fluidframework/odsp-doclib-utils": "^0.35.0",
     "@fluidframework/protocol-base": "^0.1019.0-0",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
+    "jwt-decode": "^2.2.0",
     "proper-lockfile": "^4.1.1"
   },
   "devDependencies": {
@@ -65,6 +66,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0-0",
     "@fluidframework/mocha-test-setup": "^0.35.0",
     "@microsoft/api-extractor": "^7.7.2",
+    "@types/jwt-decode": "^2.2.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -58,6 +58,7 @@
     "@fluidframework/odsp-doclib-utils": "^0.35.0",
     "@fluidframework/protocol-base": "^0.1019.0-0",
     "@fluidframework/protocol-definitions": "^0.1019.0-0",
+    "debug": "^4.1.1",
     "jwt-decode": "^2.2.0",
     "proper-lockfile": "^4.1.1"
   },
@@ -66,6 +67,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0-0",
     "@fluidframework/mocha-test-setup": "^0.35.0",
     "@microsoft/api-extractor": "^7.7.2",
+    "@types/debug": "^4.1.5",
     "@types/jwt-decode": "^2.2.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.17.24",

--- a/packages/utils/tool-utils/src/debug.ts
+++ b/packages/utils/tool-utils/src/debug.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import registerDebug from "debug";
+import { pkgName, pkgVersion } from "./packageVersion";
+
+export const debug = registerDebug("fluid:tool-utils");
+debug(`Package: ${pkgName} - Version: ${pkgVersion}`);

--- a/packages/utils/tool-utils/src/fluidToolRC.ts
+++ b/packages/utils/tool-utils/src/fluidToolRC.ts
@@ -19,8 +19,15 @@ export interface IAsyncCache<TKey, TValue> {
 }
 
 export interface IResources {
-    tokens?: { [key: string]: IOdspTokens };
-    pushTokens?: IOdspTokens;
+    tokens?: {
+        version?: number;
+        data: {
+            [key: string]: {
+                storage?: IOdspTokens,
+                push?: IOdspTokens
+            }
+        }
+    }
 }
 
 const getRCFileName = () => path.join(os.homedir(), ".fluidtoolrc");

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -14,12 +14,10 @@ import {
     getLoginPageUrl,
     TokenRequestCredentials,
 } from "@fluidframework/odsp-doclib-utils";
-import registerDebug from "debug";
 import jwtDecode from "jwt-decode";
+import { debug } from "./debug";
 import { IAsyncCache, loadRC, saveRC, lockRC } from "./fluidToolRC";
 import { serverListenAndHandle, endResponse } from "./httpHelpers";
-
-const debug = registerDebug("fluid:tool-utils");
 
 const odspAuthRedirectPort = 7000;
 const odspAuthRedirectOrigin = `http://localhost:${odspAuthRedirectPort}`;


### PR DESCRIPTION
Got e2e test running against ODSP, with 1140 passing and 144 failing.
- Implement ODSP test drvier's `createContainerUrl` function.  Need to turn that async, as it needs the call to get the itemId, and then reuse the urlResolver.getAbsoluteUrl to construct the Url.
- Update the token cache in `.fluidtoolrc` so store tenant specific push token.
- Check for token expirary before returning the token from cache.
- Pass the response when constructing the Odsp error object in the doclib utils to get better error messages.
- Fix `sharedStringLoading.spec.ts` test to use `createContainerUrl` instead of `createCreateNewRequest` to get the resolve URL
- Disable `container.spec.ts` for all services other then local. These are all API test that doesn't really need a service.

Todos:
- Using a set of temporary environment variables to pass the username, password, tenent and driverId.  Will improve a consistent and additional ways to pass these information for all our tools that use the test server.
- Discovered a coverage regression in `contextReload.spec.ts`, where we no longer create old Loader to test with new runtime.
- Fix the remaining test (likely need to revisit how we implement the barrier to make sure everything is in sync)
- Currently, it takes 41 mins to run the tests.   Needs to look into speeding it up.
- Running it in our CI
