### PR TITLE
Fix #5156: Flaky canvas test

### DIFF
--- a/examples/data-objects/canvas/test/canvas.test.ts
+++ b/examples/data-objects/canvas/test/canvas.test.ts
@@ -27,6 +27,7 @@ describe("canvas", () => {
         await page.mouse.down();
         await page.mouse.move(126, 19);
         await page.mouse.up();
+        await page.waitFor(() => window["FluidLoader"].isSynchronized());
 
         // compare canvases
         const result = await page.evaluate(() => {
@@ -37,14 +38,22 @@ describe("canvas", () => {
             const height = Math.min(...canvases.map((c) => c.height));
 
             const imgs = canvases.map((c) => c.getContext("2d").getImageData(0, 0, width, height).data);
-
-            if (imgs[0].length === 0 || imgs[1].length === 0 || imgs[0].some((e, i) => imgs[1][i] !== e)) {
-                return false;
-            } else {
-                return true;
+            if (imgs[0].length == 0) {
+                return "Canvas 1 doesn't have any pixels";
             }
+            if (imgs[1].length == 0) {
+                return "Canvas 2 doesn't have any pixels";
+            }
+
+            const diff: { index: number, value1: number, value2: number }[] = [];
+            imgs[0].forEach((value, index) => {
+                if (imgs[1][index] !== value) {
+                    diff.push({index, value1: value, value2: imgs[1][index]});
+                }
+            });
+            return diff;
         });
 
-        expect(result).toEqual(true);
+        expect(result).toEqual([]);
     });
 });

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -44120,6 +44120,14 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
+		"use-resize-observer": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-7.0.0.tgz",
+			"integrity": "sha512-+RjrQsk/mL8aKy4TGBDiPkUv6whyeoGDMIZYk0gOGHOlnrsjImC+jG6lfAFcBCKAG9epGRL419adhDNdkDCQkA==",
+			"requires": {
+				"resize-observer-polyfill": "^1.5.1"
+			}
+		},
 		"util": {
 			"version": "0.12.3",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",


### PR DESCRIPTION
- Add `isSynchronized` function exported by `webpack-fluid-loader` so that tests can wait for when containers are synchronized after test actions.
- Modified the canvas test to wait for synchronized
- Enhance how we check the result in the canvas test

Fix #5156 