### PR TITLE
Remove winston dependency from a few server packages

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -53,8 +53,7 @@
     "async": "^2.6.1",
     "lodash": "^4.17.21",
     "moniker": "^0.1.2",
-    "nconf": "^0.11.0",
-    "winston": "^3.1.0"
+    "nconf": "^0.11.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0-0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -53,8 +53,7 @@
     "async": "^2.6.1",
     "lodash": "^4.17.19",
     "moniker": "^0.1.2",
-    "nconf": "^0.11.0",
-    "winston": "^3.1.0"
+    "nconf": "^0.11.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0-0",

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -41,7 +41,7 @@ export class DocumentContextManager extends EventEmitter {
         assert(head.offset > this.tail.offset && head.offset <= this.head.offset);
 
         // Create the new context and register for listeners on it
-        const context = new DocumentContext(head, () => this.tail);
+        const context = new DocumentContext(head, this.partitionContext.log, () => this.tail);
         this.contexts.add(context);
         context.addListener("checkpoint", () => this.updateCheckpoint());
         context.addListener("error", (error, errorData: IContextErrorData) => this.emit("error", error, errorData));

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -6,7 +6,6 @@
 import assert from "assert";
 import { EventEmitter } from "events";
 import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
-import * as winston from "winston";
 
 export class DocumentContext extends EventEmitter implements IContext {
     // We track two offsets - head and tail. Head represents the largest offset related to this document we
@@ -17,7 +16,10 @@ export class DocumentContext extends EventEmitter implements IContext {
 
     private closed = false;
 
-    constructor(head: IQueuedMessage, private readonly getLatestTail: () => IQueuedMessage) {
+    constructor(
+        head: IQueuedMessage,
+        public readonly log: ILogger | undefined,
+        private readonly getLatestTail: () => IQueuedMessage) {
         super();
 
         // Head represents the largest offset related to the document that is not checkpointed.
@@ -74,10 +76,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 
     public error(error: any, errorData: IContextErrorData) {
         this.emit("error", error, errorData);
-    }
-
-    public get log(): ILogger | undefined {
-        return winston;
     }
 
     public close() {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -6,7 +6,6 @@
 import assert from "assert";
 import { EventEmitter } from "events";
 import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
-import * as winston from "winston";
 
 export class DocumentContext extends EventEmitter implements IContext {
     // We track two offsets - head and tail. Head represents the largest offset related to this document we
@@ -17,7 +16,10 @@ export class DocumentContext extends EventEmitter implements IContext {
 
     private closed = false;
 
-    constructor(head: IQueuedMessage, private readonly getLatestTail: () => IQueuedMessage) {
+    constructor(
+        head: IQueuedMessage,
+        public readonly log: ILogger | undefined,
+        private readonly getLatestTail: () => IQueuedMessage) {
         super();
 
         // Head represents the largest offset related to the document that is not checkpointed.
@@ -74,10 +76,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 
     public error(error: any, errorData: IContextErrorData) {
         this.emit("error", error, errorData);
-    }
-
-    public get log(): ILogger {
-        return winston;
     }
 
     public close() {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -13,7 +13,6 @@ import {
 import { AsyncQueue, queue } from "async";
 import * as _ from "lodash";
 import { Provider } from "nconf";
-import * as winston from "winston";
 import { DocumentContext } from "./documentContext";
 
 export class DocumentPartition {
@@ -53,7 +52,6 @@ export class DocumentPartition {
                 } catch (error) {
                     // TODO dead letter queue for bad messages, etc... when the lambda is throwing an exception
                     // for now we will simply continue on to keep the queue flowing
-                    winston.error("Error processing partition message", error);
                     context.error(error, { restart: false, tenantId, documentId });
                     this.corrupt = true;
                 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -5,13 +5,12 @@
 
 import { EventEmitter } from "events";
 import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
-import * as winston from "winston";
 import { CheckpointManager } from "./checkpointManager";
 
 export class Context extends EventEmitter implements IContext {
     private closed = false;
 
-    constructor(private readonly checkpointManager: CheckpointManager) {
+    constructor(private readonly checkpointManager: CheckpointManager, public readonly log: ILogger | undefined) {
         super();
     }
 
@@ -37,10 +36,6 @@ export class Context extends EventEmitter implements IContext {
      */
     public error(error: any, errorData: IContextErrorData) {
         this.emit("error", error, errorData);
-    }
-
-    public get log(): ILogger {
-        return winston;
     }
 
     /**

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -5,13 +5,12 @@
 
 import { EventEmitter } from "events";
 import { IContext, IQueuedMessage, ILogger, IContextErrorData } from "@fluidframework/server-services-core";
-import * as winston from "winston";
 import { CheckpointManager } from "./checkpointManager";
 
 export class Context extends EventEmitter implements IContext {
     private closed = false;
 
-    constructor(private readonly checkpointManager: CheckpointManager) {
+    constructor(private readonly checkpointManager: CheckpointManager, public readonly log: ILogger | undefined) {
         super();
     }
 
@@ -37,10 +36,6 @@ export class Context extends EventEmitter implements IContext {
      */
     public error(error: any, errorData: IContextErrorData) {
         this.emit("error", error, errorData);
-    }
-
-    public get log(): ILogger | undefined {
-        return winston;
     }
 
     /**

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -46,7 +46,7 @@ export class Partition extends EventEmitter {
         const partitionConfig = new Provider({}).defaults(clonedConfig).use("memory");
 
         this.checkpointManager = new CheckpointManager(id, consumer);
-        this.context = new Context(this.checkpointManager);
+        this.context = new Context(this.checkpointManager, this.logger);
         this.context.on("error", (error: any, errorData: IContextErrorData) => {
             this.emit("error", error, errorData);
         });

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -53,6 +53,8 @@ export class PartitionManager extends EventEmitter {
     }
 
     public async stop(): Promise<void> {
+        this.logger?.info("Stop requested");
+
         // Drain all pending messages from the partitions
         const partitionsStoppedP: Promise<void>[] = [];
         for (const [, partition] of this.partitions) {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -4,10 +4,9 @@
  */
 
 import { Deferred } from "@fluidframework/common-utils";
-import { IConsumer, IContextErrorData, IPartitionLambdaFactory } from "@fluidframework/server-services-core";
+import { IConsumer, IContextErrorData, ILogger, IPartitionLambdaFactory } from "@fluidframework/server-services-core";
 import { IRunner } from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
-import * as winston from "winston";
 import { PartitionManager } from "./partitionManager";
 
 export class KafkaRunner implements IRunner {
@@ -21,7 +20,7 @@ export class KafkaRunner implements IRunner {
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    public start(): Promise<void> {
+    public start(logger: ILogger | undefined): Promise<void> {
         if (this.deferred) {
             throw new Error("Already started");
         }
@@ -38,7 +37,7 @@ export class KafkaRunner implements IRunner {
             deferred.reject(error);
         });
 
-        this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, winston);
+        this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, logger);
         this.partitionManager.on("error", (error, errorData: IContextErrorData) => {
             deferred.reject(error);
         });
@@ -53,8 +52,6 @@ export class KafkaRunner implements IRunner {
         if (!this.deferred) {
             return;
         }
-
-        winston.info("Stop requested");
 
         // Stop listening for new updates
         await this.consumer.pause();

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { DocumentContext } from "../../document-router/documentContext";
-import { TestKafka } from "@fluidframework/server-test-utils";
+import { DebugLogger, TestKafka } from "@fluidframework/server-test-utils";
 import { IContextErrorData } from "@fluidframework/server-services-core";
 
 function validateException(fn: () => void) {
@@ -24,7 +24,7 @@ describe("document-router", () => {
         let contextTailOffset = TestKafka.createdQueuedMessage(-1);
 
         beforeEach(async () => {
-            testContext = new DocumentContext(offset0, () => contextTailOffset);
+            testContext = new DocumentContext(offset0, DebugLogger.create("fluid-server:TestDocumentContext"), () => contextTailOffset);
         });
 
         describe(".setHead", () => {

--- a/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/context.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/context.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { IContextErrorData } from "@fluidframework/server-services-core";
-import { TestConsumer, TestKafka } from "@fluidframework/server-test-utils";
+import { DebugLogger, TestConsumer, TestKafka } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { CheckpointManager } from "../../kafka-service/checkpointManager";
 import { Context } from "../../kafka-service/context";
@@ -19,7 +19,7 @@ describe("kafka-service", () => {
             const testKafka = new TestKafka();
             testConsumer = testKafka.createConsumer();
             checkpointManager = new CheckpointManager(0, testConsumer);
-            testContext = new Context(checkpointManager);
+            testContext = new Context(checkpointManager, DebugLogger.create("fluid-server:TestContext"));
         });
 
         describe(".checkpoint", () => {

--- a/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/runner.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/kafka-service/runner.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TestConsumer, TestKafka, TestProducer } from "@fluidframework/server-test-utils";
+import { DebugLogger, TestConsumer, TestKafka, TestProducer } from "@fluidframework/server-test-utils";
 import { strict as assert } from "assert";
 import { Provider } from "nconf";
 import { KafkaRunner } from "../../kafka-service/runner";
@@ -28,7 +28,7 @@ describe("kafka-service", () => {
 
         describe(".start", () => {
             it("Should be able to stop after processing messages", async () => {
-                const startP = testRunner.start();
+                const startP = testRunner.start(DebugLogger.create("fluid-server:TestRunner"));
                 testConsumer.rebalance();
 
                 const messageCount = 10;
@@ -54,7 +54,7 @@ describe("kafka-service", () => {
             }
 
             it("Should resolve start promise on kafka error ", async () => {
-                const startP = testRunner.start();
+                const startP = testRunner.start(DebugLogger.create("fluid-server:TestRunner"));
                 testConsumer.rebalance();
 
                 testProducer.send([{}], "test");
@@ -64,7 +64,7 @@ describe("kafka-service", () => {
             });
 
             it("Should resolve start promise on lambda error ", async () => {
-                const startP = testRunner.start();
+                const startP = testRunner.start(DebugLogger.create("fluid-server:TestRunner"));
                 testFactory.setThrowHandler(true);
                 testConsumer.rebalance();
 

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -8,9 +8,6 @@
   "author": "Microsoft",
   "sideEffects": false,
   "main": "dist/index.js",
-  "browser": {
-    "winston": false
-  },
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "concurrently npm:build:compile npm:lint",

--- a/server/routerlicious/packages/routerlicious/src/alfred/www.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/www.ts
@@ -4,11 +4,18 @@
  */
 
 import * as path from "path";
+import * as winston from "winston";
+import { configureLogging } from "@fluidframework/server-services";
 import { runService } from "@fluidframework/server-services-utils";
 import { AlfredResourcesFactory, AlfredRunnerFactory } from "@fluidframework/server-routerlicious-base";
+
+const configPath = path.join(__dirname, "../../config/config.json");
+
+configureLogging(configPath);
 
 runService(
     new AlfredResourcesFactory(),
     new AlfredRunnerFactory(),
+    winston,
     "alfred",
-    path.join(__dirname, "../../config/config.json"));
+    configPath);

--- a/server/routerlicious/packages/routerlicious/src/event-hub-service/command.ts
+++ b/server/routerlicious/packages/routerlicious/src/event-hub-service/command.ts
@@ -5,8 +5,10 @@
 
 import { IKafkaResources, KafkaRunnerFactory } from "@fluidframework/server-lambdas-driver";
 import * as utils from "@fluidframework/server-services-utils";
+import { configureLogging } from "@fluidframework/server-services";
 import commander from "commander";
 import nconf from "nconf";
+import * as winston from "winston";
 
 export function execute(
     factoryFn: (name: string, lambda: string) => utils.IResourcesFactory<IKafkaResources>,
@@ -19,10 +21,13 @@ export function execute(
         .version(packageDetails.version)
         .arguments("<name> <lambda>")
         .action((name: string, lambda: string) => {
+            configureLogging(configOrPath);
+
             action = true;
             utils.runService(
                 factoryFn(name, lambda),
                 new KafkaRunnerFactory(),
+                winston,
                 name,
                 configOrPath);
         })

--- a/server/routerlicious/packages/routerlicious/src/kafka-service/command.ts
+++ b/server/routerlicious/packages/routerlicious/src/kafka-service/command.ts
@@ -5,8 +5,10 @@
 
 import { IKafkaResources, KafkaRunnerFactory } from "@fluidframework/server-lambdas-driver";
 import * as utils from "@fluidframework/server-services-utils";
+import { configureLogging } from "@fluidframework/server-services";
 import commander from "commander";
 import nconf from "nconf";
+import * as winston from "winston";
 
 export function execute(
     factoryFn: (name: string, lambda: string) => utils.IResourcesFactory<IKafkaResources>,
@@ -19,10 +21,13 @@ export function execute(
         .version(packageDetails.version)
         .arguments("<name> <lambda>")
         .action((name: string, lambda: string) => {
+            configureLogging(configOrPath);
+
             action = true;
             utils.runService(
                 factoryFn(name, lambda),
                 new KafkaRunnerFactory(),
+                winston,
                 name,
                 configOrPath);
         })

--- a/server/routerlicious/packages/routerlicious/src/riddler/www.ts
+++ b/server/routerlicious/packages/routerlicious/src/riddler/www.ts
@@ -4,11 +4,18 @@
  */
 
 import * as path from "path";
+import * as winston from "winston";
 import * as utils from "@fluidframework/server-services-utils";
+import { configureLogging } from "@fluidframework/server-services";
 import { RiddlerResourcesFactory, RiddlerRunnerFactory } from "@fluidframework/server-routerlicious-base";
+
+const configPath = path.join(__dirname, "../../config/config.json");
+
+configureLogging(configPath);
 
 utils.runService(
     new RiddlerResourcesFactory(),
     new RiddlerRunnerFactory(),
+    winston,
     "riddler",
-    path.join(__dirname, "../../config/config.json"));
+    configPath);

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -56,8 +56,7 @@
     "jsonwebtoken": "^8.4.0",
     "nconf": "^0.11.0",
     "sillyname": "0.1.0",
-    "uuid": "^8.3.1",
-    "winston": "^3.1.0"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0-0",

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -9,7 +9,6 @@ export * from "./conversion";
 export * from "./dns";
 export * from "./errorTrackingService";
 export * from "./generateNames";
-export * from "./logger";
 export * from "./port";
 export * from "./runner";
 export * from "./throttlerMiddleware";

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -59,6 +59,7 @@
     "debug": "^4.1.1",
     "lru-cache": "^6.0.0",
     "mongodb": "3.1.13",
+    "nconf": "^0.11.0",
     "redis": "^2.8.0",
     "socket.io": "^2.2.0",
     "socket.io-emitter": "^3.1.1",

--- a/server/routerlicious/packages/services/src/index.ts
+++ b/server/routerlicious/packages/services/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from "./kafkaFactory";
+export * from "./logger";
 export * from "./messageReceiver";
 export * from "./messageSender";
 export * from "./metricClient";


### PR DESCRIPTION
- Remove `winston` dependency from `lambdas`, `lambdas-driver`, & `service-utils` packages
- Pass the `ILogger` interface around more instead of requiring `winston`
- The `winston` logger is now configured from `routerlicious` instead of `service-utils`