### PR TITLE
Allow the Summarizer Client to Reconnect

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -429,7 +429,6 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                     type: summarizerClientType,
                 },
                 [DriverHeader.summarizingClient]: true,
-                [LoaderHeader.reconnect]: false,
                 [LoaderHeader.sequenceNumber]: this.context.deltaManager.lastSequenceNumber,
                 [LoaderHeader.executionContext]: this.enableWorker ? "worker" : undefined,
             },


### PR DESCRIPTION
By setting reconnect to false the summarizer client will close its container on connection error. The container will not be re-created, and the document will be stuck without a summarizer.