### PR TITLE
Real Svc Tests: Don't Merge Results

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -167,5 +167,5 @@ jobs:
         testResultsFormat: 'JUnit'
         testResultsFiles: '**/*junit-report.xml'
         searchFolder: ${{ parameters.buildDirectory }}/nyc
-        mergeTestResults: true
+        mergeTestResults: false
       condition: succeededOrFailed()


### PR DESCRIPTION
merging results looses information about which test driver the results apply to.