### PR TITLE
Fix occasional errors during rdkafka rebalancing

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -23,6 +23,11 @@ export class Context extends EventEmitter implements IContext {
         }
 
         this.checkpointManager.checkpoint(queuedMessage).catch((error) => {
+            if (this.closed) {
+                // don't emit errors after closing
+                return;
+            }
+
             // Close context on error. Once the checkpointManager enters an error state it will stay there.
             // We will look to restart on checkpointing given it likely indicates a Kafka connection issue.
             this.error(error, { restart: true });

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -35,7 +35,7 @@ export interface IConsumer {
     /**
      * Event Handler.
      */
-    on(event: "connected" | "disconnected" | "closed", listener: () => void): this;
+    on(event: "connected" | "disconnected" | "closed" | "paused" | "resumed", listener: () => void): this;
     on(event: "data", listener: (message: IQueuedMessage) => void): this;
     on(event: "rebalancing", listener: (partitions: IPartition[]) => void): this;
     on(event: "rebalanced", listener: (partitions: IPartitionWithEpoch[]) => void): this;


### PR DESCRIPTION
- Cleanup left over stuff from lost partitions after completing the rebalance - `Partition for commit was unassigned` errors are expected when we having pending commits during a rebalance. It will now reject those after the balance, which means those old partitions will already be closed. So the errors shouldn't be seen in error handlers.
- Fix unhandled error events from context checkpointing - this occurs when there's a checkpoint in progress as a partition is lost due to rebalancing
- Add `paused` and `resumed` events to the consumer