### PR TITLE
Remove URI from response exception to avoid logging PII.

### DIFF
--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -56,8 +56,7 @@ export function exceptionToResponse(err: any): IResponse {
 }
 
 export function responseToException(response: IResponse, request: IRequest) {
-    // add one more 'frame' to message
-    const message = `${response.value}\nNot found: ${request.url}`;
+    const message = response.value;
     const err = new Error(message);
     const responseErr = err as any as IResponseException;
     responseErr.errorFromRequestFluidObject = true;


### PR DESCRIPTION
The concern here is that query param is not controlled and could contain PII even in 1P scenarios where path itself might be Ok