### PR TITLE
Async broadcaster publisher

### DIFF
--- a/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/broadcaster/lambda.ts
@@ -28,7 +28,7 @@ class BroadcasterBatch {
 
 // Set immediate is not available in all environments, specifically it does not work in a browser.
 // Fallback to set timeout in those cases
-let taskScheduleFunction: (cb: () => void) => unknown;
+let taskScheduleFunction: (cb: () => any) => unknown;
 let clearTaskScheduleTimerFunction: (timer: any) => void;
 
 if (typeof setImmediate === "function") {
@@ -113,23 +113,32 @@ export class BroadcasterLambda implements IPartitionLambda {
         }
 
         // Invoke the next send after a delay to give IO time to create more batches
-        this.messageSendingTimerId = taskScheduleFunction(() => {
+        this.messageSendingTimerId = taskScheduleFunction(async () => {
             const batchOffset = this.pendingOffset;
 
             this.current = this.pending;
             this.pending = new Map<string, BroadcasterBatch>();
             this.pendingOffset = undefined;
 
-            this.messageSendingTimerId = undefined;
-
             // Process all the batches + checkpoint
-            this.current.forEach((batch, topic) => {
+            const promises: Promise<void>[] = [];
+
+            for (const [topic, batch] of this.current) {
                 if (this.publisher.emit) {
-                    this.publisher.emit(topic, batch.event, batch.documentId, batch.messages);
+                    promises.push(this.publisher.emit(topic, batch.event, batch.documentId, batch.messages));
                 } else {
                     this.publisher.to(topic).emit(batch.event, batch.documentId, batch.messages);
                 }
-            });
+            }
+
+            try {
+                await Promise.all(promises);
+            } catch (ex) {
+                this.context.error(ex, { restart: true });
+                return;
+            }
+
+            this.messageSendingTimerId = undefined;
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.context.checkpoint(batchOffset!);

--- a/server/routerlicious/packages/services-core/src/publisher.ts
+++ b/server/routerlicious/packages/services-core/src/publisher.ts
@@ -31,7 +31,7 @@ export interface IPublisher {
      * Used to emit an event to a topic
      * This will be used in place of "to().emit()" when defined
      */
-    emit?(topic: string, event: string, ...args: any[]): void;
+    emit?(topic: string, event: string, ...args: any[]): Promise<void>;
 
     /**
      * Closes the publisher

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -35,7 +35,7 @@ export interface IConsumer {
     /**
      * Event Handler.
      */
-    on(event: "connected" | "disconnected" | "closed", listener: () => void): this;
+    on(event: "connected" | "disconnected" | "closed" | "paused" | "resumed", listener: () => void): this;
     on(event: "data", listener: (message: IQueuedMessage) => void): this;
     on(event: "rebalancing", listener: (partitions: IPartition[]) => void): this;
     on(event: "rebalanced", listener: (partitions: IPartitionWithEpoch[]) => void): this;

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -35,7 +35,7 @@ export interface IConsumer {
     /**
      * Event Handler.
      */
-    on(event: "connected" | "disconnected" | "closed" | "paused" | "resumed", listener: () => void): this;
+    on(event: "connected" | "disconnected" | "closed", listener: () => void): this;
     on(event: "data", listener: (message: IQueuedMessage) => void): this;
     on(event: "rebalancing", listener: (partitions: IPartition[]) => void): this;
     on(event: "rebalanced", listener: (partitions: IPartitionWithEpoch[]) => void): this;

--- a/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
+++ b/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
@@ -42,7 +42,7 @@ export class SocketIoRedisPublisher implements core.IPublisher {
         return new SocketIoRedisTopic(this.io.to(topic));
     }
 
-    public emit(topic: string, event: string, ...args: any[]): void {
+    public async emit(topic: string, event: string, ...args: any[]): Promise<void> {
         this.io.to(topic).emit(event, ...args);
     }
 


### PR DESCRIPTION
Make the `IPublisher` `emit` method async. 

This will allow changing the emit call to wait for the redis publish to complete. `ioredis` returns promises for all it's redis command methods. Waiting for the publish command to finish before processing the next batch should be more efficient because it will allow for batching more messages into each individual command