### PR TITLE
Batch CI Build For Real Svc Tests

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -23,6 +23,7 @@ parameters:
   default: false
 
 trigger:
+  batch: true
   branches:
     include:
     - main


### PR DESCRIPTION
This will batch changes that come in while a build is running into the next build, rather than a build per change, which leads to concurrent builds and lots of 429s