### PR TITLE
Add a listener to listen to error event catch the error event from and log the error.

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -121,6 +121,11 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
             kafkaProducerPollIntervalMs,
             kafkaNumberOfPartitions,
             kafkaReplicationFactor);
+
+        producer.on("error", (error) => {
+            winston.error(error);
+        });
+
         const redisConfig = config.get("redis");
         const webSocketLibrary = config.get("alfred:webSocketLib");
         const authEndpoint = config.get("auth:endpoint");

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -15,6 +15,7 @@ import {
 } from "@fluidframework/server-services-core";
 import * as kafka from "kafka-node";
 import { ensureTopics } from "./kafkaTopics";
+import winston from "winston";
 
 /**
  * Kafka producer using the kafka-node library
@@ -195,8 +196,7 @@ export class KafkaNodeProducer implements IProducer {
         }
 
         this.connecting = this.connected = false;
-
-        this.events.emit("error", error);
+        winston.error(error);
         this.connect();
     }
 }

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -15,7 +15,6 @@ import {
 } from "@fluidframework/server-services-core";
 import * as kafka from "kafka-node";
 import { ensureTopics } from "./kafkaTopics";
-import winston from "winston";
 
 /**
  * Kafka producer using the kafka-node library
@@ -196,7 +195,8 @@ export class KafkaNodeProducer implements IProducer {
         }
 
         this.connecting = this.connected = false;
-        winston.error(error);
+
+        this.events.emit("error", error);
         this.connect();
     }
 }


### PR DESCRIPTION
When Alfred is not able to connect to kafka and create topics, we are throwing an error which is not be caught which is causing Alfred and the ordering service to not function

Add a listener after create producer to catch the error event and log the error.