### PR TITLE
Remove TaskManager

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -6,7 +6,7 @@
 The `createDetachedContainer` and `rehydrateDetachedContainerFromSnapshot` APIs are removed from the `ILoader` interface, and have been moved to the new `IHostLoader` interface.  The `Loader` class now implements `IHostLoader` instead, and consumers who need these methods should operate on an `IHostLoader` instead of an `ILoader`, such as by creating a `Loader`.
 
 ### TaskManager removed
-The `TaskManager` has been removed, as well as methods to access it (e.g. the `.taskManager` member on `DataObject`).  The `AgentScheduler` should be used instead for the time being and can be accessed through the `ContainerRuntime` (e.g. `await this.context.containerRuntime.getScheduler()`), though we expect this will also be deprecated and removed in a future release when an alternative is made available (see #4413).
+The `TaskManager` has been removed, as well as methods to access it (e.g. the `.taskManager` member on `DataObject`).  The `AgentScheduler` should be used instead for the time being and can be accessed via a request on the `ContainerRuntime` (e.g. `await this.context.containerRuntime.request({ url: "/_scheduler" })`), though we expect this will also be deprecated and removed in a future release when an alternative is made available (see #4413).
 
 ## 0.35 Breaking changes
 - [Removed some api implementations from odsp driver](#Removed-some-api-implemenations-from-odsp-driver)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,8 +1,13 @@
 ## 0.36 Breaking changes
+<<<<<<< HEAD
 - [Some `ILoader` APIs moved to `IHostLoader`](#Some-ILoader-APIs-moved-to-IHostLoader)
+- [taskManager member removed from DataObject](#taskManager-member-removed-from-DataObject)
 
 ### Some `ILoader` APIs moved to `IHostLoader`
 The `createDetachedContainer` and `rehydrateDetachedContainerFromSnapshot` APIs are removed from the `ILoader` interface, and have been moved to the new `IHostLoader` interface.  The `Loader` class now implements `IHostLoader` instead, and consumers who need these methods should operate on an `IHostLoader` instead of an `ILoader`, such as by creating a `Loader`.
+
+### taskManager member removed from DataObject
+The `taskManager` member has been removed from DataObject.  It can still be accessed through the `ContainerRuntime`, e.g. `await this.context.containerRuntime.getTaskManager()`, though we expect it will be deprecated and removed in a future release.
 
 ## 0.35 Breaking changes
 - [Removed some api implementations from odsp driver](#Removed-some-api-implemenations-from-odsp-driver)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,13 +1,12 @@
 ## 0.36 Breaking changes
-<<<<<<< HEAD
 - [Some `ILoader` APIs moved to `IHostLoader`](#Some-ILoader-APIs-moved-to-IHostLoader)
-- [taskManager member removed from DataObject](#taskManager-member-removed-from-DataObject)
+- [TaskManager removed](#TaskManager-removed)
 
 ### Some `ILoader` APIs moved to `IHostLoader`
 The `createDetachedContainer` and `rehydrateDetachedContainerFromSnapshot` APIs are removed from the `ILoader` interface, and have been moved to the new `IHostLoader` interface.  The `Loader` class now implements `IHostLoader` instead, and consumers who need these methods should operate on an `IHostLoader` instead of an `ILoader`, such as by creating a `Loader`.
 
-### taskManager member removed from DataObject
-The `taskManager` member has been removed from DataObject.  It can still be accessed through the `ContainerRuntime`, e.g. `await this.context.containerRuntime.getTaskManager()`, though we expect it will be deprecated and removed in a future release.
+### TaskManager removed
+The `TaskManager` has been removed, as well as methods to access it (e.g. the `.taskManager` member on `DataObject`).  The `AgentScheduler` should be used instead for the time being and can be accessed through the `ContainerRuntime` (e.g. `await this.context.containerRuntime.getScheduler()`), though we expect this will also be deprecated and removed in a future release when an alternative is made available (see #4413).
 
 ## 0.35 Breaking changes
 - [Removed some api implementations from odsp driver](#Removed-some-api-implemenations-from-odsp-driver)

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -6,6 +6,7 @@
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
+import { IAgentScheduler } from "@fluidframework/runtime-definitions";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -57,7 +58,11 @@ export class Clicker extends DataObject implements IFluidHTMLView {
         const agentTaskId = "agent";
         const clickerAgent = new ClickerAgent(this.counter);
 
-        this.context.containerRuntime.getScheduler().then(async (agentScheduler) => {
+        this.context.containerRuntime.request({ url: "/_scheduler" }).then(async (agentSchedulerResponse) => {
+            if (agentSchedulerResponse.status === 404) {
+                throw new Error("Agent scheduler not found");
+            }
+            const agentScheduler = agentSchedulerResponse.value as IAgentScheduler;
             await agentScheduler.pick(agentTaskId, async () => {
                 console.log(`Picked`);
                 await clickerAgent.run();

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -34,7 +34,7 @@ export class Clicker extends DataObject implements IFluidHTMLView {
     protected async hasInitialized() {
         const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
         this._counter = await counterHandle?.get();
-        await this.setupAgent();
+        this.setupAgent();
     }
 
     // #region IFluidHTMLView
@@ -53,14 +53,16 @@ export class Clicker extends DataObject implements IFluidHTMLView {
 
     // #endregion IFluidHTMLView
 
-    public async setupAgent() {
-        const agentScheduler = await this.context.containerRuntime.getScheduler();
+    public setupAgent() {
         const agentTaskId = "agent";
         const clickerAgent = new ClickerAgent(this.counter);
-        await agentScheduler.pick(agentTaskId, async () => {
-            console.log(`Picked`);
-            await clickerAgent.run();
-        });
+
+        this.context.containerRuntime.getScheduler().then(async (agentScheduler) => {
+            await agentScheduler.pick(agentTaskId, async () => {
+                console.log(`Picked`);
+                await clickerAgent.run();
+            });
+        }).catch((err) => { console.error(err); });
     }
 
     private get counter() {

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -35,7 +35,7 @@ export class Clicker extends DataObject implements IFluidHTMLView {
     protected async hasInitialized() {
         const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
         this._counter = await counterHandle?.get();
-        this.setupAgent();
+        await this.setupAgent();
     }
 
     // #region IFluidHTMLView
@@ -54,13 +54,14 @@ export class Clicker extends DataObject implements IFluidHTMLView {
 
     // #endregion IFluidHTMLView
 
-    public setupAgent() {
+    public async setupAgent() {
+        const taskManager = await this.context.containerRuntime.getTaskManager();
         const agentTask: ITask = {
             id: "agent",
             instance: new ClickerAgent(this.counter),
         };
-        this.taskManager.register(agentTask);
-        this.taskManager.pick(agentTask.id, true).then(() => {
+        taskManager.register(agentTask);
+        taskManager.pick(agentTask.id, true).then(() => {
             console.log(`Picked`);
         }, (err) => {
             console.log(err);

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -54,8 +54,7 @@ export class Clicker extends DataObject implements IFluidHTMLView {
     // #endregion IFluidHTMLView
 
     public async setupAgent() {
-        const taskManager = await this.context.containerRuntime.getTaskManager();
-        const agentScheduler = taskManager.IAgentScheduler;
+        const agentScheduler = await this.context.containerRuntime.getScheduler();
         const agentTaskId = "agent";
         const clickerAgent = new ClickerAgent(this.counter);
         await agentScheduler.pick(agentTaskId, async () => {

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -6,7 +6,6 @@
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
-import { ITask } from "@fluidframework/runtime-definitions";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -56,15 +55,12 @@ export class Clicker extends DataObject implements IFluidHTMLView {
 
     public async setupAgent() {
         const taskManager = await this.context.containerRuntime.getTaskManager();
-        const agentTask: ITask = {
-            id: "agent",
-            instance: new ClickerAgent(this.counter),
-        };
-        taskManager.register(agentTask);
-        taskManager.pick(agentTask.id, true).then(() => {
+        const agentScheduler = taskManager.IAgentScheduler;
+        const agentTaskId = "agent";
+        const clickerAgent = new ClickerAgent(this.counter);
+        await agentScheduler.pick(agentTaskId, async () => {
             console.log(`Picked`);
-        }, (err) => {
-            console.log(err);
+            await clickerAgent.run();
         });
     }
 

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -179,7 +179,11 @@ export class SharedTextRunner
         debug(`id is ${this.runtime.id}`);
         debug(`Partial load fired: ${performance.now()}`);
 
-        const agentScheduler = await this.context.containerRuntime.getScheduler();
+        const agentSchedulerResponse = await this.context.containerRuntime.request({ url: "/_scheduler" });
+        if (agentSchedulerResponse.status === 404) {
+            throw new Error("Agent scheduler not found");
+        }
+        const agentScheduler = agentSchedulerResponse.value as IAgentScheduler;
 
         const options = parse(window.location.search.substr(1));
         setTranslation(

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -27,9 +27,8 @@ import {
 } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
 import {
+    IAgentScheduler,
     IFluidDataStoreContext,
-    ITask,
-    ITaskManager,
 } from "@fluidframework/runtime-definitions";
 import {
     SharedNumberSequence,
@@ -76,7 +75,6 @@ export class SharedTextRunner
     private insightsMap: ISharedMap;
     private rootView: ISharedMap;
     private collabDoc: Document;
-    private taskManager: ITaskManager;
     private uiInitialized = false;
     private readonly title: string = "Shared Text";
 
@@ -181,7 +179,8 @@ export class SharedTextRunner
         debug(`id is ${this.runtime.id}`);
         debug(`Partial load fired: ${performance.now()}`);
 
-        this.taskManager = await this.context.containerRuntime.getTaskManager();
+        const taskManager = await this.context.containerRuntime.getTaskManager();
+        const agentScheduler = taskManager.IAgentScheduler;
 
         const options = parse(window.location.search.substr(1));
         setTranslation(
@@ -195,7 +194,7 @@ export class SharedTextRunner
 
         const taskScheduler = new TaskScheduler(
             this.context,
-            this.taskManager,
+            agentScheduler,
             this.sharedString,
             this.insightsMap,
         );
@@ -264,7 +263,7 @@ export class SharedTextRunner
 class TaskScheduler {
     constructor(
         private readonly componentContext: IFluidDataStoreContext,
-        private readonly taskManager: ITaskManager,
+        private readonly agentScheduler: IAgentScheduler,
         private readonly sharedString: SharedString,
         private readonly insightsMap: ISharedMap,
     ) {
@@ -279,16 +278,12 @@ class TaskScheduler {
             : undefined;
 
         if (intelTokens?.key?.length > 0) {
-            const intelTask: ITask = {
-                id: "intel",
-                instance: new TextAnalyzer(this.sharedString, this.insightsMap, intelTokens),
-            };
-            this.taskManager.register(intelTask);
-            this.taskManager.pick(intelTask.id).then(() => {
+            const intelTaskId = "intel";
+            const textAnalyzer = new TextAnalyzer(this.sharedString, this.insightsMap, intelTokens);
+            this.agentScheduler.pick(intelTaskId, async () => {
                 console.log(`Picked text analyzer`);
-            }, (err) => {
-                console.log(JSON.stringify(err));
-            });
+                await textAnalyzer.run();
+            }).catch((err) => { console.error(err); });
         } else {
             console.log("No intel key provided.");
         }

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -179,8 +179,7 @@ export class SharedTextRunner
         debug(`id is ${this.runtime.id}`);
         debug(`Partial load fired: ${performance.now()}`);
 
-        const taskManager = await this.context.containerRuntime.getTaskManager();
-        const agentScheduler = taskManager.IAgentScheduler;
+        const agentScheduler = await this.context.containerRuntime.getScheduler();
 
         const options = parse(window.location.search.substr(1));
         setTranslation(

--- a/packages/runtime/agent-scheduler/src/index.ts
+++ b/packages/runtime/agent-scheduler/src/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { TaskManagerFactory, TaskManager } from "./scheduler";
+export { AgentSchedulerFactory } from "./scheduler";

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -7,7 +7,6 @@ import { EventEmitter } from "events";
 import { assert } from "@fluidframework/common-utils";
 import {
     IFluidHandle,
-    IFluidRunnable,
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
@@ -380,7 +379,6 @@ export class TaskManager implements ITaskManager {
 
     protected readonly taskUrl = "_tasks";
 
-    private readonly taskMap = new Map<string, IFluidRunnable>();
     constructor(
         private readonly scheduler: IAgentScheduler,
         private readonly runtime: IFluidDataStoreRuntime,
@@ -391,18 +389,8 @@ export class TaskManager implements ITaskManager {
     public async request(request: IRequest): Promise<IResponse> {
         if (request.url === "" || request.url === "/") {
             return { status: 200, mimeType: "fluid/object", value: this };
-        } else if (!request.url.startsWith(this.taskUrl)) {
-            return create404Response(request);
         } else {
-            const trimmedUrl = request.url.substr(this.taskUrl.length);
-            const taskUrl = trimmedUrl.length > 0 && trimmedUrl.startsWith("/")
-                ? trimmedUrl.substr(1)
-                : "";
-            if (taskUrl === "" || !this.taskMap.has(taskUrl)) {
-                return create404Response(request);
-            } else {
-                return { status: 200, mimeType: "fluid/object", value: this.taskMap.get(taskUrl) };
-            }
+            return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
         }
     }
 }

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -20,7 +20,6 @@ import {
     IFluidDataStoreFactory,
     NamedFluidDataStoreRegistryEntry,
 } from "@fluidframework/runtime-definitions";
-import { create404Response } from "@fluidframework/runtime-utils";
 import debug from "debug";
 import { v4 as uuid } from "uuid";
 
@@ -369,11 +368,9 @@ class AgentSchedulerRuntime extends FluidDataStoreRuntime {
     public async request(request: IRequest) {
         const response = await super.request(request);
         if (response.status === 404) {
-            const agentScheduler = await this.agentSchedulerP;
             if (request.url === "" || request.url === "/") {
+                const agentScheduler = await this.agentSchedulerP;
                 return { status: 200, mimeType: "fluid/object", value: agentScheduler };
-            } else {
-                return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
             }
         }
         return response;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1790,10 +1790,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     /**
-     * @deprecated starting in 0.36, use getScheduler() instead.  To be removed in 0.38.
+     * @deprecated starting in 0.36. The AgentScheduler can be requested directly, though this will also be removed in
+     * a future release when an alternative is available: containerRuntime.request({ url: "/_scheduler" }).
+     * getTaskManager should be removed in 0.38.
      */
     public async getTaskManager(): Promise<IProvideAgentScheduler> {
-        console.error("getTaskManager is deprecated.  Please move to getScheduler.");
+        console.error("getTaskManager is deprecated.");
         const agentScheduler = await this.getScheduler();
         // Prior versions would return a TaskManager, which was an IProvideAgentScheduler -- returning this for back
         // compat.  Wrapping the agentScheduler in an IProvideAgentScheduler will help catch any cases where customers
@@ -1801,12 +1803,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return { IAgentScheduler: agentScheduler };
     }
 
-    public async getScheduler(): Promise<IAgentScheduler> {
-        const agentScheduler = await requestFluidObject<IAgentScheduler>(
+    private async getScheduler(): Promise<IAgentScheduler> {
+        return requestFluidObject<IAgentScheduler>(
             await this.getDataStore(taskSchedulerId, true),
             "",
         );
-        return agentScheduler.IAgentScheduler;
     }
 
     private updateLeader(leadership: boolean) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { TaskManagerFactory } from "@fluidframework/agent-scheduler";
+import { AgentSchedulerFactory } from "@fluidframework/agent-scheduler";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IFluidObject,
@@ -90,8 +90,8 @@ import {
     ISummaryStats,
     ISummaryTreeWithStats,
     ISummarizeInternalResult,
+    IProvideAgentScheduler,
     IAgentScheduler,
-    ITaskManager,
     IChannelSummarizeResult,
     CreateChildSummarizerNodeParam,
     SummarizeInternalFn,
@@ -443,7 +443,7 @@ class ContainerRuntimeDataStoreRegistry extends FluidDataStoreRegistry {
     constructor(namedEntries: NamedFluidDataStoreRegistryEntries) {
         super([
             ...namedEntries,
-            TaskManagerFactory.registryEntry,
+            AgentSchedulerFactory.registryEntry,
         ]);
     }
 }
@@ -528,7 +528,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // Create all internal data stores if not already existing on storage or loaded a detached
         // container from snapshot(ex. draft mode).
         if (!context.existing) {
-            await runtime.createRootDataStore(TaskManagerFactory.type, taskSchedulerId);
+            await runtime.createRootDataStore(AgentSchedulerFactory.type, taskSchedulerId);
         }
 
         runtime.subscribeToLeadership();
@@ -1789,12 +1789,18 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
+    public async getTaskManager(): Promise<IProvideAgentScheduler> {
+        console.error("getTaskManager is deprecated.  Please move to getScheduler.");
+        const agentScheduler = await this.getScheduler();
+        return { IAgentScheduler: agentScheduler };
+    }
+
     public async getScheduler(): Promise<IAgentScheduler> {
-        const taskManager = await requestFluidObject<ITaskManager>(
+        const agentScheduler = await requestFluidObject<IAgentScheduler>(
             await this.getDataStore(taskSchedulerId, true),
             "",
         );
-        return taskManager.IAgentScheduler;
+        return agentScheduler.IAgentScheduler;
     }
 
     private updateLeader(leadership: boolean) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1789,6 +1789,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
+    /**
+     * @deprecated starting in 0.36, use getScheduler() instead.  To be removed in 0.38.
+     */
     public async getTaskManager(): Promise<IProvideAgentScheduler> {
         console.error("getTaskManager is deprecated.  Please move to getScheduler.");
         const agentScheduler = await this.getScheduler();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1791,7 +1791,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
     /**
      * @deprecated starting in 0.36. The AgentScheduler can be requested directly, though this will also be removed in
-     * a future release when an alternative is available: containerRuntime.request({ url: "/_scheduler" }).
+     * a future release when an alternative is available: containerRuntime.request(\{ url: "/_scheduler" \}).
      * getTaskManager should be removed in 0.38.
      */
     public async getTaskManager(): Promise<IProvideAgentScheduler> {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1795,6 +1795,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public async getTaskManager(): Promise<IProvideAgentScheduler> {
         console.error("getTaskManager is deprecated.  Please move to getScheduler.");
         const agentScheduler = await this.getScheduler();
+        // Prior versions would return a TaskManager, which was an IProvideAgentScheduler -- returning this for back
+        // compat.  Wrapping the agentScheduler in an IProvideAgentScheduler will help catch any cases where customers
+        // try to call other TaskManager functionality.
         return { IAgentScheduler: agentScheduler };
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1789,7 +1789,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    public async getTaskManager(): Promise<ITaskManager> {
+    private async getTaskManager(): Promise<ITaskManager> {
         return requestFluidObject<ITaskManager>(
             await this.getDataStore(taskSchedulerId, true),
             "");

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1789,14 +1789,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    private async getTaskManager(): Promise<ITaskManager> {
-        return requestFluidObject<ITaskManager>(
-            await this.getDataStore(taskSchedulerId, true),
-            "");
-    }
-
     public async getScheduler(): Promise<IAgentScheduler> {
-        const taskManager = await this.getTaskManager();
+        const taskManager = await requestFluidObject<ITaskManager>(
+            await this.getDataStore(taskSchedulerId, true),
+            "",
+        );
         return taskManager.IAgentScheduler;
     }
 

--- a/packages/runtime/runtime-definitions/src/agent.ts
+++ b/packages/runtime/runtime-definitions/src/agent.ts
@@ -3,27 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import {
-    IFluidLoadable,
-    IFluidRouter,
-} from "@fluidframework/core-interfaces";
-
-export const ITaskManager: keyof IProvideTaskManager = "ITaskManager";
-
-export interface IProvideTaskManager {
-    readonly ITaskManager: ITaskManager;
-}
-
-/**
- * Task manager enables app to register and pick tasks.
- */
-export interface ITaskManager extends IProvideTaskManager, IFluidLoadable, IFluidRouter {
-    /**
-     * access to IAgentScheduler
-     */
-    readonly IAgentScheduler: IAgentScheduler;
-}
-
 export const IAgentScheduler: keyof IProvideAgentScheduler = "IAgentScheduler";
 
 export interface IProvideAgentScheduler {
@@ -88,5 +67,5 @@ export interface IAgentScheduler extends IProvideAgentScheduler {
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IFluidObject extends
-        Readonly<Partial<IProvideTaskManager & IProvideAgentScheduler>> { }
+        Readonly<Partial<IProvideAgentScheduler>> { }
 }

--- a/packages/runtime/runtime-definitions/src/agent.ts
+++ b/packages/runtime/runtime-definitions/src/agent.ts
@@ -6,23 +6,7 @@
 import {
     IFluidLoadable,
     IFluidRouter,
-    IFluidRunnable,
 } from "@fluidframework/core-interfaces";
-
-/**
- * Definition of a Task.
- */
-export interface ITask {
-    /**
-     * Id of the task
-     */
-    id: string;
-
-    /**
-     * Instance of the task that implements IFluidRunnable
-     */
-    instance: IFluidRunnable;
-}
 
 export const ITaskManager: keyof IProvideTaskManager = "ITaskManager";
 
@@ -38,18 +22,6 @@ export interface ITaskManager extends IProvideTaskManager, IFluidLoadable, IFlui
      * access to IAgentScheduler
      */
     readonly IAgentScheduler: IAgentScheduler;
-
-    /**
-     * Registers tasks task so that the client can run the task later.
-     */
-    register(...tasks: ITask[]): void;
-
-    /**
-     * Pick a task that was registered prior.
-     *
-     * @param worker - Flag that will execute tasks in web worker if connected to a service that supports them.
-     */
-    pick(taskId: string, worker?: boolean): Promise<void>;
 }
 
 export const IAgentScheduler: keyof IProvideAgentScheduler = "IAgentScheduler";

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -38,7 +38,7 @@ import {
     ISummarizerNodeWithGC,
     SummarizeInternalFn,
 } from "./summary";
-import { ITaskManager } from "./agent";
+import { IAgentScheduler } from "./agent";
 
 /**
  * Runtime flush mode handling
@@ -127,7 +127,7 @@ export interface IContainerRuntimeBase extends
      */
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
 
-    getTaskManager(): Promise<ITaskManager>;
+    getScheduler(): Promise<IAgentScheduler>;
 
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -38,7 +38,6 @@ import {
     ISummarizerNodeWithGC,
     SummarizeInternalFn,
 } from "./summary";
-import { IAgentScheduler } from "./agent";
 
 /**
  * Runtime flush mode handling
@@ -126,8 +125,6 @@ export interface IContainerRuntimeBase extends
      * @param relativeUrl - A relative request within the container
      */
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
-
-    getScheduler(): Promise<IAgentScheduler>;
 
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 

--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -29,7 +29,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         beforeEach(async () => {
             const container = await args.makeTestContainer();
             scheduler = await requestFluidObject<IAgentScheduler>(container, taskSchedulerId)
-                .then((taskManager) => taskManager.IAgentScheduler);
+                .then((agentScheduler) => agentScheduler.IAgentScheduler);
 
             const dataObject = await requestFluidObject<TestDataObject>(container, "default");
 
@@ -109,7 +109,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             // Create a new Container for the first document.
             container1 = await args.makeTestContainer();
             scheduler1 = await requestFluidObject<IAgentScheduler>(container1, taskSchedulerId)
-                .then((taskManager) => taskManager.IAgentScheduler);
+                .then((agentScheduler) => agentScheduler.IAgentScheduler);
             const dataObject1 = await requestFluidObject<TestDataObject>(container1, "default");
 
             // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick
@@ -124,7 +124,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             // Load existing Container for the second document.
             container2 = await args.loadTestContainer();
             scheduler2 = await requestFluidObject<IAgentScheduler>(container2, taskSchedulerId)
-                .then((taskManager) => taskManager.IAgentScheduler);
+                .then((agentScheduler) => agentScheduler.IAgentScheduler);
             const dataObject2 = await requestFluidObject<TestDataObject>(container2, "default");
 
             // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick

--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { TaskManager } from "@fluidframework/agent-scheduler";
 import { IContainer } from "@fluidframework/container-definitions";
 import { taskSchedulerId } from "@fluidframework/container-runtime";
 import { IAgentScheduler } from "@fluidframework/runtime-definitions";
@@ -29,7 +28,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         beforeEach(async () => {
             const container = await args.makeTestContainer();
-            scheduler = await requestFluidObject<TaskManager>(container, taskSchedulerId)
+            scheduler = await requestFluidObject<IAgentScheduler>(container, taskSchedulerId)
                 .then((taskManager) => taskManager.IAgentScheduler);
 
             const dataObject = await requestFluidObject<TestDataObject>(container, "default");
@@ -109,7 +108,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         beforeEach(async () => {
             // Create a new Container for the first document.
             container1 = await args.makeTestContainer();
-            scheduler1 = await requestFluidObject<TaskManager>(container1, taskSchedulerId)
+            scheduler1 = await requestFluidObject<IAgentScheduler>(container1, taskSchedulerId)
                 .then((taskManager) => taskManager.IAgentScheduler);
             const dataObject1 = await requestFluidObject<TestDataObject>(container1, "default");
 
@@ -124,7 +123,7 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             }
             // Load existing Container for the second document.
             container2 = await args.loadTestContainer();
-            scheduler2 = await requestFluidObject<TaskManager>(container2, taskSchedulerId)
+            scheduler2 = await requestFluidObject<IAgentScheduler>(container2, taskSchedulerId)
                 .then((taskManager) => taskManager.IAgentScheduler);
             const dataObject2 = await requestFluidObject<TestDataObject>(container2, "default");
 

--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -28,6 +28,8 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
 
         beforeEach(async () => {
             const container = await args.makeTestContainer();
+            // Back-compat: querying for IAgentScheduler since this request would return an ITaskManager prior to 0.36.
+            // Remove the query in 0.38 when back compat is no longer a concern.
             scheduler = await requestFluidObject<IAgentScheduler>(container, taskSchedulerId)
                 .then((agentScheduler) => agentScheduler.IAgentScheduler);
 
@@ -108,6 +110,8 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
         beforeEach(async () => {
             // Create a new Container for the first document.
             container1 = await args.makeTestContainer();
+            // Back-compat: querying for IAgentScheduler since this request would return an ITaskManager prior to 0.36.
+            // Remove the query in 0.38 when back compat is no longer a concern.
             scheduler1 = await requestFluidObject<IAgentScheduler>(container1, taskSchedulerId)
                 .then((agentScheduler) => agentScheduler.IAgentScheduler);
             const dataObject1 = await requestFluidObject<TestDataObject>(container1, "default");
@@ -123,6 +127,8 @@ const tests = (argsFactory: () => ITestObjectProvider) => {
             }
             // Load existing Container for the second document.
             container2 = await args.loadTestContainer();
+            // Back-compat: querying for IAgentScheduler since this request would return an ITaskManager prior to 0.36.
+            // Remove the query in 0.38 when back compat is no longer a concern.
             scheduler2 = await requestFluidObject<IAgentScheduler>(container2, taskSchedulerId)
                 .then((agentScheduler) => agentScheduler.IAgentScheduler);
             const dataObject2 = await requestFluidObject<TestDataObject>(container2, "default");


### PR DESCRIPTION
Removes `TaskManager`, promoting `AgentScheduler` usage instead (which `TaskManager` was already using in its implementation).

For the pay-for-play effort, we're trying to remove `Loader` references from the lower layers of the runtime.  `TaskManager`'s main augmentation over the `AgentScheduler` is that it spins up new clients to run tasks in, but as a result it has a dependency on the `Loader` to do so.  It does not appear that this functionality is getting usage currently, after checking the following:

1. Not used by FFX
2. Our telemetry doesn't show any instances of clientTypes noninteractive/agent, which would be expected if used
3. Our two demos that use it (clicker and shared-text) don't appear to use it correctly currently (clicker errors out and shared-text likely would too if we had an intel key).

Customers that do want to spin up new clients for tasks are of course capable of doing so by making their own `Loader` calls after `AgentScheduler` picks them for the task.

For N-1 compat, I'm keeping the `getTaskManager()` method on the `ContainerRuntime` but only providing an `IProvideAgentScheduler` in response (this is sufficient for our tests and to avoid runtime breaks in the non-use scenarios, e.g. `DataObject`).

Note that while this change somewhat fixes the two demos, they are still buggy on initial load (I think due to not handling detached container creation correctly).  I'll look at real fixes in a future change, using a new DDS I'm working on for #4413.