### PR TITLE
Fix F5 debugging for replay test

### DIFF
--- a/packages/test/snapshots/src/test/replay.spec.ts
+++ b/packages/test/snapshots/src/test/replay.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { describe } from "mocha";
 import { Mode, processContent } from "../replayMultipleFiles";
 
 describe("Snapshots", function() {

--- a/packages/test/snapshots/src/test/tsconfig.json
+++ b/packages/test/snapshots/src/test/tsconfig.json
@@ -9,7 +9,6 @@
         ],
         "declaration": false,
         "declarationMap": false,
-        "strict": false
     },
     "include": [
         "./**/*"


### PR DESCRIPTION
Import error on mocha.describe not being there when invoked with F5.  Not sure why it doesn't repro when running on the command.

Anyway, the import is not necessary since mocha would inject it by default, so no need to explicit import