### PR TITLE
Run tinylicious e2e tests with 2 in parallel

### DIFF
--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -31,7 +31,8 @@
     "test:realsvc:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc",
     "test:realsvc:routerlicious": "cross-env FLUID_TEST_DRIVER=routerlicious npm run test:realsvc:run",
     "test:realsvc:run": "mocha dist/test --config src/test/.mocharc.js",
-    "test:realsvc:tinylicious": "cross-env FLUID_TEST_DRIVER=tinylicious start-server-and-test start:tinylicious:test 3000 test:realsvc:run",
+    "test:realsvc:tinylicious": "cross-env FLUID_TEST_DRIVER=tinylicious start-server-and-test start:tinylicious:test 3000 test:realsvc:tinylicious:run",
+    "test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --parallel --jobs 2",
     "test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"


### PR DESCRIPTION
Since the service is single thread, add more doesn't help.  Might want to look at spawning a tinylicious instance per test file in the future.

About 25% reduction in run time (4m => 3m)