### PR TITLE
Make context logger optional

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -76,7 +76,7 @@ export class DocumentContext extends EventEmitter implements IContext {
         this.emit("error", error, errorData);
     }
 
-    public get log(): ILogger {
+    public get log(): ILogger | undefined {
         return winston;
     }
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -39,7 +39,7 @@ export class Context extends EventEmitter implements IContext {
         this.emit("error", error, errorData);
     }
 
-    public get log(): ILogger {
+    public get log(): ILogger | undefined {
         return winston;
     }
 

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -47,12 +47,14 @@ export class CheckpointContext {
             },
             (error) => {
                 // TODO flag context as error
-                const messageMetaData = {
-                    documentId: this.id,
-                    tenantId: this.tenantId,
-                };
-                this.context.log.error(
-                    `Error writing checkpoint to MongoDB: ${JSON.stringify(error)}`, { messageMetaData });
+                this.context.log?.error(
+                    `Error writing checkpoint to MongoDB: ${JSON.stringify(error)}`,
+                    {
+                        messageMetaData: {
+                            documentId: this.id,
+                            tenantId: this.tenantId,
+                        },
+                    });
             });
     }
 
@@ -88,12 +90,14 @@ export class CheckpointContext {
         // Retry the checkpoint on error
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         return updateP.catch((error) => {
-            const messageMetaData = {
-                documentId: this.id,
-                tenantId: this.tenantId,
-            };
-            this.context.log.error(
-                `Error writing checkpoint to MongoDB: ${JSON.stringify(error)}`, { messageMetaData });
+            this.context.log?.error(
+                `Error writing checkpoint to MongoDB: ${JSON.stringify(error)}`,
+                {
+                    messageMetaData: {
+                        documentId: this.id,
+                        tenantId: this.tenantId,
+                    },
+                });
             return new Promise<void>((resolve, reject) => {
                 resolve(this.checkpointCore(checkpoint));
             });

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -409,11 +409,12 @@ export class DeliLambda implements IPartitionLambda {
             const controlMessage = systemContent as IControlMessage;
             switch (controlMessage.type) {
                 case ControlMessageType.UpdateDSN: {
-                    const messageMetaData = {
-                        documentId: this.documentId,
-                        tenantId: this.tenantId,
-                    };
-                    this.context.log.info(`Update DSN: ${JSON.stringify(controlMessage)}`, { messageMetaData });
+                    this.context.log?.info(`Update DSN: ${JSON.stringify(controlMessage)}`, {
+                        messageMetaData: {
+                            documentId: this.documentId,
+                            tenantId: this.tenantId,
+                        }
+                    });
 
                     const controlContents = controlMessage.contents as IUpdateDSNControlMessageContents;
                     const dsn = controlContents.durableSequenceNumber;
@@ -422,7 +423,12 @@ export class DeliLambda implements IPartitionLambda {
                         if (controlContents.clearCache && this.noActiveClients) {
                             instruction = InstructionType.ClearCache;
                             this.canClose = true;
-                            this.context.log.info(`Deli cache will be cleared`, { messageMetaData });
+                            this.context.log?.info(`Deli cache will be cleared`, {
+                                messageMetaData: {
+                                    documentId: this.documentId,
+                                    tenantId: this.tenantId,
+                                }
+                            });
                         }
 
                         this.durableSequenceNumber = dsn;

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -413,7 +413,7 @@ export class DeliLambda implements IPartitionLambda {
                         messageMetaData: {
                             documentId: this.documentId,
                             tenantId: this.tenantId,
-                        }
+                        },
                     });
 
                     const controlContents = controlMessage.contents as IUpdateDSNControlMessageContents;
@@ -427,7 +427,7 @@ export class DeliLambda implements IPartitionLambda {
                                 messageMetaData: {
                                     documentId: this.documentId,
                                     tenantId: this.tenantId,
-                                }
+                                },
                             });
                         }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -205,12 +205,14 @@ export class DeliLambda implements IPartitionLambda {
                 this.checkpointContext.checkpoint(checkpoint);
             },
             (error) => {
-                const messageMetaData = {
-                    documentId: this.documentId,
-                    tenantId: this.tenantId,
-                };
-                this.context.log.error(
-                    `Could not send message to scriptorium: ${JSON.stringify(error)}`, { messageMetaData });
+                this.context.log?.error(
+                    `Could not send message to scriptorium: ${JSON.stringify(error)}`,
+                    {
+                        messageMetaData: {
+                            documentId: this.documentId,
+                            tenantId: this.tenantId,
+                        },
+                    });
                 this.context.error(error, {
                     restart: true,
                     tenantId: this.tenantId,
@@ -533,11 +535,11 @@ export class DeliLambda implements IPartitionLambda {
         if (clientSequenceNumber === expectedClientSequenceNumber) {
             return IncomingMessageOrder.ConsecutiveOrSystem;
         } else if (clientSequenceNumber > expectedClientSequenceNumber) {
-            this.context.log.info(
+            this.context.log?.info(
                 `Gap ${clientId}:${expectedClientSequenceNumber} > ${clientSequenceNumber}`, { messageMetaData });
             return IncomingMessageOrder.Gap;
         } else {
-            this.context.log.info(
+            this.context.log?.info(
                 `Duplicate ${clientId}:${expectedClientSequenceNumber} < ${clientSequenceNumber}`, { messageMetaData });
             return IncomingMessageOrder.Duplicate;
         }
@@ -550,11 +552,15 @@ export class DeliLambda implements IPartitionLambda {
 
     private sendToAlfred(message: IRawOperationMessage) {
         this.reverseProducer.send([message], message.tenantId, message.documentId).catch((error) => {
-            const messageMetaData = {
-                documentId: this.documentId,
-                tenantId: this.tenantId,
-            };
-            this.context.log.error(`Could not send message to alfred: ${JSON.stringify(error)}`, { messageMetaData });
+            this.context.log?.error(
+                `Could not send message to alfred: ${JSON.stringify(error)}`,
+                {
+                    messageMetaData: {
+                        documentId: this.documentId,
+                        tenantId: this.tenantId,
+
+                    },
+                });
             this.context.error(error, {
                 restart: true,
                 tenantId: this.tenantId,

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -91,7 +91,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
                 const lastCheckpointFromSummary =
                     await this.loadStateFromSummary(tenantId, documentId, gitManager, context.log);
                 if (lastCheckpointFromSummary === undefined) {
-                    context.log.error(`Summary cannot be fetched`, { messageMetaData });
+                    context.log?.error(`Summary cannot be fetched`, { messageMetaData });
                     lastCheckpoint = getDefaultCheckpooint(leaderEpoch);
                 } else {
                     lastCheckpoint = lastCheckpointFromSummary;
@@ -153,7 +153,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         tenantId: string,
         documentId: string,
         gitManager: IGitManager,
-        logger: ILogger): Promise<IDeliState | undefined> {
+        logger: ILogger | undefined): Promise<IDeliState | undefined> {
         const existingRef = await gitManager.getRef(encodeURIComponent(documentId));
         if (existingRef) {
             try {

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -82,11 +82,11 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         // was created within a different tenant.
         // eslint-disable-next-line no-null/no-null
         if (dbObject.deli === undefined || dbObject.deli === null) {
-            context.log.info(`New document. Setting empty deli checkpoint`, { messageMetaData });
+            context.log?.info(`New document. Setting empty deli checkpoint`, { messageMetaData });
             lastCheckpoint = getDefaultCheckpooint(leaderEpoch);
         } else {
             if (dbObject.deli === "") {
-                context.log.info(`Existing document. Fetching checkpoint from summary`, { messageMetaData });
+                context.log?.info(`Existing document. Fetching checkpoint from summary`, { messageMetaData });
 
                 const lastCheckpointFromSummary =
                     await this.loadStateFromSummary(tenantId, documentId, gitManager, context.log);
@@ -101,7 +101,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
                     // the sequence number is 'n' rather than '0'.
                     lastCheckpoint.logOffset = -1;
                     lastCheckpoint.epoch = leaderEpoch;
-                    context.log.info(JSON.stringify(lastCheckpoint));
+                    context.log?.info(JSON.stringify(lastCheckpoint));
                 }
             } else {
                 lastCheckpoint = JSON.parse(dbObject.deli);
@@ -165,8 +165,8 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
                     documentId,
                     tenantId,
                 };
-                logger.error(`Error fetching deli state from summary`, { messageMetaData });
-                logger.error(JSON.stringify(exception), { messageMetaData });
+                logger?.error(`Error fetching deli state from summary`, { messageMetaData });
+                logger?.error(JSON.stringify(exception), { messageMetaData });
                 return undefined;
             }
         }
@@ -184,7 +184,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
         tenantId: string,
         documentId: string,
         gitManager: IGitManager,
-        logger: ILogger,
+        logger: ILogger | undefined,
         checkpoint: IDeliState,
         leaderEpoch: number): Promise<IDeliState> {
         let newCheckpoint = checkpoint;
@@ -202,11 +202,14 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
                 newCheckpoint.logOffset = logOffset;
                 // Now create the summary.
                 await this.createSummaryWithLatestTerm(gitManager, newCheckpoint, documentId);
-                const messageMetaData = {
-                    documentId,
-                    tenantId,
-                };
-                logger.info(`Created a summary on epoch tick`, { messageMetaData });
+                logger?.info(
+                    `Created a summary on epoch tick`,
+                    {
+                        messageMetaData: {
+                            documentId,
+                            tenantId,
+                        },
+                    });
             }
         }
         return newCheckpoint;

--- a/server/routerlicious/packages/lambdas/src/foreman/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/foreman/lambda.ts
@@ -98,12 +98,14 @@ export class ForemanLambda extends SequencedLambda {
                         type: "tasks:start",
                     },
                 );
-                const messageMetaData = {
-                    documentId: docId,
-                    tenantId,
-                };
-                this.context.log.info(
-                    `Request to ${queueName}: ${clientId}:${JSON.stringify(tasks)}`, { messageMetaData });
+                this.context.log?.info(
+                    `Request to ${queueName}: ${clientId}:${JSON.stringify(tasks)}`,
+                    {
+                        messageMetaData: {
+                            documentId: docId,
+                            tenantId,
+                        },
+                    });
             }
         }
     }

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -175,11 +175,6 @@ export class ScribeLambda extends SequencedLambda {
                     this.processFromPending(this.minSequenceNumber);
                 }
 
-                const messageMetaData = {
-                    documentId: this.documentId,
-                    tenantId: this.tenantId,
-                };
-
                 this.clearCache = false;
                 if (value.operation.type === MessageType.Summarize) {
                     // Process up to the summary op ref seq to get the protocol state at the summary op.
@@ -216,15 +211,25 @@ export class ScribeLambda extends SequencedLambda {
                                     await this.sendSummaryAck(summaryResponse.message as ISummaryAck);
                                     await this.sendSummaryConfirmationMessage(operation.sequenceNumber, false);
                                     this.protocolHead = this.protocolHandler.sequenceNumber;
-                                    this.context.log.info(
+                                    this.context.log?.info(
                                         `Client summary success @${value.operation.sequenceNumber}`,
-                                        { messageMetaData },
+                                        {
+                                            messageMetaData: {
+                                                documentId: this.documentId,
+                                                tenantId: this.tenantId,
+                                            },
+                                        },
                                     );
                                 } else {
                                     await this.sendSummaryNack(summaryResponse.message as ISummaryNack);
-                                    this.context.log.error(
+                                    this.context.log?.error(
                                         `Client summary failure @${value.operation.sequenceNumber}`,
-                                        { messageMetaData },
+                                        {
+                                            messageMetaData: {
+                                                documentId: this.documentId,
+                                                tenantId: this.tenantId,
+                                            },
+                                        },
                                     );
                                     this.revertProtocolState(prevState.protocolState, prevState.pendingOps);
                                 }
@@ -273,15 +278,28 @@ export class ScribeLambda extends SequencedLambda {
                                 await this.sendSummaryConfirmationMessage(
                                     operation.sequenceNumber,
                                     this.serviceConfiguration.scribe.clearCacheAfterServiceSummary);
-                                this.context.log.info(
-                                    `Service summary success @${operation.sequenceNumber}`, { messageMetaData });
+                                this.context.log?.info(
+                                    `Service summary success @${operation.sequenceNumber}`,
+                                    {
+                                        messageMetaData: {
+                                            documentId: this.documentId,
+                                            tenantId: this.tenantId,
+                                        },
+                                    },
+                                );
                             }
                         } catch (ex) {
                             // If this flag is set, we should ignore any storage speciic error and move forward
                             // to process the next message.
                             if (this.serviceConfiguration.scribe.ignoreStorageException) {
-                                this.context.log.error(
-                                    `Service summary failure @${operation.sequenceNumber}`, { messageMetaData });
+                                this.context.log?.error(
+                                    `Service summary failure @${operation.sequenceNumber}`,
+                                    {
+                                        messageMetaData: {
+                                            documentId: this.documentId,
+                                            tenantId: this.tenantId,
+                                        },
+                                    });
                             } else {
                                 throw ex;
                             }
@@ -331,7 +349,7 @@ export class ScribeLambda extends SequencedLambda {
                     this.protocolHandler.processMessage(message, false);
                 }
             } catch (error) {
-                this.context.log.error(`Protocol error ${error}`,
+                this.context.log?.error(`Protocol error ${error}`,
                     {
                         documentId: this.documentId,
                         tenantId: this.tenantId,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -72,7 +72,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
         };
         // If the document doesn't exist then we trivially accept every message
         if (!document) {
-            context.log.info(`Creating NoOpLambda due to missing`, { messageMetaData });
+            context.log?.info(`Creating NoOpLambda due to missing`, { messageMetaData });
             return new NoOpLambda(context);
         }
 
@@ -85,13 +85,13 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
         // Restore scribe state if not present in the cache. Mongodb casts undefined as null so we are checking
         // both to be safe. Empty sring denotes a cache that was cleared due to a service summary
         if (document.scribe === undefined || document.scribe === null) {
-            context.log.info(`New document. Setting empty scribe checkpoint`, { messageMetaData });
+            context.log?.info(`New document. Setting empty scribe checkpoint`, { messageMetaData });
             lastCheckpoint = DefaultScribe;
             opMessages = [];
         } else if (document.scribe === "") {
-            context.log.info(`Existing document. Fetching checkpoint from summary`, { messageMetaData });
+            context.log?.info(`Existing document. Fetching checkpoint from summary`, { messageMetaData });
             if (!latestSummary.fromSummary) {
-                context.log.error(`Summary can't be fetched`, { messageMetaData });
+                context.log?.error(`Summary can't be fetched`, { messageMetaData });
                 lastCheckpoint = DefaultScribe;
                 opMessages = [];
             } else {
@@ -102,7 +102,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
                 // is okay. Conceptually this is similar to default checkpoint where logOffset is -1. In this case,
                 // the sequence number is 'n' rather than '0'.
                 lastCheckpoint.logOffset = -1;
-                context.log.info(JSON.stringify(lastCheckpoint));
+                context.log?.info(JSON.stringify(lastCheckpoint));
             }
         } else {
             lastCheckpoint = JSON.parse(document.scribe);

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -51,7 +51,7 @@ export interface IContext {
     /**
      * Used to log events / errors.
      */
-    readonly log: ILogger;
+    readonly log: ILogger | undefined;
 }
 
 export interface IPartitionLambda {


### PR DESCRIPTION
Change `log` type to `ILogger | undefined`. 

This allows servers to not provide a logger. An alternative could be to implement a `NoOpLogger` which does nothing. However not passing a logger is better because some log messages might include complex contents or `JSON.stringify` calls, which would end up wasting compute. Making the logger `undefined` would allow the optional chaining to end the evaluation before running the statement. 