### PR TITLE
remove event.emit to reconnect to kafka instead of restart process

### DIFF
--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -15,6 +15,7 @@ import {
 } from "@fluidframework/server-services-core";
 import * as kafka from "kafka-node";
 import { ensureTopics } from "./kafkaTopics";
+import winston from "winston";
 
 /**
  * Kafka producer using the kafka-node library
@@ -195,8 +196,7 @@ export class KafkaNodeProducer implements IProducer {
         }
 
         this.connecting = this.connected = false;
-
-        this.events.emit("error", error);
+        winston.error(error);
         this.connect();
     }
 }


### PR DESCRIPTION
When Alfred is not able to connect to kafka and create topics, we are throwing an error which is not be caught which is causing Alfred and the ordering service to not function

instead of bubble up the error and restart the process when create topics failed, we decide to reconnect to kafka and try to recreate the topics again.