### PR TITLE
Make logger non-optional in r11s driver

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -11,7 +11,7 @@ import {
     createGenericNetworkError,
 } from "@fluidframework/driver-utils";
 import { IClient, IConnect } from "@fluidframework/protocol-definitions";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 
 export enum R11sErrorType {
     authorizationError = "authorizationError",
@@ -66,6 +66,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection impleme
         io: SocketIOClientStatic,
         client: IClient,
         url: string,
+        logger: ITelemetryLogger,
         timeoutMs = 20000): Promise<IDocumentDeltaConnection> {
         const socket = io(
             url,
@@ -88,7 +89,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection impleme
             versions: protocolVersions,
         };
 
-        const deltaConnection = new R11sDocumentDeltaConnection(socket, id, new TelemetryNullLogger());
+        const deltaConnection = new R11sDocumentDeltaConnection(socket, id, logger);
 
         await deltaConnection.initialize(connectMessage, timeoutMs);
         return deltaConnection;

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -30,7 +30,7 @@ export class DocumentService implements api.IDocumentService {
         private readonly historianApi: boolean,
         private readonly directCredentials: ICredentials | undefined,
         private readonly gitCache: IGitCache | undefined,
-        private readonly logger: ITelemetryLogger | undefined,
+        private readonly logger: ITelemetryLogger,
         protected tokenProvider: ITokenProvider,
         protected tenantId: string,
         protected documentId: string,
@@ -124,7 +124,8 @@ export class DocumentService implements api.IDocumentService {
             ordererToken.jwt,
             io,
             client,
-            this.ordererUrl);
+            this.ordererUrl,
+            this.logger);
     }
 
     public getErrorTrackingService() {


### PR DESCRIPTION
As recommended by @vladsud in #5200, this change makes the logger param required in r11s-driver `DeltaStorageService`, `R11sDocumentDeltaConnection`, and `DocumentService`.