### PR TITLE
Bump server to new version of common-utils

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -653,16 +653,16 @@
 			"integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.27.0.tgz",
-			"integrity": "sha512-FF45LAAmpftBIVeQp26fOWLBqnfpq0d+W6z3LgX7TLF4l0HbwWbn5xnJmbUYwr83+mRJxuWfJ4Y5TWBH+3UBzQ==",
+			"version": "0.28.0-18295",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.28.0-18295.tgz",
+			"integrity": "sha512-dDASNpEFjNDoiaCy8zzeodhk1n5GBNzWOBc0A2hKSv1RRaUeOSndWSg5QEa+DKXAmhuYNjy3jAYj0RUzu38iOA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@types/events": "^3.0.0",
 				"assert": "^2.0.0",
 				"base64-js": "^1.3.1",
 				"events": "^3.1.0",
-				"lodash": "^4.17.19",
+				"lodash": "^4.17.21",
 				"sha.js": "^2.4.11"
 			}
 		},

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/server-services-core": "^0.1021.0",
     "@fluidframework/server-services-utils": "^0.1021.0",
     "async": "^2.6.1",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-base": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/protocol-definitions": "^0.1021.0",
     "@fluidframework/server-lambdas": "^0.1021.0",
     "@fluidframework/server-memory-orderer": "^0.1021.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/protocol-base": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",
     "@fluidframework/server-lambdas": "^0.1021.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -53,7 +53,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",
     "assert": "^2.0.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",
     "@fluidframework/server-kafka-orderer": "^0.1021.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -39,7 +39,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",
     "@fluidframework/server-kafka-orderer": "^0.1021.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-base": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",
     "@fluidframework/server-services-client": "^0.1021.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/server-services-core": "^0.1021.0",
     "@fluidframework/server-services-ordering-zookeeper": "^0.1021.0",
     "@fluidframework/server-services-utils": "^0.1021.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-base": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/protocol-definitions": "^0.1021.0",
     "@fluidframework/server-services-client": "^0.1021.0",
     "@fluidframework/server-services-core": "^0.1021.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.28.0-0",
     "@fluidframework/gitresources": "^0.1021.0",
     "@fluidframework/protocol-base": "^0.1021.0",
     "@fluidframework/protocol-definitions": "^0.1021.0",


### PR DESCRIPTION
Need to bump client (https://github.com/microsoft/FluidFramework/pull/5383#event-4411035407), but getting failures in npm pack due to duplicate versions of common-utils, so bumping server as well.
