### PR TITLE
move files around for cleaner packaging

### DIFF
--- a/packages/loader/driver-utils/src/compliantLogging.ts
+++ b/packages/loader/driver-utils/src/compliantLogging.ts
@@ -1,0 +1,40 @@
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+
+export function extractLogCompliantMessageProperties(
+    message: Partial<ISequencedDocumentMessage>,
+) {
+    const safeProps: Partial<{
+        messageClientId: string,
+        sequenceNumber: number,
+        clientSequenceNumber: number,
+        referenceSequenceNumber: number,
+        minimumSequenceNumber: number,
+        messageTimestamp: number,
+    }> = {};
+
+    if (typeof message.clientId === "string") {
+        safeProps.messageClientId = message.clientId;
+    }
+
+    if (typeof message.sequenceNumber === "number") {
+        safeProps.sequenceNumber = message.sequenceNumber;
+    }
+
+    if (typeof message.clientSequenceNumber === "number") {
+        safeProps.clientSequenceNumber = message.clientSequenceNumber;
+    }
+
+    if (typeof message.referenceSequenceNumber === "number") {
+        safeProps.referenceSequenceNumber = message.referenceSequenceNumber;
+    }
+
+    if (typeof message.minimumSequenceNumber === "number") {
+        safeProps.minimumSequenceNumber = message.minimumSequenceNumber;
+    }
+
+    if (typeof message.timestamp === "number") {
+        safeProps.messageTimestamp = message.timestamp;
+    }
+
+    return safeProps;
+}

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -13,3 +13,4 @@ export * from "./network";
 export * from "./readAndParse";
 export * from "./fluidResolvedUrl";
 export * from "./summaryForCreateNew";
+export * from "./compliantLogging";

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
+    "@fluidframework/container-definitions": "^0.19.1",
     "@fluidframework/common-utils": "^0.27.0",
     "debug": "^4.1.1",
     "events": "^3.1.0"


### PR DESCRIPTION
Drafting this now (in advance of sufficient testing) to enable dialog about code destinations.

Edit 1: So one thing that seems a little tricky is that @anthony-murphy had asked for `DataCorruptionError` to makes its way to "telemetry-utils" but `assertFluidOpInvariant()` recommended by @vladsud will depend on it (unless Error class is parameterized), and I'm guessing the transient dependency on "telemetry-utils" is not what you were expecting and I'm guessing you want to avoid it...

Also @vladsud , you had mentioned in a [previous PR](https://github.com/microsoft/FluidFramework/pull/5144#discussion_r577150752) that you wanted to consolidate some PII logic used in `TelemetryLogger.prepareErrorObject()`.  Please confirm that [this](https://github.com/microsoft/FluidFramework/pull/5321/files#diff-a8e8af708cd24804ad20446f3a666813d33871f415efed5b116b64a381f93298R62-R65) meets your expectations.