### PR TITLE
fix return in externalstoragemanager read

### DIFF
--- a/server/gitrest/src/externalStorageManager.ts
+++ b/server/gitrest/src/externalStorageManager.ts
@@ -40,6 +40,7 @@ export class ExternalStorageManager implements IExternalStorageManager {
             winston.info("External storage is not enabled");
             return false;
         }
+        let result = true;
         await Axios.post<void>(
             `${this.endpoint}/file/${tenantId}/${documentId}`,
             undefined,
@@ -50,10 +51,10 @@ export class ExternalStorageManager implements IExternalStorageManager {
             }).catch((error) => {
                 const messageMetaData = { tenantId, documentId };
                 winston.error(`Failed to read document: ${safeStringify(error, undefined, 2)}`, { messageMetaData });
-                return false;
+                result = false;
             });
 
-        return true;
+            return result;
     }
 
     public async write(tenantId: string, ref: string, sha: string, update: boolean): Promise<void> {

--- a/server/gitrest/src/externalStorageManager.ts
+++ b/server/gitrest/src/externalStorageManager.ts
@@ -54,7 +54,7 @@ export class ExternalStorageManager implements IExternalStorageManager {
                 result = false;
             });
 
-            return result;
+        return result;
     }
 
     public async write(tenantId: string, ref: string, sha: string, update: boolean): Promise<void> {


### PR DESCRIPTION
Currently externalStorageManager read method always returns true even if we catch an error on the post request.  It is because we are returning false within the resolve function instead of outside. This causes getref to be recursively called causing many errors in byos and gitrest, and eventually causing scribe to crash. This PR fixes this retry loop.