### PR TITLE
Performance events: add ability to skip start event

### DIFF
--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -354,16 +354,17 @@ export class MultiSinkLogger extends TelemetryLogger {
  * Helper class to log performance events
  */
 export class PerformanceEvent {
-    public static start(logger: ITelemetryLogger, event: ITelemetryGenericEvent) {
-        return new PerformanceEvent(logger, event);
+    public static start(logger: ITelemetryLogger, event: ITelemetryGenericEvent, reportStartEvent = true) {
+        return new PerformanceEvent(logger, event, reportStartEvent);
     }
 
     public static timedExec<T>(
         logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
         callback: (event: PerformanceEvent) => T,
+        reportStartEvent = true,
     ) {
-        const perfEvent = PerformanceEvent.start(logger, event);
+        const perfEvent = PerformanceEvent.start(logger, event, reportStartEvent);
         try {
             const ret = callback(perfEvent);
             // Event might have been cancelled or ended in the callback
@@ -381,8 +382,9 @@ export class PerformanceEvent {
         logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
         callback: (event: PerformanceEvent) => Promise<T>,
+        reportStartEvent = true,
     ) {
-        const perfEvent = PerformanceEvent.start(logger, event);
+        const perfEvent = PerformanceEvent.start(logger, event, reportStartEvent);
         try {
             const ret = await callback(perfEvent);
             // Event might have been cancelled or ended in the callback
@@ -403,9 +405,12 @@ export class PerformanceEvent {
     protected constructor(
         private readonly logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
+        reportStartEvent: boolean,
     ) {
         this.event = { ...event };
-        this.reportEvent("start");
+        if (reportStartEvent) {
+            this.reportEvent("start");
+        }
 
         if (typeof window === "object" && window != null && window.performance) {
             this.startMark = `${event.eventName}-start`;

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -351,20 +351,32 @@ export class MultiSinkLogger extends TelemetryLogger {
 }
 
 /**
+ * Describes what events PerformanceEvent should log
+ * By default, all events are logged, but client can override this behavior
+ * For example, there is rarely a need to record start event, as we really after
+ * success / failure tracking, including duration (on success).
+ */
+export interface IPerformanceEventMarkers {
+    start?: true;
+    end?: true;
+    cancel?: true;
+}
+
+/**
  * Helper class to log performance events
  */
 export class PerformanceEvent {
-    public static start(logger: ITelemetryLogger, event: ITelemetryGenericEvent, reportStartEvent = true) {
-        return new PerformanceEvent(logger, event, reportStartEvent);
+    public static start(logger: ITelemetryLogger, event: ITelemetryGenericEvent, markers?: IPerformanceEventMarkers) {
+        return new PerformanceEvent(logger, event, markers);
     }
 
     public static timedExec<T>(
         logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
         callback: (event: PerformanceEvent) => T,
-        reportStartEvent = true,
+        markers?: IPerformanceEventMarkers,
     ) {
-        const perfEvent = PerformanceEvent.start(logger, event, reportStartEvent);
+        const perfEvent = PerformanceEvent.start(logger, event, markers);
         try {
             const ret = callback(perfEvent);
             // Event might have been cancelled or ended in the callback
@@ -382,9 +394,9 @@ export class PerformanceEvent {
         logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
         callback: (event: PerformanceEvent) => Promise<T>,
-        reportStartEvent = true,
+        markers?: IPerformanceEventMarkers,
     ) {
-        const perfEvent = PerformanceEvent.start(logger, event, reportStartEvent);
+        const perfEvent = PerformanceEvent.start(logger, event, markers);
         try {
             const ret = await callback(perfEvent);
             // Event might have been cancelled or ended in the callback
@@ -405,10 +417,10 @@ export class PerformanceEvent {
     protected constructor(
         private readonly logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
-        reportStartEvent: boolean,
+        private readonly markers: IPerformanceEventMarkers = {start: true, end: true, cancel: true},
     ) {
         this.event = { ...event };
-        if (reportStartEvent) {
+        if (this.markers.start) {
             this.reportEvent("start");
         }
 
@@ -423,8 +435,8 @@ export class PerformanceEvent {
     }
 
     public end(props?: ITelemetryProperties, eventNameSuffix = "end"): void {
-        if (!this.reportEvent(eventNameSuffix, props)) {
-            return;
+        if (this.markers.end) {
+            this.reportEvent(eventNameSuffix, props);
         }
 
         if (this.startMark && this.event) {
@@ -438,20 +450,21 @@ export class PerformanceEvent {
     }
 
     public cancel(props?: ITelemetryProperties, error?: any): void {
-        this.reportEvent("cancel", props, error);
+        if (this.markers.cancel) {
+            this.reportEvent("cancel", props, error);
+        }
         this.event = undefined;
     }
 
     /**
      * Report the event, if it hasn't already been reported.
-     * Returns a boolean indicating if it was reported this time.
      */
-    public reportEvent(eventNameSuffix: string, props?: ITelemetryProperties, error?: any): boolean {
+    public reportEvent(eventNameSuffix: string, props?: ITelemetryProperties, error?: any) {
         // There are strange sequences involving muliple Promise chains
         // where the event can be cancelled and then later a callback is invoked
         // and the caller attempts to end directly, e.g. issue #3936. Just return.
         if (!this.event) {
-            return false;
+            return;
         }
 
         const event: ITelemetryPerformanceEvent = { ...this.event, ...props };
@@ -461,7 +474,6 @@ export class PerformanceEvent {
         }
 
         this.logger.sendPerformanceEvent(event, error);
-        return true;
     }
 }
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -359,7 +359,7 @@ export class MultiSinkLogger extends TelemetryLogger {
 export interface IPerformanceEventMarkers {
     start?: true;
     end?: true;
-    cancel?: true;
+    cancel?: "generic" | "error"; // tells wether to issue "generic" or "error" category cancel event
 }
 
 /**
@@ -417,7 +417,7 @@ export class PerformanceEvent {
     protected constructor(
         private readonly logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
-        private readonly markers: IPerformanceEventMarkers = {start: true, end: true, cancel: true},
+        private readonly markers: IPerformanceEventMarkers = {start: true, end: true, cancel: "generic"},
     ) {
         this.event = { ...event };
         if (this.markers.start) {
@@ -450,8 +450,8 @@ export class PerformanceEvent {
     }
 
     public cancel(props?: ITelemetryProperties, error?: any): void {
-        if (this.markers.cancel) {
-            this.reportEvent("cancel", props, error);
+        if (this.markers.cancel !== undefined) {
+            this.reportEvent("cancel", {category: this.markers.cancel, ...props}, error);
         }
         this.event = undefined;
     }


### PR DESCRIPTION
Quite often we care about collecting perf stats / know when something failed and why, but not really interested in start event.
It's great to have an option to drop start event to reduce amount of noise and cost of telemetry.