### PR TITLE
lockfile update

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -7624,7 +7624,7 @@
 		"@microsoft/tsdoc": {
 			"version": "0.12.19",
 			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-			"integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
+			"integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
 			"dev": true
 		},
 		"@mixer/webpack-bundle-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,7 +2091,7 @@
     "@microsoft/tsdoc": {
       "version": "0.12.19",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz",
-      "integrity": "sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==",
+      "integrity": "sha1-IXPMuSRpqvYgMfqUmdIbFtB/m1c=",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {


### PR DESCRIPTION
@tylerbutler - do you know why the sha for this package switched from sha512 to sha1?  (Probably obvious but this is just after `git pulll; npm i`)