### PR TITLE
BlobManager asserts: duplicate payloads

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -80,15 +80,15 @@ export class BlobManager {
             () => this.attachBlobCallback(response.id),
         );
 
-        assert(!this.pendingBlobIds.has(response.id));
-        assert(!this.blobIds.has(response.id));
-        this.pendingBlobIds.add(response.id);
+        // Note - server will de-dup blobs, so we might get existing blobId!
+        if (!this.blobIds.has(response.id)) {
+            this.pendingBlobIds.add(response.id);
+        }
 
         return handle;
     }
 
     public addBlobId(blobId: string) {
-        assert(!this.blobIds.has(blobId));
         this.blobIds.add(blobId);
         this.pendingBlobIds.delete(blobId);
     }


### PR DESCRIPTION
Server will dedup same content and return same ID.
This was not accounted in asserts I've added, so changing them to make less strict.