### PR TITLE
Fix regression of graph item URL encoding in odsp-driver

### DIFF
--- a/packages/drivers/odsp-driver/src/graph.ts
+++ b/packages/drivers/odsp-driver/src/graph.ts
@@ -236,7 +236,7 @@ async function getFileDefaultUrl(
                 const token = await getToken({ ...options, siteUrl, type: "OneDrive" });
                 const { url, headers } = getUrlAndHeadersWithAuth(
                     `${siteUrl}/_api/web/GetFileByUrl(@a1)/ListItemAllFields/GetSharingInformation?@a1=${
-                        encodeURIComponent(graphItem.webDavUrl)
+                        encodeURIComponent(`'${graphItem.webDavUrl}'`)
                     }`, tokenFromResponse(token));
                 const requestInit = {
                     method: "POST",


### PR DESCRIPTION
Due to the absence of quotes around the graph item URL parameter (a1) in the request, the service was returning a 400 error with message:
{"error":{"code":"-1, Microsoft.SharePoint.Client.InvalidClientQueryException","message":{"lang":"en-US","value":"The query string \"fileUrl\" is missing or invalid."}}}

This restores the necessary quotes that were dropped here:
https://github.com/microsoft/FluidFramework/pull/4994/files#diff-5b7aa3dec916218344fabaf9e20645ca29a6db28d1a5cac2c4b87ff5b332c10fR228