### PR TITLE
Get more e2e test to pass with ODSP

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2568,43 +2568,43 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.34.1.tgz",
-			"integrity": "sha512-dpHeiaWTYRMPGx6a6/BQZ/kcX5AclYIhDTyzPHCWTfaR+JzFVa3f95zPrW5Jh9YzIMmcs6tlQOzGnnCdIPY0nQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.35.0.tgz",
+			"integrity": "sha512-qNlqnDQm6Sa4AjiOYzeINdWDOIKn9IZMlcy6llJR5wqwxM3MDQOFE6o/Mng/2ebOhGbvXl3Wnf+t5iGwfbOCfQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
-				"@fluidframework/map": "^0.34.1",
-				"@fluidframework/register-collection": "^0.34.1",
-				"@fluidframework/runtime-definitions": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/map": "^0.35.0",
+				"@fluidframework/register-collection": "^0.35.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.34.1.tgz",
-			"integrity": "sha512-8WBRdZ1rY4MA7Y8vTPCGOT44LSKBf2vTYD4MTbQ7aIsBycbjb1QESdbyxZNAf4RTMiNw4hRq9X94WWCq5unXKg==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.35.0.tgz",
+			"integrity": "sha512-CkYQSOkskpC3439Qwx8oqPyrZFQqXS/CiekWDT465Zw1tFSd2BBv3d7FRvhsYxXyWAGXBVwd1eGiSK8/kOU9sw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/container-loader": "^0.34.1",
-				"@fluidframework/container-runtime": "^0.34.1",
-				"@fluidframework/container-runtime-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
-				"@fluidframework/map": "^0.34.1",
-				"@fluidframework/request-handler": "^0.34.1",
-				"@fluidframework/runtime-definitions": "^0.34.1",
-				"@fluidframework/runtime-utils": "^0.34.1",
-				"@fluidframework/synthesize": "^0.34.1",
-				"@fluidframework/view-interfaces": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-loader": "^0.35.0",
+				"@fluidframework/container-runtime": "^0.35.0",
+				"@fluidframework/container-runtime-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/map": "^0.35.0",
+				"@fluidframework/request-handler": "^0.35.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/synthesize": "^0.35.0",
+				"@fluidframework/view-interfaces": "^0.35.0",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			}
@@ -2724,31 +2724,31 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
-			"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.35.0.tgz",
+			"integrity": "sha512-GXHbw8vJfsT8r3TDrV1Lppox5DuuURxX7QN2LUwK6Z3V4xQS7SXLO++iUQnvfYVTzShyECaPrPkfo6bpzA39kQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.1.tgz",
-			"integrity": "sha512-N9SDMAEbO4PL1G2LjN1setLaOC7r4D9kskl/A6BLUekv2a8NAIUYOX3tYqEeG/1KGRBlz6pssoTSpbDtmz2FUQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.35.0.tgz",
+			"integrity": "sha512-3YKMoJeKRIaOm/KJPi/+mJM6aepjiSWqfHEtXgUTWo5D0jtYtYcNs4n0HopaV1P+06HrtziE9uHezGgEpqY/EA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/container-utils": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
-				"@fluidframework/driver-utils": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-utils": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -2757,26 +2757,26 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.1.tgz",
-			"integrity": "sha512-WOtUs9Iq5iasaD4nSTKK+fNx9dPqMFojOoJL1+CBiEPBQb/DWdM5TNupN5muJ2Spo14i2luby4N3eh+INa+7AQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.35.0.tgz",
+			"integrity": "sha512-k6nquTheO/3j0lofewQzJIdiIrSgKHJJcNekPtOAuGriOVMZPCuIAMxJpEaMiabC4ndD7+r6BWpeTUeqVbEvbA==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.34.1",
+				"@fluidframework/agent-scheduler": "^0.35.0",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/container-runtime-definitions": "^0.34.1",
-				"@fluidframework/container-utils": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
-				"@fluidframework/driver-utils": "^0.34.1",
-				"@fluidframework/garbage-collector": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-runtime-definitions": "^0.35.0",
+				"@fluidframework/container-utils": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
+				"@fluidframework/garbage-collector": "^0.35.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.1",
-				"@fluidframework/runtime-utils": "^0.34.1",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -2784,55 +2784,55 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.34.1.tgz",
-			"integrity": "sha512-furN8aglfIHZEZf1OAii4EVwEmpXZSEHrxNaKiLchPKc/PJcK8Engzb8XN+oHEG79haw5iJMQNWPfDZWp8TcLg==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.35.0.tgz",
+			"integrity": "sha512-DfJ17FEQMJzJCl9cPUwuuwB27M1VlcvoJUw4J6GWa5LyFzwjjV2yxP997N7oWzVneNi3u/Mr86lI4VTavQMJNQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.1",
+				"@fluidframework/runtime-definitions": "^0.35.0",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
-			"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.35.0.tgz",
+			"integrity": "sha512-EqfjgHIEn6Dy30yd7Sn5Tt6+H8xrfDTfmfLoAVa6J+dUd+tykFCMlx6zrJGXSVlnTXKlQp+OZK0hszp6a6J9fQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
-			"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.35.0.tgz",
+			"integrity": "sha512-1mvdiohJ/Dmxiw/R5rGeNNPTEsqKsQyA+ksk6ZB0PMuW7i9XkgZu9MjkmaSe1fe65Hu+F2dstoVAWJcQOrb+8g=="
 		},
 		"@fluidframework/datastore": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
-			"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.35.0.tgz",
+			"integrity": "sha512-j0ViHPO+lrEySOLsKm7hsKPnCWKbgBUpkJ1QgPrrPBZLo8YW4rs7mtXLVpKr5bZ6zbcoPKFAi9pRYguIkmEwvw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/container-utils": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
-				"@fluidframework/driver-utils": "^0.34.1",
-				"@fluidframework/garbage-collector": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-utils": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
+				"@fluidframework/garbage-collector": "^0.35.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.1",
-				"@fluidframework/runtime-utils": "^0.34.1",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19",
@@ -2840,56 +2840,56 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
-			"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.35.0.tgz",
+			"integrity": "sha512-xFQJ3S5R6wFTitr7jHpiq1nnFO1QvB3G3U1ZhdOkxNyj8tjrVczs/XGdPKtrzaUU9JOA+dFaaBidKgYr0CKxfw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.1",
+				"@fluidframework/runtime-definitions": "^0.35.0",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.34.1.tgz",
-			"integrity": "sha512-PE+vfqnwltsfGZ5NQmEUYmdKHwnjsdbyywp9hYsV6A4g+mvm4JcRaFJQszOVpHFnV4uf8D2JWpvjJvB6A+X2UA==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.35.0.tgz",
+			"integrity": "sha512-uT1RL2++YPdlIxUxOL9ig4ojaHJnPIWLnJxSEbRmC3MmkUNKHcpfdrcsv8CfdXZExIMZdI8O5qyWKDyvcoIAlQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/driver-definitions": "^0.34.1",
-				"@fluidframework/driver-utils": "^0.34.1",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
-			"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.35.0.tgz",
+			"integrity": "sha512-mqojfwkn9dF2ApMpVvucAplIPBM4G1rne7jHew/HheALRrMI4QYHkUiuqxAaWwjOeTRh55LQ+bLXJVTpkjWVkg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
-			"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.35.0.tgz",
+			"integrity": "sha512-adWHjEz1PHMDd9v+YkX7O9rgF6yYADfcxq9oGZKmrEd7jxQ+DVIeTNPk9d+mZchyWGb/eONawmbueQ3tRHKAZg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
 				"@fluidframework/gitresources": "^0.1019.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			}
@@ -2912,13 +2912,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
-			"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.35.0.tgz",
+			"integrity": "sha512-2ZLg/T/+Rpe/XxkcmnW9cvD0DyzFoZgBV9IDgdw6s/sQ0oUrfZ/AbORfEp6e1NarqIsQLSSOtUJWA5GBl2cYQA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/runtime-definitions": "^0.34.1"
+				"@fluidframework/runtime-definitions": "^0.35.0"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -2927,17 +2927,18 @@
 			"integrity": "sha512-29wAJDIRmCwkcCtxTnX9jl5lcrdN7CKIjn3kzRVL76V5S71nJnJkmdV4p8Zh0d+Bkoal47r4HF8kmDKVrB8jOw=="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.34.1.tgz",
-			"integrity": "sha512-2HwlUnafMSMU29TBD6vco7FyDFHguK5ray6SnfVbCJA8z9ox+pqDEj1xLPmlQtTNQ38RdDCeIQ/PKqZiqArsAA==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.35.0.tgz",
+			"integrity": "sha512-P0+sUoVcBxmtc/wxJNCpkBLBETZ6mrcblZUqthTl7CuyAbQocrRLO5mYDdA+4aurA3PaLh/7SWUOEaxyb9h/Mw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
-				"@fluidframework/driver-utils": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-base": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/routerlicious-driver": "^0.34.1",
+				"@fluidframework/routerlicious-driver": "^0.35.0",
 				"@fluidframework/server-local-server": "^0.1019.0",
 				"@fluidframework/server-services-client": "^0.1019.0",
 				"@fluidframework/server-services-core": "^0.1019.0",
@@ -2949,262 +2950,35 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.1.tgz",
-			"integrity": "sha512-VBot7Jt/CgX11h6+crHDQ1WSPbTbbdL6Ogag6b1o1jrqQoSXSZEKo6bLrwFOHMTAEqeLAN1fhjmYxCwOug5oAg==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.35.0.tgz",
+			"integrity": "sha512-wq736gU+2/7oVb8hxwyA+h0mJEvmCSRj+o45RvciRhet4fHSNJqFGvBou2vVYi4Gs4J+QW0wYMK/VRaYBmRYDA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.1",
+				"@fluidframework/shared-object-base": "^0.35.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.34.1.tgz",
-			"integrity": "sha512-ESoEVOMW1MD+s4Y2hdQ6uG2SfW+TxI9IUUHWzhirMOYGJ1d7HYjsqgR2B+tIN0yKIS5Q7gd77WDiolLWc6oEeQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.35.0.tgz",
+			"integrity": "sha512-55t17NeacOH9dSCavwJ6SffoxYOt8EFK58Io4ky1trch0NhTAIGMjxY5QilJlhLXDqRX5VMau9zLikAUwoD86A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0"
-			}
-		},
-		"@fluidframework/odsp-doclib-utils": {
-			"version": "0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.33.3.tgz",
-			"integrity": "sha512-N2TnLX4dRNlujGzCiXlnGHUBhOznejrxoTNk44D2eQQgw8891RrUGUbf0rvZzeerLOU7cbScWMel0DdeqvdHJg==",
-			"requires": {
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/driver-utils": "^0.33.3",
-				"node-fetch": "^2.6.1"
-			},
-			"dependencies": {
-				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
-						"assert": "^2.0.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
-				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"debug": "^4.1.1",
-						"events": "^3.1.0"
-					}
-				}
-			}
-		},
-		"@fluidframework/odsp-driver": {
-			"version": "0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.33.3.tgz",
-			"integrity": "sha512-3AcPaaIsNJk0J1/SonCXYAsn+o+M4wLAPzikxIp4E/OFzv13ZPoSGla7EJyEEX4wFhx6usUp09Sf4HPVv0W9jQ==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-base": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/driver-utils": "^0.33.3",
-				"@fluidframework/gitresources": "^0.1018.0",
-				"@fluidframework/odsp-doclib-utils": "^0.33.3",
-				"@fluidframework/protocol-base": "^0.1018.0",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/telemetry-utils": "^0.33.3",
-				"abort-controller": "^3.0.0",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"lodash": "^4.17.19",
-				"node-fetch": "^2.6.1",
-				"sha.js": "^2.4.11",
-				"sinon": "^7.4.2",
-				"socket.io-client": "^2.1.1",
-				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
-				},
-				"@fluidframework/driver-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.3.tgz",
-					"integrity": "sha512-cwAR9rulHON59BQUzTI/BolOayEjrE0x1zPS546t041KbC4Gf/jF/5qPFTU78uHskYxcZAuYUsrZnadz7D0FrA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"debug": "^4.1.1"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
-						"assert": "^2.0.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
-				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"debug": "^4.1.1",
-						"events": "^3.1.0"
-					}
-				}
-			}
-		},
-		"@fluidframework/odsp-urlresolver": {
-			"version": "0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.33.3.tgz",
-			"integrity": "sha512-i7xTTX/8TQokviijjJbQiwnYi27mnMv8jjDQ/AnEc8huSfA3O74XiPsRyqPtdzBF61n1aPiA2D8CEdi0v0+G+Q==",
-			"requires": {
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/odsp-driver": "^0.33.3",
-				"assert": "^2.0.0"
-			},
-			"dependencies": {
-				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				}
 			}
 		},
 		"@fluidframework/protocol-base": {
@@ -3228,85 +3002,84 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.1.tgz",
-			"integrity": "sha512-EmMofoT8ErUbUDkpoF0W62wzZADbfeKfVEeFZcLFTSAVpYpr+p27D2INsLInbpVmAJ+iU8msgDcIQdAFXQfCzw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.35.0.tgz",
+			"integrity": "sha512-JhPEhIgrY9h+Xrx1OF4JSZNNdUBr+3FAWGftwK6a3b1H16k8ahdgaRhXpTnWUayT8WM2wi9/Rjh/cvDxdRKV7Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.1",
+				"@fluidframework/shared-object-base": "^0.35.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.34.1.tgz",
-			"integrity": "sha512-JdFStPKZ4H77L80Y4KFT85oHK1N/RWafkOPIlfQ6q0SkxunjjTjKHGhcpSVE5Dpv2PPZFXRD5r8/PApJivO1ew==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.35.0.tgz",
+			"integrity": "sha512-JW3667io6KX4YajUcktvL09mj8+Jcv5+3LbRpozdzmLgH1BCX+h9ZUqRhT41kQHdyOPWJZHiOnyhwA9TI4EStw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-runtime-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/runtime-definitions": "^0.34.1",
-				"@fluidframework/runtime-utils": "^0.34.1",
+				"@fluidframework/container-runtime-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
 				"assert": "^2.0.0"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.34.1.tgz",
-			"integrity": "sha512-JOHG/IYXlftGIo+iBBag8odyQ2M1Hqs2Z/f5ijfZMq/jqZExY3g0FUp2gd5P6j+CsqJYEnX8vwsgU/Zmp2bkbA==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.35.0.tgz",
+			"integrity": "sha512-XcOyAk5Qkqoew1Ua41TcuYSNyXJZjF3wt7u+X+zGz0zo+Sz63lIk1ElMx24NePsQDC5BxwXcljT2KAxMj8w5GA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/driver-base": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
-				"@fluidframework/driver-utils": "^0.34.1",
+				"@fluidframework/driver-base": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
 				"@fluidframework/gitresources": "^0.1019.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@fluidframework/server-services-client": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0",
 				"axios": "^0.21.1",
 				"debug": "^4.1.1",
 				"isomorphic-ws": "^4.0.1",
-				"jwt-decode": "^2.2.0",
 				"socket.io-client": "^2.1.1",
 				"uuid": "^8.3.1",
 				"ws": "^6.1.2"
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
-			"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.35.0.tgz",
+			"integrity": "sha512-LR8zfEc0piPIIsgwZtRAC+qVN2pod2YK4vm4i2jABIsKQctXHANjMJ/vRYRUQMZa/aY3yj/rjzyeeDDNEXg5nQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
-			"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.35.0.tgz",
+			"integrity": "sha512-HT79jK/0OYyh8e0RD2k7RLdBcNzDCgo0IBpFVCRhdmAerVUqRVs8uIYzjGQPbIQUlodHfWe4llIFOzQygJfHGw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
-				"@fluidframework/garbage-collector": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/garbage-collector": "^0.35.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.1",
+				"@fluidframework/runtime-definitions": "^0.35.0",
 				"assert": "^2.0.0"
 			}
 		},
@@ -4241,37 +4014,37 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
-			"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.35.0.tgz",
+			"integrity": "sha512-M6sMrIbAo3gM2i7qKOspDRAMAPeuy0jo2IxstqIpYXq7cN9MmwhVJI+gBXwb43SDNekpmEtmfd2cfsb9p9ACWg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.1",
-				"@fluidframework/runtime-utils": "^0.34.1",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.34.1.tgz",
-			"integrity": "sha512-xf64OgibYmWgxa4UA8qnDtsnKWJz4wJ42/PGsANjfcP+P4QMVU1BYOyky0GKJE2M6Nu3aSu/E2wQGqnN2MCvkw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.35.0.tgz",
+			"integrity": "sha512-MbUyEfSrHrZ/mDa6Ceo0Ra328gA61q0k5MMqzTaOt3Pz47Z861kAwqDLAIhZkHt/8ien+OKa54NfYz1zg/N5Yw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.34.1"
+				"@fluidframework/core-interfaces": "^0.35.0"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
-			"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.35.0.tgz",
+			"integrity": "sha512-UY0Tc9Hu27atyhH2G9GAZumfAYvJ21CzCYok8lRctTgi9fBADyDexvY5WVO12CuBeg/WZDYUNK8vkYuxV9FVcA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
@@ -4280,508 +4053,33 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.34.1.tgz",
-			"integrity": "sha512-1u7/qy09Pe/xKYFYB6TWMzvosCysyvG9LdOl+iMu7zczCsNY/rw+FWL7DCbfaKrzSOYiBVot7zqlOfnraqfxOw==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.35.0.tgz",
+			"integrity": "sha512-AgbDNwGn1NikNhxeJNpeCSCER+Ke1RGEGBgYERpEEDukxiZca+kMUB9YOpglMoZOk4r8XY0wcAfoTTi44RpbMA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/server-local-server": "^0.1019.0",
 				"uuid": "^8.3.1"
-			}
-		},
-		"@fluidframework/test-drivers": {
-			"version": "0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.33.3.tgz",
-			"integrity": "sha512-G/nx6oibaqyGhpUVXhITARFyJ4Am3AF6Px0nGn1d2rXKLO3/Lxxrc0tYzji6x2Ntv2lM9x1V5n3F+ivYsQXvyA==",
-			"requires": {
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/local-driver": "^0.33.3",
-				"@fluidframework/odsp-doclib-utils": "^0.33.3",
-				"@fluidframework/odsp-driver": "^0.33.3",
-				"@fluidframework/odsp-urlresolver": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/routerlicious-driver": "^0.33.3",
-				"@fluidframework/server-local-server": "^0.1018.0",
-				"@fluidframework/test-runtime-utils": "^0.33.3",
-				"@fluidframework/tinylicious-driver": "^0.33.3",
-				"@fluidframework/tool-utils": "^0.33.3",
-				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
-				},
-				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@types/node": "^10.17.24"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "10.17.54",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
-							"integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ=="
-						}
-					}
-				},
-				"@fluidframework/driver-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.3.tgz",
-					"integrity": "sha512-cwAR9rulHON59BQUzTI/BolOayEjrE0x1zPS546t041KbC4Gf/jF/5qPFTU78uHskYxcZAuYUsrZnadz7D0FrA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"debug": "^4.1.1"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
-						"assert": "^2.0.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/local-driver": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.3.tgz",
-					"integrity": "sha512-KwM0ZiSx7YO3ey9a6PonQRCC3pQ2fVTNSzPzJW9c90eYwjBoTIc0LcSTar4G1b+wEr/EKuCmFxyKPn1+HbSR2Q==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.3",
-						"@fluidframework/server-local-server": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@fluidframework/server-test-utils": "^0.1018.0",
-						"assert": "^2.0.0",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.0.2",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
-				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.3.tgz",
-					"integrity": "sha512-YKGbfZxpeAuAhTjQs3pF5nXyp9W7t/0UkerOvJfiBGRltv6i3OgIU4C7GOB25qXIWDtSKALJo80dbOuB5yFCjA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
-						"assert": "^2.0.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"isomorphic-ws": "^4.0.1",
-						"jwt-decode": "^2.2.0",
-						"socket.io-client": "^2.1.1",
-						"uuid": "^8.3.1",
-						"ws": "^6.1.2"
-					}
-				},
-				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@types/node": "^10.17.24"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "10.17.54",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
-							"integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ=="
-						}
-					}
-				},
-				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"assert": "^2.0.0"
-					}
-				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1018.0.tgz",
-					"integrity": "sha512-kA7VFQwaWwDmFsTntzERPbACLkZmWy2qGs9hgjH7gMyYA8IvCy9/EwaFKRzCE8wnBBRR/zN+RmgDjJQ/s7WbHQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-local-server": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1018.0.tgz",
-					"integrity": "sha512-Z66H1oUvp4Fw5mdcXLeEfQ1+fSaaUIxRgJYD4AYKzVVOZy5QTPN06or2YYpMw6nMLo6V0pOZdu66bHty5ThEXg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-lambdas": "^0.1018.0",
-						"@fluidframework/server-memory-orderer": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@fluidframework/server-test-utils": "^0.1018.0",
-						"jsrsasign": "^10.0.2",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1018.0.tgz",
-					"integrity": "sha512-qa6qmdz30EEXjx2E2ulv9fME4FSO+Dow8hCNZZhpZqI0LE1GFFcpR+ZHxL0JP8ZKid/QI2iID4giY2opJ4wrNw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-lambdas": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^12.19.0",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^8.3.1",
-						"ws": "^6.1.2"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1018.0.tgz",
-					"integrity": "sha512-V/+sFDHPmp0iZp9Z+H+gNGnA8r0VemgmIwkAEBVIjY7puhHAZfUwz6LbZpT9/7eWOs9Uk3ShGdsq6X5DpRODwA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@types/node": "^12.19.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.0.2",
-						"jwt-decode": "^3.0.0",
-						"sillyname": "0.1.0",
-						"uuid": "^8.3.1"
-					},
-					"dependencies": {
-						"jwt-decode": {
-							"version": "3.1.2",
-							"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-							"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-						}
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1018.0.tgz",
-					"integrity": "sha512-OaNkZ8trEVB5lgSnUZg0GDKndk/E8LJaHDuqbQp9wLz4B8cDqg1XpSnv+SOjk/M4CTg+KkldsookL5zmfuf0Dw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@types/nconf": "^0.0.37",
-						"@types/node": "^12.19.0",
-						"debug": "^4.1.1",
-						"nconf": "^0.10.0"
-					}
-				},
-				"@fluidframework/server-test-utils": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1018.0.tgz",
-					"integrity": "sha512-YNV2LoKgVkyUokjAuYOp5s76cT+nbxfi7Y9CXsFHTnNsMEHeghbsVXX3/HJPAPYBSGCsSLAfS//CusoQ0l88iA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"debug": "^4.1.1",
-						"lodash": "^4.17.19",
-						"string-hash": "^1.1.3",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"debug": "^4.1.1",
-						"events": "^3.1.0"
-					}
-				},
-				"@fluidframework/test-runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-0wDS4+X6WGbUrCQ7d84KRoPZ+XxsU912T6+rtEs2/q4Qnjl+Bodz67ukp8YzktUYYfYFHeVDTtYTsjM3zbyTvA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
-						"assert": "^2.0.0",
-						"axios": "^0.21.1",
-						"jsrsasign": "^10.0.2",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"nconf": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-					"integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
-					"requires": {
-						"async": "^1.4.0",
-						"ini": "^1.3.0",
-						"secure-keys": "^1.0.0",
-						"yargs": "^3.19.0"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-						}
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"y18n": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-					"integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-				},
-				"yargs": {
-					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"requires": {
-						"camelcase": "^2.0.1",
-						"cliui": "^3.0.3",
-						"decamelize": "^1.1.1",
-						"os-locale": "^1.4.0",
-						"string-width": "^1.0.1",
-						"window-size": "^0.1.4",
-						"y18n": "^3.2.0"
-					}
-				}
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.34.1.tgz",
-			"integrity": "sha512-DmtlnbX7Zz6U0unXWWV/1JvVLow7iUjWiQg0cPp5iYTNUGtnLpQzLZjOXrK/9Seju+NvTr4cY479jvQ3Y6+NMg==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.35.0.tgz",
+			"integrity": "sha512-HbzfwWTTq/vVlbM6/ZuphuP/YGbJL6rp5o56gcC0LpHyik09p54p+yAd14vPF/3lFhfLQWes4hFOlLPdnt7AgA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.1",
-				"@fluidframework/core-interfaces": "^0.34.1",
-				"@fluidframework/datastore-definitions": "^0.34.1",
-				"@fluidframework/driver-definitions": "^0.34.1",
-				"@fluidframework/driver-utils": "^0.34.1",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/routerlicious-driver": "^0.34.1",
-				"@fluidframework/runtime-definitions": "^0.34.1",
-				"@fluidframework/runtime-utils": "^0.34.1",
-				"@fluidframework/telemetry-utils": "^0.34.1",
+				"@fluidframework/routerlicious-driver": "^0.35.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
 				"assert": "^2.0.0",
 				"axios": "^0.21.1",
 				"jsrsasign": "^10.0.2",
@@ -4794,204 +4092,12 @@
 			"integrity": "sha512-ZRSSKPXMm/ni/hDztf38GMBtzFez0Q9XXaY5abd2rQz76A3wIK+yzQerTqnZYBnwrzGwZi22Ne1FXND1JeFMZA==",
 			"dev": true
 		},
-		"@fluidframework/tinylicious-driver": {
-			"version": "0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.33.3.tgz",
-			"integrity": "sha512-Ap6fLDFplpnEeB4vQZvgFaZX6MlAofuj9tGiwXVL8/IiFfCbnqHdU2QC2bDCul/LkaE4IKK+nezakD6N9fTfGg==",
-			"requires": {
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/driver-utils": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/routerlicious-driver": "^0.33.3",
-				"jsrsasign": "^10.0.2",
-				"uuid": "^8.3.1"
-			},
-			"dependencies": {
-				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
-				},
-				"@fluidframework/driver-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.3.tgz",
-					"integrity": "sha512-cwAR9rulHON59BQUzTI/BolOayEjrE0x1zPS546t041KbC4Gf/jF/5qPFTU78uHskYxcZAuYUsrZnadz7D0FrA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"debug": "^4.1.1"
-					}
-				},
-				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
-						"assert": "^2.0.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
-				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.3.tgz",
-					"integrity": "sha512-YKGbfZxpeAuAhTjQs3pF5nXyp9W7t/0UkerOvJfiBGRltv6i3OgIU4C7GOB25qXIWDtSKALJo80dbOuB5yFCjA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
-						"assert": "^2.0.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"isomorphic-ws": "^4.0.1",
-						"jwt-decode": "^2.2.0",
-						"socket.io-client": "^2.1.1",
-						"uuid": "^8.3.1",
-						"ws": "^6.1.2"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1018.0.tgz",
-					"integrity": "sha512-V/+sFDHPmp0iZp9Z+H+gNGnA8r0VemgmIwkAEBVIjY7puhHAZfUwz6LbZpT9/7eWOs9Uk3ShGdsq6X5DpRODwA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@types/node": "^12.19.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.0.2",
-						"jwt-decode": "^3.0.0",
-						"sillyname": "0.1.0",
-						"uuid": "^8.3.1"
-					},
-					"dependencies": {
-						"jwt-decode": {
-							"version": "3.1.2",
-							"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-							"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-						}
-					}
-				},
-				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/common-utils": "^0.27.0",
-						"debug": "^4.1.1",
-						"events": "^3.1.0"
-					}
-				},
-				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
-				}
-			}
-		},
-		"@fluidframework/tool-utils": {
-			"version": "0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.33.3.tgz",
-			"integrity": "sha512-j5h7lPA1CT8VPeeuRWrgFgj5pKDCJkuOLMixrzHEPCUC0PrwcCIk18uzw4Pzzkwp8C1FuhOF95T20d5TedpKQA==",
-			"requires": {
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/odsp-doclib-utils": "^0.33.3",
-				"@fluidframework/protocol-base": "^0.1018.0",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"proper-lockfile": "^4.1.1"
-			},
-			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				}
-			}
-		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.34.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.34.1.tgz",
-			"integrity": "sha512-DLTGrEQkhtkKVlsv2B1WJzYBmuWu16PWpqIAoAJi4aJQDgLlML6hOsQOi0DOLA2ud60dHWnWfUeduUPq7rbh+Q==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.35.0.tgz",
+			"integrity": "sha512-gCsYUGqfD0+q/GBbFB6eQ/Cigm7m03jOMxgD4jQ7B04FdN1yFvPrveHJEGTn3q0CE71jSoDQgssUEpk3tTohKg==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.34.1"
+				"@fluidframework/core-interfaces": "^0.35.0"
 			}
 		},
 		"@graphql-codegen/cli": {
@@ -21842,7 +20948,8 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -25567,6 +24674,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -29328,6 +28436,30 @@
 			}
 		},
 		"old-aqueduct": {
+			"version": "npm:@fluidframework/aqueduct@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.35.0.tgz",
+			"integrity": "sha512-CkYQSOkskpC3439Qwx8oqPyrZFQqXS/CiekWDT465Zw1tFSd2BBv3d7FRvhsYxXyWAGXBVwd1eGiSK8/kOU9sw==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-loader": "^0.35.0",
+				"@fluidframework/container-runtime": "^0.35.0",
+				"@fluidframework/container-runtime-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/map": "^0.35.0",
+				"@fluidframework/request-handler": "^0.35.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/synthesize": "^0.35.0",
+				"@fluidframework/view-interfaces": "^0.35.0",
+				"assert": "^2.0.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"old-aqueduct2": {
 			"version": "npm:@fluidframework/aqueduct@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.34.1.tgz",
 			"integrity": "sha512-8WBRdZ1rY4MA7Y8vTPCGOT44LSKBf2vTYD4MTbQ7aIsBycbjb1QESdbyxZNAf4RTMiNw4hRq9X94WWCq5unXKg==",
@@ -29349,76 +28481,52 @@
 				"@fluidframework/view-interfaces": "^0.34.1",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
-			}
-		},
-		"old-aqueduct2": {
-			"version": "npm:@fluidframework/aqueduct@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.33.3.tgz",
-			"integrity": "sha512-5O8CHFauIcl4yY9ThWT68z0VQFOVm4N4nL2+qNwqzgnWVfl7XJdobnjl8XxCcxnaLvhiSjumGvCwrFHvXb5zPQ==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.3",
-				"@fluidframework/container-loader": "^0.33.3",
-				"@fluidframework/container-runtime": "^0.33.3",
-				"@fluidframework/container-runtime-definitions": "^0.33.3",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/map": "^0.33.3",
-				"@fluidframework/request-handler": "^0.33.3",
-				"@fluidframework/runtime-definitions": "^0.33.3",
-				"@fluidframework/runtime-utils": "^0.33.3",
-				"@fluidframework/synthesize": "^0.33.3",
-				"@fluidframework/view-interfaces": "^0.33.3",
-				"assert": "^2.0.0",
-				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/agent-scheduler": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.3.tgz",
-					"integrity": "sha512-fj31CTuOyzTfK3ZjPEgBKC/iY772VFG1uR3OQGh4fhUjkhLN0x5QET6yMb/0awn6PnJh5U5UOk9x6i8RFUbepw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.34.1.tgz",
+					"integrity": "sha512-dpHeiaWTYRMPGx6a6/BQZ/kcX5AclYIhDTyzPHCWTfaR+JzFVa3f95zPrW5Jh9YzIMmcs6tlQOzGnnCdIPY0nQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/map": "^0.33.3",
-						"@fluidframework/register-collection": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/map": "^0.34.1",
+						"@fluidframework/register-collection": "^0.34.1",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-loader": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.3.tgz",
-					"integrity": "sha512-psEeTVp6IoDTuBwAXvf/y9EMjXoceAo0Lb3bouBrS+xXgH1XOu/GIMIz5UdwHP1qmCBwWEfylPipOzsGSsSCSw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.1.tgz",
+					"integrity": "sha512-N9SDMAEbO4PL1G2LjN1setLaOC7r4D9kskl/A6BLUekv2a8NAIUYOX3tYqEeG/1KGRBlz6pssoTSpbDtmz2FUQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -29427,26 +28535,26 @@
 					}
 				},
 				"@fluidframework/container-runtime": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.3.tgz",
-					"integrity": "sha512-pUfoH/oP426KL7pUI2NWtuuvO7sSdeG4I5rxid9YbGsCIUIeHCXKFJuGsnwbQDOtn7jGHKtNYHUQtOXvxwkghw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.1.tgz",
+					"integrity": "sha512-WOtUs9Iq5iasaD4nSTKK+fNx9dPqMFojOoJL1+CBiEPBQb/DWdM5TNupN5muJ2Spo14i2luby4N3eh+INa+7AQ==",
 					"requires": {
-						"@fluidframework/agent-scheduler": "^0.33.3",
+						"@fluidframework/agent-scheduler": "^0.34.1",
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-runtime-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-runtime-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -29454,55 +28562,55 @@
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-3wOVmhXjo4ceQwVHXLnZZ3XJof4YN2/kxDiOuBqakrYJEIq2yI2E/PcINcVAp4FQXjBRAiLRwio24Nlqr1CVeA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-furN8aglfIHZEZf1OAii4EVwEmpXZSEHrxNaKiLchPKc/PJcK8Engzb8XN+oHEG79haw5iJMQNWPfDZWp8TcLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -29510,188 +28618,163 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
 				"@fluidframework/map": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.3.tgz",
-					"integrity": "sha512-K2xg59GetB2mefPTNU51nA1z+YVhSDqEkXvOsGCP0/tFzyPjPZAzHrUq8TyA4EVpKspcucqOlnA3WohDU/yNjA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.1.tgz",
+					"integrity": "sha512-VBot7Jt/CgX11h6+crHDQ1WSPbTbbdL6Ogag6b1o1jrqQoSXSZEKo6bLrwFOHMTAEqeLAN1fhjmYxCwOug5oAg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/shared-object-base": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
 					}
 				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
 				"@fluidframework/register-collection": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.3.tgz",
-					"integrity": "sha512-eDsxcxydAFHLt8GShswm4bJKNS3mPFEajbBzw4Xy5nN6N0BHFlrBv+HQBuYAPz4EwoPeFuIaKAziJT/zCF2r3w==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.1.tgz",
+					"integrity": "sha512-EmMofoT8ErUbUDkpoF0W62wzZADbfeKfVEeFZcLFTSAVpYpr+p27D2INsLInbpVmAJ+iU8msgDcIQdAFXQfCzw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/shared-object-base": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/request-handler": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.33.3.tgz",
-					"integrity": "sha512-9Nmb6HeQgo0tl2npX3oNNNg46ysrZ9DQBBVvhagpNFDn4Y+85N8mRbLkkmtPhbu/juST6GWaNZN/Eh+2fVSQag==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.34.1.tgz",
+					"integrity": "sha512-JdFStPKZ4H77L80Y4KFT85oHK1N/RWafkOPIlfQ6q0SkxunjjTjKHGhcpSVE5Dpv2PPZFXRD5r8/PApJivO1ew==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-runtime-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
+						"@fluidframework/container-runtime-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/synthesize": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.33.3.tgz",
-					"integrity": "sha512-YJx/I6XCqrEesE+hSPkA6e5z/nXyZNHf8ArWVzUPbB1QpuA5CTtbKCvzEluuop3R14hzMpdbYKYt4HhbLL4YTQ==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.34.1.tgz",
+					"integrity": "sha512-xf64OgibYmWgxa4UA8qnDtsnKWJz4wJ42/PGsANjfcP+P4QMVU1BYOyky0GKJE2M6Nu3aSu/E2wQGqnN2MCvkw==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.3"
+						"@fluidframework/core-interfaces": "^0.34.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -29700,16 +28783,30 @@
 					}
 				},
 				"@fluidframework/view-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.33.3.tgz",
-					"integrity": "sha512-QiikF8+dmf3BHx+mHC+p+pXr2IBfXSg7aURuVjOZMbfsX1YWrmmMh6q+hamGIbTnUnp4UhZ4X9qV6ZcwR5X3Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.34.1.tgz",
+					"integrity": "sha512-DLTGrEQkhtkKVlsv2B1WJzYBmuWu16PWpqIAoAJi4aJQDgLlML6hOsQOi0DOLA2ud60dHWnWfUeduUPq7rbh+Q==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.3"
+						"@fluidframework/core-interfaces": "^0.34.1"
 					}
 				}
 			}
 		},
 		"old-cell": {
+			"version": "npm:@fluidframework/cell@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.35.0.tgz",
+			"integrity": "sha512-hZdVfJdJnm1SDDjyb+4M6/T2DEyb/uisvOkF+42HLL8+pSG3oHJbuDq7EyO1sWE+jIfO8cJgrHEf2SoSyzdX0A==",
+			"requires": {
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1"
+			}
+		},
+		"old-cell2": {
 			"version": "npm:@fluidframework/cell@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.34.1.tgz",
 			"integrity": "sha512-zcFB+eyxaWQLE4LPyJP0EMYBY2Tb2uVojoRg0YLBmnR4o8FAEF6otgMvEhfiOx2HN6Kr14LaqeBZrrJUVQ93PA==",
@@ -29721,69 +28818,55 @@
 				"@fluidframework/shared-object-base": "^0.34.1",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
-			}
-		},
-		"old-cell2": {
-			"version": "npm:@fluidframework/cell@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.33.3.tgz",
-			"integrity": "sha512-3JUhEXoGD6RZtHYl9EC1Ih1Y50EQj8BAnxE02iabtJQh0aXNjXmesaudVH0YscxXsLIYDLzMhlesOnTH76SNaQ==",
-			"requires": {
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -29791,135 +28874,110 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -29930,6 +28988,17 @@
 			}
 		},
 		"old-container-definitions": {
+			"version": "npm:@fluidframework/container-definitions@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.35.0.tgz",
+			"integrity": "sha512-GXHbw8vJfsT8r3TDrV1Lppox5DuuURxX7QN2LUwK6Z3V4xQS7SXLO++iUQnvfYVTzShyECaPrPkfo6bpzA39kQ==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0"
+			}
+		},
+		"old-container-definitions2": {
 			"version": "npm:@fluidframework/container-definitions@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
 			"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
@@ -29938,45 +29007,48 @@
 				"@fluidframework/core-interfaces": "^0.34.1",
 				"@fluidframework/driver-definitions": "^0.34.1",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
-			}
-		},
-		"old-container-definitions2": {
-			"version": "npm:@fluidframework/container-definitions@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-			"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				}
 			}
 		},
 		"old-container-loader": {
+			"version": "npm:@fluidframework/container-loader@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.35.0.tgz",
+			"integrity": "sha512-3YKMoJeKRIaOm/KJPi/+mJM6aepjiSWqfHEtXgUTWo5D0jtYtYcNs4n0HopaV1P+06HrtziE9uHezGgEpqY/EA==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-utils": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
+				"@fluidframework/protocol-base": "^0.1019.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"lodash": "^4.17.19",
+				"uuid": "^8.3.1"
+			}
+		},
+		"old-container-loader2": {
 			"version": "npm:@fluidframework/container-loader@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.1.tgz",
 			"integrity": "sha512-N9SDMAEbO4PL1G2LjN1setLaOC7r4D9kskl/A6BLUekv2a8NAIUYOX3tYqEeG/1KGRBlz6pssoTSpbDtmz2FUQ==",
@@ -29996,114 +29068,67 @@
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.19",
 				"uuid": "^8.3.1"
-			}
-		},
-		"old-container-loader2": {
-			"version": "npm:@fluidframework/container-loader@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.3.tgz",
-			"integrity": "sha512-psEeTVp6IoDTuBwAXvf/y9EMjXoceAo0Lb3bouBrS+xXgH1XOu/GIMIz5UdwHP1qmCBwWEfylPipOzsGSsSCSw==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.3",
-				"@fluidframework/container-utils": "^0.33.3",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/driver-utils": "^0.33.3",
-				"@fluidframework/protocol-base": "^0.1018.0",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/telemetry-utils": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"lodash": "^4.17.19",
-				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30114,6 +29139,33 @@
 			}
 		},
 		"old-container-runtime": {
+			"version": "npm:@fluidframework/container-runtime@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.35.0.tgz",
+			"integrity": "sha512-k6nquTheO/3j0lofewQzJIdiIrSgKHJJcNekPtOAuGriOVMZPCuIAMxJpEaMiabC4ndD7+r6BWpeTUeqVbEvbA==",
+			"requires": {
+				"@fluidframework/agent-scheduler": "^0.35.0",
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-runtime-definitions": "^0.35.0",
+				"@fluidframework/container-utils": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
+				"@fluidframework/garbage-collector": "^0.35.0",
+				"@fluidframework/protocol-base": "^0.1019.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"double-ended-queue": "^2.1.0-0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"old-container-runtime2": {
 			"version": "npm:@fluidframework/container-runtime@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.1.tgz",
 			"integrity": "sha512-WOtUs9Iq5iasaD4nSTKK+fNx9dPqMFojOoJL1+CBiEPBQb/DWdM5TNupN5muJ2Spo14i2luby4N3eh+INa+7AQ==",
@@ -30138,114 +29190,87 @@
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^8.3.1"
-			}
-		},
-		"old-container-runtime2": {
-			"version": "npm:@fluidframework/container-runtime@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.3.tgz",
-			"integrity": "sha512-pUfoH/oP426KL7pUI2NWtuuvO7sSdeG4I5rxid9YbGsCIUIeHCXKFJuGsnwbQDOtn7jGHKtNYHUQtOXvxwkghw==",
-			"requires": {
-				"@fluidframework/agent-scheduler": "^0.33.3",
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.3",
-				"@fluidframework/container-runtime-definitions": "^0.33.3",
-				"@fluidframework/container-utils": "^0.33.3",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/driver-utils": "^0.33.3",
-				"@fluidframework/garbage-collector": "^0.33.3",
-				"@fluidframework/protocol-base": "^0.1018.0",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-definitions": "^0.33.3",
-				"@fluidframework/runtime-utils": "^0.33.3",
-				"@fluidframework/telemetry-utils": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"double-ended-queue": "^2.1.0-0",
-				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/agent-scheduler": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.3.tgz",
-					"integrity": "sha512-fj31CTuOyzTfK3ZjPEgBKC/iY772VFG1uR3OQGh4fhUjkhLN0x5QET6yMb/0awn6PnJh5U5UOk9x6i8RFUbepw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.34.1.tgz",
+					"integrity": "sha512-dpHeiaWTYRMPGx6a6/BQZ/kcX5AclYIhDTyzPHCWTfaR+JzFVa3f95zPrW5Jh9YzIMmcs6tlQOzGnnCdIPY0nQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/map": "^0.33.3",
-						"@fluidframework/register-collection": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/map": "^0.34.1",
+						"@fluidframework/register-collection": "^0.34.1",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-3wOVmhXjo4ceQwVHXLnZZ3XJof4YN2/kxDiOuBqakrYJEIq2yI2E/PcINcVAp4FQXjBRAiLRwio24Nlqr1CVeA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-furN8aglfIHZEZf1OAii4EVwEmpXZSEHrxNaKiLchPKc/PJcK8Engzb8XN+oHEG79haw5iJMQNWPfDZWp8TcLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -30253,167 +29278,142 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
 				"@fluidframework/map": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.3.tgz",
-					"integrity": "sha512-K2xg59GetB2mefPTNU51nA1z+YVhSDqEkXvOsGCP0/tFzyPjPZAzHrUq8TyA4EVpKspcucqOlnA3WohDU/yNjA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.1.tgz",
+					"integrity": "sha512-VBot7Jt/CgX11h6+crHDQ1WSPbTbbdL6Ogag6b1o1jrqQoSXSZEKo6bLrwFOHMTAEqeLAN1fhjmYxCwOug5oAg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/shared-object-base": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
 					}
 				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
 				"@fluidframework/register-collection": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.3.tgz",
-					"integrity": "sha512-eDsxcxydAFHLt8GShswm4bJKNS3mPFEajbBzw4Xy5nN6N0BHFlrBv+HQBuYAPz4EwoPeFuIaKAziJT/zCF2r3w==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.1.tgz",
+					"integrity": "sha512-EmMofoT8ErUbUDkpoF0W62wzZADbfeKfVEeFZcLFTSAVpYpr+p27D2INsLInbpVmAJ+iU8msgDcIQdAFXQfCzw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/shared-object-base": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30424,16 +29424,30 @@
 			}
 		},
 		"old-core-interfaces": {
+			"version": "npm:@fluidframework/core-interfaces@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.35.0.tgz",
+			"integrity": "sha512-1mvdiohJ/Dmxiw/R5rGeNNPTEsqKsQyA+ksk6ZB0PMuW7i9XkgZu9MjkmaSe1fe65Hu+F2dstoVAWJcQOrb+8g=="
+		},
+		"old-core-interfaces2": {
 			"version": "npm:@fluidframework/core-interfaces@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
 			"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 		},
-		"old-core-interfaces2": {
-			"version": "npm:@fluidframework/core-interfaces@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-			"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
-		},
 		"old-counter": {
+			"version": "npm:@fluidframework/counter@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.35.0.tgz",
+			"integrity": "sha512-8JjXFxfTDGeLIqewWFOYzH2dqDhjZKFo/bn0h4bsTXJZMpxWuiKGdasyPMneXXRHdEWZqlMoFHFJ+cf+9JNvfA==",
+			"requires": {
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1"
+			}
+		},
+		"old-counter2": {
 			"version": "npm:@fluidframework/counter@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.34.1.tgz",
 			"integrity": "sha512-HGRiSN1PkmDSiD30YwQKVgPlLx+jCT8V1i2mymsYF5Y56rOYjZHEein8VFeaHO5hq5Fo4OG5HN2awSbputQwHw==",
@@ -30445,69 +29459,55 @@
 				"@fluidframework/shared-object-base": "^0.34.1",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
-			}
-		},
-		"old-counter2": {
-			"version": "npm:@fluidframework/counter@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.33.3.tgz",
-			"integrity": "sha512-JN7R3WqPRGzODhVBGkc9XeA9wfJLcPFi0nHtTMLCXxzOOElKOmlctZ6z9sm8aDguDVcNW98i7v48ZJ3HE9BPHg==",
-			"requires": {
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -30515,135 +29515,110 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30654,6 +29629,20 @@
 			}
 		},
 		"old-datastore-definitions": {
+			"version": "npm:@fluidframework/datastore-definitions@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.35.0.tgz",
+			"integrity": "sha512-xFQJ3S5R6wFTitr7jHpiq1nnFO1QvB3G3U1ZhdOkxNyj8tjrVczs/XGdPKtrzaUU9JOA+dFaaBidKgYr0CKxfw==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@types/node": "^10.17.24"
+			}
+		},
+		"old-datastore-definitions2": {
 			"version": "npm:@fluidframework/datastore-definitions@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
 			"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
@@ -30665,73 +29654,61 @@
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@fluidframework/runtime-definitions": "^0.34.1",
 				"@types/node": "^10.17.24"
-			}
-		},
-		"old-datastore-definitions2": {
-			"version": "npm:@fluidframework/datastore-definitions@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-			"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.3",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-definitions": "^0.33.3",
-				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				}
 			}
 		},
 		"old-driver-definitions": {
+			"version": "npm:@fluidframework/driver-definitions@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.35.0.tgz",
+			"integrity": "sha512-mqojfwkn9dF2ApMpVvucAplIPBM4G1rne7jHew/HheALRrMI4QYHkUiuqxAaWwjOeTRh55LQ+bLXJVTpkjWVkg==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0"
+			}
+		},
+		"old-driver-definitions2": {
 			"version": "npm:@fluidframework/driver-definitions@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
 			"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
@@ -30739,34 +29716,31 @@
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/core-interfaces": "^0.34.1",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
-			}
-		},
-		"old-driver-definitions2": {
-			"version": "npm:@fluidframework/driver-definitions@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-			"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				}
 			}
 		},
 		"old-ink": {
+			"version": "npm:@fluidframework/ink@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.35.0.tgz",
+			"integrity": "sha512-jflXWGRvNUDEIn58Kqi1KP3euLJTl/AKXjUKAr9P7sb86De/IFaLXjtpM4drc2VFbZ41a3hm/Q5t9ahjxiDPJA==",
+			"requires": {
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"uuid": "^8.3.1"
+			}
+		},
+		"old-ink2": {
 			"version": "npm:@fluidframework/ink@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.34.1.tgz",
 			"integrity": "sha512-cGL27WjKrCpet0saHNbuXxVQqigp7TwcebnhPrNtA0+1mYdPo4AqBTDlUovAmYt8BFnfgHW9y8NxfPbSbv4c5A==",
@@ -30779,70 +29753,55 @@
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
-			}
-		},
-		"old-ink2": {
-			"version": "npm:@fluidframework/ink@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.33.3.tgz",
-			"integrity": "sha512-WeP49akI5qgouMpEN53pUKFMnw8dGOFWRFN/k99v9zTPdaQyHfIIvMm3tUkiMt65sfsjLa5ff3R8ziM1b+i26g==",
-			"requires": {
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -30850,135 +29809,110 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30989,6 +29923,29 @@
 			}
 		},
 		"old-local-driver": {
+			"version": "npm:@fluidframework/local-driver@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.35.0.tgz",
+			"integrity": "sha512-P0+sUoVcBxmtc/wxJNCpkBLBETZ6mrcblZUqthTl7CuyAbQocrRLO5mYDdA+4aurA3PaLh/7SWUOEaxyb9h/Mw==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-base": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/driver-utils": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/routerlicious-driver": "^0.35.0",
+				"@fluidframework/server-local-server": "^0.1019.0",
+				"@fluidframework/server-services-client": "^0.1019.0",
+				"@fluidframework/server-services-core": "^0.1019.0",
+				"@fluidframework/server-test-utils": "^0.1019.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"jsrsasign": "^10.0.2",
+				"uuid": "^8.3.1"
+			}
+		},
+		"old-local-driver2": {
 			"version": "npm:@fluidframework/local-driver@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.34.1.tgz",
 			"integrity": "sha512-2HwlUnafMSMU29TBD6vco7FyDFHguK5ray6SnfVbCJA8z9ox+pqDEj1xLPmlQtTNQ38RdDCeIQ/PKqZiqArsAA==",
@@ -31008,116 +29965,69 @@
 				"debug": "^4.1.1",
 				"jsrsasign": "^10.0.2",
 				"uuid": "^8.3.1"
-			}
-		},
-		"old-local-driver2": {
-			"version": "npm:@fluidframework/local-driver@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.3.tgz",
-			"integrity": "sha512-KwM0ZiSx7YO3ey9a6PonQRCC3pQ2fVTNSzPzJW9c90eYwjBoTIc0LcSTar4G1b+wEr/EKuCmFxyKPn1+HbSR2Q==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/driver-utils": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/routerlicious-driver": "^0.33.3",
-				"@fluidframework/server-local-server": "^0.1018.0",
-				"@fluidframework/server-services-client": "^0.1018.0",
-				"@fluidframework/server-services-core": "^0.1018.0",
-				"@fluidframework/server-test-utils": "^0.1018.0",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"jsrsasign": "^10.0.2",
-				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/driver-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.3.tgz",
-					"integrity": "sha512-cwAR9rulHON59BQUzTI/BolOayEjrE0x1zPS546t041KbC4Gf/jF/5qPFTU78uHskYxcZAuYUsrZnadz7D0FrA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.34.1.tgz",
+					"integrity": "sha512-PE+vfqnwltsfGZ5NQmEUYmdKHwnjsdbyywp9hYsV6A4g+mvm4JcRaFJQszOVpHFnV4uf8D2JWpvjJvB6A+X2UA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
 				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.3.tgz",
-					"integrity": "sha512-YKGbfZxpeAuAhTjQs3pF5nXyp9W7t/0UkerOvJfiBGRltv6i3OgIU4C7GOB25qXIWDtSKALJo80dbOuB5yFCjA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.34.1.tgz",
+					"integrity": "sha512-JOHG/IYXlftGIo+iBBag8odyQ2M1Hqs2Z/f5ijfZMq/jqZExY3g0FUp2gd5P6j+CsqJYEnX8vwsgU/Zmp2bkbA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/driver-base": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/server-services-client": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"debug": "^4.1.1",
@@ -31128,241 +30038,37 @@
 						"ws": "^6.1.2"
 					}
 				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1018.0.tgz",
-					"integrity": "sha512-kA7VFQwaWwDmFsTntzERPbACLkZmWy2qGs9hgjH7gMyYA8IvCy9/EwaFKRzCE8wnBBRR/zN+RmgDjJQ/s7WbHQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-local-server": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1018.0.tgz",
-					"integrity": "sha512-Z66H1oUvp4Fw5mdcXLeEfQ1+fSaaUIxRgJYD4AYKzVVOZy5QTPN06or2YYpMw6nMLo6V0pOZdu66bHty5ThEXg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-lambdas": "^0.1018.0",
-						"@fluidframework/server-memory-orderer": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@fluidframework/server-test-utils": "^0.1018.0",
-						"jsrsasign": "^10.0.2",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1018.0.tgz",
-					"integrity": "sha512-qa6qmdz30EEXjx2E2ulv9fME4FSO+Dow8hCNZZhpZqI0LE1GFFcpR+ZHxL0JP8ZKid/QI2iID4giY2opJ4wrNw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-lambdas": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^12.19.0",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^8.3.1",
-						"ws": "^6.1.2"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1018.0.tgz",
-					"integrity": "sha512-V/+sFDHPmp0iZp9Z+H+gNGnA8r0VemgmIwkAEBVIjY7puhHAZfUwz6LbZpT9/7eWOs9Uk3ShGdsq6X5DpRODwA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@types/node": "^12.19.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.0.2",
-						"jwt-decode": "^3.0.0",
-						"sillyname": "0.1.0",
-						"uuid": "^8.3.1"
-					},
-					"dependencies": {
-						"jwt-decode": {
-							"version": "3.1.2",
-							"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-							"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-						}
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1018.0.tgz",
-					"integrity": "sha512-OaNkZ8trEVB5lgSnUZg0GDKndk/E8LJaHDuqbQp9wLz4B8cDqg1XpSnv+SOjk/M4CTg+KkldsookL5zmfuf0Dw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@types/nconf": "^0.0.37",
-						"@types/node": "^12.19.0",
-						"debug": "^4.1.1",
-						"nconf": "^0.10.0"
-					}
-				},
-				"@fluidframework/server-test-utils": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1018.0.tgz",
-					"integrity": "sha512-YNV2LoKgVkyUokjAuYOp5s76cT+nbxfi7Y9CXsFHTnNsMEHeghbsVXX3/HJPAPYBSGCsSLAfS//CusoQ0l88iA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"debug": "^4.1.1",
-						"lodash": "^4.17.19",
-						"string-hash": "^1.1.3",
-						"uuid": "^8.3.1"
-					}
-				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
 						"debug": "^4.1.1",
 						"events": "^3.1.0"
 					}
-				},
-				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"nconf": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-					"integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
-					"requires": {
-						"async": "^1.4.0",
-						"ini": "^1.3.0",
-						"secure-keys": "^1.0.0",
-						"yargs": "^3.19.0"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-						}
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"y18n": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-					"integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-				},
-				"yargs": {
-					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"requires": {
-						"camelcase": "^2.0.1",
-						"cliui": "^3.0.3",
-						"decamelize": "^1.1.1",
-						"os-locale": "^1.4.0",
-						"string-width": "^1.0.1",
-						"window-size": "^0.1.4",
-						"y18n": "^3.2.0"
-					}
 				}
 			}
 		},
 		"old-map": {
+			"version": "npm:@fluidframework/map@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.35.0.tgz",
+			"integrity": "sha512-wq736gU+2/7oVb8hxwyA+h0mJEvmCSRj+o45RvciRhet4fHSNJqFGvBou2vVYi4Gs4J+QW0wYMK/VRaYBmRYDA==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/protocol-base": "^0.1019.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"path-browserify": "^1.0.1"
+			}
+		},
+		"old-map2": {
 			"version": "npm:@fluidframework/map@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.1.tgz",
 			"integrity": "sha512-VBot7Jt/CgX11h6+crHDQ1WSPbTbbdL6Ogag6b1o1jrqQoSXSZEKo6bLrwFOHMTAEqeLAN1fhjmYxCwOug5oAg==",
@@ -31377,72 +30083,55 @@
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
-			}
-		},
-		"old-map2": {
-			"version": "npm:@fluidframework/map@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.3.tgz",
-			"integrity": "sha512-K2xg59GetB2mefPTNU51nA1z+YVhSDqEkXvOsGCP0/tFzyPjPZAzHrUq8TyA4EVpKspcucqOlnA3WohDU/yNjA==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/protocol-base": "^0.1018.0",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -31450,135 +30139,110 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -31589,6 +30253,27 @@
 			}
 		},
 		"old-matrix": {
+			"version": "npm:@fluidframework/matrix@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.35.0.tgz",
+			"integrity": "sha512-tm/t6CfkZf3cz5IRoawc4nzONeaaFdq4nl5G05PPfLzC+vlZlq2hlrubeWx7D8SuuXSt+UsN4rdRKFa4s01D2Q==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/merge-tree": "^0.35.0",
+				"@fluidframework/protocol-base": "^0.1019.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
+				"@tiny-calc/nano": "0.0.0-alpha.5",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"tslib": "^1.10.0"
+			}
+		},
+		"old-matrix2": {
 			"version": "npm:@fluidframework/matrix@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.34.1.tgz",
 			"integrity": "sha512-KGOOJYiHmMP4XEdBSakGz3ae8JkCimISdUdpl/thiE2ND14OacwQ+CJuRQirdGYtngpoNJimAQ60GgYQwQE1jw==",
@@ -31607,76 +30292,55 @@
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"tslib": "^1.10.0"
-			}
-		},
-		"old-matrix2": {
-			"version": "npm:@fluidframework/matrix@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.33.3.tgz",
-			"integrity": "sha512-MtufLCXYVkL/gBrsyYLsNZbBFtP0XhcJu55NJUkb35bH/YS2ZAaBfocvk9ElH6mWmsL+lbE/HlzMr56/DTwMaQ==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/merge-tree": "^0.33.3",
-				"@fluidframework/protocol-base": "^0.1018.0",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-utils": "^0.33.3",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"@fluidframework/telemetry-utils": "^0.33.3",
-				"@tiny-calc/nano": "0.0.0-alpha.5",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"tslib": "^1.10.0"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -31684,150 +30348,125 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
 				"@fluidframework/merge-tree": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.33.3.tgz",
-					"integrity": "sha512-nsXvkH/FTu03CdfVVqrLDfcVv10GAem3tzWW2UsUiJr6vxnkMgrWC/jGsi/ELQqr8v95BwujiwLxszFk0N3Qqg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.34.1.tgz",
+					"integrity": "sha512-ESoEVOMW1MD+s4Y2hdQ6uG2SfW+TxI9IUUHWzhirMOYGJ1d7HYjsqgR2B+tIN0yKIS5Q7gd77WDiolLWc6oEeQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -31838,6 +30477,20 @@
 			}
 		},
 		"old-ordered-collection": {
+			"version": "npm:@fluidframework/ordered-collection@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.35.0.tgz",
+			"integrity": "sha512-6Jj/QR/e/dpF2mfbFdy+qcThp73pqO/wtkhooam6TLMt7AkT0o4pT6lgeQflW9RfD8qatc9HOn0a+m93acHBaw==",
+			"requires": {
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"assert": "^2.0.0",
+				"uuid": "^8.3.1"
+			}
+		},
+		"old-ordered-collection2": {
 			"version": "npm:@fluidframework/ordered-collection@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.34.1.tgz",
 			"integrity": "sha512-KHP8y3BuqGNxG2PQ+G7CX0KnVfpoWcEuTgfMbGqpKfjWKttj7NGaMfWcL5XL6eqSDBN0L8UYseONEBjY1DBcaA==",
@@ -31849,69 +30502,55 @@
 				"@fluidframework/shared-object-base": "^0.34.1",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
-			}
-		},
-		"old-ordered-collection2": {
-			"version": "npm:@fluidframework/ordered-collection@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.33.3.tgz",
-			"integrity": "sha512-jmY6SITOqHfJ/65hLoB3puVWKXwf8XHXrfXA0JOi9LmcLXXB7AMioXL5uckiryT1KtOqy9Qvk+g2xQUmh7czfA==",
-			"requires": {
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"assert": "^2.0.0",
-				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -31919,135 +30558,110 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -32058,6 +30672,21 @@
 			}
 		},
 		"old-register-collection": {
+			"version": "npm:@fluidframework/register-collection@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.35.0.tgz",
+			"integrity": "sha512-JhPEhIgrY9h+Xrx1OF4JSZNNdUBr+3FAWGftwK6a3b1H16k8ahdgaRhXpTnWUayT8WM2wi9/Rjh/cvDxdRKV7Q==",
+			"requires": {
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/protocol-base": "^0.1019.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1"
+			}
+		},
+		"old-register-collection2": {
 			"version": "npm:@fluidframework/register-collection@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.1.tgz",
 			"integrity": "sha512-EmMofoT8ErUbUDkpoF0W62wzZADbfeKfVEeFZcLFTSAVpYpr+p27D2INsLInbpVmAJ+iU8msgDcIQdAFXQfCzw==",
@@ -32070,70 +30699,55 @@
 				"@fluidframework/shared-object-base": "^0.34.1",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
-			}
-		},
-		"old-register-collection2": {
-			"version": "npm:@fluidframework/register-collection@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.3.tgz",
-			"integrity": "sha512-eDsxcxydAFHLt8GShswm4bJKNS3mPFEajbBzw4Xy5nN6N0BHFlrBv+HQBuYAPz4EwoPeFuIaKAziJT/zCF2r3w==",
-			"requires": {
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/protocol-base": "^0.1018.0",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -32141,135 +30755,110 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
-					}
-				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -32280,6 +30869,20 @@
 			}
 		},
 		"old-runtime-definitions": {
+			"version": "npm:@fluidframework/runtime-definitions@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.35.0.tgz",
+			"integrity": "sha512-LR8zfEc0piPIIsgwZtRAC+qVN2pod2YK4vm4i2jABIsKQctXHANjMJ/vRYRUQMZa/aY3yj/rjzyeeDDNEXg5nQ==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@types/node": "^10.17.24"
+			}
+		},
+		"old-runtime-definitions2": {
 			"version": "npm:@fluidframework/runtime-definitions@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
 			"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
@@ -32291,59 +30894,56 @@
 				"@fluidframework/driver-definitions": "^0.34.1",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@types/node": "^10.17.24"
-			}
-		},
-		"old-runtime-definitions2": {
-			"version": "npm:@fluidframework/runtime-definitions@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-			"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.3",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				}
 			}
 		},
 		"old-sequence": {
+			"version": "npm:@fluidframework/sequence@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.35.0.tgz",
+			"integrity": "sha512-2QsZvRVkZdE6DBKgHfVQyIaLWhHOEjtmUL34T9KzDrwfJF8rMcjOj9JOUXtabr+kD5lC7C6ekK2FBBwHpw7tCw==",
+			"requires": {
+				"@fluidframework/common-definitions": "^0.19.1",
+				"@fluidframework/common-utils": "^0.27.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/map": "^0.35.0",
+				"@fluidframework/merge-tree": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/shared-object-base": "^0.35.0",
+				"@fluidframework/telemetry-utils": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1"
+			}
+		},
+		"old-sequence2": {
 			"version": "npm:@fluidframework/sequence@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.34.1.tgz",
 			"integrity": "sha512-eUZ3e6/631z8lj0PF1xzjZRuloWufViQdnEoHILPcpgKAq33X9+y6UjWK0/4+yIRw6Mo5yDl8HJYTcjwx16zZQ==",
@@ -32360,74 +30960,55 @@
 				"@fluidframework/telemetry-utils": "^0.34.1",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
-			}
-		},
-		"old-sequence2": {
-			"version": "npm:@fluidframework/sequence@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.33.3.tgz",
-			"integrity": "sha512-sco4q8nr+JGqt+yD1tF75vwfEQh9fA1inCzsdSddpnUe+Qs3IgxKnW6mwz7IdjU4iqDOqmEy2uCL2EsyQutqNQ==",
-			"requires": {
-				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/map": "^0.33.3",
-				"@fluidframework/merge-tree": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-utils": "^0.33.3",
-				"@fluidframework/shared-object-base": "^0.33.3",
-				"@fluidframework/telemetry-utils": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -32435,167 +31016,142 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
 				"@fluidframework/map": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.3.tgz",
-					"integrity": "sha512-K2xg59GetB2mefPTNU51nA1z+YVhSDqEkXvOsGCP0/tFzyPjPZAzHrUq8TyA4EVpKspcucqOlnA3WohDU/yNjA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.1.tgz",
+					"integrity": "sha512-VBot7Jt/CgX11h6+crHDQ1WSPbTbbdL6Ogag6b1o1jrqQoSXSZEKo6bLrwFOHMTAEqeLAN1fhjmYxCwOug5oAg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/shared-object-base": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
 					}
 				},
 				"@fluidframework/merge-tree": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.33.3.tgz",
-					"integrity": "sha512-nsXvkH/FTu03CdfVVqrLDfcVv10GAem3tzWW2UsUiJr6vxnkMgrWC/jGsi/ELQqr8v95BwujiwLxszFk0N3Qqg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.34.1.tgz",
+					"integrity": "sha512-ESoEVOMW1MD+s4Y2hdQ6uG2SfW+TxI9IUUHWzhirMOYGJ1d7HYjsqgR2B+tIN0yKIS5Q7gd77WDiolLWc6oEeQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -32606,6 +31162,34 @@
 			}
 		},
 		"old-test-utils": {
+			"version": "npm:@fluidframework/test-utils@0.35.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.35.0.tgz",
+			"integrity": "sha512-MOd2kZV1D5nhwgyAS9sEot2Y/Js31sUFi+DCzb9BBKj9mUu1FaOywR1N9mgASX3t9VeiTeJrafsTGAgJrkOBeQ==",
+			"requires": {
+				"@fluidframework/aqueduct": "^0.35.0",
+				"@fluidframework/container-definitions": "^0.35.0",
+				"@fluidframework/container-loader": "^0.35.0",
+				"@fluidframework/container-runtime": "^0.35.0",
+				"@fluidframework/core-interfaces": "^0.35.0",
+				"@fluidframework/datastore": "^0.35.0",
+				"@fluidframework/datastore-definitions": "^0.35.0",
+				"@fluidframework/driver-definitions": "^0.35.0",
+				"@fluidframework/local-driver": "^0.35.0",
+				"@fluidframework/map": "^0.35.0",
+				"@fluidframework/protocol-definitions": "^0.1019.0",
+				"@fluidframework/request-handler": "^0.35.0",
+				"@fluidframework/routerlicious-driver": "^0.35.0",
+				"@fluidframework/runtime-definitions": "^0.35.0",
+				"@fluidframework/runtime-utils": "^0.35.0",
+				"@fluidframework/server-local-server": "^0.1019.0",
+				"@fluidframework/test-driver-definitions": "^0.35.0",
+				"@fluidframework/test-runtime-utils": "^0.35.0",
+				"assert": "^2.0.0",
+				"debug": "^4.1.1",
+				"uuid": "^8.3.1"
+			}
+		},
+		"old-test-utils2": {
 			"version": "npm:@fluidframework/test-utils@0.34.1",
 			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.34.1.tgz",
 			"integrity": "sha512-kxhWdwuZcihpC5qk8vFyNk0rwFlgN7TCJmvJoO3PaS/7wBwDFI/EWGiiTq8wYiIFnIvBuYqdOs8JiKGAUWGBow==",
@@ -32631,104 +31215,76 @@
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
-			}
-		},
-		"old-test-utils2": {
-			"version": "npm:@fluidframework/test-utils@0.33.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.33.3.tgz",
-			"integrity": "sha512-bKGTp3B1LGnkTC4yQndEuiQh4Wk9JgRIV7pjnzErDEmSuQBnp04SfvzS60j807DFx1NRxM16ZDPQL3D93YVNjA==",
-			"requires": {
-				"@fluidframework/aqueduct": "^0.33.3",
-				"@fluidframework/container-definitions": "^0.33.3",
-				"@fluidframework/container-loader": "^0.33.3",
-				"@fluidframework/container-runtime": "^0.33.3",
-				"@fluidframework/core-interfaces": "^0.33.3",
-				"@fluidframework/datastore": "^0.33.3",
-				"@fluidframework/datastore-definitions": "^0.33.3",
-				"@fluidframework/driver-definitions": "^0.33.3",
-				"@fluidframework/local-driver": "^0.33.3",
-				"@fluidframework/map": "^0.33.3",
-				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/request-handler": "^0.33.3",
-				"@fluidframework/routerlicious-driver": "^0.33.3",
-				"@fluidframework/runtime-definitions": "^0.33.3",
-				"@fluidframework/runtime-utils": "^0.33.3",
-				"@fluidframework/server-local-server": "^0.1018.0",
-				"@fluidframework/test-drivers": "^0.33.3",
-				"@fluidframework/test-runtime-utils": "^0.33.3",
-				"assert": "^2.0.0",
-				"debug": "^4.1.1",
-				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/agent-scheduler": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.3.tgz",
-					"integrity": "sha512-fj31CTuOyzTfK3ZjPEgBKC/iY772VFG1uR3OQGh4fhUjkhLN0x5QET6yMb/0awn6PnJh5U5UOk9x6i8RFUbepw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.34.1.tgz",
+					"integrity": "sha512-dpHeiaWTYRMPGx6a6/BQZ/kcX5AclYIhDTyzPHCWTfaR+JzFVa3f95zPrW5Jh9YzIMmcs6tlQOzGnnCdIPY0nQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/map": "^0.33.3",
-						"@fluidframework/register-collection": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/map": "^0.34.1",
+						"@fluidframework/register-collection": "^0.34.1",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/aqueduct": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.33.3.tgz",
-					"integrity": "sha512-5O8CHFauIcl4yY9ThWT68z0VQFOVm4N4nL2+qNwqzgnWVfl7XJdobnjl8XxCcxnaLvhiSjumGvCwrFHvXb5zPQ==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.34.1.tgz",
+					"integrity": "sha512-8WBRdZ1rY4MA7Y8vTPCGOT44LSKBf2vTYD4MTbQ7aIsBycbjb1QESdbyxZNAf4RTMiNw4hRq9X94WWCq5unXKg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-loader": "^0.33.3",
-						"@fluidframework/container-runtime": "^0.33.3",
-						"@fluidframework/container-runtime-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/map": "^0.33.3",
-						"@fluidframework/request-handler": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/synthesize": "^0.33.3",
-						"@fluidframework/view-interfaces": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-loader": "^0.34.1",
+						"@fluidframework/container-runtime": "^0.34.1",
+						"@fluidframework/container-runtime-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/map": "^0.34.1",
+						"@fluidframework/request-handler": "^0.34.1",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/synthesize": "^0.34.1",
+						"@fluidframework/view-interfaces": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.3.tgz",
-					"integrity": "sha512-VENxP5Z2n2+fBOhFcNaybPxVikGYUeDtE6EP4AOc4n5hnsYD/7Lps7RjwAA6KjdOQGrWl1XZh3RZv/nw6q08SA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.1.tgz",
+					"integrity": "sha512-UeD63gBOwFjTwmR4qwDIDJhtED69Utsz0tolnOfIlUqKEFRA/VrLKK+lb73EypizRjoWgLSo/+ljUUfIEYQERQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/container-loader": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.3.tgz",
-					"integrity": "sha512-psEeTVp6IoDTuBwAXvf/y9EMjXoceAo0Lb3bouBrS+xXgH1XOu/GIMIz5UdwHP1qmCBwWEfylPipOzsGSsSCSw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.1.tgz",
+					"integrity": "sha512-N9SDMAEbO4PL1G2LjN1setLaOC7r4D9kskl/A6BLUekv2a8NAIUYOX3tYqEeG/1KGRBlz6pssoTSpbDtmz2FUQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -32737,26 +31293,26 @@
 					}
 				},
 				"@fluidframework/container-runtime": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.3.tgz",
-					"integrity": "sha512-pUfoH/oP426KL7pUI2NWtuuvO7sSdeG4I5rxid9YbGsCIUIeHCXKFJuGsnwbQDOtn7jGHKtNYHUQtOXvxwkghw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.1.tgz",
+					"integrity": "sha512-WOtUs9Iq5iasaD4nSTKK+fNx9dPqMFojOoJL1+CBiEPBQb/DWdM5TNupN5muJ2Spo14i2luby4N3eh+INa+7AQ==",
 					"requires": {
-						"@fluidframework/agent-scheduler": "^0.33.3",
+						"@fluidframework/agent-scheduler": "^0.34.1",
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-runtime-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-runtime-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -32764,55 +31320,55 @@
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-3wOVmhXjo4ceQwVHXLnZZ3XJof4YN2/kxDiOuBqakrYJEIq2yI2E/PcINcVAp4FQXjBRAiLRwio24Nlqr1CVeA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-furN8aglfIHZEZf1OAii4EVwEmpXZSEHrxNaKiLchPKc/PJcK8Engzb8XN+oHEG79haw5iJMQNWPfDZWp8TcLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.3.tgz",
-					"integrity": "sha512-rh4GNOv6iJ4Zu9Ko8opAyAExESZUPbjpzrJNbMBKyvxZlUi+ScYrW1JwaMp+ERpHRNQuoVg90r7HrPBAeJfVKg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.1.tgz",
+					"integrity": "sha512-sXnKFYkTEr4x1zp40DSwcVdIvnroPAklKcvyu68Fxi6LUKG+Np9Nl6lDnW1mnD6l90QxL/VsGmMFwfl7KXEMgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.3.tgz",
-					"integrity": "sha512-Zh8TmZ0xgZvku4uZnBFOwyJyxUVYgV1dqiiW4nCalrdqS/kWqik5uwoL8KH++xPYxi8nQK3IHuh90G23X6iyUQ=="
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.1.tgz",
+					"integrity": "sha512-6ixt/Ayc+XmCcw6dnQuYpyccUa+yMZLBL8M0KZY0C7KnrPfW7SNKxG/Now40jKhswDqx3fr1CRtekM0kII0Jpg=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.3.tgz",
-					"integrity": "sha512-BXRZbStRIxUTrJILXcrHDHDBztulYN8peuA3CV+G/hfI7u7vprglkgsl+M5tllgWdE51m/pRv01BQMI54nK/Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.1.tgz",
+					"integrity": "sha512-SCIU+Q1OFWcxQI5rNS/avvAJB2J8q0pQlNs2yBZBABzMskPUrh5OmXwWm8nMSpJFU0JifUQggdfgb9yaBGt6Fw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/container-utils": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/container-utils": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -32820,91 +31376,86 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.3.tgz",
-					"integrity": "sha512-cOwH9GK5cm8f8H40pStURF8DtwiyJyxVgvJ9v+tGkYI9U9gI5QMWwJzR3qtcCKtJNvxKqXdeC45TXlmO4w/bxA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.1.tgz",
+					"integrity": "sha512-hCNGbZ8cu1/ieUER/+IF/WsEAcQjvCpMcuAUjc6rxDS6wyOaR3MJFxVptqhnpKmfYYpZBidAeRwBlFtL/NpeEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.3.tgz",
-					"integrity": "sha512-cwAR9rulHON59BQUzTI/BolOayEjrE0x1zPS546t041KbC4Gf/jF/5qPFTU78uHskYxcZAuYUsrZnadz7D0FrA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.34.1.tgz",
+					"integrity": "sha512-PE+vfqnwltsfGZ5NQmEUYmdKHwnjsdbyywp9hYsV6A4g+mvm4JcRaFJQszOVpHFnV4uf8D2JWpvjJvB6A+X2UA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.3.tgz",
-					"integrity": "sha512-Sk722SAEZy1IIBX/VmT3aFWOGHqOvJoUrTJwd5iUHy6LmwSBArXAmNlmr/xWNuRZGrlvCPCkQ3mpY10o7qDnyw==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-cS6Xtm+kot7Wg7b9Y0flHoZk+P76No7ITrY9jVOuEr+S45YXXQmW8E+JZz4bdGl0L0uf5R4mVN58HR5gubjlLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0"
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.3.tgz",
-					"integrity": "sha512-KvghwtZ8wrnTD44YtswzHaZoBHhLX3RKOmuxg8MkYNl5shH+zg8cRaa5vLoNGDoJGtGQOE03Vh60IiI4uUysBg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.1.tgz",
+					"integrity": "sha512-hGj5I/xZRn3NE4LpFa/oiGq0g8Z/hiGp7l/TklJdMc046hNqJViYMf/kzSA5swmt1EGsrYXKU09PQf9lA5eGxw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.3.tgz",
-					"integrity": "sha512-WzxUrG70B3nzEhs5kKUoBUFIeQRt13IvU2hJe8JZ3/WfuJ0B+P1FwV/bzkS5xuUocMn1iVcR8rTW+/An+ocBpg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.1.tgz",
+					"integrity": "sha512-fDp6lHVJMFCpMwZ/sbfRSGkBNbURof3Wzwl4VU39AOLm9Z1IeTWBw30jl9tQQVuNwpkgV4Dq6IzydFrrDKfbgw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.3"
+						"@fluidframework/runtime-definitions": "^0.34.1"
 					}
 				},
-				"@fluidframework/gitresources": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1018.0.tgz",
-					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
-				},
 				"@fluidframework/local-driver": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.3.tgz",
-					"integrity": "sha512-KwM0ZiSx7YO3ey9a6PonQRCC3pQ2fVTNSzPzJW9c90eYwjBoTIc0LcSTar4G1b+wEr/EKuCmFxyKPn1+HbSR2Q==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.34.1.tgz",
+					"integrity": "sha512-2HwlUnafMSMU29TBD6vco7FyDFHguK5ray6SnfVbCJA8z9ox+pqDEj1xLPmlQtTNQ38RdDCeIQ/PKqZiqArsAA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.3",
-						"@fluidframework/server-local-server": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@fluidframework/server-test-utils": "^0.1018.0",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/routerlicious-driver": "^0.34.1",
+						"@fluidframework/server-local-server": "^0.1019.0",
+						"@fluidframework/server-services-client": "^0.1019.0",
+						"@fluidframework/server-services-core": "^0.1019.0",
+						"@fluidframework/server-test-utils": "^0.1019.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"jsrsasign": "^10.0.2",
@@ -32912,85 +31463,65 @@
 					}
 				},
 				"@fluidframework/map": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.3.tgz",
-					"integrity": "sha512-K2xg59GetB2mefPTNU51nA1z+YVhSDqEkXvOsGCP0/tFzyPjPZAzHrUq8TyA4EVpKspcucqOlnA3WohDU/yNjA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.1.tgz",
+					"integrity": "sha512-VBot7Jt/CgX11h6+crHDQ1WSPbTbbdL6Ogag6b1o1jrqQoSXSZEKo6bLrwFOHMTAEqeLAN1fhjmYxCwOug5oAg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/shared-object-base": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
 					}
 				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1018.0.tgz",
-					"integrity": "sha512-mfVosXGexMiYRuz5LNNyx2stxVL3W6fLeaiYD7mxjXAopn3moy0BO6ThQrwy0uxtbq4j626yLCHxW+Gx5GRLqg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"assert": "^2.0.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1018.0.tgz",
-					"integrity": "sha512-YH3iyIOGpfS+aDBnEU0IeBFtOm9HKfkYQe1aE99aBzBm6iA4FzjprbP02Tmspt+ViqaC45SgIzOjlrhqQh0DUA==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.19.1"
-					}
-				},
 				"@fluidframework/register-collection": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.3.tgz",
-					"integrity": "sha512-eDsxcxydAFHLt8GShswm4bJKNS3mPFEajbBzw4Xy5nN6N0BHFlrBv+HQBuYAPz4EwoPeFuIaKAziJT/zCF2r3w==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.1.tgz",
+					"integrity": "sha512-EmMofoT8ErUbUDkpoF0W62wzZADbfeKfVEeFZcLFTSAVpYpr+p27D2INsLInbpVmAJ+iU8msgDcIQdAFXQfCzw==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/shared-object-base": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/request-handler": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.33.3.tgz",
-					"integrity": "sha512-9Nmb6HeQgo0tl2npX3oNNNg46ysrZ9DQBBVvhagpNFDn4Y+85N8mRbLkkmtPhbu/juST6GWaNZN/Eh+2fVSQag==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.34.1.tgz",
+					"integrity": "sha512-JdFStPKZ4H77L80Y4KFT85oHK1N/RWafkOPIlfQ6q0SkxunjjTjKHGhcpSVE5Dpv2PPZFXRD5r8/PApJivO1ew==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-runtime-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
+						"@fluidframework/container-runtime-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.3.tgz",
-					"integrity": "sha512-YKGbfZxpeAuAhTjQs3pF5nXyp9W7t/0UkerOvJfiBGRltv6i3OgIU4C7GOB25qXIWDtSKALJo80dbOuB5yFCjA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.34.1.tgz",
+					"integrity": "sha512-JOHG/IYXlftGIo+iBBag8odyQ2M1Hqs2Z/f5ijfZMq/jqZExY3g0FUp2gd5P6j+CsqJYEnX8vwsgU/Zmp2bkbA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/driver-base": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/gitresources": "^0.1019.0",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/server-services-client": "^0.1019.0",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"debug": "^4.1.1",
@@ -33002,205 +31533,67 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.3.tgz",
-					"integrity": "sha512-SE1Wqn56Fh6R8bVd3K73GGj1k2wLawPtvfHm6roYAmGGvVv3pVg6IhiRrPhcm/u39kUQJfLgwpmDrCwnheE38A==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.1.tgz",
+					"integrity": "sha512-x08OoXS18pxcOuvgalDM4L96SxBrUobTSPde5EMlIE/0TuMowfO3Og8VVxzKHzW3S9qwgLuc+d44EbbAZ1HqZw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-D1D5PXhSowtwdIm5ahM625z3dkIjt0wlkmsHFy4qvfu3Liqf6VzQTVJX8QW+u8pCE850MtO6VuwPXC61WTcMsA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-lmMNLiHapxSjDIbhzm7FVAdTsWVeU2Lrd4DzErtUS+XsDaPcZp9QSweychhAnsS8vl04gtNhH1EMF5ft70hQ0w==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/garbage-collector": "^0.33.3",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/garbage-collector": "^0.34.1",
+						"@fluidframework/protocol-base": "^0.1019.0",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
 						"assert": "^2.0.0"
 					}
 				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1018.0.tgz",
-					"integrity": "sha512-kA7VFQwaWwDmFsTntzERPbACLkZmWy2qGs9hgjH7gMyYA8IvCy9/EwaFKRzCE8wnBBRR/zN+RmgDjJQ/s7WbHQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@types/semver": "^6.0.1",
-						"async": "^2.6.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"jsonwebtoken": "^8.4.0",
-						"lodash": "^4.17.19",
-						"nconf": "^0.10.0",
-						"semver": "^6.3.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-local-server": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1018.0.tgz",
-					"integrity": "sha512-Z66H1oUvp4Fw5mdcXLeEfQ1+fSaaUIxRgJYD4AYKzVVOZy5QTPN06or2YYpMw6nMLo6V0pOZdu66bHty5ThEXg==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-lambdas": "^0.1018.0",
-						"@fluidframework/server-memory-orderer": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@fluidframework/server-test-utils": "^0.1018.0",
-						"jsrsasign": "^10.0.2",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1018.0.tgz",
-					"integrity": "sha512-qa6qmdz30EEXjx2E2ulv9fME4FSO+Dow8hCNZZhpZqI0LE1GFFcpR+ZHxL0JP8ZKid/QI2iID4giY2opJ4wrNw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-lambdas": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^12.19.0",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.19",
-						"moniker": "^0.1.2",
-						"uuid": "^8.3.1",
-						"ws": "^6.1.2"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.4",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-							"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
-						}
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1018.0.tgz",
-					"integrity": "sha512-V/+sFDHPmp0iZp9Z+H+gNGnA8r0VemgmIwkAEBVIjY7puhHAZfUwz6LbZpT9/7eWOs9Uk3ShGdsq6X5DpRODwA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@types/node": "^12.19.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.0.2",
-						"jwt-decode": "^3.0.0",
-						"sillyname": "0.1.0",
-						"uuid": "^8.3.1"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.4",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-							"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
-						},
-						"jwt-decode": {
-							"version": "3.1.2",
-							"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-							"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-						}
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1018.0.tgz",
-					"integrity": "sha512-OaNkZ8trEVB5lgSnUZg0GDKndk/E8LJaHDuqbQp9wLz4B8cDqg1XpSnv+SOjk/M4CTg+KkldsookL5zmfuf0Dw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@types/nconf": "^0.0.37",
-						"@types/node": "^12.19.0",
-						"debug": "^4.1.1",
-						"nconf": "^0.10.0"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.4",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-							"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
-						}
-					}
-				},
-				"@fluidframework/server-test-utils": {
-					"version": "0.1018.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1018.0.tgz",
-					"integrity": "sha512-YNV2LoKgVkyUokjAuYOp5s76cT+nbxfi7Y9CXsFHTnNsMEHeghbsVXX3/HJPAPYBSGCsSLAfS//CusoQ0l88iA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/gitresources": "^0.1018.0",
-						"@fluidframework/protocol-base": "^0.1018.0",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/server-services-core": "^0.1018.0",
-						"debug": "^4.1.1",
-						"lodash": "^4.17.19",
-						"string-hash": "^1.1.3",
-						"uuid": "^8.3.1"
-					}
-				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.3.tgz",
-					"integrity": "sha512-f95Dtl4rAkkUp8ns6iy/B8prFfqBnraoyJ5kaTv8zhgya6FvrKUElVAcEwzs8rr/hKV5bfDvQwobrOez+VT8eg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.1.tgz",
+					"integrity": "sha512-W4B2fuWg5fcudWVFS6Ibkxzmh2jFWiutpIoURuKY0A33WObJaGE7l7s1IS2wQQQqIkKgCLNSF/kzJT+ehwUFhw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/synthesize": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.33.3.tgz",
-					"integrity": "sha512-YJx/I6XCqrEesE+hSPkA6e5z/nXyZNHf8ArWVzUPbB1QpuA5CTtbKCvzEluuop3R14hzMpdbYKYt4HhbLL4YTQ==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.34.1.tgz",
+					"integrity": "sha512-xf64OgibYmWgxa4UA8qnDtsnKWJz4wJ42/PGsANjfcP+P4QMVU1BYOyky0GKJE2M6Nu3aSu/E2wQGqnN2MCvkw==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.3"
+						"@fluidframework/core-interfaces": "^0.34.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.3.tgz",
-					"integrity": "sha512-X9msv7QZz8fhGEmTNdhNWcSw0MSpO8ypa9qiKqYtBByKDtvXze6L4AY7BQrcCXwsb0pMLsoKRGdjzpG16QaigA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.1.tgz",
+					"integrity": "sha512-ersAPj5f42OxvarGlJNbaFn75XhfibtqVMcOjlteKWA/X9Bbfc4t2O6rnNioAIlLZC9jBgqbnRTIwYJXBqWirA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -33208,23 +31601,35 @@
 						"events": "^3.1.0"
 					}
 				},
+				"@fluidframework/test-driver-definitions": {
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.34.1.tgz",
+					"integrity": "sha512-1u7/qy09Pe/xKYFYB6TWMzvosCysyvG9LdOl+iMu7zczCsNY/rw+FWL7DCbfaKrzSOYiBVot7zqlOfnraqfxOw==",
+					"requires": {
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/server-local-server": "^0.1019.0",
+						"uuid": "^8.3.1"
+					}
+				},
 				"@fluidframework/test-runtime-utils": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.33.3.tgz",
-					"integrity": "sha512-0wDS4+X6WGbUrCQ7d84KRoPZ+XxsU912T6+rtEs2/q4Qnjl+Bodz67ukp8YzktUYYfYFHeVDTtYTsjM3zbyTvA==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.34.1.tgz",
+					"integrity": "sha512-DmtlnbX7Zz6U0unXWWV/1JvVLow7iUjWiQg0cPp5iYTNUGtnLpQzLZjOXrK/9Seju+NvTr4cY479jvQ3Y6+NMg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.3",
-						"@fluidframework/core-interfaces": "^0.33.3",
-						"@fluidframework/datastore-definitions": "^0.33.3",
-						"@fluidframework/driver-definitions": "^0.33.3",
-						"@fluidframework/driver-utils": "^0.33.3",
-						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.3",
-						"@fluidframework/runtime-definitions": "^0.33.3",
-						"@fluidframework/runtime-utils": "^0.33.3",
-						"@fluidframework/telemetry-utils": "^0.33.3",
+						"@fluidframework/container-definitions": "^0.34.1",
+						"@fluidframework/core-interfaces": "^0.34.1",
+						"@fluidframework/datastore-definitions": "^0.34.1",
+						"@fluidframework/driver-definitions": "^0.34.1",
+						"@fluidframework/driver-utils": "^0.34.1",
+						"@fluidframework/protocol-definitions": "^0.1019.0",
+						"@fluidframework/routerlicious-driver": "^0.34.1",
+						"@fluidframework/runtime-definitions": "^0.34.1",
+						"@fluidframework/runtime-utils": "^0.34.1",
+						"@fluidframework/telemetry-utils": "^0.34.1",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"jsrsasign": "^10.0.2",
@@ -33232,108 +31637,11 @@
 					}
 				},
 				"@fluidframework/view-interfaces": {
-					"version": "0.33.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.33.3.tgz",
-					"integrity": "sha512-QiikF8+dmf3BHx+mHC+p+pXr2IBfXSg7aURuVjOZMbfsX1YWrmmMh6q+hamGIbTnUnp4UhZ4X9qV6ZcwR5X3Lg==",
+					"version": "0.34.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.34.1.tgz",
+					"integrity": "sha512-DLTGrEQkhtkKVlsv2B1WJzYBmuWu16PWpqIAoAJi4aJQDgLlML6hOsQOi0DOLA2ud60dHWnWfUeduUPq7rbh+Q==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.3"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"nconf": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-					"integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
-					"requires": {
-						"async": "^1.4.0",
-						"ini": "^1.3.0",
-						"secure-keys": "^1.0.0",
-						"yargs": "^3.19.0"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-						}
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"y18n": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-					"integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-				},
-				"yargs": {
-					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"requires": {
-						"camelcase": "^2.0.1",
-						"cliui": "^3.0.3",
-						"decamelize": "^1.1.1",
-						"os-locale": "^1.4.0",
-						"string-width": "^1.0.1",
-						"window-size": "^0.1.4",
-						"y18n": "^3.2.0"
+						"@fluidframework/core-interfaces": "^0.34.1"
 					}
 				}
 			}
@@ -33494,6 +31802,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
 			"requires": {
 				"lcid": "^1.0.0"
 			}
@@ -45278,7 +43587,8 @@
 		"window-size": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+			"dev": true
 		},
 		"windows-release": {
 			"version": "3.3.0",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -27,6 +27,7 @@
     "test": "npm run test:realsvc",
     "test:realsvc": "npm run test:realsvc:local && npm run test:realsvc:tinylicious",
     "test:realsvc:local": "cross-env FLUID_TEST_DRIVER= npm run test:realsvc:run",
+    "test:realsvc:odsp": "cross-env FLUID_TEST_DRIVER=odsp FLUID_TEST_TIMEOUT=20s npm run test:realsvc:run",
     "test:realsvc:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc",
     "test:realsvc:routerlicious": "cross-env FLUID_TEST_DRIVER=routerlicious npm run test:realsvc:run",
     "test:realsvc:run": "mocha dist/test --config src/test/.mocharc.js",

--- a/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -9,13 +9,16 @@ import { IContainer } from "@fluidframework/container-definitions";
 import { taskSchedulerId } from "@fluidframework/container-runtime";
 import { IAgentScheduler } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { timeoutPromise, defaultTimeoutDurationMs } from "@fluidframework/test-utils";
 import { generateTest, ITestObjectProvider, TestDataObject } from "./compatUtils";
 import * as oldTypes from "./oldVersionTypes";
 
 const tests = (argsFactory: () => ITestObjectProvider) => {
+    let leaderTimeout = defaultTimeoutDurationMs;
     let args: ITestObjectProvider;
     beforeEach(() => {
         args = argsFactory();
+        leaderTimeout = args.driver.type === "odsp" ? 5000 : defaultTimeoutDurationMs;
     });
     afterEach(() => {
         args.reset();
@@ -36,8 +39,11 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             // tasks. Sending an op will switch it to "write" mode.
             dataObject._root.set("tempKey", "tempValue");
 
-            while (!container.deltaManager.active) {
-                await args.opProcessingController.process();
+            if (!dataObject._context.leader) {
+                // Wait until we are the leader before we proceed.
+                await timeoutPromise((res) => dataObject._context.on("leader", res), {
+                    durationMs: leaderTimeout,
+                });
             }
         });
 
@@ -47,7 +53,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         it("Can pick tasks", async () => {
             await scheduler.pick("task1", async () => { });
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler.pickedTasks(), [leader, "task1"]);
         });
 
@@ -111,8 +117,11 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick
             // tasks. Sending an op will switch it to "write" mode.
             dataObject1._root.set("tempKey1", "tempValue1");
-            while (!container1.deltaManager.active) {
-                await args.opProcessingController.process();
+            if (!dataObject1._context.leader) {
+                // Wait until we are the leader before we proceed.
+                await timeoutPromise((res) => dataObject1._context.on("leader", res), {
+                    durationMs: leaderTimeout,
+                });
             }
             // Load existing Container for the second document.
             container2 = await args.loadTestContainer();
@@ -123,9 +132,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick
             // tasks. Sending an op will switch it to "write" mode.
             dataObject2._root.set("tempKey2", "tempValue2");
-            while (!container2.deltaManager.active) {
-                await args.opProcessingController.process();
-            }
+            await args.ensureSynchronized();
         });
 
         it("No tasks initially", async () => {
@@ -136,12 +143,12 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         it("Clients agree on picking tasks sequentially", async () => {
             await scheduler1.pick("task1", async () => { });
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks(), [leader, "task1"]);
             assert.deepStrictEqual(scheduler2.pickedTasks(), []);
             await scheduler2.pick("task2", async () => { });
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks(), [leader, "task1"]);
             assert.deepStrictEqual(scheduler2.pickedTasks(), ["task2"]);
         });
@@ -154,7 +161,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             await scheduler2.pick("task3", async () => { });
             await scheduler2.pick("task4", async () => { });
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks(), [leader, "task1", "task2", "task3"]);
             assert.deepStrictEqual(scheduler2.pickedTasks(), ["task4"]);
         });
@@ -170,7 +177,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             await scheduler2.pick("task5", async () => { });
             await scheduler2.pick("task6", async () => { });
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks(), [leader, "task1", "task2", "task5"]);
             assert.deepStrictEqual(scheduler2.pickedTasks(), ["task4", "task6"]);
         });
@@ -186,7 +193,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             await scheduler2.pick("task5", async () => { });
             await scheduler2.pick("task6", async () => { });
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             await scheduler1.release("task4").catch((err) => {
                 assert.deepStrictEqual(err.message, "task4 was never picked");
             });
@@ -209,15 +216,15 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             await scheduler2.pick("task5", async () => { });
             await scheduler2.pick("task6", async () => { });
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks(), [leader, "task1", "task2", "task5"]);
             assert.deepStrictEqual(scheduler2.pickedTasks(), ["task4", "task6"]);
             await scheduler1.release("task2", "task1", "task5");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks(), [leader]);
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler2.pickedTasks().sort(), ["task1", "task2", "task4", "task5", "task6"]);
             await scheduler1.pick("task1", async () => { });
             await scheduler1.pick("task2", async () => { });
@@ -225,7 +232,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             await scheduler1.pick("task6", async () => { });
             await scheduler2.release("task2", "task1", "task4", "task5", "task6");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks().sort(),
                 [leader, "task1", "task2", "task4", "task5", "task6"]);
         });
@@ -233,7 +240,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         it("Releasing leadership should automatically elect a new leader", async () => {
             await scheduler1.release(leader);
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.deepStrictEqual(scheduler1.pickedTasks(), []);
             assert.deepStrictEqual(scheduler2.pickedTasks(), [leader]);
         });

--- a/packages/test/end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/batching.spec.ts
@@ -99,7 +99,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         dataObject2map2 = await dataObject2.getSharedObject<SharedMap>(map2Id);
 
         await waitForCleanContainers(dataObject1, dataObject2);
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
     });
 
     describe("Local ops batch metadata verification", () => {
@@ -122,7 +122,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -139,7 +139,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 1, "Incorrect number of messages received on local client");
@@ -166,7 +166,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -191,7 +191,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 0, "Incorrect number of messages received on local client");
@@ -216,7 +216,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 });
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -243,7 +243,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 (dataObject1.context.containerRuntime as IContainerRuntime).flush();
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 4, "Incorrect number of messages received on local client");
@@ -264,7 +264,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 dataObject2.context.containerRuntime.setFlushMode(FlushMode.Automatic);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 1, "Incorrect number of messages received on local client");
@@ -309,7 +309,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 dataObject2.context.containerRuntime.setFlushMode(FlushMode.Automatic);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(
                     dataObject1BatchMessages.length, 6, "Incorrect number of messages received on local client");
@@ -356,7 +356,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -374,7 +374,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -396,7 +396,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Check that the document dirty state is cleaned after the ops are processed.
                 // Verify that the document dirty state is cleaned after the ops are processed.
@@ -425,7 +425,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -443,7 +443,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -462,7 +462,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);
@@ -483,7 +483,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Check that the document dirty state is cleaned after the ops are processed.
                 // Verify that the document dirty state is cleaned after the ops are processed.
@@ -514,7 +514,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 verifyDocumentDirtyState(dataObject1, true);
 
                 // Wait for the ops to get processed by both the containers.
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
                 verifyDocumentDirtyState(dataObject1, false);

--- a/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -61,7 +61,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Set a starting value in the cell
         sharedCell1.set(initialCellValue);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
     });
 
     function verifyCellValue(cell: ISharedCell, expectedValue, index: number) {
@@ -100,7 +100,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     it("can set and get cell data in 3 containers correctly", async () => {
         sharedCell2.set(newCellValue);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         verifyCellValues(newCellValue, newCellValue, newCellValue);
     });
@@ -108,7 +108,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     it("can delete cell data in 3 containers correctly", async () => {
         sharedCell3.delete();
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         verifyCellEmpty(true, true, true);
     });
@@ -134,7 +134,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         sharedCell1.set(newCellValue);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         assert.equal(user1ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 1");
         assert.equal(user2ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 2");
@@ -151,7 +151,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         verifyCellValues("value1", "value2", "value3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         verifyCellValues("value3", "value3", "value3");
     });
@@ -164,7 +164,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         verifyCellValues("value1.1", undefined, "value1.3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         verifyCellValues("value1.3", "value1.3", "value1.3");
     });
@@ -181,7 +181,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         sharedCell2.set("value2.2");
         verifyCellValues("value2.1", "value2.2", "value2.3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         verifyCellValues("value2.2", "value2.2", "value2.2");
     });
@@ -195,7 +195,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         verifyCellValues("value3.1", "value3.2", undefined);
         verifyCellEmpty(false, false, true);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         verifyCellValues(undefined, undefined, undefined);
         verifyCellEmpty(true, true, true);
@@ -209,7 +209,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         detachedCell1.set(detachedCell2.handle);
         sharedCell1.set(detachedCell1.handle);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         async function getCellDataStore(cellP: Promise<ISharedCell>): Promise<ISharedCell> {
             const cell = await cellP;

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -9,6 +9,7 @@ import {
     ILoader,
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
@@ -38,9 +39,13 @@ export interface ITestObjectProvider {
     urlResolver: IUrlResolver | oldTypes.IUrlResolver,
     defaultCodeDetails: IFluidCodeDetails | oldTypes.IFluidCodeDetails,
     opProcessingController: OpProcessingController | oldTypes.OpProcessingController,
+
+    ensureSynchronized(): Promise<void>;
     reset(): void,
+
     documentId: string,
     driver: ITestDriver;
+
 }
 
 export interface ITestOptions {
@@ -122,6 +127,7 @@ export const generateNonCompatTest = (
             );
             const driver = getFluidTestDriver();
             return new TestObjectProvider(
+                Loader,
                 driver as any,
                 runtimeFactory,
             );
@@ -136,7 +142,7 @@ export const generateCompatTest = (
     // Run against all currently supported versions by default
     const oldApis = options.oldApis ?? [old, old2];
     oldApis.forEach((oldApi: oldTypes.OldApi) => {
-        describe("compat - old loader, new runtime", function() {
+        describe(`compat ${oldApi.versionString} - old loader, new runtime`, function() {
             tests(() => {
                 const driver = getFluidTestDriver();
                 return oldApi.createTestObjectProvider(
@@ -150,7 +156,7 @@ export const generateCompatTest = (
             }, oldApi);
         });
 
-        describe("compat - new loader, old runtime", function() {
+        describe(`compat ${oldApi.versionString} - new loader, old runtime`, function() {
             tests(() => {
                 const driver = getFluidTestDriver();
                 return oldApi.createTestObjectProvider(
@@ -164,7 +170,7 @@ export const generateCompatTest = (
             }, oldApi);
         });
 
-        describe("compat - new ContainerRuntime, old DataStoreRuntime", function() {
+        describe(`compat ${oldApi.versionString} - new ContainerRuntime, old DataStoreRuntime`, function() {
             tests(() => {
                 const driver = getFluidTestDriver();
                 return oldApi.createTestObjectProvider(
@@ -178,7 +184,7 @@ export const generateCompatTest = (
             }, oldApi);
         });
 
-        describe("compat - old ContainerRuntime, new DataStoreRuntime", function() {
+        describe(`compat ${oldApi.versionString} - old ContainerRuntime, new DataStoreRuntime`, function() {
             tests(() => {
                 const driver = getFluidTestDriver();
                 return oldApi.createTestObjectProvider(

--- a/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -124,7 +124,7 @@ function generate(
             for (const item of input) {
                 addP.push(collection1.add(item));
             }
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             await Promise.all(addP);
 
             const removeP1 = acquireAndComplete(collection3);
@@ -138,7 +138,7 @@ function generate(
             const removeEmptyP = acquireAndComplete(collection1);
 
             // Now process all the incoming and outgoing
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             // Verify the value is in the correct order
             assert.strictEqual(await removeP1, output[0], "Unexpected value in document 1");
@@ -163,7 +163,7 @@ function generate(
             await args.opProcessingController.pauseProcessing();
 
             const waitOn2P = waitAcquireAndComplete(collection2);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             let added = false;
             waitOn2P.then(
                 (value) => {
@@ -187,18 +187,18 @@ function generate(
             added = true;
 
             // Now process the incoming
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             await Promise.all([addP1, addP2, addP3]);
             assert.strictEqual(await waitOn2P, output[0],
                 "Unexpected wait before add resolved value in document 2 added in document 1");
 
             const waitOn1P = waitAcquireAndComplete(collection1);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.strictEqual(await waitOn1P, output[1],
                 "Unexpected wait after add resolved value in document 1 added in document 3");
 
             const waitOn3P = waitAcquireAndComplete(collection3);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assert.strictEqual(await waitOn3P, output[2],
                 "Unexpected wait after add resolved value in document 13added in document 2");
         });
@@ -339,7 +339,7 @@ function generate(
             const removeEmptyP = acquireAndComplete(collection1);
 
             // Now process all
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             await Promise.all(p);
             assert.strictEqual(await removeEmptyP, undefined, "Remove of empty collection should be undefined");
             assert.strictEqual(addCount1, 3, "Incorrect number add events in document 1");

--- a/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -114,7 +114,7 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
             const write2P = collection2.write("key1", "value2");
             const write3P = collection3.write("key1", "value3");
             await Promise.all([write1P, write2P, write3P]);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             const versions = collection1.readVersions("key1");
             assert(versions);
             assert.strictEqual(versions.length, 3, "Concurrent updates were not preserved");
@@ -144,28 +144,28 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
             const write2P = collection2.write("key1", "value2");
             const write3P = collection3.write("key1", "value3");
             await Promise.all([write1P, write2P, write3P]);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             const versions = collection1.readVersions("key1");
             assert(versions);
             assert.strictEqual(versions.length, 3, "Concurrent updates were not preserved");
 
             await collection3.write("key1", "value4");
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             const versions2 = collection1.readVersions("key1");
             assert(versions2);
             assert.strictEqual(versions2.length, 1, "Happened after value did not overwrite");
             assert.strictEqual(versions2[0], "value4", "Happened after value did not overwrite");
 
             await collection2.write("key1", "value5");
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             const versions3 = collection1.readVersions("key1");
             assert(versions3);
             assert.strictEqual(versions3.length, 1, "Happened after value did not overwrite");
             assert.strictEqual(versions3[0], "value5", "Happened after value did not overwrite");
 
             await collection1.write("key1", "value6");
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             const versions4 = collection1.readVersions("key1");
             assert(versions4);
             assert.strictEqual(versions4.length, 1, "Happened after value did not overwrite");
@@ -175,7 +175,7 @@ function generate(name: string, ctor: ISharedObjectConstructor<IConsensusRegiste
             const write8P = collection2.write("key1", "value8");
             const write9P = collection3.write("key1", "value9");
             await Promise.all([write7P, write8P, write9P]);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             const versions5 = collection3.readVersions("key1");
             assert(versions5);
             assert.strictEqual(versions5.length, 3, "Concurrent happened after updates should overwrite and preserve");

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -206,6 +206,7 @@ describe("Container", () => {
             createPrimedDataStoreFactory());
 
         const localTestObjectProvider = new TestObjectProvider(
+            Loader,
             driver,
             runtimeFactory);
 

--- a/packages/test/end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -53,7 +53,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         const dataStore3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedCounter3 = await dataStore3.getSharedObject<SharedCounter>(counterId);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
     });
 
     function verifyCounterValue(counter: ISharedCounter, expectedValue, index: number) {
@@ -85,10 +85,10 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         it("can increment and decrement the value in 3 containers correctly", async () => {
             sharedCounter2.increment(7);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             verifyCounterValues(7, 7, 7);
             sharedCounter3.increment(-20);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             verifyCounterValues(-13, -13, -13);
         });
 
@@ -132,7 +132,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 // do the increment
                 incrementer.increment(incrementAmount);
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // event count is correct
                 assert.equal(eventCount1, expectedEventCount);

--- a/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -56,7 +56,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
         sharedDirectory3 = await dataObject3.getSharedObject<SharedDirectory>(directoryId);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
     });
 
     function expectAllValues(msg, key, path, value1, value2, value3) {
@@ -107,7 +107,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         it("should set a key in the directory in three containers correctly", async () => {
             sharedDirectory1.set("testKey1", "testValue1");
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             expectAllAfterValues("testKey1", "/", "testValue1");
         });
     });
@@ -115,13 +115,13 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     describe("Root operations", () => {
         beforeEach("Populate with a value under the root", async () => {
             sharedDirectory1.set("testKey1", "testValue1");
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             expectAllAfterValues("testKey1", "/", "testValue1");
         });
 
         it("should delete a value in 3 containers correctly", async () => {
             sharedDirectory2.delete("testKey1");
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             const hasKey1 = sharedDirectory1.has("testKey1");
             assert.equal(hasKey1, false, "testKey1 not deleted in container 1");
@@ -136,7 +136,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         it("should have the correct size in three containers", async () => {
             sharedDirectory3.set("testKey3", true);
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             // check the number of keys in the map (2 keys set)
             expectAllSize(2);
@@ -146,7 +146,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             sharedDirectory2.set("testKey1", undefined);
             sharedDirectory2.set("testKey2", undefined);
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             expectAllAfterValues("testKey1", "/", undefined);
             expectAllAfterValues("testKey2", "/", undefined);
@@ -186,7 +186,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
             sharedDirectory1.set("testKey1", "updatedValue");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             assert.equal(user1ValueChangedCount, 0, "Incorrect number of valueChanged op received in container 1");
             assert.equal(user2ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 2");
@@ -204,7 +204,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/", "value1", "value2", "value3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey1", "/", "value3");
             });
@@ -217,7 +217,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/", "value1.1", undefined, "value1.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey1", "/", "value1.3");
             });
@@ -235,7 +235,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 expectAllBeforeValues("testKey2", "/", "value2.1", "value2.2", "value2.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey2", "/", "value2.2");
             });
@@ -248,7 +248,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 expectAllBeforeValues("testKey3", "/", "value3.1", "value3.2", undefined);
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey3", "/", undefined);
             });
@@ -263,7 +263,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 assert.equal(sharedDirectory3.size, 0, "Incorrect map size after clear");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey1", "/", undefined);
                 expectAllSize(0);
@@ -281,7 +281,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 sharedDirectory2.set("testKey2", "value2.2");
                 expectAllBeforeValues("testKey2", "/", "value2.1", "value2.2", "value2.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey2", "/", "value2.2");
                 expectAllSize(1);
@@ -294,7 +294,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 sharedDirectory3.set("testKey3", "value3.3");
                 expectAllBeforeValues("testKey3", "/", "value3.1", undefined, "value3.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey3", "/", "value3.3");
                 expectAllSize(1);
@@ -306,7 +306,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 const newMap = SharedMap.create(dataObject1.runtime);
                 sharedDirectory1.set("mapKey", newMap.handle);
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 const [map1, map2, map3] = await Promise.all([
                     sharedDirectory1.get<IFluidHandle<ISharedMap>>("mapKey")?.get(),
@@ -320,7 +320,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 map2.set("testMapKey", "testMapValue");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 assert.equal(map3.get("testMapKey"), "testMapValue", "Wrong values in map in container 3");
             });
@@ -331,7 +331,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         it("should set a key in a SubDirectory in three containers correctly", async () => {
             sharedDirectory1.createSubDirectory("testSubDir1").set("testKey1", "testValue1");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             expectAllAfterValues("testKey1", "testSubDir1", "testValue1");
         });
@@ -339,14 +339,14 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         it("should delete a key in a SubDirectory in three containers correctly", async () => {
             sharedDirectory2.createSubDirectory("testSubDir1").set("testKey1", "testValue1");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             expectAllAfterValues("testKey1", "testSubDir1", "testValue1");
             const subDir1 = sharedDirectory3.getWorkingDirectory("testSubDir1");
             assert(subDir1);
             subDir1.delete("testKey1");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             expectAllAfterValues("testKey1", "testSubDir1", undefined);
         });
@@ -354,12 +354,12 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         it("should delete a child SubDirectory in a SubDirectory in three containers correctly", async () => {
             sharedDirectory2.createSubDirectory("testSubDir1").set("testKey1", "testValue1");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             expectAllAfterValues("testKey1", "testSubDir1", "testValue1");
             sharedDirectory3.deleteSubDirectory("testSubDir1");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             assert.equal(
                 sharedDirectory1.getWorkingDirectory("testSubDir1"),
@@ -380,12 +380,12 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             sharedDirectory2.createSubDirectory("testSubDir1").set("testKey2", "testValue2");
             sharedDirectory3.createSubDirectory("otherSubDir2").set("testKey3", "testValue3");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             expectAllSize(2, "testSubDir1");
             sharedDirectory3.getWorkingDirectory("testSubDir1")?.clear();
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             expectAllSize(0, "testSubDir1");
         });
@@ -427,7 +427,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
             sharedDirectory1.createSubDirectory("testSubDir1").set("testKey1", "updatedValue");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             assert.equal(user1ValueChangedCount, 0, "Incorrect number of valueChanged op received in container 1");
             assert.equal(user2ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 2");
@@ -443,7 +443,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             beforeEach(async () => {
                 sharedDirectory1.createSubDirectory("testSubDir").set("dummyKey", "dummyValue");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 root1SubDir = sharedDirectory1.getWorkingDirectory("testSubDir");
                 root2SubDir = sharedDirectory2.getWorkingDirectory("testSubDir");
@@ -458,7 +458,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1", "value2", "value3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey1", "/testSubDir", "value3");
             });
@@ -471,7 +471,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1.1", undefined, "value1.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey1", "/testSubDir", "value1.3");
             });
@@ -488,7 +488,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 root2SubDir.set("testKey2", "value2.2");
                 expectAllBeforeValues("testKey2", "/testSubDir", "value2.1", "value2.2", "value2.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey2", "/testSubDir", "value2.2");
             });
@@ -501,7 +501,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
                 expectAllBeforeValues("testKey3", "/testSubDir", "value3.1", "value3.2", undefined);
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey3", "/testSubDir", undefined);
             });
@@ -514,7 +514,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1.1", "value1.2", undefined);
                 assert.equal(root3SubDir.size, 0, "Incorrect map size after clear");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey1", "/testSubDir", undefined);
                 expectAllSize(0, "/testSubDir");
@@ -532,7 +532,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 root2SubDir.set("testKey2", "value2.2");
                 expectAllBeforeValues("testKey2", "/testSubDir", "value2.1", "value2.2", "value2.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey2", "/testSubDir", "value2.2");
                 expectAllSize(1, "/testSubDir");
@@ -545,7 +545,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 root3SubDir.set("testKey3", "value3.3");
                 expectAllBeforeValues("testKey3", "/testSubDir", "value3.1", undefined, "value3.3");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 expectAllAfterValues("testKey3", "/testSubDir", "value3.3");
                 expectAllSize(1, "/testSubDir");
@@ -578,7 +578,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 // Now add the handle to an attached directory so the new directory gets attached too.
                 sharedDirectory1.set("newSharedDirectory", newDirectory1.handle);
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // The new directory should be available in the remote client and it should contain that key that was
                 // set in local state.
@@ -593,7 +593,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 // Set a new value for the same key in the remote directory.
                 newDirectory2.set("newKey", "anotherNewValue");
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the new value is updated in both the directories.
                 assert.equal(
@@ -617,7 +617,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 // Now add the handle to an attached directory so the new directory gets attached too.
                 sharedDirectory1.set("newSharedDirectory", newDirectory1.handle);
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // The new directory should be available in the remote client and it should contain that key that was
                 // set in local state.
@@ -631,7 +631,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                 // Delete the sub directory from the remote client.
                 newDirectory2.deleteSubDirectory(subDirName);
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
 
                 // Verify that the sub directory is deleted from both the directories.
                 assert.equal(

--- a/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -41,7 +41,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         const secondContainer = await args.loadTestContainer();
         secondContainerObject1 = await requestFluidObject<TestDataObject>(secondContainer, "default");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
     });
 
     it("should generate the absolute path for ContainerRuntime correctly", () => {
@@ -90,7 +90,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Add the handle to the root DDS of `firstContainerObject1`.
         firstContainerObject1._root.set("sharedMap", sharedMapHandle);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         // Get the handle in the remote client.
         const remoteSharedMapHandle = secondContainerObject1._root.get<IFluidHandle<SharedMap>>("sharedMap");
@@ -121,7 +121,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Add the handle to the root DDS of `firstContainerObject1` so that the FluidDataObjectRuntime is different.
         firstContainerObject1._root.set("sharedMap", sharedMap.handle);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         // Get the handle in the remote client.
         const remoteSharedMapHandle = secondContainerObject1._root.get<IFluidHandle<SharedMap>>("sharedMap");
@@ -149,7 +149,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // FluidDataObjectRuntime is different.
         firstContainerObject1._root.set("dataObject2", firstContainerObject2.handle);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         // Get the handle in the remote client.
         const remoteDataObjectHandle =

--- a/packages/test/end-to-end-tests/src/test/leader.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/leader.spec.ts
@@ -41,7 +41,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         const container2 = await args.loadTestContainer() as Container;
         await ensureConnected(container2);
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
 
         // Currently, we load a container in write mode from the start. See issue #3304.
@@ -79,7 +79,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         // write something to get out of view only mode and take leadership
         dataObject1.root.set("blah", "blah");
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         checkExpected(config);
         assert(dataObject1.context.leader);
@@ -88,13 +88,13 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     it("force read only", async () => {
         // write something to get out of view only mode and take leadership
         dataObject1.root.set("blah", "blah");
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         const config = { dataObject: dataObject1, name: "dataObject1", leader: false, notleader: true };
         setupListener(config);
 
         container1.forceReadonly(true);
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         checkExpected(config);
         assert(!dataObject1.context.leader);
@@ -105,7 +105,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         dataObject1.root.set("blah", "blah");
 
         // Make sure we reconnect as a writer and processed the op
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         const container2 = await args.loadTestContainer() as Container;
         const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
@@ -113,7 +113,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Currently, we load a container in write mode from the start. See issue #3304.
         // Once that is fix, this needs to change
         await ensureConnected(container2);
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         assert(dataObject1.context.leader);
         assert(!dataObject2.context.leader);
@@ -125,7 +125,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         container1.close();
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         checkExpected(config1);
         checkExpected(config2);
@@ -136,7 +136,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     it("Concurrent update", async () => {
         // write something to get out of view only mode and take leadership
         dataObject1.root.set("blah", "blah");
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
         assert(dataObject1.context.leader);
 
         const container2 = await args.loadTestContainer() as Container;
@@ -148,7 +148,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Currently, we load a container in write mode from the start. See issue #3304.
         // Once that is fix, this needs to change
         await Promise.all([ensureConnected(container2), ensureConnected(container3)]);
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         assert(dataObject1.context.leader);
         assert(!dataObject2.context.leader);
@@ -174,7 +174,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         config2.leader = true;
         config3.leader = true;
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
         assert((dataObject2.context.leader || dataObject3.context.leader) &&
             (!dataObject2.context.leader || !dataObject3.context.leader),
             "only one container should be the leader");

--- a/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -56,7 +56,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         sharedMap1.set("testKey1", "testValue");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
     });
 
     function expectAllValues(msg, key, value1, value2, value3) {
@@ -97,7 +97,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         sharedMap2.set("testKey1", undefined);
         sharedMap2.set("testKey2", undefined);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey1", undefined);
         expectAllAfterValues("testKey2", undefined);
@@ -106,7 +106,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     it("Should delete values in 3 containers correctly", async () => {
         sharedMap2.delete("testKey1");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         const hasKey1 = sharedMap1.has("testKey1");
         assert.equal(hasKey1, false, "testKey1 not deleted in container 1");
@@ -121,7 +121,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     it("Should check if three containers has same number of keys", async () => {
         sharedMap3.set("testKey3", true);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllSize(2);
     });
@@ -160,7 +160,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         sharedMap1.set("testKey1", "updatedValue");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         assert.equal(user1ValueChangedCount, 0, "Incorrect number of valueChanged op received in container 1");
         assert.equal(user2ValueChangedCount, 1, "Incorrect number of valueChanged op received in container 2");
@@ -177,7 +177,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         expectAllBeforeValues("testKey1", "value1", "value2", "value3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey1", "value3");
     });
@@ -190,7 +190,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         expectAllBeforeValues("testKey1", "value1.1", undefined, "value1.3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey1", "value1.3");
     });
@@ -207,7 +207,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         sharedMap2.set("testKey2", "value2.2");
         expectAllBeforeValues("testKey2", "value2.1", "value2.2", "value2.3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey2", "value2.2");
     });
@@ -220,7 +220,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         expectAllBeforeValues("testKey3", "value3.1", "value3.2", undefined);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey3", undefined);
     });
@@ -233,7 +233,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         expectAllBeforeValues("testKey1", "value1.1", "value1.2", undefined);
         assert.equal(sharedMap3.size, 0, "Incorrect map size after clear");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey1", undefined);
         expectAllSize(0);
@@ -251,7 +251,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         sharedMap2.set("testKey2", "value2.2");
         expectAllBeforeValues("testKey2", "value2.1", "value2.2", "value2.3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey2", "value2.2");
         expectAllSize(1);
@@ -264,7 +264,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         sharedMap3.set("testKey3", "value3.3");
         expectAllBeforeValues("testKey3", "value3.1", undefined, "value3.3");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         expectAllAfterValues("testKey3", "value3.3");
         expectAllSize(1);
@@ -292,7 +292,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Now add the handle to an attached map so the new map gets attached too.
         sharedMap1.set("newSharedMap", newSharedMap1.handle);
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         // The new map should be available in the remote client and it should contain that key that was
         // set in local state.
@@ -303,7 +303,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // Set a new value for the same key in the remote map.
         newSharedMap2.set("newKey", "anotherNewValue");
 
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         // Verify that the new value is updated in both the maps.
         assert.equal(newSharedMap2.get("newKey"), "anotherNewValue", "The new value is not updated in map 2");

--- a/packages/test/end-to-end-tests/src/test/oldVersion2.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion2.ts
@@ -9,6 +9,7 @@ export { IDocumentServiceFactory, IUrlResolver } from "old-driver-definitions2";
 export { LocalResolver } from "old-local-driver2";
 export { IFluidDataStoreFactory } from "old-runtime-definitions2";
 export { OpProcessingController } from "old-test-utils2";
+export const versionString = "N-2";
 
 import {
     ContainerRuntimeFactoryWithDefaultDataStore,
@@ -19,12 +20,9 @@ import { SharedCell } from "old-cell2";
 import { IRuntimeFactory } from "old-container-definitions2";
 import { Loader } from "old-container-loader2";
 import { IContainerRuntimeOptions } from "old-container-runtime2";
-import { IFluidCodeDetails } from "old-core-interfaces2";
 import { SharedCounter } from "old-counter2";
 import { IChannelFactory } from "old-datastore-definitions2";
-import { IDocumentServiceFactory } from "old-driver-definitions2";
 import { Ink } from "old-ink2";
-import { LocalDocumentServiceFactory, LocalResolver } from "old-local-driver2";
 import { SharedDirectory, SharedMap } from "old-map2";
 import { SharedMatrix } from "old-matrix2";
 import { ConsensusQueue } from "old-ordered-collection2";
@@ -33,14 +31,10 @@ import { IFluidDataStoreFactory } from "old-runtime-definitions2";
 import { SharedString, SparseMatrix } from "old-sequence2";
 import {
     ChannelFactoryRegistry,
-    fluidEntryPoint,
-    LocalCodeLoader,
-    OpProcessingController,
     TestContainerRuntimeFactory,
     TestFluidObjectFactory,
 } from "old-test-utils2";
 
-import { v4 as uuid } from "uuid";
 import {
     createRuntimeFactory,
     DataObjectFactoryType,
@@ -51,152 +45,6 @@ import {
     V2,
 } from "./compatUtils";
 import * as newVer from "./newVersion";
-
-const defaultCodeDetails: IFluidCodeDetails = {
-    package: "defaultTestPackage",
-    config: {},
-};
-
-/**
- * @deprecated - remove once 0.34 is released. see oldVersion for necessary changes
- */
-export class LocalTestObjectProvider<TestContainerConfigType> {
-    private _documentServiceFactory: IDocumentServiceFactory | undefined;
-    private _defaultUrlResolver: LocalResolver | undefined;
-    private _opProcessingController: OpProcessingController | undefined;
-    private _documentId?: string;
-
-    /**
-     * Create a set of object to
-     * @param createFluidEntryPoint - callback to create a fluidEntryPoint, with an optiona; set of channel name
-     * and factory for TestFluidObject
-     * @param serviceConfiguration - optional serviceConfiguration to create the LocalDeltaConnectionServer with
-     * @param _deltaConnectionServer - optional deltaConnectionServer to share documents between different provider
-     */
-    constructor(
-        private readonly createFluidEntryPoint: (testContainerConfig?: TestContainerConfigType) => fluidEntryPoint,
-        private readonly serviceConfiguration?: Partial<newVer.IClientConfiguration>,
-        private _deltaConnectionServer?: newVer.ILocalDeltaConnectionServer | undefined,
-    ) {
-
-    }
-
-    readonly driver: newVer.ITestDriver = {
-        type: "local",
-        version: "0.33.0",
-        createContainerUrl: async (testId)=>`http://localhost${testId}`,
-        createCreateNewRequest: (testId)=>this.urlResolver.createCreateNewRequest(testId),
-        createDocumentServiceFactory: ()=>this.documentServiceFactory as any as newVer.IDocumentServiceFactory,
-        createUrlResolver: ()=>this.urlResolver,
-    };
-
-    get defaultCodeDetails() {
-        return defaultCodeDetails;
-    }
-
-    get deltaConnectionServer() {
-        if (!this._deltaConnectionServer) {
-            this._deltaConnectionServer = newVer.LocalDeltaConnectionServer.create(
-                undefined,
-                this.serviceConfiguration,
-            );
-        }
-        return this._deltaConnectionServer;
-    }
-
-    get documentServiceFactory() {
-        if (!this._documentServiceFactory) {
-            this._documentServiceFactory = new LocalDocumentServiceFactory(this.deltaConnectionServer as any);
-        }
-        return this._documentServiceFactory;
-    }
-
-    get urlResolver() {
-        if (!this._defaultUrlResolver) {
-            this._defaultUrlResolver = new LocalResolver();
-        }
-        return this._defaultUrlResolver;
-    }
-
-    get opProcessingController() {
-        if (!this._opProcessingController) {
-            this._opProcessingController = new OpProcessingController(this.deltaConnectionServer as any);
-        }
-        return this._opProcessingController;
-    }
-
-    get documentId(): string {
-        if(this._documentId === undefined) {
-            this._documentId = uuid();
-        }
-        return this._documentId;
-    }
-
-    private createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>) {
-        const codeLoader = new LocalCodeLoader(packageEntries);
-        return new Loader({
-            urlResolver: this.urlResolver,
-            documentServiceFactory: this.documentServiceFactory,
-            codeLoader,
-        });
-    }
-
-    /**
-     * Make a test loader
-     * @param testContainerConfig - optional configuring the test Container
-     */
-    public makeTestLoader(testContainerConfig?: TestContainerConfigType) {
-        return this.createLoader([[defaultCodeDetails, this.createFluidEntryPoint(testContainerConfig)]]);
-    }
-
-    /**
-     * Make a container using a default document id and code details
-     * @param testContainerConfig - optional configuring the test Container
-     */
-    public async makeTestContainer(testContainerConfig?: TestContainerConfigType) {
-        const loader = this.makeTestLoader(testContainerConfig);
-        const container =
-            await newVer.createAndAttachContainer(
-                defaultCodeDetails,
-                loader as any,
-                this.urlResolver.createCreateNewRequest(this.documentId));
-
-        // TODO: the old version delta manager on the container doesn't do pause/resume count
-        // We can't use it to do pause/resume, or it will conflict with the call from the runtime's
-        // DeltaManagerProxy. Reach in to get in until > 0.28
-        const deltaManagerProxy = (container as any)._context.deltaManager;
-        this.opProcessingController.addDeltaManagers(deltaManagerProxy);
-        return container;
-    }
-
-    /**
-     * Load a container using a default document id and code details
-     * @param testContainerConfig - optional configuring the test Container
-     */
-    public async loadTestContainer(testContainerConfig?: TestContainerConfigType) {
-        const loader = this.makeTestLoader(testContainerConfig);
-        const container = await loader.resolve({ url: `http://localhost/${this.documentId}` });
-
-        // TODO: the old version delta manager on the container doesn't do pause/resume count
-        // We can't use it to do pause/resume, or it will conflict with the call from the runtime's
-        // DeltaManagerProxy. Reach in to get in until > 0.28
-        const deltaManagerProxy = (container as any)._context.deltaManager;
-        this.opProcessingController.addDeltaManagers(deltaManagerProxy);
-        return container;
-    }
-
-    /**
-     * Close out the DeltaConnectionServer and clear all the document and reset to original state.
-     * The object can continue to be used afterwards
-     */
-    public async reset() {
-        await this._deltaConnectionServer?.webSocketServer.close();
-        this._deltaConnectionServer = undefined;
-        this._documentServiceFactory = undefined;
-        this._opProcessingController = undefined;
-        this._documentId = undefined;
-    }
-}
 
 // A simple old-version dataStore with runtime/root exposed for testing
 // purposes. Used to test compatibility of context reload between
@@ -312,16 +160,12 @@ export function createTestObjectProvider(
             : createRuntimeFactory(type, dataStoreFactory, containerOptions?.runtimeOptions);
     };
 
-    // back-compat: 0.33 begins using TestObjectProvider instead of LocalTestObjectProvider
-    // Once this file references 0.33, oldLoader should create a TestObjectProvider instead
-    if (oldLoader) {
-        return new LocalTestObjectProvider(
-            containerFactoryFn as () => IRuntimeFactory, serviceConfiguration);
-    } else {
-        if (driver === undefined) {
-            throw new Error("Must provide a driver when using the current loader");
-        }
-        return new newVer.TestObjectProvider(
-            driver, containerFactoryFn as () => newVer.IRuntimeFactory);
+    if (driver === undefined) {
+        throw new Error("Must provide a driver when using the current loader");
     }
+
+    return new newVer.TestObjectProvider(
+        oldLoader ? Loader as unknown as typeof newVer.Loader : newVer.Loader,
+        driver,
+        containerFactoryFn as () => newVer.IRuntimeFactory);
 }

--- a/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -178,7 +178,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
                     assertIntervals([{ start: 0, end: 2 }]);
                 }
 
-                await args.opProcessingController.process();
+                await args.ensureSynchronized();
             }
         });
     });
@@ -206,7 +206,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             const container2 = await args.loadTestContainer(testContainerConfig);
             const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
             const intervals2 = await sharedString2.getIntervalCollection("intervals").getView();
@@ -218,7 +218,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             sharedString2.insertText(4, "x");
             assertIntervalsHelper(sharedString2, intervals2, [{ start: 1, end: 7 }]);
 
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
             assertIntervalsHelper(sharedString1, intervals1, [{ start: 1, end: 7 }]);
         });
     });
@@ -261,7 +261,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         // This functionality is used in Word and FlowView's "add comment" functionality.
         it("Can store shared objects in a shared string's interval collection via properties", async () => {
             sharedMap1.set("outerString", SharedString.create(dataObject1.runtime).handle);
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             const outerString1 = await sharedMap1.get<IFluidHandle<SharedString>>("outerString")?.get();
             const outerString2 = await sharedMap2.get<IFluidHandle<SharedString>>("outerString")?.get();
@@ -273,7 +273,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             outerString1.insertText(0, "outer string");
 
             const intervalCollection1 = outerString1.getIntervalCollection("comments");
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             const intervalCollection2 = outerString2.getIntervalCollection("comments");
             const intervalCollection3 = outerString3.getIntervalCollection("comments");
@@ -290,7 +290,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             const nestedMap = SharedMap.create(dataObject1.runtime);
             nestedMap.set("nestedKey", "nestedValue");
             intervalCollection1.add(8, 9, IntervalType.SlideOnRemove, { story: nestedMap.handle });
-            await args.opProcessingController.process();
+            await args.ensureSynchronized();
 
             const serialized1 = intervalCollection1.serializeInternal();
             const serialized2 = intervalCollection2.serializeInternal();

--- a/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -53,7 +53,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         assert.equal(sharedString1.getText(), text, "The retrieved text should match the inserted text.");
 
         // Wait for the ops to to be submitted and processed across the containers.
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         assert.equal(sharedString2.getText(), text, "The inserted text should have synced across the containers");
     });
@@ -64,7 +64,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         assert.equal(sharedString1.getText(), text, "The retrieved text should match the inserted text.");
 
         // Wait for the ops to to be submitted and processed across the containers.
-        await args.opProcessingController.process();
+        await args.ensureSynchronized();
 
         // Create a initialize a new container with the same id.
         const newContainer = await args.loadTestContainer(testContainerConfig) as Container;

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -36,11 +36,13 @@ export class TestObjectProvider<TestContainerConfigType> {
      * and factory for TestFluidObject
      */
     constructor(
+        public readonly LoaderConstructor: typeof Loader,
         public readonly driver: ITestDriver,
         private readonly createFluidEntryPoint: (testContainerConfig?: TestContainerConfigType) => fluidEntryPoint,
     ) {
 
     }
+
     get documentServiceFactory() {
         if (!this._documentServiceFactory) {
             this._documentServiceFactory = this.driver.createDocumentServiceFactory();
@@ -75,7 +77,7 @@ export class TestObjectProvider<TestContainerConfigType> {
 
     private createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>) {
         const codeLoader = new LocalCodeLoader(packageEntries);
-        return new Loader({
+        return new this.LoaderConstructor({
             urlResolver: this.urlResolver,
             documentServiceFactory: this.documentServiceFactory,
             codeLoader,
@@ -128,5 +130,10 @@ export class TestObjectProvider<TestContainerConfigType> {
         this._urlResolver = undefined;
         this._opProcessingController = undefined;
         this._documentId = undefined;
+    }
+
+    public async ensureSynchronized() {
+        await this.opProcessingController.process();
+        return this._loaderContainerTracker.ensureSynchronized();
     }
 }


### PR DESCRIPTION
Down to 88 (from 144) failing test.

- Implement `ensuredSynchronized` to looks at container dirty state and matching seqNum to ensure that all the container's state are in sync
  - This is better OpProcessController, because it consider the pending ops managed by the container runtime as well and take care of view only client disconnect and reconnect.
  - Will eventually retire the code to monitor ops to make sure they are process, as this is simpler and cover more scenarios.
- Remove dependency to old TestObjectProvider, and always use the newest one, so we don't have to patch it.  We already inject the drivers, so make it pass in the Loader (It can be extended to dynamically injected in the future) 
- add npm script `test:realsvc:odsp` to start the ODSP script.
- Improve stability of agent schedule test by waiting for "leader" instead of relying on OpProcessControlller, since leader election timing might be indeterministic in terms of submitting ops.