### PR TITLE
Experimental fluid-build task worker processes

### DIFF
--- a/packages/test/end-to-end-tests/tsconfig.esnext.json
+++ b/packages/test/end-to-end-tests/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "outDir": "./lib",
-        "module": "esnext"
-    }
-}

--- a/tools/build-tools/.vscode/launch.json
+++ b/tools/build-tools/.vscode/launch.json
@@ -25,6 +25,12 @@
                 "${workspaceFolder}/**/*.js"
             ],
             "cwd": "${workspaceFolder}",
-        }
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach by Process ID",
+            "processId": "${command:PickProcess}"
+        },
     ],
 }

--- a/tools/build-tools/package-lock.json
+++ b/tools/build-tools/package-lock.json
@@ -3450,6 +3450,12 @@
         "underscore": "1.8.3"
       }
     },
+    "typescript": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "dev": true
+    },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",

--- a/tools/build-tools/package-lock.json
+++ b/tools/build-tools/package-lock.json
@@ -24,6 +24,13 @@
         "msgpack-lite": "^0.1.26",
         "pako": "^1.0.10",
         "typescript": "^3.7.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.9",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -3442,11 +3449,6 @@
         "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
-    },
-    "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
     },
     "underscore": {
       "version": "1.8.3",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -55,7 +55,8 @@
     "@types/rimraf": "^2.0.3",
     "@types/semver": "^7.1.0",
     "@types/shelljs": "^0.8.8",
-    "@types/webpack": "^4.41.22"
+    "@types/webpack": "^4.41.22",
+    "typescript": "~4.1.3"
   },
   "peerDependencies": {
     "eslint": "~7.18.0",

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -43,8 +43,7 @@
     "rimraf": "^2.6.2",
     "semver": "^7.1.2",
     "shelljs": "^0.8.4",
-    "sort-package-json": "1.40.0",
-    "typescript": "^3.7.4"
+    "sort-package-json": "1.40.0"
   },
   "devDependencies": {
     "@types/async": "^2.4.1",
@@ -57,5 +56,9 @@
     "@types/semver": "^7.1.0",
     "@types/shelljs": "^0.8.8",
     "@types/webpack": "^4.41.22"
+  },
+  "peerDependencies": {
+    "eslint": "~7.18.0",
+    "typescript": "~4.1.3"
   }
 }

--- a/tools/build-tools/src/common/fluidRepo.ts
+++ b/tools/build-tools/src/common/fluidRepo.ts
@@ -8,7 +8,6 @@ import { Package, Packages } from "./npmPackage";
 import { MonoRepo, MonoRepoKind } from "./monoRepo";
 import { getPackageManifest } from "./fluidUtils";
 import { ExecAsyncResult } from "./utils";
-import { isTemplateSpan } from "typescript";
 
 export interface IPackageManifest {
     repoPackages: {

--- a/tools/build-tools/src/common/logging.ts
+++ b/tools/build-tools/src/common/logging.ts
@@ -12,9 +12,9 @@ export function logVerbose(msg: string) {
     }
 }
 
-export function logStatus(msg: string) {
+function log(msg: string, logFunc: (msg: string) => void) {
     if (!commonOptions.logtime) {
-        console.log(msg);
+        logFunc(msg);
         return;
     }
     const date = new Date();
@@ -24,5 +24,13 @@ export function logStatus(msg: string) {
     if (mins.length === 1) { mins = '0' + mins; }
     let secs = date.getSeconds().toString();
     if (secs.length === 1) { secs = '0' + secs; }
-    console.log(chalk.yellow(`[${hours}:${mins}:${secs}] `) + msg);
+    logFunc(chalk.yellow(`[${hours}:${mins}:${secs}] `) + msg);
+}
+
+export function logStatus(msg: string) {
+    log(msg, console.log);
+}
+
+export function logError(msg: string) {
+    log(`ERROR: ${msg}`, console.error);
 }

--- a/tools/build-tools/src/common/npmPackage.ts
+++ b/tools/build-tools/src/common/npmPackage.ts
@@ -230,13 +230,12 @@ async function queueExec<TItem, TResult>(items: Iterable<TItem>, exec: (item: TI
         logStatus(`[${++numDone}/${p.length}] ${messageCallback(item)} - ${elapsedTime.toFixed(3)}s`);
         return result;
     } : exec;
-    const q = queue(async (taskExec: TaskExec<TItem, TResult>, callback) => {
+    const q = queue(async (taskExec: TaskExec<TItem, TResult>) => {
         try {
             taskExec.resolve(await timedExec(taskExec.item));
         } catch (e) {
             taskExec.reject(e);
         }
-        callback();
     }, options.concurrency);
     const p: Promise<TResult>[] = [];
     for (const item of items) {

--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -51,7 +51,6 @@ class BuildContext {
 export class BuildPackage {
     private buildTask?: Task | null = null;
     private buildScriptNames: string[];
-    private loaded = false;
     public readonly parents = new Array<BuildPackage>();
     public readonly dependentPackages = new Array<BuildPackage>();
     public level: number = -1;
@@ -95,7 +94,7 @@ export class BuildPackage {
 export class BuildGraph {
     private readonly buildPackages = new Map<string, BuildPackage>();
     private readonly buildContext = new BuildContext(
-        options.worker ? new WorkerPool(options.worker_threads) : undefined);
+        options.worker ? new WorkerPool(options.workerThreads, options.workerMemoryLimit) : undefined);
 
     public constructor(
         private readonly packages: Package[],

--- a/tools/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/tools/build-tools/src/fluidBuild/fluidBuild.ts
@@ -6,7 +6,7 @@
 import { commonOptions } from "../common/commonOptions";
 import { FluidRepoBuild } from "./fluidRepoBuild";
 import { getResolvedFluidRoot } from "../common/fluidUtils";
-import { logStatus } from "../common/logging";
+import { logStatus, logError, logVerbose } from "../common/logging";
 import { Timer } from "../common/timer";
 import { existsSync } from "../common/utils";
 import { BuildResult } from "./buildGraph";
@@ -35,110 +35,107 @@ async function main() {
     const repo = new FluidRepoBuild(resolvedRoot, options.services);
     timer.time("Package scan completed");
 
-    try {
-        // Set matched package based on options filter
-        const matched = repo.setMatched(options);
-        if (!matched) {
-            console.error("ERROR: No package matched");
-            process.exit(-4)
-        }
-
-        // Dependency checks
-        if (options.depcheck) {
-            repo.depcheck();
-            timer.time("Dependencies check completed", true)
-        }
-
-        // Uninstall
-        if (options.uninstall) {
-            if (!await repo.uninstall()) {
-                console.error(`ERROR: uninstall failed`);
-                process.exit(-8);
-            }
-            timer.time("Uninstall completed", true);
-
-            if (!options.install) {
-                let errorStep: string | undefined = undefined;
-                if (options.symlink) {
-                    errorStep = "symlink";
-                } else if (options.clean) {
-                    errorStep = "clean";
-                } else if (options.build) {
-                    errorStep = "build";
-                }
-                if (errorStep) {
-                    console.warn(`WARNING: Skipping ${errorStep} after uninstall`);
-                }
-                process.exit(0);
-            }
-        }
-
-        // Install or check install
-        if (options.install) {
-            console.log("Installing packages");
-            if (!await repo.install(options.nohoist)) {
-                console.error(`ERROR: Install failed`);
-                process.exit(-5);
-            }
-            timer.time("Install completed", true);
-        }
-
-        // Symlink check
-        const symlinkTaskName = options.symlink ? "Symlink" : "Symlink check";
-        await repo.symlink(options);
-        timer.time(`${symlinkTaskName} completed`, options.symlink);
-
-        // Check scripts
-        await repo.checkPackages(options.fix);
-        timer.time("Check scripts completed");
-
-
-        if (options.clean || options.build !== false) {
-            logStatus(`Symlink in ${options.fullSymlink ? "full" : options.fullSymlink === false ? "isolated" : "non-dependent"} mode`);
-
-            // build the graph
-            const buildGraph = repo.createBuildGraph(options, options.buildScriptNames);
-            timer.time("Build graph creation completed");
-
-            // Check install
-            if (!await buildGraph.checkInstall()) {
-                console.error("ERROR: Dependency not installed. Use --install to fix.");
-                process.exit(-10);
-            }
-            timer.time("Check install completed");
-
-            if (options.clean) {
-                if (!await buildGraph.clean()) {
-                    console.error(`ERROR: Clean failed`);
-                    process.exit(-9);
-                }
-                timer.time("Clean completed");
-            }
-
-            if (options.build !== false) {
-                // Run the build
-                const buildResult = await buildGraph.build(timer);
-                const buildStatus = buildResultString(buildResult);
-                const elapsedTime = timer.time();
-                if (commonOptions.timer) {
-                    const totalElapsedTime = buildGraph.totalElapsedTime;
-                    const concurrency = buildGraph.totalElapsedTime / elapsedTime;
-                    logStatus(`Execution time: ${totalElapsedTime.toFixed(3)}s, Concurrency: ${concurrency.toFixed(3)}`);
-                    logStatus(`Build ${buildStatus} - ${elapsedTime.toFixed(3)}s`);
-                } else {
-                    logStatus(`Build ${buildStatus}`);
-                }
-            }
-        }
-
-        if (options.build === false) {
-            logStatus(`Other switches with no explicit build script, not building.`);
-        }
-
-        logStatus(`Total time: ${(timer.getTotalTime() / 1000).toFixed(3)}s`);
-    } catch (e) {
-        logStatus(`ERROR: ${e.message}`);
+    // Set matched package based on options filter
+    const matched = repo.setMatched(options);
+    if (!matched) {
+        logError("No package matched");
+        process.exit(-4)
     }
+
+    // Dependency checks
+    if (options.depcheck) {
+        repo.depcheck();
+        timer.time("Dependencies check completed", true)
+    }
+
+    // Uninstall
+    if (options.uninstall) {
+        if (!await repo.uninstall()) {
+            logError(`uninstall failed`);
+            process.exit(-8);
+        }
+        timer.time("Uninstall completed", true);
+
+        if (!options.install) {
+            let errorStep: string | undefined = undefined;
+            if (options.symlink) {
+                errorStep = "symlink";
+            } else if (options.clean) {
+                errorStep = "clean";
+            } else if (options.build) {
+                errorStep = "build";
+            }
+            if (errorStep) {
+                console.warn(`WARNING: Skipping ${errorStep} after uninstall`);
+            }
+            process.exit(0);
+        }
+    }
+
+    // Install or check install
+    if (options.install) {
+        console.log("Installing packages");
+        if (!await repo.install(options.nohoist)) {
+            logError(`Install failed`);
+            process.exit(-5);
+        }
+        timer.time("Install completed", true);
+    }
+
+    // Symlink check
+    const symlinkTaskName = options.symlink ? "Symlink" : "Symlink check";
+    await repo.symlink(options);
+    timer.time(`${symlinkTaskName} completed`, options.symlink);
+
+    // Check scripts
+    await repo.checkPackages(options.fix);
+    timer.time("Check scripts completed");
+
+
+    if (options.clean || options.build !== false) {
+        logStatus(`Symlink in ${options.fullSymlink ? "full" : options.fullSymlink === false ? "isolated" : "non-dependent"} mode`);
+
+        // build the graph
+        const buildGraph = repo.createBuildGraph(options, options.buildScriptNames);
+        timer.time("Build graph creation completed");
+
+        // Check install
+        if (!await buildGraph.checkInstall()) {
+            logError("Dependency not installed. Use --install to fix.");
+            process.exit(-10);
+        }
+        timer.time("Check install completed");
+
+        if (options.clean) {
+            if (!await buildGraph.clean()) {
+                logError(`Clean failed`);
+                process.exit(-9);
+            }
+            timer.time("Clean completed");
+        }
+
+        if (options.build !== false) {
+            // Run the build
+            const buildResult = await buildGraph.build(timer);
+            const buildStatus = buildResultString(buildResult);
+            const elapsedTime = timer.time();
+            if (commonOptions.timer) {
+                const totalElapsedTime = buildGraph.totalElapsedTime;
+                const concurrency = buildGraph.totalElapsedTime / elapsedTime;
+                logStatus(`Execution time: ${totalElapsedTime.toFixed(3)}s, Concurrency: ${concurrency.toFixed(3)}`);
+                logStatus(`Build ${buildStatus} - ${elapsedTime.toFixed(3)}s`);
+            } else {
+                logStatus(`Build ${buildStatus}`);
+            }
+        }
+    }
+
+    if (options.build === false) {
+        logStatus(`Other switches with no explicit build script, not building.`);
+    }
+
+    logStatus(`Total time: ${(timer.getTotalTime() / 1000).toFixed(3)}s`);
+
 }
 
 function buildResultString(buildResult: BuildResult) {
@@ -153,6 +150,6 @@ function buildResultString(buildResult: BuildResult) {
 }
 
 main().catch(error => {
-    console.error("ERROR: Unexpected error");
-    console.error(error.stack);
+    logStatus(`ERROR: Unexpected error. ${error.message}`);
+    logStatus(error.stack);
 });

--- a/tools/build-tools/src/fluidBuild/options.ts
+++ b/tools/build-tools/src/fluidBuild/options.ts
@@ -30,6 +30,9 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
     samples: boolean;
     fix: boolean;
     services: boolean;
+    worker: boolean;
+    worker_threads: boolean;
+
 }
 
 // defaults
@@ -56,6 +59,8 @@ export const options: FastBuildOptions = {
     all: false,
     server: false,
     services: false,
+    worker: false,
+    worker_threads: false,
 };
 
 function printUsage() {
@@ -255,6 +260,17 @@ export function parseOptions(argv: string[]) {
 
         if (arg === "--showExec") {
             options.showExec = true;
+            continue;
+        }
+
+        if (arg === "--worker") {
+            options.worker = true;
+            continue;
+        }
+
+        if (arg === "--worker_threads") {
+            options.worker_threads = true;
+            options.worker = true;
             continue;
         }
 

--- a/tools/build-tools/src/fluidBuild/options.ts
+++ b/tools/build-tools/src/fluidBuild/options.ts
@@ -31,8 +31,8 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
     fix: boolean;
     services: boolean;
     worker: boolean;
-    worker_threads: boolean;
-
+    workerThreads: boolean;
+    workerMemoryLimit: number;
 }
 
 // defaults
@@ -60,7 +60,8 @@ export const options: FastBuildOptions = {
     server: false,
     services: false,
     worker: false,
-    worker_threads: false,
+    workerThreads: false,
+    workerMemoryLimit: -1,
 };
 
 function printUsage() {
@@ -268,10 +269,25 @@ export function parseOptions(argv: string[]) {
             continue;
         }
 
-        if (arg === "--worker_threads") {
-            options.worker_threads = true;
+        if (arg === "--workerThreads") {
+            options.workerThreads = true;
             options.worker = true;
             continue;
+        }
+
+        if (arg === "--workerMemoryLimitMB") {
+            if (i !== process.argv.length - 1) {
+                const mb = parseInt(process.argv[++i]);
+                if (!isNaN(mb)) {
+                    options.workerMemoryLimit = mb * 1024 * 1024;
+                    continue;
+                }
+                console.error("ERROR: Argument for --workerMemoryLimitMB is not a number");
+            } else {
+                console.error("ERROR: Missing argument for --workerMemoryLimit");
+            }
+            error = true;
+            break;
         }
 
         // Package regexp or paths

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -98,7 +98,7 @@ export abstract class LeafTask extends Task {
             // rerun on the main thread in case the work has an unknown exception
             const result = await this.execCommand();
             if (!result.error) {
-                console.warn(`${this.node.pkg.nameColored}: warning: failed in worker but succeeded directly ${this.command}`)
+                console.warn(`${this.node.pkg.nameColored}: warning: failed in worker but succeeded directly '${this.command}'`)
             }
             return result;
         }

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
@@ -80,6 +80,11 @@ export class EsLintTask extends LintBaseTask {
         }
         super.addDependentTasks(dependentTasks);
     }
+
+    protected get useWorker() {
+        // eslint can't use worker thread as it needs to change the current working directory
+        return this.node.buildContext.workerPool?.useWorkerThreads === false;
+    }
 }
 
 export class TsFormatTask extends LintBaseTask {

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -316,7 +316,13 @@ export class TscTask extends LeafTask {
         this._tsBuildInfo = undefined;
     }
 
-    protected get useWorker() { return true; }
+    protected get useWorker() {
+        // TODO: Worker doesn't implement all mode.  This is not comprehensive filtering yet.
+        const parsed = this.parsedCommandLine;
+        return parsed !== undefined
+            && (parsed.fileNames.length === 0 || parsed.options.project === undefined)
+            && !parsed.watchOptions;
+    }
 };
 
 // Base class for tasks that are dependent on a tsc compile

--- a/tools/build-tools/src/fluidBuild/tasks/task.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/task.ts
@@ -18,9 +18,8 @@ export interface TaskExec {
 
 export abstract class Task {
     public static createTaskQueue(): AsyncPriorityQueue<TaskExec> {
-        return priorityQueue(async (taskExec: TaskExec, callback) => {
+        return priorityQueue(async (taskExec: TaskExec) => {
             taskExec.resolve(await taskExec.task.exec());
-            callback();
         }, options.concurrency);
     }
 
@@ -62,8 +61,8 @@ export abstract class Task {
     public abstract get isLeaf(): boolean;
     public abstract matchTask(command: string, options?: any): Task | undefined;
     public abstract collectLeafTasks(leafTasks: LeafTask[]): void;
-    protected abstract async checkIsUpToDate(): Promise<boolean>;
-    protected abstract async runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult>;
+    protected abstract checkIsUpToDate(): Promise<boolean>;
+    protected abstract runTask(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult>;
 
     public get forced() {
         return options.force && (options.matchedOnly !== true || this.package.matched);

--- a/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
@@ -5,11 +5,12 @@
 
 import type { WorkerMessage, WorkerExecResult } from "./worker";
 
+const eslintPath = require.resolve("eslint/lib/cli");
 const eslint = require("eslint/lib/cli");
+
 export async function lint(message: WorkerMessage): Promise<WorkerExecResult> {
     const oldArgv = process.argv;
     const oldCwd = process.cwd();
-
     try {
         // TODO: better parsing, assume split delimited for now.
         const argv = message.command.split(" ");
@@ -17,10 +18,9 @@ export async function lint(message: WorkerMessage): Promise<WorkerExecResult> {
         // Some rules look at process.argv directly and change behaviors
         // (e.g. eslint-plugin-react log some error to console only if format is not set)
         // So just overwrite our argv
-        process.argv = [process.argv0, ...argv];
+        process.argv = [process.argv0, eslintPath, ...argv.slice(1)];
         process.chdir(message.cwd);
-
-        return { code: await eslint.execute(argv) };
+        return { code: await eslint.execute(process.argv) };
     } finally {
         process.argv = oldArgv;
         process.chdir(oldCwd);

--- a/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
@@ -1,0 +1,37 @@
+import type { WorkerMessage, WorkerExecResult } from "./worker";
+
+const eslint = require("eslint/lib/cli");
+export async function lint(message: WorkerMessage): Promise<WorkerExecResult> {
+    process.chdir(message.cwd);
+
+    // TODO: better parsing, assume split delimited for now.
+    const argv = message.command.split(" ");
+
+    // Some rules look at process.argv directly and change behaviors
+    // (e.g. eslint-plugin-react log some error to console only if format is not set)
+    // So just overwrite our argv
+    process.argv = argv
+
+    const oldLog = console.log;
+    const oldError = console.error;
+    let stdoutLines: string[] = [];
+    let stderrLines: string[] = [];
+    console.log = (...args: any[]) => {
+        stdoutLines.push(args.join(" "));
+    };
+    console.error = (...args: any[]) => {
+        stderrLines.push(args.join(" "));
+    };
+
+    try {
+        const code = await eslint.execute(argv.slice(1));
+        return {
+            code,
+            stdout: stdoutLines.join("\n"),
+            stderr: stderrLines.join("\n"),
+        };
+    } finally {
+        console.log = oldLog;
+        console.error = oldError;
+    }
+}

--- a/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/eslintWorker.ts
@@ -1,37 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import type { WorkerMessage, WorkerExecResult } from "./worker";
 
 const eslint = require("eslint/lib/cli");
 export async function lint(message: WorkerMessage): Promise<WorkerExecResult> {
-    process.chdir(message.cwd);
-
-    // TODO: better parsing, assume split delimited for now.
-    const argv = message.command.split(" ");
-
-    // Some rules look at process.argv directly and change behaviors
-    // (e.g. eslint-plugin-react log some error to console only if format is not set)
-    // So just overwrite our argv
-    process.argv = argv
-
-    const oldLog = console.log;
-    const oldError = console.error;
-    let stdoutLines: string[] = [];
-    let stderrLines: string[] = [];
-    console.log = (...args: any[]) => {
-        stdoutLines.push(args.join(" "));
-    };
-    console.error = (...args: any[]) => {
-        stderrLines.push(args.join(" "));
-    };
+    const oldArgv = process.argv;
+    const oldCwd = process.cwd();
 
     try {
-        const code = await eslint.execute(argv.slice(1));
-        return {
-            code,
-            stdout: stdoutLines.join("\n"),
-            stderr: stderrLines.join("\n"),
-        };
+        // TODO: better parsing, assume split delimited for now.
+        const argv = message.command.split(" ");
+
+        // Some rules look at process.argv directly and change behaviors
+        // (e.g. eslint-plugin-react log some error to console only if format is not set)
+        // So just overwrite our argv
+        process.argv = [process.argv0, ...argv];
+        process.chdir(message.cwd);
+
+        return { code: await eslint.execute(argv) };
     } finally {
-        console.log = oldLog;
-        console.error = oldError;
+        process.argv = oldArgv;
+        process.chdir(oldCwd);
     }
 }

--- a/tools/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as ts from "typescript";
+import * as TscUtils from "../../tscUtils";
+import type { WorkerMessage, WorkerExecResult } from "./worker";
+
+function convertDiagnostics(diagnostics: ts.SortedReadonlyArray<ts.Diagnostic>) {
+    const messages: string[] = [];
+    diagnostics.forEach(diagnostic => {
+        if (diagnostic.file) {
+            let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
+            let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+            messages.push(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
+        } else {
+            messages.push(ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
+        }
+    });
+    return messages.join("\n");
+}
+
+export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
+    const { command, cwd } = msg;
+    let commandLine = TscUtils.parseCommandLine(command);
+    let diagnostics: ts.Diagnostic[] = [];
+
+    if (commandLine) {
+        const configFileName = TscUtils.findConfigFile(cwd, commandLine);
+        if (configFileName) {
+            commandLine = ts.getParsedCommandLineOfConfigFile(
+                configFileName,
+                commandLine.options,
+                {
+                    ...ts.sys,
+                    getCurrentDirectory: () => cwd,
+                    onUnRecoverableConfigFileDiagnostic: (diagnostic: ts.Diagnostic) => {
+                        diagnostics.push(diagnostic);
+                    }
+                })!;
+        } else {
+            throw new Error("Unknown config file in commane line");
+        }
+    }
+
+    let code = ts.ExitStatus.DiagnosticsPresent_OutputsSkipped;
+    if (commandLine && diagnostics.length === 0) {
+        const incremental = !!(commandLine.options.incremental || commandLine.options.composite);
+        const param = {
+            rootNames: commandLine.fileNames,
+            options: TscUtils.convertToOptionsWithAbsolutePath(commandLine.options, cwd),
+            projectReferences: commandLine.projectReferences,
+        };
+        const program = incremental ?
+            ts.createIncrementalProgram(param) :
+            ts.createProgram(param);
+
+        diagnostics.push(...program.getConfigFileParsingDiagnostics());
+        diagnostics.push(...program.getSyntacticDiagnostics());
+        diagnostics.push(...program.getOptionsDiagnostics());
+        diagnostics.push(...program.getGlobalDiagnostics());
+        diagnostics.push(...program.getSemanticDiagnostics());
+
+        const emitResult = program.emit();
+        diagnostics.push(...emitResult.diagnostics);
+
+        if (!emitResult.emitSkipped) {
+            code = diagnostics.length !== 0 ? ts.ExitStatus.DiagnosticsPresent_OutputsGenerated : ts.ExitStatus.Success;
+        }
+    }
+
+    const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
+    return {
+        code,
+        stderr: convertDiagnostics(sortedDiagnostics)
+    };
+}

--- a/tools/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -71,8 +71,6 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
     }
 
     const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
-    return {
-        code,
-        stderr: convertDiagnostics(sortedDiagnostics)
-    };
+    console.log(convertDiagnostics(sortedDiagnostics));
+    return { code };
 }

--- a/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { parentPort } from "worker_threads";
+import { compile } from "./tscWorker";
+import { lint } from "./eslintWorker";
+
+export interface WorkerMessage {
+    workerName: string,
+    command: string,
+    cwd: string,
+};
+
+export interface WorkerExecResult {
+    code: number;
+    stdout?: string,
+    stderr?: string,
+    error?: Error,  // unhandled exception, main thread should rerun it.
+}
+
+const workers: { [key: string]: (message: WorkerMessage) => Promise<WorkerExecResult> } = {
+    "tsc": compile,
+    "eslint": lint,
+}
+
+async function messageHandler(msg: WorkerMessage): Promise<WorkerExecResult> {
+    try {
+        const worker = workers[msg.workerName];
+        if (worker) {
+            return worker(msg);
+        }
+        throw new Error(`Invalid workerName ${msg.workerName}`);
+    } catch (error) {
+        // any unhandled exception thrown is going to rerun on main thread.
+        return { error, code: -1 };
+    }
+}
+
+if (parentPort) {
+    parentPort.on("message", (message: WorkerMessage) => {
+        messageHandler(message).then(parentPort!.postMessage.bind(parentPort));
+    });
+} else if (process.send) {
+    process.on('message', (message: WorkerMessage) => {
+        messageHandler(message).then(process.send!.bind(process));
+    });
+    process.on("uncaughtException", (error)=> {
+        console.error(`ERROR: Uncaught exception. ${error.message}\n${error.stack}`);
+        process.exit(-1);
+    });
+    process.on("unhandledRejection", (reason, promise)=> {
+        console.error(`ERROR: Unhandled promise rejection. ${reason}`);
+        process.exit(-1);
+    });
+    process.on("beforeExit", () => {
+        console.error("ERROR: Process exited");
+        process.exit(-1);
+    });
+} else {
+    throw new Error("Invalid worker invocation");
+}
+
+

--- a/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/worker.ts
@@ -15,8 +15,6 @@ export interface WorkerMessage {
 
 export interface WorkerExecResult {
     code: number;
-    stdout?: string,
-    stderr?: string,
     error?: Error,  // unhandled exception, main thread should rerun it.
 }
 

--- a/tools/build-tools/src/fluidBuild/tasks/workers/workerPool.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/workerPool.ts
@@ -7,6 +7,11 @@ import * as child_process from "child_process";
 import { Worker } from "worker_threads";
 import { WorkerMessage, WorkerExecResult } from "./worker";
 
+export interface WorkerExecResultWithOutput extends WorkerExecResult {
+    stdout: string,
+    stderr: string,
+}
+
 export class WorkerPool {
     private readonly threadWorkerPool: Worker[] = [];
     private readonly processWorkerPool: child_process.ChildProcess[] = [];
@@ -16,7 +21,7 @@ export class WorkerPool {
     private getThreadWorker() {
         let worker: Worker | undefined = this.threadWorkerPool.pop();
         if (!worker) {
-            worker = new Worker(`${__dirname}/worker.js`);
+            worker = new Worker(`${__dirname}/worker.js`, { stdout: true, stderr: true });
         }
         return worker;
     }
@@ -24,50 +29,57 @@ export class WorkerPool {
     private getProcessWorker() {
         let worker: child_process.ChildProcess | undefined = this.processWorkerPool.pop();
         if (!worker) {
-            worker = child_process.fork(`${__dirname}/worker.js`);
+            worker = child_process.fork(`${__dirname}/worker.js`, undefined, { silent: true });
         }
         return worker;
     }
 
-    public async runOnWorker(workerName: string, command: string, cwd: string): Promise<WorkerExecResult> {
+    public async runOnWorker(workerName: string, command: string, cwd: string): Promise<WorkerExecResultWithOutput> {
         const workerMessage: WorkerMessage = { workerName, command, cwd };
-        if (this.useWorkerThreads) {
-            const worker = this.getThreadWorker();
-            const p = new Promise<WorkerExecResult>((res, rej) => {
-                worker.once("message", res);
-                worker.postMessage(workerMessage);
+        const cleanup: (() => void)[] = [];
+        const installTemporaryListener = (object: EventEmitter, event: string, handler: any) => {
+            object.on(event, handler);
+            cleanup.push(() => object.off(event, handler));
+        }
+        const setupWorker = (worker: Worker | child_process.ChildProcess, res: (value: WorkerExecResultWithOutput) => void) => {
+            let stdout = "";
+            let stderr = "";
+            installTemporaryListener(worker.stdout, "data", (chunk: any) => { stdout += chunk; });
+            installTemporaryListener(worker.stderr, "data", (chunk: any) => { stderr += chunk; });
+            worker.once("message", (result: WorkerExecResult) => {
+                res({ ...result, stdout, stderr });
             });
-            const res = await p;
-            this.threadWorkerPool.push(worker);
-            return res;
-        } else {
-            const worker = this.getProcessWorker();
+        }
+        try {
+            if (this.useWorkerThreads) {
+                const worker = this.getThreadWorker();
+                const res = await new Promise<WorkerExecResultWithOutput>((res, rej) => {
+                    setupWorker(worker, res);
+                    worker.postMessage(workerMessage);
+                });
+                this.threadWorkerPool.push(worker);
+                return res;
+            } else {
+                const worker = this.getProcessWorker();
+                const res = new Promise<WorkerExecResultWithOutput>((res, rej) => {
+                    const setupErrorListener = (event: string) => {
+                        installTemporaryListener(worker, event, () => { rej(new Error(`Worker ${event}`)); });
+                    }
 
-            const cleanup: (() => void)[] = [];
-            const p = new Promise<WorkerExecResult>((res, rej) => {
-                const setupErrorListener = (event: string) => {
-                    const handler = () => {
-                        rej(new Error(`Worker ${event}`));
-                    };
-                    worker.on(event, handler);
-                    cleanup.push(() => { worker.off(event, handler) });
-                }
+                    setupWorker(worker, res);
 
-                setupErrorListener("close");
-                setupErrorListener("disconnect");
-                setupErrorListener("error");
-                setupErrorListener("exit");
-                worker.once("message", res);
-                worker.send(workerMessage);
-            });
+                    setupErrorListener("close");
+                    setupErrorListener("disconnect");
+                    setupErrorListener("error");
+                    setupErrorListener("exit");
+                    worker.send(workerMessage);
+                });
 
-            try {
-                const res = await p;
                 this.processWorkerPool.push(worker);
                 return res;
-            } finally {
-                cleanup.forEach(value => value());
             }
+        } finally {
+            cleanup.forEach(value => value());
         }
     }
 

--- a/tools/build-tools/src/fluidBuild/tasks/workers/workerPool.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/workers/workerPool.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as child_process from "child_process";
+import { Worker } from "worker_threads";
+import { WorkerMessage, WorkerExecResult } from "./worker";
+
+export class WorkerPool {
+    private readonly threadWorkerPool: Worker[] = [];
+    private readonly processWorkerPool: child_process.ChildProcess[] = [];
+    constructor(public readonly useWorkerThreads: boolean) {
+    }
+
+    private getThreadWorker() {
+        let worker: Worker | undefined = this.threadWorkerPool.pop();
+        if (!worker) {
+            worker = new Worker(`${__dirname}/worker.js`);
+        }
+        return worker;
+    }
+
+    private getProcessWorker() {
+        let worker: child_process.ChildProcess | undefined = this.processWorkerPool.pop();
+        if (!worker) {
+            worker = child_process.fork(`${__dirname}/worker.js`);
+        }
+        return worker;
+    }
+
+    public async runOnWorker(workerName: string, command: string, cwd: string): Promise<WorkerExecResult> {
+        const workerMessage: WorkerMessage = { workerName, command, cwd };
+        if (this.useWorkerThreads) {
+            const worker = this.getThreadWorker();
+            const p = new Promise<WorkerExecResult>((res, rej) => {
+                worker.once("message", res);
+                worker.postMessage(workerMessage);
+            });
+            const res = await p;
+            this.threadWorkerPool.push(worker);
+            return res;
+        } else {
+            const worker = this.getProcessWorker();
+
+            const cleanup: (() => void)[] = [];
+            const p = new Promise<WorkerExecResult>((res, rej) => {
+                const setupErrorListener = (event: string) => {
+                    const handler = () => {
+                        rej(new Error(`Worker ${event}`));
+                    };
+                    worker.on(event, handler);
+                    cleanup.push(() => { worker.off(event, handler) });
+                }
+
+                setupErrorListener("close");
+                setupErrorListener("disconnect");
+                setupErrorListener("error");
+                setupErrorListener("exit");
+                worker.once("message", res);
+                worker.send(workerMessage);
+            });
+
+            try {
+                const res = await p;
+                this.processWorkerPool.push(worker);
+                return res;
+            } finally {
+                cleanup.forEach(value => value());
+            }
+        }
+    }
+
+    public reset() {
+        this.threadWorkerPool.forEach((worker) => {
+            worker.terminate();
+        });
+        this.threadWorkerPool.length = 0;
+
+        this.processWorkerPool.forEach((worker) => {
+            worker.kill();
+        });
+        this.processWorkerPool.length = 0;
+    }
+}

--- a/tools/build-tools/src/fluidBuild/tscUtils.ts
+++ b/tools/build-tools/src/fluidBuild/tscUtils.ts
@@ -10,7 +10,7 @@ export function parseCommandLine(command: string) {
     // TODO: parse the command line for real, split space for now.
     const args = command.split(" ");
 
-    const parsedCommand = ts.parseCommandLine(args);
+    const parsedCommand = ts.parseCommandLine(args.slice(1));
     if (parsedCommand.errors.length) {
         return undefined;
     }
@@ -39,4 +39,15 @@ export function readConfigFile(path: string) {
         return undefined;
     }
     return configFile.config;
+}
+
+export function convertToOptionsWithAbsolutePath(options: ts.CompilerOptions, cwd: string) {
+    const result = { ...options };
+    for (const key of ["configFilePath", "declarationDir", "outDir", "rootDir", "project"]) {
+        const value = result[key] as string;
+        if (value !== undefined) {
+            result[key] = path.resolve(cwd, value);
+        }
+    }
+    return result;
 }


### PR DESCRIPTION
Create reusable worker process to host tsc and eslint code.  Reduce full build by ~47% (from 420s to 220s) on windows
This is experimental for now as there are existing issues that needs to be addressed, and flushing out unknown issue.

Known issues:
- The eslint worker code is really closed to the officially one, but the original tsc cli is less reusable and needed to replicate more behaviors.   Currently, error message for tsc isn't exactly the same as invoking the original.
- Memory leaks can cause the worker memory usage to balloon up.  Needs to investigate why that is.

Use the `--worker  flags to enable, and `--workerMemoryLimitMB &lt;number of MB&gt;` to limit worker memory usage.

