### PR TITLE
Op fetch batch size

### DIFF
--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -53,7 +53,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 
         // if we got full batch, and did not fully satisfy original request, then there is likely more...
         // Note that it's not disallowed to return more ops than requested!
-        if (result.messages.length !== length && batchLength !== length) {
+        if (result.messages.length >= batchLength && result.messages.length !== length) {
             result.partialResult = true;
         }
         return result;

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -18,6 +18,8 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ITokenProvider } from "./tokens";
 import { DocumentStorageService } from "./documentStorageService";
 
+const MaxBatchDeltas = 2000; // Maximum number of ops we can fetch at a time
+
 /**
  * Storage service limited to only being able to fetch documents for a specific document
  */
@@ -44,7 +46,17 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
                 return { messages, partialResult: true };
             }
         }
-        return this.storageService.get(this.tenantId, this.id, from, to);
+
+        const length = to - from - 1; // to & from are exclusive!
+        const batchLength = Math.min(MaxBatchDeltas, length); // limit number of ops we retrieve at once
+        const result = await this.storageService.get(this.tenantId, this.id, from, from + batchLength + 1);
+
+        // if we got full batch, and did not fully satisfy original request, then there is likely more...
+        // Note that it's not disallowed to return more ops than requested!
+        if (result.messages.length !== length && batchLength !== length) {
+            result.partialResult = true;
+        }
+        return result;
     }
 }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -65,7 +65,7 @@ const MaxReconnectDelaySeconds = 8;
 const InitialReconnectDelaySeconds = 1;
 const MissingFetchDelaySeconds = 0.1;
 const MaxFetchDelaySeconds = 10;
-const MaxBatchDeltas = 2000;
+const MaxBatchDeltas = 5000; // Please see Issue #5211 for data around batch sizing
 const DefaultChunkSize = 16 * 1024;
 
 function getNackReconnectInfo(nackContent: INackContent) {

--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -55,7 +55,7 @@ async function* loadAllSequencedMessages(
     documentService?: IDocumentService,
     dir?: string,
     files?: string[]) {
-    const batch = 2000;
+    const batch = 20000; // see data in issue #5211 on possible sizes we can use.
     let lastSeq = 0;
 
     // If we have local save, read ops from there first


### PR DESCRIPTION
Please see https://github.com/microsoft/FluidFramework/issues/5211 for a bunch of details on timing, sizing, etc.
Long term, I think API and how we approach it is wrong - driver API should be streaming API, leaving up to the driver to decide on strategy (fetch in chunks, or stream all ops in one call, etc.).

I'm going to keep that issue opened as I'm going to bring multi-request change as a next step.

And with all the telemetry just added (see https://github.com/microsoft/FluidFramework/pull/5273, https://github.com/microsoft/FluidFramework/pull/5360), we will learn on the best strategy to catch up the fastest (given payloads we have). It's possible that I'll need to go back to 2K ops as it's faster to do 3x overlapping of 2K ops, vs. 1x 5K.
(multi-request will not fit into same release, so 1x 5K is intended to ship and provide data).

Note: Things are clearly arbitrary RE being tuned to particular payload. But same is true for 2K ops :) In future, it would be great to have this layer moved to driver and be adaptable.