### PR TITLE
Op processing telemetry

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -159,7 +159,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 export interface IDeltaQueueEvents<T> extends IErrorEvent {
     (event: "push" | "op", listener: (task: T) => void);
     /**
-     * @param count - number of elements (T) processed before becoming idle
+     * @param count - number of events (T) processed before becoming idle
      * @param duration - amount of time it took to process elements (milliseconds).
      */
     (event: "idle", listener: (count: number, duration: number) => void);

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -158,7 +158,11 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 /** Events emitted by a Delta Queue */
 export interface IDeltaQueueEvents<T> extends IErrorEvent {
     (event: "push" | "op", listener: (task: T) => void);
-    (event: "idle", listener: () => void);
+    /**
+     * @param count - number of elements (T) processed before becoming idle
+     * @param duration - amount of time it took to process elements (milliseconds).
+     */
+    (event: "idle", listener: (count: number, duration: number) => void);
 }
 
 /**

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -4,7 +4,7 @@
  */
 
 import { IDeltaQueue, IDeltaQueueEvents } from "@fluidframework/container-definitions";
-import { assert, Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
+import { assert, performance, Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import Deque from "double-ended-queue";
 
 export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> implements IDeltaQueue<T> {
@@ -118,11 +118,15 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
      * Executes the delta processing loop until a stop condition is reached.
      */
     private processDeltas() {
+        const start = performance.now();
+        let count = 0;
+
         // For grouping to work we must process all local messages immediately and in the single turn.
         // So loop over them until no messages to process, we have become paused, or hit an error.
         while (!(this.q.length === 0 || this.paused || this.error !== undefined)) {
             // Get the next message in the queue
             const next = this.q.shift();
+            count++;
             // Process the message.
             try {
                 // We know next is defined since we did a length check just prior to shifting.
@@ -136,7 +140,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
         }
 
         if (this.q.length === 0) {
-            this.emit("idle");
+            this.emit("idle", count, performance.now() - start);
         }
     }
 }

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -64,7 +64,7 @@ class OpPerfTelemetry {
         this.deltaManager.inbound.on("idle", (count: number, duration: number) => {
             // Do not want to log zero for sure.
             // We are more interested in aggregates, so logging only if we are processing some number of ops
-            // Cut-off is arbitrary - can be increases or decreased based on amount of data collected and questions we
+            // Cut-off is arbitrary - can be increased or decreased based on amount of data collected and questions we
             // want to get answered
             // back-compat: Once 0.36 loader version saturates (count & duration args were added there),
             // we can remove typeof check.

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -60,6 +60,22 @@ class OpPerfTelemetry {
             this.connectionOpSeqNumber = undefined;
             this.firstConnection = false;
         });
+
+        this.deltaManager.inbound.on("idle", (count: number, duration: number) => {
+            // Do not want to log zero for sure.
+            // We are more interested in aggregates, so logging only if we are processing some number of ops
+            // Cut-off is arbitrary - can be increases or decreased based on amount of data collected and questions we
+            // want to get answered
+            // back-compat: Once 0.36 loader version saturates (count & duration args were added there),
+            // we can remove typeof check.
+            if (typeof count === "number" && count >= 100) {
+                this.logger.sendPerformanceEvent({
+                    eventName: "GetDeltas_OpProcessing",
+                    count,
+                    duration,
+                });
+            }
+        });
     }
 
     private reportGettingUpToDate() {


### PR DESCRIPTION
Place where it would be good to get feedback: I'm using "idle" event. That means I'm not measuring all the cases.
In particular batches will not be measured very well, as they pause op processing.
I do not think it's a big deal, but we could chose to add dedicated event if this is a concern.