### PR TITLE
Remove LoaderHeader.executionContext

### DIFF
--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -244,7 +244,6 @@ export enum LoaderHeader {
     cache = "fluid-cache",
 
     clientDetails = "fluid-client-details",
-    executionContext = "execution-context",
 
     /**
      * Start the container in a paused, unconnected state. Defaults to false
@@ -269,7 +268,6 @@ export interface ILoaderHeader {
     [LoaderHeader.cache]: boolean;
     [LoaderHeader.clientDetails]: IClientDetails;
     [LoaderHeader.pause]: boolean;
-    [LoaderHeader.executionContext]: string;
     [LoaderHeader.sequenceNumber]: number;
     [LoaderHeader.reconnect]: boolean;
     [LoaderHeader.version]: string | undefined | null;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -80,22 +80,15 @@ export class RelativeLoader extends EventEmitter implements ILoader {
     public async request(request: IRequest): Promise<IResponse> {
         const containerUrl = this.containerUrl();
         if (request.url.startsWith("/")) {
-            if (this.needExecutionContext(request)) {
-                if (containerUrl === undefined) {
-                    throw new Error("Container url is not provided");
-                }
-                return (this.loader as Loader).requestWorker(containerUrl, request);
+            let container: IContainer;
+            if (canUseCache(request)) {
+                container = await this.containerDeferred.promise;
+            } else if (containerUrl === undefined) {
+                throw new Error("Container url is not provided");
             } else {
-                let container: IContainer;
-                if (canUseCache(request)) {
-                    container = await this.containerDeferred.promise;
-                } else if (containerUrl === undefined) {
-                    throw new Error("Container url is not provided");
-                } else {
-                    container = await this.loader.resolve({ url: containerUrl, headers: request.headers });
-                }
-                return container.request(request);
+                container = await this.loader.resolve({ url: containerUrl, headers: request.headers });
             }
+            return container.request(request);
         }
 
         return this.loader.request(request);
@@ -103,10 +96,6 @@ export class RelativeLoader extends EventEmitter implements ILoader {
 
     public resolveContainer(container: Container) {
         this.containerDeferred.resolve(container);
-    }
-
-    private needExecutionContext(request: IRequest): boolean {
-        return (request.headers !== undefined && request.headers[LoaderHeader.executionContext] !== undefined);
     }
 }
 
@@ -307,35 +296,6 @@ export class Loader extends EventEmitter implements IHostLoader {
             const resolved = await this.resolveCore(request);
             return resolved.container.request({ url: `${resolved.parsed.path}${resolved.parsed.query}` });
         });
-    }
-
-    public async requestWorker(containerUrl: string, request: IRequest): Promise<IResponse> {
-        // Currently the loader only supports web worker environment. Eventually we will
-        // detect environment and bring appropriate loader (e.g., worker_thread for node).
-        const supportedEnvironment = "webworker";
-        const proxyLoaderFactory = this.services.proxyLoaderFactories.get(supportedEnvironment);
-
-        // If the loader does not support any other environment, request falls back to current loader.
-        if (proxyLoaderFactory === undefined) {
-            const container = await this.resolve({ url: containerUrl, headers: request.headers });
-            return container.request(request);
-        } else {
-            const resolved = await this.services.urlResolver.resolve({ url: containerUrl, headers: request.headers });
-            const resolvedAsFluid = resolved as IFluidResolvedUrl;
-            const parsed = parseUrl(resolvedAsFluid.url);
-            if (parsed === undefined) {
-                return Promise.reject(new Error(`Invalid URL ${resolvedAsFluid.url}`));
-            }
-            const { fromSequenceNumber } =
-                this.parseHeader(parsed, { url: containerUrl, headers: request.headers });
-            const proxyLoader = await proxyLoaderFactory.createProxyLoader(
-                parsed.id,
-                this.services.options,
-                resolvedAsFluid,
-                fromSequenceNumber,
-            );
-            return proxyLoader.request(request);
-        }
     }
 
     private getKeyForContainerCache(request: IRequest, parsedUrl: IParsedUrl): string {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -213,9 +213,6 @@ export interface IContainerRuntimeOptions {
     // This defaults to true and must be explicitly set to false to disable.
     generateSummaries?: boolean;
 
-    // Experimental flag that will execute tasks in web worker if connected to a service that supports them.
-    enableWorker?: boolean;
-
     // Delay before first attempt to spawn summarizing container
     initialSummarizerDelayMs?: number;
 
@@ -673,7 +670,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         chunks: [string, string[]][],
         private readonly runtimeOptions: IContainerRuntimeOptions = {
             generateSummaries: true,
-            enableWorker: false,
         },
         private readonly containerScope: IFluidObject,
         public readonly logger: ITelemetryLogger,
@@ -787,7 +783,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.summaryManager = new SummaryManager(
             context,
             this.runtimeOptions.generateSummaries !== false,
-            !!this.runtimeOptions.enableWorker,
             this.logger,
             (summarizer) => { this.nextSummarizerP = summarizer; },
             this.previousState.nextSummarizerP,

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -167,7 +167,6 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     constructor(
         private readonly context: IContainerContext,
         private readonly summariesEnabled: boolean,
-        private readonly enableWorker: boolean,
         parentLogger: ITelemetryLogger,
         private readonly setNextSummarizer: (summarizer: Promise<Summarizer>) => void,
         private nextSummarizerP?: Promise<Summarizer>,
@@ -431,7 +430,6 @@ export class SummaryManager extends EventEmitter implements IDisposable {
                 [DriverHeader.summarizingClient]: true,
                 [LoaderHeader.reconnect]: false,
                 [LoaderHeader.sequenceNumber]: this.context.deltaManager.lastSequenceNumber,
-                [LoaderHeader.executionContext]: this.enableWorker ? "worker" : undefined,
             },
             url: "/_summarizer",
         };


### PR DESCRIPTION
This change removes `LoaderHeader.executionContext` and code responding to it from the runtime.

I don't believe we are pursuing this approach to web worker summarization further at this point, so this is just intended to be a simplifying change.  Based on more recent conversations, I think we are more interested in pursuing summarization within the interactive client or other strategies that reuse more of the interactive client's resources (e.g. delta connection).

This change does not currently remove the `@fluidframework/execution-context-loader` or related code from gateway since I am primarily concerned with the main runtime packages, but I can also clear these up in this change or log an issue if desired.