### PR TITLE
Restore testing with old Loader/Container in contextReload.spec.ts

### DIFF
--- a/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -11,7 +11,6 @@ import { IAgentScheduler } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { timeoutPromise, defaultTimeoutDurationMs } from "@fluidframework/test-utils";
 import { generateTest, ITestObjectProvider, TestDataObject } from "./compatUtils";
-import * as oldTypes from "./oldVersionTypes";
 
 const tests = (argsFactory: () => ITestObjectProvider) => {
     let leaderTimeout = defaultTimeoutDurationMs;
@@ -102,8 +101,8 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
     });
 
     describe("Multiple clients", () => {
-        let container1: IContainer | oldTypes.IContainer;
-        let container2: IContainer | oldTypes.IContainer;
+        let container1: IContainer;
+        let container2: IContainer;
         let scheduler1: IAgentScheduler;
         let scheduler2: IAgentScheduler;
 

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -81,7 +81,7 @@ export class TestDataObject extends DataObject {
     public get _root() { return this.root; }
 }
 
-export const createPrimedDataStoreFactory = (registry?: ChannelFactoryRegistry): IFluidDataStoreFactory => {
+const createPrimedDataStoreFactory = (registry?: ChannelFactoryRegistry): IFluidDataStoreFactory => {
     return new DataObjectFactory(
         TestDataObject.type,
         TestDataObject,
@@ -89,7 +89,7 @@ export const createPrimedDataStoreFactory = (registry?: ChannelFactoryRegistry):
         {});
 };
 
-export const createTestFluidDataStoreFactory = (registry: ChannelFactoryRegistry = []): IFluidDataStoreFactory => {
+const createTestFluidDataStoreFactory = (registry: ChannelFactoryRegistry = []): IFluidDataStoreFactory => {
     return new TestFluidObjectFactory(registry);
 };
 

--- a/packages/test/end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/end-to-end-tests/src/test/compatUtils.ts
@@ -32,13 +32,13 @@ export interface ITestObjectProvider {
      * Used to create a test Container.
      * In generateLocalCompatTest(), this Container and its runtime will be arbitrarily-versioned.
      */
-    makeTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer | oldTypes.IContainer>,
-    loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer | oldTypes.IContainer>,
-    makeTestLoader(testContainerConfig?: ITestContainerConfig): ILoader | oldTypes.ILoader,
-    documentServiceFactory: IDocumentServiceFactory | oldTypes.IDocumentServiceFactory,
-    urlResolver: IUrlResolver | oldTypes.IUrlResolver,
-    defaultCodeDetails: IFluidCodeDetails | oldTypes.IFluidCodeDetails,
-    opProcessingController: OpProcessingController | oldTypes.OpProcessingController,
+    makeTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>,
+    loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>,
+    makeTestLoader(testContainerConfig?: ITestContainerConfig): ILoader,
+    documentServiceFactory: IDocumentServiceFactory,
+    urlResolver: IUrlResolver,
+    defaultCodeDetails: IFluidCodeDetails,
+    opProcessingController: OpProcessingController,
 
     ensureSynchronized(): Promise<void>;
     reset(): void,

--- a/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IContainer, IDeltaManager } from "@fluidframework/container-definitions";
+import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
@@ -54,12 +54,12 @@ function generate(
 
         beforeEach(async () => {
             // Create a Container for the first client.
-            const container1 = await args.makeTestContainer(testContainerConfig) as IContainer;
+            const container1 = await args.makeTestContainer(testContainerConfig);
             dataStore1 = await requestFluidObject<ITestFluidObject>(container1, "default");
             sharedMap1 = await dataStore1.getSharedObject<SharedMap>(mapId);
 
             // Load the Container that was created by the first client.
-            const container2 = await args.loadTestContainer(testContainerConfig) as IContainer;
+            const container2 = await args.loadTestContainer(testContainerConfig);
             dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
             sharedMap2 = await dataStore2.getSharedObject<SharedMap>(mapId);
             deltaManager2 = container2.deltaManager;

--- a/packages/test/end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/container.spec.ts
@@ -19,7 +19,7 @@ import { LocalCodeLoader, TestObjectProvider, LoaderContainerTracker } from "@fl
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestDriver } from "@fluidframework/test-driver-definitions";
-import { createPrimedDataStoreFactory, createRuntimeFactory, TestDataObject } from "./compatUtils";
+import { getDataStoreFactory, createRuntimeFactory, TestDataObject } from "./compatUtils";
 
 const id = "fluid-test://localhost/containerTest";
 const testRequest: IRequest = { url: id };
@@ -40,10 +40,10 @@ describe("Container", () => {
         loaderContainerTracker.reset();
     });
     async function loadContainer(props?: Partial<ILoaderProps>) {
-        const loader =  new Loader({
-            ... props,
+        const loader = new Loader({
+            ...props,
             urlResolver: props?.urlResolver ?? driver.createUrlResolver(),
-            documentServiceFactory :
+            documentServiceFactory:
                 props?.documentServiceFactory ?? driver.createDocumentServiceFactory(),
             codeLoader: props?.codeLoader ?? new LocalCodeLoader([]),
         });
@@ -203,7 +203,7 @@ describe("Container", () => {
     it("Delta manager receives readonly event when calling container.forceReadonly()", async () => {
         const runtimeFactory = (_?: unknown) => createRuntimeFactory(
             TestDataObject.type,
-            createPrimedDataStoreFactory());
+            getDataStoreFactory());
 
         const localTestObjectProvider = new TestObjectProvider(
             Loader,

--- a/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/contextReload.spec.ts
@@ -64,7 +64,7 @@ describe("context reload (hot-swap)", function() {
     const loaderContainerTracker = new LoaderContainerTracker();
     const codeDetails = (version: string): oldTypes.IFluidCodeDetails => {
         return {
-            package: { name: TestDataStore.type, version, fluid:{}},
+            package: { name: TestDataStore.type, version, fluid: {} },
             config: {},
         };
     };
@@ -73,7 +73,7 @@ describe("context reload (hot-swap)", function() {
     const proposeAndWaitForReload = async (version: string, ...containers: IContainer[]) => {
         const ps = [
             // propose
-            containers[0].proposeCodeDetails(codeDetails(version)).then(()=>{}),
+            containers[0].proposeCodeDetails(codeDetails(version)).then(() => { }),
             // wait for "contextChanged" events on all containers
             ...containers.map(
                 async (c) => timeoutPromise((resolve, reject) =>
@@ -83,10 +83,13 @@ describe("context reload (hot-swap)", function() {
         return Promise.all(ps);
     };
 
-    async function createContainer(packageEntries, documentId: string): Promise<IContainer> {
-        const loader: ILoader = new Loader({
+    async function createContainer(
+        packageEntries,
+        documentId: string,
+        LoaderConstructor = Loader): Promise<IContainer> {
+        const loader: ILoader = new LoaderConstructor({
             codeLoader: new LocalCodeLoader(packageEntries),
-            options:{ hotSwapContext: true },
+            options: { hotSwapContext: true },
             urlResolver: driver.createUrlResolver(),
             documentServiceFactory: driver.createDocumentServiceFactory(),
         });
@@ -95,17 +98,6 @@ describe("context reload (hot-swap)", function() {
             defaultCodeDetails,
             loader,
             driver.createCreateNewRequest(documentId));
-    }
-
-    async function loadContainer(packageEntries, documentId): Promise<IContainer> {
-        const loader: ILoader = new Loader({
-            codeLoader: new LocalCodeLoader(packageEntries),
-            options:{ hotSwapContext: true },
-            urlResolver: driver.createUrlResolver(),
-            documentServiceFactory: driver.createDocumentServiceFactory(),
-        });
-        loaderContainerTracker.add(loader);
-        return loader.resolve({ url: await driver.createContainerUrl(documentId) });
     }
 
     const createRuntimeFactory = (dataStore): IRuntimeFactory => {
@@ -117,7 +109,7 @@ describe("context reload (hot-swap)", function() {
         );
     };
     let driver: ITestDriver;
-    before(()=>{
+    before(() => {
         driver = getFluidTestDriver() as unknown as ITestDriver;
     });
 
@@ -142,7 +134,7 @@ describe("context reload (hot-swap)", function() {
             const test = ["fluid", "is great!"];
             dataStoreV1._root.set(test[0], test[1]);
 
-            while(!dataStoreV1._runtime.deltaManager.active) {
+            while (!dataStoreV1._runtime.deltaManager.active) {
                 await opProcessingController.process();
             }
 
@@ -165,7 +157,7 @@ describe("context reload (hot-swap)", function() {
             const test = ["fluid", "is great!"];
             dataStoreV1._root.set(test[0], test[1]);
 
-            while(!dataStoreV1._runtime.deltaManager.active) {
+            while (!dataStoreV1._runtime.deltaManager.active) {
                 await opProcessingController.process();
             }
 
@@ -185,7 +177,7 @@ describe("context reload (hot-swap)", function() {
             const test = ["fluid", "is great!"];
             dataStoreV1._root.set(test[0], test[1]);
 
-            while(!dataStoreV1._runtime.deltaManager.active) {
+            while (!dataStoreV1._runtime.deltaManager.active) {
                 await opProcessingController.process();
             }
 
@@ -219,6 +211,17 @@ describe("context reload (hot-swap)", function() {
     });
 
     describe("two containers", () => {
+        async function loadContainer(packageEntries, documentId): Promise<IContainer> {
+            const loader: ILoader = new Loader({
+                codeLoader: new LocalCodeLoader(packageEntries),
+                options: { hotSwapContext: true },
+                urlResolver: driver.createUrlResolver(),
+                documentServiceFactory: driver.createDocumentServiceFactory(),
+            });
+            loaderContainerTracker.add(loader);
+            return loader.resolve({ url: await driver.createContainerUrl(documentId) });
+        }
+
         it("loads version 2", async () => {
             const docId = createDocumentId();
             opProcessingController = new OpProcessingController();
@@ -250,7 +253,7 @@ describe("context reload (hot-swap)", function() {
             const test = ["fluid", "is great!"];
             dataStores[0]._root.set(test[0], test[1]);
 
-            while(!dataStores[0]._runtime.deltaManager.active) {
+            while (!dataStores[0]._runtime.deltaManager.active) {
                 await opProcessingController.process();
             }
 
@@ -282,7 +285,8 @@ describe("context reload (hot-swap)", function() {
                             [codeDetails(V1), oldApi.createOldRuntimeFactory(oldApi.OldTestDataObjectV1)],
                             [codeDetails(V2), createRuntimeFactory(TestDataStoreV2)],
                         ],
-                        documentId);
+                        documentId,
+                        oldApi.Loader as unknown as  typeof Loader);
                     dataStoreV1 = await requestFluidObject<TestDataStoreV1>(container, "default");
                     assert.strictEqual(dataStoreV1.version, TestDataStoreV1.version);
 
@@ -298,7 +302,7 @@ describe("context reload (hot-swap)", function() {
                         [codeDetails(V1), createRuntimeFactory(TestDataStoreV1)],
                         [codeDetails(V2), oldApi.createOldRuntimeFactory(oldApi.OldTestDataObjectV2)],
                     ],
-                    createDocumentId());
+                        createDocumentId());
                     dataStoreV1 = await requestFluidObject<TestDataStoreV1>(container, "default");
                     assert.strictEqual(dataStoreV1.version, TestDataStoreV1.version);
 

--- a/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -192,6 +192,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
     it("ReAttach detached container on failed attach", async () => {
         const container = await loader.createDetachedContainer(args.defaultCodeDetails);
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         const oldFunc = args.documentServiceFactory.createContainer;
         args.documentServiceFactory.createContainer = (a, b, c) => { throw new Error("Test Error"); };
         let failedOnce = false;

--- a/packages/test/end-to-end-tests/src/test/newVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/newVersion.ts
@@ -28,8 +28,6 @@ export { SharedString, SparseMatrix } from "@fluidframework/sequence";
 export { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 export { ITestDriver } from "@fluidframework/test-driver-definitions";
 export {
-    createLocalLoader,
-    createAndAttachContainer,
     ChannelFactoryRegistry,
     LocalCodeLoader,
     OpProcessingController,

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -9,6 +9,7 @@ export { IDocumentServiceFactory, IUrlResolver } from "old-driver-definitions";
 export { LocalResolver } from "old-local-driver";
 export { IFluidDataStoreFactory } from "old-runtime-definitions";
 export { OpProcessingController } from "old-test-utils";
+export { Loader } from "old-container-loader";
 export const versionString = "N-1";
 
 import {

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -17,7 +17,7 @@ import {
     DataObjectFactory,
 } from "old-aqueduct";
 import { SharedCell } from "old-cell";
-import { IContainer, IRuntimeFactory } from "old-container-definitions";
+import { IRuntimeFactory } from "old-container-definitions";
 import { IContainerRuntimeOptions } from "old-container-runtime";
 import { SharedCounter } from "old-counter";
 import { IChannelFactory } from "old-datastore-definitions";
@@ -30,8 +30,6 @@ import { IFluidDataStoreFactory } from "old-runtime-definitions";
 import { SharedString, SparseMatrix } from "old-sequence";
 import {
     ChannelFactoryRegistry,
-    createAndAttachContainer,
-    createLocalLoader,
     TestContainerRuntimeFactory,
     TestFluidObjectFactory,
 } from "old-test-utils";
@@ -142,17 +140,6 @@ export function createOldRuntimeFactory(dataStore): IRuntimeFactory {
         factory,
         [[type, Promise.resolve(new DataObjectFactory(type, dataStore, [], {}))]],
     );
-}
-
-export async function createOldContainer(
-    documentId,
-    packageEntries,
-    server,
-    urlResolver,
-    codeDetails,
-): Promise<IContainer> {
-    const loader = createLocalLoader(packageEntries, server, urlResolver, { hotSwapContext: true });
-    return createAndAttachContainer(codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
 }
 
 export function createTestObjectProvider(

--- a/packages/test/end-to-end-tests/src/test/oldVersion.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion.ts
@@ -34,13 +34,9 @@ import {
     TestContainerRuntimeFactory,
     TestFluidObjectFactory,
 } from "old-test-utils";
-import { Loader } from "old-container-loader";
 
 import {
-    createRuntimeFactory,
     DataObjectFactoryType,
-    getDataStoreFactory,
-    ITestObjectProvider,
     ITestContainerConfig,
     V1,
     V2,
@@ -114,7 +110,7 @@ const createOldTestFluidDataStoreFactory = (
     return new TestFluidObjectFactory(convertRegistry(registry));
 };
 
-function getOldDataStoreFactory(containerOptions?: ITestContainerConfig) {
+export function getDataStoreFactory(containerOptions?: ITestContainerConfig) {
     switch (containerOptions?.fluidDataObjectType) {
         case undefined:
         case DataObjectFactoryType.Primed:
@@ -126,7 +122,7 @@ function getOldDataStoreFactory(containerOptions?: ITestContainerConfig) {
     }
 }
 
-const createOldTestRuntimeFactory = (
+export const createRuntimeFactory = (
     type: string,
     dataStoreFactory: newVer.IFluidDataStoreFactory | IFluidDataStoreFactory,
     runtimeOptions: IContainerRuntimeOptions = { initialSummarizerDelayMs: 0 },
@@ -141,32 +137,4 @@ export function createOldRuntimeFactory(dataStore): IRuntimeFactory {
         factory,
         [[type, Promise.resolve(new DataObjectFactory(type, dataStore, [], {}))]],
     );
-}
-
-export function createTestObjectProvider(
-    oldLoader: boolean,
-    oldContainerRuntime: boolean,
-    oldDataStoreRuntime: boolean,
-    type: string,
-    serviceConfiguration?: Partial<newVer.IClientConfiguration>,
-    driver?: newVer.ITestDriver,
-): ITestObjectProvider {
-    const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {
-        const dataStoreFactory = oldDataStoreRuntime
-            ? getOldDataStoreFactory(containerOptions)
-            : getDataStoreFactory(containerOptions);
-
-        return oldContainerRuntime
-            ? createOldTestRuntimeFactory(type, dataStoreFactory, containerOptions?.runtimeOptions)
-            : createRuntimeFactory(type, dataStoreFactory, containerOptions?.runtimeOptions);
-    };
-
-    if (driver === undefined) {
-        throw new Error("Must provide a driver when using the current loader");
-    }
-
-    return new newVer.TestObjectProvider(
-        oldLoader ? Loader as unknown as typeof newVer.Loader : newVer.Loader,
-        driver,
-        containerFactoryFn as () => newVer.IRuntimeFactory);
 }

--- a/packages/test/end-to-end-tests/src/test/oldVersion2.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion2.ts
@@ -9,6 +9,7 @@ export { IDocumentServiceFactory, IUrlResolver } from "old-driver-definitions2";
 export { LocalResolver } from "old-local-driver2";
 export { IFluidDataStoreFactory } from "old-runtime-definitions2";
 export { OpProcessingController } from "old-test-utils2";
+export { Loader } from "old-container-loader2";
 export const versionString = "N-2";
 
 import {

--- a/packages/test/end-to-end-tests/src/test/oldVersion2.ts
+++ b/packages/test/end-to-end-tests/src/test/oldVersion2.ts
@@ -19,7 +19,6 @@ import {
 } from "old-aqueduct2";
 import { SharedCell } from "old-cell2";
 import { IRuntimeFactory } from "old-container-definitions2";
-import { Loader } from "old-container-loader2";
 import { IContainerRuntimeOptions } from "old-container-runtime2";
 import { SharedCounter } from "old-counter2";
 import { IChannelFactory } from "old-datastore-definitions2";
@@ -37,10 +36,7 @@ import {
 } from "old-test-utils2";
 
 import {
-    createRuntimeFactory,
     DataObjectFactoryType,
-    getDataStoreFactory,
-    ITestObjectProvider,
     ITestContainerConfig,
     V1,
     V2,
@@ -114,7 +110,7 @@ const createOldTestFluidDataStoreFactory = (
     return new TestFluidObjectFactory(convertRegistry(registry));
 };
 
-function getOldDataStoreFactory(containerOptions?: ITestContainerConfig) {
+export function getDataStoreFactory(containerOptions?: ITestContainerConfig) {
     switch (containerOptions?.fluidDataObjectType) {
         case undefined:
         case DataObjectFactoryType.Primed:
@@ -126,7 +122,7 @@ function getOldDataStoreFactory(containerOptions?: ITestContainerConfig) {
     }
 }
 
-const createOldTestRuntimeFactory = (
+export const createRuntimeFactory = (
     type: string,
     dataStoreFactory: newVer.IFluidDataStoreFactory | IFluidDataStoreFactory,
     runtimeOptions: IContainerRuntimeOptions = { initialSummarizerDelayMs: 0 },
@@ -141,32 +137,4 @@ export function createOldRuntimeFactory(dataStore): IRuntimeFactory {
         factory,
         [[type, Promise.resolve(new DataObjectFactory(type, dataStore, [], {}))]],
     );
-}
-
-export function createTestObjectProvider(
-    oldLoader: boolean,
-    oldContainerRuntime: boolean,
-    oldDataStoreRuntime: boolean,
-    type: string,
-    serviceConfiguration?: Partial<newVer.IClientConfiguration>,
-    driver?: newVer.ITestDriver,
-): ITestObjectProvider {
-    const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {
-        const dataStoreFactory = oldDataStoreRuntime
-            ? getOldDataStoreFactory(containerOptions)
-            : getDataStoreFactory(containerOptions);
-
-        return oldContainerRuntime
-            ? createOldTestRuntimeFactory(type, dataStoreFactory, containerOptions?.runtimeOptions)
-            : createRuntimeFactory(type, dataStoreFactory, containerOptions?.runtimeOptions);
-    };
-
-    if (driver === undefined) {
-        throw new Error("Must provide a driver when using the current loader");
-    }
-
-    return new newVer.TestObjectProvider(
-        oldLoader ? Loader as unknown as typeof newVer.Loader : newVer.Loader,
-        driver,
-        containerFactoryFn as () => newVer.IRuntimeFactory);
 }


### PR DESCRIPTION
One step to make things more injectable.  Delete versions of createTestObjectProvider and make it injectable.

Also:
- Restore testing with old Loader/Container in `contextReload.spec.ts`
- Remove old type from `ITestObjectProvider`.  We won't get compile time error, but since we are moving toward the direction of dynamic injection, we won't be getting those either.
- Delete unused function `createOldContainer`