### PR TITLE
Bug fix for sending the same correlation id in historian client

### DIFF
--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -105,13 +105,16 @@ export class BasicRestWrapper extends RestWrapper {
         private readonly axios: AxiosInstance = Axios,
         private readonly refreshDefaultQueryString?: () => Record<string, unknown>,
         private readonly refreshDefaultHeaders?: () => Record<string, unknown>,
+        private readonly getCorrelationId?: () => string | undefined,
     ) {
         super(baseurl, defaultQueryString, maxContentLength);
     }
 
     protected async request<T>(requestConfig: AxiosRequestConfig, statusCode: number, canRetry = true): Promise<T> {
         const options = { ...requestConfig };
-        options.headers = this.generateHeaders(options.headers, uuid());
+        options.headers = this.generateHeaders(
+            options.headers,
+            (this.getCorrelationId && this.getCorrelationId()) || uuid());
 
         return new Promise<T>((resolve, reject) => {
             this.axios.request<T>(options)

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -62,7 +62,7 @@ export class TenantManager implements core.ITenantManager {
             token: fromUtf8ToBase64(`${credentials.user}`),
         };
         const defaultHeaders = {
-            "Authorization": getAuthorizationTokenFromCredentials(credentials),
+            Authorization: getAuthorizationTokenFromCredentials(credentials),
         };
         const baseUrl = `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`;
         const restWrapper = new BasicRestWrapper(

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -14,7 +14,6 @@ import { generateToken, getCorrelationId } from "@fluidframework/server-services
 import * as core from "@fluidframework/server-services-core";
 import Axios from "axios";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
-import { v4 as uuid } from "uuid";
 
 export class Tenant implements core.ITenant {
     public get id(): string {
@@ -64,11 +63,17 @@ export class TenantManager implements core.ITenantManager {
         };
         const defaultHeaders = {
             "Authorization": getAuthorizationTokenFromCredentials(credentials),
-            // TODO: all requests from this GitManager will have the same correlation id. Is this intended behavior?
-            "x-correlation-id": getCorrelationId() || uuid(),
         };
         const baseUrl = `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`;
-        const restWrapper = new BasicRestWrapper(baseUrl, defaultQueryString, undefined, defaultHeaders);
+        const restWrapper = new BasicRestWrapper(
+            baseUrl,
+            defaultQueryString,
+            undefined,
+            defaultHeaders,
+            undefined,
+            undefined,
+            undefined,
+            getCorrelationId);
         const historian = new Historian(
             `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`,
             true,


### PR DESCRIPTION
In historian client now, default headers include a fixed correlation id during construction. This fix is to pass getCorrelationId to RestWrapper and calls it when sending requests to get correlation id in the current thread (function chain).