### PR TITLE
Return 410 error when data store that has been deleted is requested externally

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -467,6 +467,22 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     }
 
     /**
+     * Tells whether the data store is referenced as per the initial summary when it was loaded.
+     * This is used to handle scenario where a data store shared with an external app is deleted and hence GC'd.
+     * If the external app tries to load this data store after it has been deleted from the original app, we detect
+     * it and return an error.
+     */
+    public async isReferencedInInitialSummary(): Promise<boolean> {
+        const initialUsedRoutes = (await this.getInitialGCSummaryDetails()).usedRoutes;
+        // If initial used routes are not available, the document is loaded from an old snapshot format. Return the
+        // data stores as referenced in that case. Otherwise, if the used routes has a self-route, it is referenced.
+        if (initialUsedRoutes === undefined || initialUsedRoutes.includes("/") || initialUsedRoutes.includes("")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * @deprecated 0.18.Should call request on the runtime directly
      */
     public async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -661,6 +661,111 @@ describe("Data Store Context Tests", () => {
                 assert.strictEqual(
                     dataStoreSummarizerNode?.isReferenced(), true, "Data store should now be referenced");
             });
+
+            it("should return initially referenced as per GC details in initial summary", async () => {
+                dataStoreAttributes = {
+                    pkg: "TestDataStore1",
+                    snapshotFormatVersion: undefined,
+                };
+                const gcDetails: IGarbageCollectionSummaryDetails = {
+                    usedRoutes: [""], // Self-route in initial summary to make it referenced.
+                };
+                const attributesBuffer = IsoBuffer.from(JSON.stringify(dataStoreAttributes), "utf-8");
+                const gcDetailsBuffer = IsoBuffer.from(JSON.stringify(gcDetails), "utf-8");
+                const blobCache = new Map<string, string>([
+                    ["fluidDataStoreAttributes", attributesBuffer.toString("base64")],
+                    ["gcDetails", gcDetailsBuffer.toString("base64")],
+                ]);
+                const snapshotTree: ISnapshotTree = {
+                    id: "dummy",
+                    blobs: {
+                        [dataStoreAttributesBlobName]: "fluidDataStoreAttributes",
+                        [gcBlobKey]: "gcDetails",
+                    },
+                    commits: {},
+                    trees: {},
+                };
+
+                remotedDataStoreContext = new RemotedFluidDataStoreContext(
+                    dataStoreId,
+                    snapshotTree,
+                    containerRuntime,
+                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    scope,
+                    createSummarizerNodeFn,
+                );
+
+                const initiallyReferenced = await remotedDataStoreContext.isReferencedInInitialSummary();
+                assert.strictEqual(initiallyReferenced, true, "Data store should be initially referenced");
+            });
+
+            it("should return initially unreferenced as per GC details in initial summary", async () => {
+                dataStoreAttributes = {
+                    pkg: "TestDataStore1",
+                    snapshotFormatVersion: undefined,
+                };
+                const gcDetails: IGarbageCollectionSummaryDetails = {
+                    usedRoutes: [], // No routes in initial summary to make it unreferenced.
+                };
+                const attributesBuffer = IsoBuffer.from(JSON.stringify(dataStoreAttributes), "utf-8");
+                const gcDetailsBuffer = IsoBuffer.from(JSON.stringify(gcDetails), "utf-8");
+                const blobCache = new Map<string, string>([
+                    ["fluidDataStoreAttributes", attributesBuffer.toString("base64")],
+                    ["gcDetails", gcDetailsBuffer.toString("base64")],
+                ]);
+                const snapshotTree: ISnapshotTree = {
+                    id: "dummy",
+                    blobs: {
+                        [dataStoreAttributesBlobName]: "fluidDataStoreAttributes",
+                        [gcBlobKey]: "gcDetails",
+                    },
+                    commits: {},
+                    trees: {},
+                };
+
+                remotedDataStoreContext = new RemotedFluidDataStoreContext(
+                    dataStoreId,
+                    snapshotTree,
+                    containerRuntime,
+                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    scope,
+                    createSummarizerNodeFn,
+                );
+
+                const initiallyReferenced = await remotedDataStoreContext.isReferencedInInitialSummary();
+                assert.strictEqual(initiallyReferenced, false, "Data store should be initially unreferenced");
+            });
+
+            it("should return initially referenced with no GC details in initial summary", async () => {
+                dataStoreAttributes = {
+                    pkg: "TestDataStore1",
+                    snapshotFormatVersion: undefined,
+                };
+                const attributesBuffer = IsoBuffer.from(JSON.stringify(dataStoreAttributes), "utf-8");
+                const blobCache = new Map<string, string>([
+                    ["fluidDataStoreAttributes", attributesBuffer.toString("base64")],
+                ]);
+                const snapshotTree: ISnapshotTree = {
+                    id: "dummy",
+                    blobs: {
+                        [dataStoreAttributesBlobName]: "fluidDataStoreAttributes",
+                    },
+                    commits: {},
+                    trees: {},
+                };
+
+                remotedDataStoreContext = new RemotedFluidDataStoreContext(
+                    dataStoreId,
+                    snapshotTree,
+                    containerRuntime,
+                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    scope,
+                    createSummarizerNodeFn,
+                );
+
+                const initiallyReferenced = await remotedDataStoreContext.isReferencedInInitialSummary();
+                assert.strictEqual(initiallyReferenced, true, "Data store should be initially referenced");
+            });
         });
     });
 });

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -346,6 +346,19 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
             }
         }
 
+        /**
+         * If the request has "errorOnResourceDeleted" header, we need to return an error if the data store being
+         * requested has been deleted.
+         *
+         * This is used to handle scenario where a data store shared with an external app is deleted and hence GC'd.
+         * The error returned signals the app to take appropriate action for deleted content.
+         */
+        if (request.headers?.errorOnResourceDeleted === true) {
+            if (!(await this.dataStoreContext.isReferencedInInitialSummary())) {
+                return { status: 410, mimeType: "text/plain", value: `${request.url} is on longer available` };
+            }
+        }
+
         // Otherwise defer to an attached request handler
         return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
     }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -354,7 +354,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
          * The error returned signals the app to take appropriate action for deleted content.
          */
         if (request.headers?.errorOnResourceDeleted === true) {
-            if (!(await this.dataStoreContext.isReferencedInInitialSummary())) {
+            // back-compat: 0.36.0. isReferencedInInitialSummary is added to IFluidDataStoreContext in 0.36.0. Remove
+            // undefined check when N >= 0.38.0.
+            const referenced = await this.dataStoreContext.isReferencedInInitialSummary?.();
+            if (referenced === false) {
                 return { status: 410, mimeType: "text/plain", value: `${request.url} is on longer available` };
             }
         }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -347,6 +347,11 @@ IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegi
      * and its children with the GC details from the previous summary.
      */
     getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails>;
+
+    /**
+     * Tells whether the data store is referenced as per the initial summary when it was loaded.
+     */
+    isReferencedInInitialSummary(): Promise<boolean>;
 }
 
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {


### PR DESCRIPTION
Fixes #4824.

Return a 410 (Gone) error code when a data store is requested that has been deleted (marked unreferenced after GC).
We do this only for external requests, i.e., requests that come from Container (loader layer). Container adds a header into the request that says return error if the content being requested is deleted.
Data store runtime returns 410 if the above header is set and the data store is unreferenced as per initial summary.

P.S. I am working on adding end-to-end tests for this.