### PR TITLE
[bump] package version for common-utils

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "Collection of utility functions for Fluid",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.27.1";
+export const pkgVersion = "0.27.2";


### PR DESCRIPTION
            @fluidframework/build-common:     0.20.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.22.1 (unchanged)
      @fluidframework/common-definitions:     0.20.0 (unchanged)
            @fluidframework/common-utils:     0.27.1 -> 0.27.2
                                  Server:   0.1018.1 (unchanged)
                                  Client:     0.33.6 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)