### PR TITLE
Bumping minimum required version of common-utils for client (0.35)

### DIFF
--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -52,7 +52,7 @@
     "@fluid-example/fluid-object-interfaces": "^0.35.4",
     "@fluid-example/search-menu": "^0.35.4",
     "@fluid-internal/client-api": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -50,7 +50,7 @@
     "@fluid-internal/client-api": "^0.35.4",
     "@fluidframework/aqueduct": "^0.35.4",
     "@fluidframework/cell": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.35.4",
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/merge-tree": "^0.35.4",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@fluid-example/flow-util-lib": "^0.35.4",
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/data-object-base": "^0.35.4",
     "@fluidframework/map": "^0.35.4",

--- a/experimental/dds/tree-graphql/package.json
+++ b/experimental/dds/tree-graphql/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluid-experimental/tree": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@graphql-codegen/plugin-helpers": "^1.18.2",
     "@graphql-codegen/visitor-plugin-common": "^1.18.2",
     "graphql": "^15.4.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2568,43 +2568,43 @@
 			}
 		},
 		"@fluidframework/agent-scheduler": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.34.2.tgz",
-			"integrity": "sha512-3Fl5h0rQfSDVpfKlWuxV6GsWPtMjABj/BHjtLJnHctIrYae32t9uMf99PPps+DVUPVSl//J8kuVO4Jp7qhA5cA==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.34.3.tgz",
+			"integrity": "sha512-XOA148+Xdry6Bdy1avTeMQc5seFQx+YuYWpq6Bq7NLPv0usNm8syC/vahfGEbwlr144z+6h/9Wi63S36JdOhnQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/map": "^0.34.2",
-				"@fluidframework/register-collection": "^0.34.2",
-				"@fluidframework/runtime-definitions": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/map": "^0.34.3",
+				"@fluidframework/register-collection": "^0.34.3",
+				"@fluidframework/runtime-definitions": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.34.2.tgz",
-			"integrity": "sha512-dmg+4JzCUToiD3pkjDui6n7F/YzLVLG0XW90cSESJ+XzZTw0M+TytMwsr0KXVlGxLp4YhVmn2VbCCRmuOlWQ8Q==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.34.3.tgz",
+			"integrity": "sha512-/jH1obmwQMggvNnr2O7QBvYX8A/r7M2INXkq3UUYZVF3lIrpieUFyaPxba9XNSkyEujKNFt7QsyN/6XmZISQyw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-loader": "^0.34.2",
-				"@fluidframework/container-runtime": "^0.34.2",
-				"@fluidframework/container-runtime-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/map": "^0.34.2",
-				"@fluidframework/request-handler": "^0.34.2",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/synthesize": "^0.34.2",
-				"@fluidframework/view-interfaces": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-loader": "^0.34.3",
+				"@fluidframework/container-runtime": "^0.34.3",
+				"@fluidframework/container-runtime-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/map": "^0.34.3",
+				"@fluidframework/request-handler": "^0.34.3",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/synthesize": "^0.34.3",
+				"@fluidframework/view-interfaces": "^0.34.3",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			}
@@ -2710,9 +2710,9 @@
 			"integrity": "sha512-H+wEaxuIHODVNqyY8XSMY6ww7ndrRfht9CXKUAUzdQjUN1Oi++YonKcD3CXWZod6afxZ6abDmltIO9wLrjOJzg=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.27.0.tgz",
-			"integrity": "sha512-FF45LAAmpftBIVeQp26fOWLBqnfpq0d+W6z3LgX7TLF4l0HbwWbn5xnJmbUYwr83+mRJxuWfJ4Y5TWBH+3UBzQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.27.2.tgz",
+			"integrity": "sha512-0SQcus/0bpxPNGFVsLl+1CB++9rlB66/sKOP1TXot191JAAxQmJgCctXQ2ycTtCOe69S8ZFStNu2T5I0IxQYsg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@types/events": "^3.0.0",
@@ -2724,31 +2724,31 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.2.tgz",
-			"integrity": "sha512-2rZEPbKxXRnbHb4uK4UrXj158ToNENZycC0hLLG6bRNIGVr+B7zJKpKUN3d5UcUTzs2DMpRSkA5HHAlBhVuw7Q==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.3.tgz",
+			"integrity": "sha512-vrFQfJOOhiFQTk6+jkms6kX3U2VD+jUu4i6gJeLlq45OgoyiyHzLnSUNbJIM7qH5CFFXLwPCyTBxsKmv+5r4bg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.2.tgz",
-			"integrity": "sha512-sGHkjPge65dorKctaXmMj4G77405+CXDYrHxXoCQWFBLK8GGk8mgD11BTEF25+282EbjRwH//EAPjGk2qlrRtQ==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.3.tgz",
+			"integrity": "sha512-ypBc5DEwipLhBvTjmbIx0uQocto7k/U7vnvyHzNrQT3y02RYZKCGyIQXYs4yOoqYhPyKf1Nmo+68UC0xuNu8GQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-utils": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-utils": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -2757,26 +2757,26 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.2.tgz",
-			"integrity": "sha512-tiKNwfA7XLz+w4/nlvROTBG+1W2Ls4KKn4EIIvJ+f1qybhoMP/049BWBBKJSPfEbtRRdFqVBLeZyGq9NCZ6Fjw==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.3.tgz",
+			"integrity": "sha512-nHaos0E2m5+OEenFuZ5WrgaUT1gaQPSqnHOWU7EwoS49iEgtdnEZ1Ig5H0IQ+iITfuoZ9ogqSTolizTpL3Akjw==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.34.2",
+				"@fluidframework/agent-scheduler": "^0.34.3",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-runtime-definitions": "^0.34.2",
-				"@fluidframework/container-utils": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
-				"@fluidframework/garbage-collector": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-runtime-definitions": "^0.34.3",
+				"@fluidframework/container-utils": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
+				"@fluidframework/garbage-collector": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -2784,55 +2784,55 @@
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.34.2.tgz",
-			"integrity": "sha512-WfgAINiIbnUt/gSpK/wqslRt85yOEUANEWVvZ7PE9LPjKl/EYm5tgruzzovQ+ceVZEE18NP82LuQCDP5cMRPfg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.34.3.tgz",
+			"integrity": "sha512-LtBmJhUJeo7so6wErPOX65w5fqVB8dmmQTBCxCB06DGrmI1CLTOoWeRy1RLVtS+asFXLrbwfWsI1+f3pDU7DNg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.2.tgz",
-			"integrity": "sha512-nX3y/B6YWOi7VxaBvdvaLpbnUU1q+LfXLdya8owB8V4d/Srd/w2H95mT9YNvRe4KzKrcc3dzgBuebWyktnIQpQ==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.34.3.tgz",
+			"integrity": "sha512-U/1P6J7/dLwaffax1IiGegodshTP3lLHAHOtMcnYMJTqEYhux4OjYdcE8ZmqJflIX6Hql73oLFl+fuisIT60dw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.2.tgz",
-			"integrity": "sha512-IETHzBxW8VB2s/a+rtHtgzdCaJ4/+ASjm2t8WzRQu1ZNyrsWTgj6ol+OyW1RlajCNfvj6azOjj5sqGU7EfxWmw=="
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.3.tgz",
+			"integrity": "sha512-62lVmR5mj136SN3/cw7d9q8q7SKTWO7QmVX3f7xu3LMvntd75Bu8QVH2QZGHyNGd6PfFUHQZwAjsm2M/3zSyRg=="
 		},
 		"@fluidframework/datastore": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.2.tgz",
-			"integrity": "sha512-Up3UFS0tJj9BEHq4innkx4PZ6iJzxoM5Jx8I6J396Tv5qT9xLlm9JcNWFRAzJfJZeKhAxyrcJyT3DxyM7zKS2A==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.34.3.tgz",
+			"integrity": "sha512-Df/BwTAQtvnuazH32sR8oMEIju/qP6fZIphAnpv4h+73/GpZrzyuyZOZ8jMe4CG2cRcVITWIJ2iPaJd1vNIfkg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-utils": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
-				"@fluidframework/garbage-collector": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-utils": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
+				"@fluidframework/garbage-collector": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"lodash": "^4.17.19",
@@ -2840,56 +2840,56 @@
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.2.tgz",
-			"integrity": "sha512-s5yscwX92jVX1QROT1oa7zDZI4dCF/gvp23kNVjr/jX65iIzqSjxsMgKQuUfB8eGfnpM23IwnX7zROGopqoWUw==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.3.tgz",
+			"integrity": "sha512-53NRTLasfpFEYYQ9lHqA3ZZ3AGDrBoNgxSh+zjnvmtnucS38zPJOFk/lRS2m9H8yF2JUhuuLX7NdRhIlgc3gag==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.34.2.tgz",
-			"integrity": "sha512-7tIz83dXoUc8XPbqHguXdvd9rk0sD9AqQCInxx7z+awGmI5h4yAmmwnq+d7YNov3HawI5oZX7qf+9gZiO6iAmA==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.34.3.tgz",
+			"integrity": "sha512-DFvXk0oM7CajdgtFv/XL7HJAxMEBZ0ZNeqGnko88fKQQeXqDTWppa6mPn2KdbCe2o31NvAdV4TFRUeNpT7WgDQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.2.tgz",
-			"integrity": "sha512-tRR/6+MK2h0YyUzegiLjKUu3p9n3E6Pm26XN3p+Cn4WAnt2FmJhN8FxTGHvFG7G3Tjhs//ECGWEBLv9dJy2y0g==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.3.tgz",
+			"integrity": "sha512-2SxnUNbmiVYuPn4IFXXHDE+ieoh2rI4tS6aD/BD5UdaDWqsIVvtupRzkkddtQmgZgA0vVhmM/GA2F+AYUha9rQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.2.tgz",
-			"integrity": "sha512-g6LS33Sfw0T0wOYLAOlf6PN7U/85c2Qeg0iY74q3ydKxXe2JCtReRRPXcEgYrybRdVjkDeEeFXf1P86oCNAEMQ==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.34.3.tgz",
+			"integrity": "sha512-PPRPlcV/fDzpvMCgYPrdanzFz+6l4qYw3UD0ss73MMsTzcnHMXkQiLMD18TQZMUhjOmImyq5g9X0qrZB5l+Z6Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
 				"@fluidframework/gitresources": "^0.1019.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			}
@@ -2912,13 +2912,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.2.tgz",
-			"integrity": "sha512-IAm4rtopFX8yD/hcAoJvZ/gA3q32AxuhH+Wr7Oamph3bShEF3dFu4oyDeUxckN6imzNIEm4vCJOQXcCLFyXxMg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.34.3.tgz",
+			"integrity": "sha512-ejKUZ4NA+k514lj7oJI1RF06Z+38FRv7xPpxE1KQb7b6y5orgiTY1rnUKd8rQy2O9lABppOYOZGNUdcICy34tw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/runtime-definitions": "^0.34.2"
+				"@fluidframework/runtime-definitions": "^0.34.3"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -2927,17 +2927,17 @@
 			"integrity": "sha512-29wAJDIRmCwkcCtxTnX9jl5lcrdN7CKIjn3kzRVL76V5S71nJnJkmdV4p8Zh0d+Bkoal47r4HF8kmDKVrB8jOw=="
 		},
 		"@fluidframework/local-driver": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.34.2.tgz",
-			"integrity": "sha512-7nL66QpVjETnMwslloUETKMYeSVSit0nUx6zgN963Go2eHho50PnpZ1o0LaTdIXgt/uH8jcm4Enu8IhqR1uEjQ==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.34.3.tgz",
+			"integrity": "sha512-lKXcBoQwVB1RMji5skOjDkKaVbnywHTCl1axx3IMZ1PebRYr/E5+4SqDr2AGzpI5HS5Q3oxewdL4biq97RfHAQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/routerlicious-driver": "^0.34.2",
+				"@fluidframework/routerlicious-driver": "^0.34.3",
 				"@fluidframework/server-local-server": "^0.1019.0",
 				"@fluidframework/server-services-client": "^0.1019.0",
 				"@fluidframework/server-services-core": "^0.1019.0",
@@ -2949,75 +2949,75 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.2.tgz",
-			"integrity": "sha512-sJLJ5JCxaVChb27V5Csgh6PFASMxExDQ/VNpxuMTCtLJrOo4pezrgb9JgEAX5Vrq0STCItUSt84tyxl6pPFMWg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.3.tgz",
+			"integrity": "sha512-46KSYx62lZRwKJYWT6OnJGsETWzc5mDVWLj9Jy5dHxqqjE/EdxTrlPn19kMTtkXx0lObZ9vsxDO3UjErBLQHNA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.34.2.tgz",
-			"integrity": "sha512-LICPB6LpN+4Wur8VWEyKHvgieijADd/TUlYYLYTVWHus+5sCyEr00rA7NTMiHm/wKAejh16pCxUhqWsE94w/TA==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.34.3.tgz",
+			"integrity": "sha512-ljWQJ4kN1g/4lIY+4evsWEKDRAjPr2mCmZ+DQcScl6rzM/HiKq2dwD1n7QB2CFlgBBfJtDP5ha5uGOlI4LAPxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.33.4.tgz",
-			"integrity": "sha512-8hXhoFfQ+9jAZj9FJd9YyhL5d7Jeh7NYFpGYgawVq4693WTzbmZ4/NUzU1LNND3IyXnioYyyiP55KTiTvj21Nw==",
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-0.33.5.tgz",
+			"integrity": "sha512-4gplFYbbYuzXK2DEOSRBkOuSajcQs0NYRS8OlpfLB2tjDaZNXl9X8oTaa/g+3//5T1OtsyG3Joyh1IreeSCySA==",
 			"requires": {
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/driver-utils": "^0.33.4",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/driver-utils": "^0.33.5",
 				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
@@ -3048,9 +3048,9 @@
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -3061,21 +3061,21 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.33.4.tgz",
-			"integrity": "sha512-r2pLu+EFO6Xzc7G+E6w88VxycsQcDzZdSQbKVc5D7LgUgI806aTyDIrRz0G+fRj5R4R6ZYyDPCQ6lUlqJ04KuA==",
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-0.33.5.tgz",
+			"integrity": "sha512-PWNEjw36IZHx926FMG0a0j4VW47zuRfZlELwuXyZy9bTnxWx1W/Bc8T4ob1bG/KrnxNwutQ9iD76bd0wy4Ppyg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-base": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/driver-utils": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-base": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/driver-utils": "^0.33.5",
 				"@fluidframework/gitresources": "^0.1018.0",
-				"@fluidframework/odsp-doclib-utils": "^0.33.4",
+				"@fluidframework/odsp-doclib-utils": "^0.33.5",
 				"@fluidframework/protocol-base": "^0.1018.0",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/telemetry-utils": "^0.33.4",
+				"@fluidframework/telemetry-utils": "^0.33.5",
 				"abort-controller": "^3.0.0",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
@@ -3088,47 +3088,47 @@
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.4.tgz",
-					"integrity": "sha512-xYhm31kUarmZbGNW7jlktUKGisMRIjZoFOk/9iev3X7WgfWF9ybPlRkRUOSbrWFUh7Jbl9ews/sFO160kP8gcw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.5.tgz",
+					"integrity": "sha512-c4b/50sEOkakuNu/yF15eIUP1TD8Z0JJRNVjkVzx3PtpADByOd2qQO6k7nExj4eKS+2COZ6o1lFgV8+oKqd+uQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
@@ -3159,9 +3159,9 @@
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -3172,28 +3172,28 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.33.4.tgz",
-			"integrity": "sha512-P5Yu4FsGCkltAJ1JBOQFyr4GZE/ObDrRr0pagTSRlc4hsm51vc0MbKZxtkRS9qwTw3oyUpkfuTKwrKKgpMOJgg==",
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-0.33.5.tgz",
+			"integrity": "sha512-bLqCnYENWU+25PpIubl0Pa1HSqmLMlDDOuqAdcDX3iDy26t2stb2SVvEfw5SqJer8LBVEKUV++ePjCkPWKumbQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/odsp-driver": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/odsp-driver": "^0.33.5",
 				"assert": "^2.0.0"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
@@ -3228,48 +3228,48 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.2.tgz",
-			"integrity": "sha512-LQoeA8FjrmCIFHet1GnIDLfWbpZ+4+gkr2+5Bmw9k44UpVxVC5T110r+0o0B9aqWoYWG3cWdfeDMgDtV1MfERA==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.3.tgz",
+			"integrity": "sha512-Zuag4pxHuG7UOI7OepVNMctfNxpvaj8ebHMu7Y02WmY/CArIfeFJlpCNjfP/o9HKjcoHpKWgWSy03uWV5HKgzg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.34.2.tgz",
-			"integrity": "sha512-k6Uk98YuqiYu8kJtzzpoibnS9CwLRRzPd7iuL6AtVf76P8kJLUWwDbO80ldNnSD/IjQxDq/Lvtm0B/O4/SpmPg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.34.3.tgz",
+			"integrity": "sha512-Dw8COhWfTdpF9BbmC7Pq/oN/ZhZg3x86tVsqtUFhQdMoIvGeyFGLXIrQUmyIKrbm6UAxaSgK9/7NGa93AyjWrw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-runtime-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
+				"@fluidframework/container-runtime-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
 				"assert": "^2.0.0"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.34.2.tgz",
-			"integrity": "sha512-6NgfbDlezic72xmUSSpjkEsplRY26WkVsKcHZlV4pGeLGP6cHNJkAEXMfTkRiabyAhKYj1V0te6/MUZ53nLwlg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.34.3.tgz",
+			"integrity": "sha512-g4SsUewQR4SbUvzthpAlWv2uLppjjnoKnWqLjalcNaeYSHgJNEFkBVEz+7lFCi9K+57VZJfvZcZT3G3kpRT5gg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/driver-base": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
+				"@fluidframework/driver-base": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
 				"@fluidframework/gitresources": "^0.1019.0",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@fluidframework/server-services-client": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"axios": "^0.21.1",
 				"debug": "^4.1.1",
@@ -3281,32 +3281,32 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.2.tgz",
-			"integrity": "sha512-uaLRkt/L8dqjSrUkUDlv6N7ANeYmb0mrIrMBPi6MJJDs6s/Sxux0rKSYw6tieORSBinhu+ZG2NGhohJJ4e5Fxg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.3.tgz",
+			"integrity": "sha512-dtkiYh3355EjpS5B/KOh+hclRR9ILGRkd3zVgfPEk0TUa8i9WGH/pbeVlRm7mDzbiXHjXO46QFM458yFjKd1PA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.2.tgz",
-			"integrity": "sha512-Esl4111mwpL6z1/IqDb9BLhNrzxuF+3JgydULTWOqyNv7w62RPCDnxPoooJNRP3xF8lSsbUKN/yYnzFHPCtUMg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.34.3.tgz",
+			"integrity": "sha512-SVhU0GMsfC0jeDx6jedPE4NVkBrp7jgnZz4h7P06i26zogVpHORsnl82v1qbaC5c4X4mIl68M0byLxHL1toiwQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/garbage-collector": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/garbage-collector": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
 				"assert": "^2.0.0"
 			}
 		},
@@ -4241,37 +4241,37 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.2.tgz",
-			"integrity": "sha512-KfCWnTVyzaO9rWobKA9dL4qYxEJeJNP74ngpKcuuUxJaUZC0eOaGsoE898wz1xUjFrTZSKjabBYMoCnUcyAogg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.34.3.tgz",
+			"integrity": "sha512-KhyIxAaJoFCehyF5ZeyDtNNtMrNUb9Fl/FTaSDiMsveRfsO0IEKVuNjADiT8ge0HXIugmSQW2Yg8X9TNcIUQXw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.34.2.tgz",
-			"integrity": "sha512-eyTW8UphotmIU3kKSU6ovVQu+pOC5sC5Ei2sYEl0CXuMYPD6+WiQ8o+06m3+sVThP/tdISi9bKem7VR9VPO42w==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.34.3.tgz",
+			"integrity": "sha512-Sp3fKTNux1LusJNoEMAbOYhTU8VpZsUnDXl++9SOEWYekhXxPOb9y+9XKWCtNkbcRRTNP2tLc+2Txt+gShNRkA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.34.2"
+				"@fluidframework/core-interfaces": "^0.34.3"
 			}
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.2.tgz",
-			"integrity": "sha512-0cRc+O4q7RW6/ioOfUazu3oGUcSMZ0XyJ6ERZkVX+G0RiK5JXDdwn5PYhNr1RTTH3WxDsbgB3sbbtYZ76r+GaQ==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.34.3.tgz",
+			"integrity": "sha512-4nvbKQONrlQDQZX7X9lUpm0/+0XRcPdVW7h5x5fgumeIvU8wS9UKmiozUh2TohMFLvKPIV9idbmDq95QB7ESig==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
@@ -4280,64 +4280,64 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.34.2.tgz",
-			"integrity": "sha512-hEZZsXlSGGPh8zXPVeoJ+PdOIG4Y/ShMFVFdbFvXJgJJPKAOSxj0Uo1ndHjrZFjt7Io8ndiOhtldfw3pJ8lEqg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-0.34.3.tgz",
+			"integrity": "sha512-wkpc4A3URGgwQwZVUlYrFcgRvrNLA9xS3pP/gC1zm/4B1gfFsfb9+sRYsBhFSxjrOyc7ny5ZY3h1pf/bL4Vguw==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@fluidframework/server-local-server": "^0.1019.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.33.4.tgz",
-			"integrity": "sha512-+lCLnRWN7Amp4RKPxa5NFbWnpTRUdjg77qEc4X2YgkOhnl9VeAl7UtIuySHBNkV9+xEj18Q4mR243PzZJOSSMA==",
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-0.33.5.tgz",
+			"integrity": "sha512-xsqv6hCOUvX+rHVQLeyCTbh5ApKhfJMvJhpDeboEw3cijvrF2+3BiuPbdtuRY8VQfFVi00qP2EHkv0ahShUq0Q==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/local-driver": "^0.33.4",
-				"@fluidframework/odsp-doclib-utils": "^0.33.4",
-				"@fluidframework/odsp-driver": "^0.33.4",
-				"@fluidframework/odsp-urlresolver": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/local-driver": "^0.33.5",
+				"@fluidframework/odsp-doclib-utils": "^0.33.5",
+				"@fluidframework/odsp-driver": "^0.33.5",
+				"@fluidframework/odsp-urlresolver": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/routerlicious-driver": "^0.33.4",
+				"@fluidframework/routerlicious-driver": "^0.33.5",
 				"@fluidframework/server-local-server": "^0.1018.0",
-				"@fluidframework/test-runtime-utils": "^0.33.4",
-				"@fluidframework/tinylicious-driver": "^0.33.4",
-				"@fluidframework/tool-utils": "^0.33.4",
+				"@fluidframework/test-runtime-utils": "^0.33.5",
+				"@fluidframework/tinylicious-driver": "^0.33.5",
+				"@fluidframework/tool-utils": "^0.33.5",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					},
 					"dependencies": {
@@ -4349,54 +4349,54 @@
 					}
 				},
 				"@fluidframework/driver-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.4.tgz",
-					"integrity": "sha512-xYhm31kUarmZbGNW7jlktUKGisMRIjZoFOk/9iev3X7WgfWF9ybPlRkRUOSbrWFUh7Jbl9ews/sFO160kP8gcw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.5.tgz",
+					"integrity": "sha512-c4b/50sEOkakuNu/yF15eIUP1TD8Z0JJRNVjkVzx3PtpADByOd2qQO6k7nExj4eKS+2COZ6o1lFgV8+oKqd+uQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -4405,17 +4405,17 @@
 					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
 				},
 				"@fluidframework/local-driver": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.4.tgz",
-					"integrity": "sha512-9c08KwFc4PFSb7oCO/bR4qW4jS4EFyRqNHGn8CA6aLyPr9p/tYSyK4ZD9hno2xjZ0p2tBxA4EaTCU9+q3waBbg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.5.tgz",
+					"integrity": "sha512-e1XYWk1Wj6TJKjVU5wXsqJWo98tb/VYyhD1OAlBt5iVNLXc2rN9sO4iWX7UY+EdQR2SKRxdkYMU3+p1GG/U9xw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.4",
+						"@fluidframework/routerlicious-driver": "^0.33.5",
 						"@fluidframework/server-local-server": "^0.1018.0",
 						"@fluidframework/server-services-client": "^0.1018.0",
 						"@fluidframework/server-services-core": "^0.1018.0",
@@ -4447,20 +4447,20 @@
 					}
 				},
 				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.4.tgz",
-					"integrity": "sha512-kW90xb/P88bqBwEPrGpvRlVzNsoJ9Oz4sPKn0Z1wtkMgyycjZLvpFu0rjPh5K+xNiC7b7/MKNcQni5a745tyWg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.5.tgz",
+					"integrity": "sha512-c2vUnr91ZmoNpckZD6drWehdaIjn9aZkS2kW+ka/B/SeXDDK0eVP4gWbcH+U4Ih94MHz6eRWQ3ghgpDdAvYwLA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-base": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"debug": "^4.1.1",
@@ -4472,15 +4472,15 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					},
@@ -4493,18 +4493,18 @@
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
@@ -4628,9 +4628,9 @@
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -4639,22 +4639,22 @@
 					}
 				},
 				"@fluidframework/test-runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-sk3lSvhcKu2i10c4FwdLp4pOfIGs3aWyDVpJVTfp102Twch+WGCvRjb1nM791trfwjwgAZmmZtLpzigIJEzi5Q==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-/g3UTeNWhhgDGAYnU7tNy+09ApMYPxIfKx5Asd+/v52d91foxf/sJQx+/4KymANkY3lSdgxn0XH69+KobvsyGw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/routerlicious-driver": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"jsrsasign": "^10.0.2",
@@ -4766,22 +4766,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.34.2.tgz",
-			"integrity": "sha512-tdoRBB2gKLlw8f2TIbJFZY5df/03TxBfhaUKUZq0l+DXVDvNq5zD9w4Z+RYTJVh5QMitPaP6r4Jfx3OaVBMv6g==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.34.3.tgz",
+			"integrity": "sha512-3w9Id1KM//ftR0csMlYuT9NsoNJ48jJ2xg5/IZZspT4JWwXPYur6OMQQ5i2OmM7diFGgMDDV0Mq3ZVthCVoY2Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/routerlicious-driver": "^0.34.2",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/routerlicious-driver": "^0.34.3",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"axios": "^0.21.1",
 				"jsrsasign": "^10.0.2",
@@ -4795,61 +4795,61 @@
 			"dev": true
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.33.4.tgz",
-			"integrity": "sha512-MCMMerPqfUIUKk4AZ+PsZWU05pI0W9fND6SioyZlvFl6iOb5q8Pi28+ZKsU+QUGVACAi1R0MYmSDCE30M8mduQ==",
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.33.5.tgz",
+			"integrity": "sha512-HQ/NfemjKleKEN3gbr2yzZl8NivT0KsQT/OiOgyI0IYgok0j4OGIrNSLPKoh2t+BftDWsLngWFs3m/CisKMcGA==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/driver-utils": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/driver-utils": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/routerlicious-driver": "^0.33.4",
+				"@fluidframework/routerlicious-driver": "^0.33.5",
 				"jsrsasign": "^10.0.2",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.4.tgz",
-					"integrity": "sha512-xYhm31kUarmZbGNW7jlktUKGisMRIjZoFOk/9iev3X7WgfWF9ybPlRkRUOSbrWFUh7Jbl9ews/sFO160kP8gcw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.5.tgz",
+					"integrity": "sha512-c4b/50sEOkakuNu/yF15eIUP1TD8Z0JJRNVjkVzx3PtpADByOd2qQO6k7nExj4eKS+2COZ6o1lFgV8+oKqd+uQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
@@ -4880,20 +4880,20 @@
 					}
 				},
 				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.4.tgz",
-					"integrity": "sha512-kW90xb/P88bqBwEPrGpvRlVzNsoJ9Oz4sPKn0Z1wtkMgyycjZLvpFu0rjPh5K+xNiC7b7/MKNcQni5a745tyWg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.5.tgz",
+					"integrity": "sha512-c2vUnr91ZmoNpckZD6drWehdaIjn9aZkS2kW+ka/B/SeXDDK0eVP4gWbcH+U4Ih94MHz6eRWQ3ghgpDdAvYwLA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-base": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"debug": "^4.1.1",
@@ -4930,9 +4930,9 @@
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -4948,12 +4948,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.33.4.tgz",
-			"integrity": "sha512-XiF5pHuogKrCuGgUIg/+MhvF2AeGtaSIE2evGO1ZUUNvZOfWF1ydCwxkvNPxEhLEWQKRoC/W6QxSULWaciwLnA==",
+			"version": "0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-0.33.5.tgz",
+			"integrity": "sha512-QhV+aOFWs8Aw+0tNyP22Mwttjgce3GptijOK0IIEs6AJ0e3N6h0SNg3rFRgLyU2vHzOrS0PHmfDyGe+7tVCA3A==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/odsp-doclib-utils": "^0.33.4",
+				"@fluidframework/odsp-doclib-utils": "^0.33.5",
 				"@fluidframework/protocol-base": "^0.1018.0",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
 				"proper-lockfile": "^4.1.1"
@@ -4987,11 +4987,11 @@
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.34.2.tgz",
-			"integrity": "sha512-XfNwhxSQO19eiwqCNprVLr7Ym1Q9spCmsO29/mLnQE9HZc8SWOgA9TM4g9c4r01FlLMinV3DQlV658F/2DcMHg==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.34.3.tgz",
+			"integrity": "sha512-Z1sz/KgT810e1M3TXaKTwHJzRpT3Vlu9wEI3f2koq7YCrZ5MMI8+W/ftdcQ/wr/IaruC6cJCMCzs/jeMbkFsyg==",
 			"requires": {
-				"@fluidframework/core-interfaces": "^0.34.2"
+				"@fluidframework/core-interfaces": "^0.34.3"
 			}
 		},
 		"@graphql-codegen/cli": {
@@ -29328,97 +29328,97 @@
 			}
 		},
 		"old-aqueduct": {
-			"version": "npm:@fluidframework/aqueduct@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.34.2.tgz",
-			"integrity": "sha512-dmg+4JzCUToiD3pkjDui6n7F/YzLVLG0XW90cSESJ+XzZTw0M+TytMwsr0KXVlGxLp4YhVmn2VbCCRmuOlWQ8Q==",
+			"version": "npm:@fluidframework/aqueduct@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.34.3.tgz",
+			"integrity": "sha512-/jH1obmwQMggvNnr2O7QBvYX8A/r7M2INXkq3UUYZVF3lIrpieUFyaPxba9XNSkyEujKNFt7QsyN/6XmZISQyw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-loader": "^0.34.2",
-				"@fluidframework/container-runtime": "^0.34.2",
-				"@fluidframework/container-runtime-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/map": "^0.34.2",
-				"@fluidframework/request-handler": "^0.34.2",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/synthesize": "^0.34.2",
-				"@fluidframework/view-interfaces": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-loader": "^0.34.3",
+				"@fluidframework/container-runtime": "^0.34.3",
+				"@fluidframework/container-runtime-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/map": "^0.34.3",
+				"@fluidframework/request-handler": "^0.34.3",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/synthesize": "^0.34.3",
+				"@fluidframework/view-interfaces": "^0.34.3",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"old-aqueduct2": {
-			"version": "npm:@fluidframework/aqueduct@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.33.4.tgz",
-			"integrity": "sha512-G4SL0puCvFGqM1/38Q41woJA110twCrMwtWJuNKOS555ac6WjyxUrJC6+g7RBRFHFy9NDCDB+/5riQFvc54mqA==",
+			"version": "npm:@fluidframework/aqueduct@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.33.5.tgz",
+			"integrity": "sha512-BgPZ9VAlM7XVBskl4gr7QbEG0W6luBnHENIz46Ej2YtZIZ6QWxc32lwVL3sxon35r7i1+Y1zE7COzLiCLJaDgg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.4",
-				"@fluidframework/container-loader": "^0.33.4",
-				"@fluidframework/container-runtime": "^0.33.4",
-				"@fluidframework/container-runtime-definitions": "^0.33.4",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
-				"@fluidframework/map": "^0.33.4",
-				"@fluidframework/request-handler": "^0.33.4",
-				"@fluidframework/runtime-definitions": "^0.33.4",
-				"@fluidframework/runtime-utils": "^0.33.4",
-				"@fluidframework/synthesize": "^0.33.4",
-				"@fluidframework/view-interfaces": "^0.33.4",
+				"@fluidframework/container-definitions": "^0.33.5",
+				"@fluidframework/container-loader": "^0.33.5",
+				"@fluidframework/container-runtime": "^0.33.5",
+				"@fluidframework/container-runtime-definitions": "^0.33.5",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
+				"@fluidframework/map": "^0.33.5",
+				"@fluidframework/request-handler": "^0.33.5",
+				"@fluidframework/runtime-definitions": "^0.33.5",
+				"@fluidframework/runtime-utils": "^0.33.5",
+				"@fluidframework/synthesize": "^0.33.5",
+				"@fluidframework/view-interfaces": "^0.33.5",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/agent-scheduler": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.4.tgz",
-					"integrity": "sha512-La5SOjQUoWKjzxMdgRMy9aIqArx1foHNVhc0pRsZ2AByPVWao58ac2bFa0xiSV7tbR65uYxpOBEdA8f/bNVRYA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.5.tgz",
+					"integrity": "sha512-4D11HLNUuH/SOAZlqB7+be1vmhOsNXCIrzNmelYf5R4mS2dTIase6XjcSTxIxZ6Yp/UjvcZJrP5oytufZTF4xQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/map": "^0.33.4",
-						"@fluidframework/register-collection": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/map": "^0.33.5",
+						"@fluidframework/register-collection": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-loader": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.4.tgz",
-					"integrity": "sha512-yZCiaeUAQNmEbKQzk38W99Qo0TpgRYmfDFdK7UIslmXPGSn2l+kPFpfi4LOV06X7kZCGmICrKf98sTQfQN18Cw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.5.tgz",
+					"integrity": "sha512-YPKXSpK2XvuEAKCSoTC0ss0wuQuggX9Kmmbfd9/XZr2F2uzbK6+zhod7NcnI1LkpLzRmhtvdKos7vaUeNnOChA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -29427,26 +29427,26 @@
 					}
 				},
 				"@fluidframework/container-runtime": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.4.tgz",
-					"integrity": "sha512-ud4/S+VgQj2XrSb+l6USV70Ef/pwgeG2P7r3B2vSqmtfEFD1D1sBTz/zvK4I/jNrLN/C18yYTXcSQ85ZpWzl0g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.5.tgz",
+					"integrity": "sha512-UdDvzszrq3OtshuDoMWjGjFGGA5dcDHbG7xPBpiq5MSmqpLS5TubQElzNzfJ/EcQyXq+zjzQBPhny92S8g1H3g==",
 					"requires": {
-						"@fluidframework/agent-scheduler": "^0.33.4",
+						"@fluidframework/agent-scheduler": "^0.33.5",
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-runtime-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-runtime-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -29454,55 +29454,55 @@
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-pwhzqukeXDTGmCaktzVKiJgDk9rKLDYRyzIXD7/XtJaHPnsEuT8tJP/+z18bk9re+n4XVRdsPCV1knll9Rd/FQ==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-jlDzxLGGQAnRKoR3VVQprYYN0yu2XflcA4BMfkVq6ODyYQW9mnd0sUp/BgIyOAYbpCcUMYdpaca4tpb+4FKcTw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -29510,54 +29510,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -29566,17 +29566,17 @@
 					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
 				},
 				"@fluidframework/map": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.4.tgz",
-					"integrity": "sha512-vnTbjXYvYLGwL9IE8Si3ZmpeDyxjcOcZ0XqxRuKxLHT7Z+SjbWTU/VgNyjseWPJ6IGF3pMfrtsF0ghP2n9AqkA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.5.tgz",
+					"integrity": "sha512-OYqYC2ltNeQkyaofrW47Poyz3Ey5GDZXlFJaMfY71ziFr/ZvEqpbg8LIIPeQF4K0DiGtftV+u/2OHwebfZfsLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.4",
+						"@fluidframework/shared-object-base": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
@@ -29603,95 +29603,95 @@
 					}
 				},
 				"@fluidframework/register-collection": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.4.tgz",
-					"integrity": "sha512-7wMGCDBxGrljYYmseHaIZ9aNopRNS04/L86YxrtvbeuXwh8b0agBhLNIiuPpwVJzq2hR9w6+/5Ij9G7SZWSbPA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.5.tgz",
+					"integrity": "sha512-FWIEBA6DpEKGT3QkORywBXRAwpG4jAKuZR6VQiFUfTtWZBgC62Wlr0yDiOEh3pOq8/edar/5VLJjZRerhJVpIQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.4",
+						"@fluidframework/shared-object-base": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/request-handler": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.33.4.tgz",
-					"integrity": "sha512-+g6s8UzFir3jZqZZ7eq+c6/hMyolSy585VT47qFWqIyqrElOZY+rAdBpcxmGJqcDBe9b0zGVM053Ed7yboHsnA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.33.5.tgz",
+					"integrity": "sha512-g5VmxiVfpGIA8OXT/QC65wYj+WDbXHsqkqlDezsrLzNbXtrWok1io/MxQr3Uo0qc8O6BxMrrpztR+giWONT1TA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-runtime-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
+						"@fluidframework/container-runtime-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/synthesize": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.33.4.tgz",
-					"integrity": "sha512-m934TgKNbr1wRM7vhOtLRLv4Necmyu6STLzH5aQY3UGMD/AxC7RX6IZr65psM+QCe17oI7LLLYkO5Du8bMoYSQ==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.33.5.tgz",
+					"integrity": "sha512-EzJ4oeeJvMfNnFH16Vwas6RQfNnUUv6E8rJdweUNjSSooNPy3adLIQRLRB5KjSl0BDt4T9rSK2fVVIVzwwzc7A==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.4"
+						"@fluidframework/core-interfaces": "^0.33.5"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -29700,90 +29700,90 @@
 					}
 				},
 				"@fluidframework/view-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.33.4.tgz",
-					"integrity": "sha512-EEJ3V5JgZxxkZO1lDb7TLqHXJVAMU1oEDN8fxVgGlYhLJl9cu3yGOXO4b/nwX+Fe2NQ9kGL+iwjjbEJkI/J2Gg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.33.5.tgz",
+					"integrity": "sha512-sIcbqDHQys43AIqv9ck1881GpAGJQHJFBKTnF4DpsQRkicLt4WDF+dr4CucXZjcpyuV4kJ/clHzAx4H1qxLzig==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.4"
+						"@fluidframework/core-interfaces": "^0.33.5"
 					}
 				}
 			}
 		},
 		"old-cell": {
-			"version": "npm:@fluidframework/cell@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.34.2.tgz",
-			"integrity": "sha512-2Th2MXYCnX9sK9so+DdMfoszjQmBEIstnmxKkTe5ZzTstG1dsV5rMfUPwAIkTNX/zjU8KUFqm288+tOqZXIrFw==",
+			"version": "npm:@fluidframework/cell@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.34.3.tgz",
+			"integrity": "sha512-JDAB89vo25VEx6aLkfYFIbXvALvTS+cOib1s/a25w/yfKg5Cu3VTmzC93mPxkBThZLPdtQa6YyE/dkYykdjitw==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"old-cell2": {
-			"version": "npm:@fluidframework/cell@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.33.4.tgz",
-			"integrity": "sha512-RraWRf6bItOllH2Qurq5Ux2RO5huayzXalCeT+fKMjSRBWzqoW9TS9doPewvqXlermaBEO6CgAIIk8O/BiZ18Q==",
+			"version": "npm:@fluidframework/cell@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-0.33.5.tgz",
+			"integrity": "sha512-bZnQS7OU09CtTOKm7XawSVqJgyIJr4/Phmjo6R3rYuVkbl67nHJWiFicstBKxc/ZzAfuY6UpSmg3InBnGw9GUQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.4",
+				"@fluidframework/shared-object-base": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -29791,54 +29791,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -29867,59 +29867,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -29930,39 +29930,39 @@
 			}
 		},
 		"old-container-definitions": {
-			"version": "npm:@fluidframework/container-definitions@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.2.tgz",
-			"integrity": "sha512-2rZEPbKxXRnbHb4uK4UrXj158ToNENZycC0hLLG6bRNIGVr+B7zJKpKUN3d5UcUTzs2DMpRSkA5HHAlBhVuw7Q==",
+			"version": "npm:@fluidframework/container-definitions@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.34.3.tgz",
+			"integrity": "sha512-vrFQfJOOhiFQTk6+jkms6kX3U2VD+jUu4i6gJeLlq45OgoyiyHzLnSUNbJIM7qH5CFFXLwPCyTBxsKmv+5r4bg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
 			}
 		},
 		"old-container-definitions2": {
-			"version": "npm:@fluidframework/container-definitions@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-			"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+			"version": "npm:@fluidframework/container-definitions@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+			"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
@@ -29977,20 +29977,20 @@
 			}
 		},
 		"old-container-loader": {
-			"version": "npm:@fluidframework/container-loader@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.2.tgz",
-			"integrity": "sha512-sGHkjPge65dorKctaXmMj4G77405+CXDYrHxXoCQWFBLK8GGk8mgD11BTEF25+282EbjRwH//EAPjGk2qlrRtQ==",
+			"version": "npm:@fluidframework/container-loader@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.34.3.tgz",
+			"integrity": "sha512-ypBc5DEwipLhBvTjmbIx0uQocto7k/U7vnvyHzNrQT3y02RYZKCGyIQXYs4yOoqYhPyKf1Nmo+68UC0xuNu8GQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-utils": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-utils": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -29999,20 +29999,20 @@
 			}
 		},
 		"old-container-loader2": {
-			"version": "npm:@fluidframework/container-loader@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.4.tgz",
-			"integrity": "sha512-yZCiaeUAQNmEbKQzk38W99Qo0TpgRYmfDFdK7UIslmXPGSn2l+kPFpfi4LOV06X7kZCGmICrKf98sTQfQN18Cw==",
+			"version": "npm:@fluidframework/container-loader@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.5.tgz",
+			"integrity": "sha512-YPKXSpK2XvuEAKCSoTC0ss0wuQuggX9Kmmbfd9/XZr2F2uzbK6+zhod7NcnI1LkpLzRmhtvdKos7vaUeNnOChA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.4",
-				"@fluidframework/container-utils": "^0.33.4",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/driver-utils": "^0.33.4",
+				"@fluidframework/container-definitions": "^0.33.5",
+				"@fluidframework/container-utils": "^0.33.5",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/driver-utils": "^0.33.5",
 				"@fluidframework/protocol-base": "^0.1018.0",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/telemetry-utils": "^0.33.4",
+				"@fluidframework/telemetry-utils": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -30021,56 +30021,56 @@
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
@@ -30101,9 +30101,9 @@
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30114,26 +30114,26 @@
 			}
 		},
 		"old-container-runtime": {
-			"version": "npm:@fluidframework/container-runtime@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.2.tgz",
-			"integrity": "sha512-tiKNwfA7XLz+w4/nlvROTBG+1W2Ls4KKn4EIIvJ+f1qybhoMP/049BWBBKJSPfEbtRRdFqVBLeZyGq9NCZ6Fjw==",
+			"version": "npm:@fluidframework/container-runtime@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.34.3.tgz",
+			"integrity": "sha512-nHaos0E2m5+OEenFuZ5WrgaUT1gaQPSqnHOWU7EwoS49iEgtdnEZ1Ig5H0IQ+iITfuoZ9ogqSTolizTpL3Akjw==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.34.2",
+				"@fluidframework/agent-scheduler": "^0.34.3",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-runtime-definitions": "^0.34.2",
-				"@fluidframework/container-utils": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
-				"@fluidframework/garbage-collector": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-runtime-definitions": "^0.34.3",
+				"@fluidframework/container-utils": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
+				"@fluidframework/garbage-collector": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -30141,26 +30141,26 @@
 			}
 		},
 		"old-container-runtime2": {
-			"version": "npm:@fluidframework/container-runtime@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.4.tgz",
-			"integrity": "sha512-ud4/S+VgQj2XrSb+l6USV70Ef/pwgeG2P7r3B2vSqmtfEFD1D1sBTz/zvK4I/jNrLN/C18yYTXcSQ85ZpWzl0g==",
+			"version": "npm:@fluidframework/container-runtime@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.5.tgz",
+			"integrity": "sha512-UdDvzszrq3OtshuDoMWjGjFGGA5dcDHbG7xPBpiq5MSmqpLS5TubQElzNzfJ/EcQyXq+zjzQBPhny92S8g1H3g==",
 			"requires": {
-				"@fluidframework/agent-scheduler": "^0.33.4",
+				"@fluidframework/agent-scheduler": "^0.33.5",
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.4",
-				"@fluidframework/container-runtime-definitions": "^0.33.4",
-				"@fluidframework/container-utils": "^0.33.4",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/driver-utils": "^0.33.4",
-				"@fluidframework/garbage-collector": "^0.33.4",
+				"@fluidframework/container-definitions": "^0.33.5",
+				"@fluidframework/container-runtime-definitions": "^0.33.5",
+				"@fluidframework/container-utils": "^0.33.5",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/driver-utils": "^0.33.5",
+				"@fluidframework/garbage-collector": "^0.33.5",
 				"@fluidframework/protocol-base": "^0.1018.0",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-definitions": "^0.33.4",
-				"@fluidframework/runtime-utils": "^0.33.4",
-				"@fluidframework/telemetry-utils": "^0.33.4",
+				"@fluidframework/runtime-definitions": "^0.33.5",
+				"@fluidframework/runtime-utils": "^0.33.5",
+				"@fluidframework/telemetry-utils": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"double-ended-queue": "^2.1.0-0",
@@ -30168,84 +30168,84 @@
 			},
 			"dependencies": {
 				"@fluidframework/agent-scheduler": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.4.tgz",
-					"integrity": "sha512-La5SOjQUoWKjzxMdgRMy9aIqArx1foHNVhc0pRsZ2AByPVWao58ac2bFa0xiSV7tbR65uYxpOBEdA8f/bNVRYA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.5.tgz",
+					"integrity": "sha512-4D11HLNUuH/SOAZlqB7+be1vmhOsNXCIrzNmelYf5R4mS2dTIase6XjcSTxIxZ6Yp/UjvcZJrP5oytufZTF4xQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/map": "^0.33.4",
-						"@fluidframework/register-collection": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/map": "^0.33.5",
+						"@fluidframework/register-collection": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-pwhzqukeXDTGmCaktzVKiJgDk9rKLDYRyzIXD7/XtJaHPnsEuT8tJP/+z18bk9re+n4XVRdsPCV1knll9Rd/FQ==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-jlDzxLGGQAnRKoR3VVQprYYN0yu2XflcA4BMfkVq6ODyYQW9mnd0sUp/BgIyOAYbpCcUMYdpaca4tpb+4FKcTw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -30253,54 +30253,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -30309,17 +30309,17 @@
 					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
 				},
 				"@fluidframework/map": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.4.tgz",
-					"integrity": "sha512-vnTbjXYvYLGwL9IE8Si3ZmpeDyxjcOcZ0XqxRuKxLHT7Z+SjbWTU/VgNyjseWPJ6IGF3pMfrtsF0ghP2n9AqkA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.5.tgz",
+					"integrity": "sha512-OYqYC2ltNeQkyaofrW47Poyz3Ey5GDZXlFJaMfY71ziFr/ZvEqpbg8LIIPeQF4K0DiGtftV+u/2OHwebfZfsLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.4",
+						"@fluidframework/shared-object-base": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
@@ -30346,74 +30346,74 @@
 					}
 				},
 				"@fluidframework/register-collection": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.4.tgz",
-					"integrity": "sha512-7wMGCDBxGrljYYmseHaIZ9aNopRNS04/L86YxrtvbeuXwh8b0agBhLNIiuPpwVJzq2hR9w6+/5Ij9G7SZWSbPA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.5.tgz",
+					"integrity": "sha512-FWIEBA6DpEKGT3QkORywBXRAwpG4jAKuZR6VQiFUfTtWZBgC62Wlr0yDiOEh3pOq8/edar/5VLJjZRerhJVpIQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.4",
+						"@fluidframework/shared-object-base": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30424,90 +30424,90 @@
 			}
 		},
 		"old-core-interfaces": {
-			"version": "npm:@fluidframework/core-interfaces@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.2.tgz",
-			"integrity": "sha512-IETHzBxW8VB2s/a+rtHtgzdCaJ4/+ASjm2t8WzRQu1ZNyrsWTgj6ol+OyW1RlajCNfvj6azOjj5sqGU7EfxWmw=="
+			"version": "npm:@fluidframework/core-interfaces@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.34.3.tgz",
+			"integrity": "sha512-62lVmR5mj136SN3/cw7d9q8q7SKTWO7QmVX3f7xu3LMvntd75Bu8QVH2QZGHyNGd6PfFUHQZwAjsm2M/3zSyRg=="
 		},
 		"old-core-interfaces2": {
-			"version": "npm:@fluidframework/core-interfaces@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-			"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+			"version": "npm:@fluidframework/core-interfaces@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+			"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 		},
 		"old-counter": {
-			"version": "npm:@fluidframework/counter@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.34.2.tgz",
-			"integrity": "sha512-QpBs3w1BPqapYHAtrcdMeo2+UqqVgbAlMzn7vpFhVa4NYNsT86qeXNqdn548+xIojfWjyUeQBi1XvGoRSY0hmA==",
+			"version": "npm:@fluidframework/counter@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.34.3.tgz",
+			"integrity": "sha512-mdJkC5j/2jPYBbwKkMtvXUoyQPfcExTqyD5Y6n6OnRDCi6v5obiFB8yXnbKE2rzvPGl8sW0hw+9zNHhluIxYmQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"old-counter2": {
-			"version": "npm:@fluidframework/counter@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.33.4.tgz",
-			"integrity": "sha512-tfMmlBsKjAdcYJKYtPbNwd5LbippOvzpihVx6r5os6pW/p1UX9n6/TDArD1iC81a3TpIF0fwNNFqxjasIdZxUw==",
+			"version": "npm:@fluidframework/counter@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-0.33.5.tgz",
+			"integrity": "sha512-po/ea9Wp4eEvNuvubAsgeGCzW9jtt2qaOkEA0OUsY7xZiX+3y+YiNVfIileCeAAsPF4Ob/PbVg/TKDELhRC2eA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.4",
+				"@fluidframework/shared-object-base": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -30515,54 +30515,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -30591,59 +30591,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30654,56 +30654,56 @@
 			}
 		},
 		"old-datastore-definitions": {
-			"version": "npm:@fluidframework/datastore-definitions@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.2.tgz",
-			"integrity": "sha512-s5yscwX92jVX1QROT1oa7zDZI4dCF/gvp23kNVjr/jX65iIzqSjxsMgKQuUfB8eGfnpM23IwnX7zROGopqoWUw==",
+			"version": "npm:@fluidframework/datastore-definitions@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.34.3.tgz",
+			"integrity": "sha512-53NRTLasfpFEYYQ9lHqA3ZZ3AGDrBoNgxSh+zjnvmtnucS38zPJOFk/lRS2m9H8yF2JUhuuLX7NdRhIlgc3gag==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-definitions": "^0.34.2",
+				"@fluidframework/runtime-definitions": "^0.34.3",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"old-datastore-definitions2": {
-			"version": "npm:@fluidframework/datastore-definitions@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-			"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+			"version": "npm:@fluidframework/datastore-definitions@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+			"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.4",
-				"@fluidframework/core-interfaces": "^0.33.4",
+				"@fluidframework/container-definitions": "^0.33.5",
+				"@fluidframework/core-interfaces": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-definitions": "^0.33.4",
+				"@fluidframework/runtime-definitions": "^0.33.5",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
@@ -30716,15 +30716,15 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
@@ -30732,29 +30732,29 @@
 			}
 		},
 		"old-driver-definitions": {
-			"version": "npm:@fluidframework/driver-definitions@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.2.tgz",
-			"integrity": "sha512-tRR/6+MK2h0YyUzegiLjKUu3p9n3E6Pm26XN3p+Cn4WAnt2FmJhN8FxTGHvFG7G3Tjhs//ECGWEBLv9dJy2y0g==",
+			"version": "npm:@fluidframework/driver-definitions@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.34.3.tgz",
+			"integrity": "sha512-2SxnUNbmiVYuPn4IFXXHDE+ieoh2rI4tS6aD/BD5UdaDWqsIVvtupRzkkddtQmgZgA0vVhmM/GA2F+AYUha9rQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0"
 			}
 		},
 		"old-driver-definitions2": {
-			"version": "npm:@fluidframework/driver-definitions@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-			"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+			"version": "npm:@fluidframework/driver-definitions@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+			"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
-				"@fluidframework/core-interfaces": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0"
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/protocol-definitions": {
 					"version": "0.1018.0",
@@ -30767,82 +30767,82 @@
 			}
 		},
 		"old-ink": {
-			"version": "npm:@fluidframework/ink@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.34.2.tgz",
-			"integrity": "sha512-KlcfVJKxf81ROHm0u6Tl/DbqEVlDiR7OCYaL3M1N+TviTQKBEqz4cPnLuQ5LV75pJgMcYlIHVYVn/AJn3VLqfg==",
+			"version": "npm:@fluidframework/ink@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.34.3.tgz",
+			"integrity": "sha512-Gg21vvp4gmf3d9j1tTLXvzZMnfdOQ6pagnDlbY8+DnA6FCpAse5foNmctJKK3d965KqYgkOlUvNCvpY66o987Q==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"old-ink2": {
-			"version": "npm:@fluidframework/ink@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.33.4.tgz",
-			"integrity": "sha512-pm9qaXNWJF1KnyVGgE4KDcGbCEWlYlwPqeoXNYyZKOgJLK/OB3gu/z5suf3UbjzsVokeUw8LLo15xOLr829prg==",
+			"version": "npm:@fluidframework/ink@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-0.33.5.tgz",
+			"integrity": "sha512-r33YMY+DyWS5bRZw8WwRMZtroPixV4k5mLdmCpbz2mTks174jODfZmAuHWYJD/+MfvvPH40GFDqBbdvq55qlFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.4",
+				"@fluidframework/shared-object-base": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -30850,54 +30850,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -30926,59 +30926,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -30989,17 +30989,17 @@
 			}
 		},
 		"old-local-driver": {
-			"version": "npm:@fluidframework/local-driver@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.34.2.tgz",
-			"integrity": "sha512-7nL66QpVjETnMwslloUETKMYeSVSit0nUx6zgN963Go2eHho50PnpZ1o0LaTdIXgt/uH8jcm4Enu8IhqR1uEjQ==",
+			"version": "npm:@fluidframework/local-driver@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.34.3.tgz",
+			"integrity": "sha512-lKXcBoQwVB1RMji5skOjDkKaVbnywHTCl1axx3IMZ1PebRYr/E5+4SqDr2AGzpI5HS5Q3oxewdL4biq97RfHAQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/driver-utils": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/driver-utils": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/routerlicious-driver": "^0.34.2",
+				"@fluidframework/routerlicious-driver": "^0.34.3",
 				"@fluidframework/server-local-server": "^0.1019.0",
 				"@fluidframework/server-services-client": "^0.1019.0",
 				"@fluidframework/server-services-core": "^0.1019.0",
@@ -31011,17 +31011,17 @@
 			}
 		},
 		"old-local-driver2": {
-			"version": "npm:@fluidframework/local-driver@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.4.tgz",
-			"integrity": "sha512-9c08KwFc4PFSb7oCO/bR4qW4jS4EFyRqNHGn8CA6aLyPr9p/tYSyK4ZD9hno2xjZ0p2tBxA4EaTCU9+q3waBbg==",
+			"version": "npm:@fluidframework/local-driver@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.5.tgz",
+			"integrity": "sha512-e1XYWk1Wj6TJKjVU5wXsqJWo98tb/VYyhD1OAlBt5iVNLXc2rN9sO4iWX7UY+EdQR2SKRxdkYMU3+p1GG/U9xw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/driver-utils": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/driver-utils": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/routerlicious-driver": "^0.33.4",
+				"@fluidframework/routerlicious-driver": "^0.33.5",
 				"@fluidframework/server-local-server": "^0.1018.0",
 				"@fluidframework/server-services-client": "^0.1018.0",
 				"@fluidframework/server-services-core": "^0.1018.0",
@@ -31033,47 +31033,47 @@
 			},
 			"dependencies": {
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.4.tgz",
-					"integrity": "sha512-xYhm31kUarmZbGNW7jlktUKGisMRIjZoFOk/9iev3X7WgfWF9ybPlRkRUOSbrWFUh7Jbl9ews/sFO160kP8gcw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.5.tgz",
+					"integrity": "sha512-c4b/50sEOkakuNu/yF15eIUP1TD8Z0JJRNVjkVzx3PtpADByOd2qQO6k7nExj4eKS+2COZ6o1lFgV8+oKqd+uQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
@@ -31104,20 +31104,20 @@
 					}
 				},
 				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.4.tgz",
-					"integrity": "sha512-kW90xb/P88bqBwEPrGpvRlVzNsoJ9Oz4sPKn0Z1wtkMgyycjZLvpFu0rjPh5K+xNiC7b7/MKNcQni5a745tyWg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.5.tgz",
+					"integrity": "sha512-c2vUnr91ZmoNpckZD6drWehdaIjn9aZkS2kW+ka/B/SeXDDK0eVP4gWbcH+U4Ih94MHz6eRWQ3ghgpDdAvYwLA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-base": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"debug": "^4.1.1",
@@ -31248,9 +31248,9 @@
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -31363,86 +31363,86 @@
 			}
 		},
 		"old-map": {
-			"version": "npm:@fluidframework/map@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.2.tgz",
-			"integrity": "sha512-sJLJ5JCxaVChb27V5Csgh6PFASMxExDQ/VNpxuMTCtLJrOo4pezrgb9JgEAX5Vrq0STCItUSt84tyxl6pPFMWg==",
+			"version": "npm:@fluidframework/map@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.34.3.tgz",
+			"integrity": "sha512-46KSYx62lZRwKJYWT6OnJGsETWzc5mDVWLj9Jy5dHxqqjE/EdxTrlPn19kMTtkXx0lObZ9vsxDO3UjErBLQHNA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"old-map2": {
-			"version": "npm:@fluidframework/map@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.4.tgz",
-			"integrity": "sha512-vnTbjXYvYLGwL9IE8Si3ZmpeDyxjcOcZ0XqxRuKxLHT7Z+SjbWTU/VgNyjseWPJ6IGF3pMfrtsF0ghP2n9AqkA==",
+			"version": "npm:@fluidframework/map@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.5.tgz",
+			"integrity": "sha512-OYqYC2ltNeQkyaofrW47Poyz3Ey5GDZXlFJaMfY71ziFr/ZvEqpbg8LIIPeQF4K0DiGtftV+u/2OHwebfZfsLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
 				"@fluidframework/protocol-base": "^0.1018.0",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.4",
+				"@fluidframework/shared-object-base": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"path-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -31450,54 +31450,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -31526,59 +31526,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -31589,20 +31589,20 @@
 			}
 		},
 		"old-matrix": {
-			"version": "npm:@fluidframework/matrix@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.34.2.tgz",
-			"integrity": "sha512-hCCr19Q5B/UQcprFI1uT39cq+W6sQ08kFO64ayGWUuBN7cV1zIGHtGimr+6CjYBVW2EyzD4u+NxpKeDV5+twQA==",
+			"version": "npm:@fluidframework/matrix@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.34.3.tgz",
+			"integrity": "sha512-yPNysTNva65ojLlwFWH/mVXj/3dj0fMb6Z5V4DDKMHkmVwW7brm03wxQ45/2TXCMKq99rtWwYkEmB4bPlWR8MQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/merge-tree": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/merge-tree": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/shared-object-base": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/shared-object-base": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
@@ -31610,20 +31610,20 @@
 			}
 		},
 		"old-matrix2": {
-			"version": "npm:@fluidframework/matrix@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.33.4.tgz",
-			"integrity": "sha512-sBgs20GX20SyD2KSTcdUs5wc6DenLy/SwGPOIfyDiEvrv8YfvnWV3YrGvCfLrX3KdB28cf6Ms5NWgjC3XU++Dg==",
+			"version": "npm:@fluidframework/matrix@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-0.33.5.tgz",
+			"integrity": "sha512-4dcEEWfQYfwG5zrCXell2rpEBgPK68rNBo7Ra3zpe7n3Jn1ozXeJlFPUj3yorARVWjvOXKUqdKVJcccMwR1BlQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
-				"@fluidframework/merge-tree": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
+				"@fluidframework/merge-tree": "^0.33.5",
 				"@fluidframework/protocol-base": "^0.1018.0",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-utils": "^0.33.4",
-				"@fluidframework/shared-object-base": "^0.33.4",
-				"@fluidframework/telemetry-utils": "^0.33.4",
+				"@fluidframework/runtime-utils": "^0.33.5",
+				"@fluidframework/shared-object-base": "^0.33.5",
+				"@fluidframework/telemetry-utils": "^0.33.5",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
@@ -31631,52 +31631,52 @@
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -31684,54 +31684,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -31740,17 +31740,17 @@
 					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
 				},
 				"@fluidframework/merge-tree": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.33.4.tgz",
-					"integrity": "sha512-8b7CRpGoV0RHHQtVCQLWKinQpO3EJ3+TkLxWUU02uoOpd6RbQSy2lDkZ46c7VJb7ZnFxxjt9hLAFR+IbJLw5yg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.33.5.tgz",
+					"integrity": "sha512-csN07krGDWPL5oj8UgH9npmx+xJeUBGdaTT9oZDjzhpGlzd/hFTVcHh/D0En4379LhwDPJsTvPG7KrH9R5QB4A==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
@@ -31775,59 +31775,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -31838,80 +31838,80 @@
 			}
 		},
 		"old-ordered-collection": {
-			"version": "npm:@fluidframework/ordered-collection@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.34.2.tgz",
-			"integrity": "sha512-nAH/VGr8pto6HKU8/u4kAu1nyNO+TSeeTv2Ks9wqmfrxCi488T9D2v8KDbFoleQA5DLizV51+m9I6vKgeadC4Q==",
+			"version": "npm:@fluidframework/ordered-collection@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.34.3.tgz",
+			"integrity": "sha512-7UDWRvd4b3moc0X4DUVZZ4oa5QXBuOpNAGTkKwxUy+rDpGQqfA+l47T3y4W3MIEndGIaKSgKNeFANzvdNTnIUA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"old-ordered-collection2": {
-			"version": "npm:@fluidframework/ordered-collection@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.33.4.tgz",
-			"integrity": "sha512-WmiVbCJedDR3TYr7B537PmKJc7RxF+x/e6L5gAs+w57inrwlRb2xn7nqVjb8D+mIg0MZ67KOaTvN4GjcI6bDCg==",
+			"version": "npm:@fluidframework/ordered-collection@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-0.33.5.tgz",
+			"integrity": "sha512-QiOzDKseYaxh5bAxpOniuK2aG5lFP702mdItHOx0UNPCrwZpKAAFccV6igYvM/ENPCb1XZ+R+dgIEJnhH1TTBA==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.4",
+				"@fluidframework/shared-object-base": "^0.33.5",
 				"assert": "^2.0.0",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -31919,54 +31919,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -31995,59 +31995,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -32058,82 +32058,82 @@
 			}
 		},
 		"old-register-collection": {
-			"version": "npm:@fluidframework/register-collection@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.2.tgz",
-			"integrity": "sha512-LQoeA8FjrmCIFHet1GnIDLfWbpZ+4+gkr2+5Bmw9k44UpVxVC5T110r+0o0B9aqWoYWG3cWdfeDMgDtV1MfERA==",
+			"version": "npm:@fluidframework/register-collection@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.34.3.tgz",
+			"integrity": "sha512-Zuag4pxHuG7UOI7OepVNMctfNxpvaj8ebHMu7Y02WmY/CArIfeFJlpCNjfP/o9HKjcoHpKWgWSy03uWV5HKgzg==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
 				"@fluidframework/protocol-base": "^0.1019.0",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/shared-object-base": "^0.34.2",
+				"@fluidframework/shared-object-base": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"old-register-collection2": {
-			"version": "npm:@fluidframework/register-collection@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.4.tgz",
-			"integrity": "sha512-7wMGCDBxGrljYYmseHaIZ9aNopRNS04/L86YxrtvbeuXwh8b0agBhLNIiuPpwVJzq2hR9w6+/5Ij9G7SZWSbPA==",
+			"version": "npm:@fluidframework/register-collection@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.5.tgz",
+			"integrity": "sha512-FWIEBA6DpEKGT3QkORywBXRAwpG4jAKuZR6VQiFUfTtWZBgC62Wlr0yDiOEh3pOq8/edar/5VLJjZRerhJVpIQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
 				"@fluidframework/protocol-base": "^0.1018.0",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/shared-object-base": "^0.33.4",
+				"@fluidframework/shared-object-base": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -32141,54 +32141,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -32217,59 +32217,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -32280,56 +32280,56 @@
 			}
 		},
 		"old-runtime-definitions": {
-			"version": "npm:@fluidframework/runtime-definitions@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.2.tgz",
-			"integrity": "sha512-uaLRkt/L8dqjSrUkUDlv6N7ANeYmb0mrIrMBPi6MJJDs6s/Sxux0rKSYw6tieORSBinhu+ZG2NGhohJJ4e5Fxg==",
+			"version": "npm:@fluidframework/runtime-definitions@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.34.3.tgz",
+			"integrity": "sha512-dtkiYh3355EjpS5B/KOh+hclRR9ILGRkd3zVgfPEk0TUa8i9WGH/pbeVlRm7mDzbiXHjXO46QFM458yFjKd1PA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
 				"@types/node": "^10.17.24"
 			}
 		},
 		"old-runtime-definitions2": {
-			"version": "npm:@fluidframework/runtime-definitions@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-			"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+			"version": "npm:@fluidframework/runtime-definitions@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+			"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/container-definitions": "^0.33.4",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
+				"@fluidframework/container-definitions": "^0.33.5",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
 				"@types/node": "^10.17.24"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
@@ -32344,90 +32344,90 @@
 			}
 		},
 		"old-sequence": {
-			"version": "npm:@fluidframework/sequence@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.34.2.tgz",
-			"integrity": "sha512-58B/cIL2wCdVgXb2lQUErMxngYROwyAEvIZ5rZXXWjIfQXaSzER2cZ7fiw5DPRoPA1z+HXGnx9gxeyl/yEwoFQ==",
+			"version": "npm:@fluidframework/sequence@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.34.3.tgz",
+			"integrity": "sha512-04sNHwNxA8YwpShx8QsMZsucijyFxOyh0lJMo2WdRLujiCqVYo6QgUjKUuvdaBSizVDVmNbQhiFWF7F6+I29yw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/map": "^0.34.2",
-				"@fluidframework/merge-tree": "^0.34.2",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/map": "^0.34.3",
+				"@fluidframework/merge-tree": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/runtime-utils": "^0.34.2",
-				"@fluidframework/shared-object-base": "^0.34.2",
-				"@fluidframework/telemetry-utils": "^0.34.2",
+				"@fluidframework/runtime-utils": "^0.34.3",
+				"@fluidframework/shared-object-base": "^0.34.3",
+				"@fluidframework/telemetry-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			}
 		},
 		"old-sequence2": {
-			"version": "npm:@fluidframework/sequence@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.33.4.tgz",
-			"integrity": "sha512-2j6eZMxSGNlpdNJxRmQUgBvnSMUdyb+UZWgMylYmDrEhz9OHOKLefUHt83w7rKDzsKpukAP41WKxfmW1edtJag==",
+			"version": "npm:@fluidframework/sequence@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.33.5.tgz",
+			"integrity": "sha512-a/j5Xct1DG1K/x3eYtaAqW1eMLg4s+L88sCu/JVS8C/zorUA3CqiniyPQcR64CvxvQKXaj3Qjjx7MEOT08LNFg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.19.1",
 				"@fluidframework/common-utils": "^0.27.0",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
-				"@fluidframework/map": "^0.33.4",
-				"@fluidframework/merge-tree": "^0.33.4",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
+				"@fluidframework/map": "^0.33.5",
+				"@fluidframework/merge-tree": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/runtime-utils": "^0.33.4",
-				"@fluidframework/shared-object-base": "^0.33.4",
-				"@fluidframework/telemetry-utils": "^0.33.4",
+				"@fluidframework/runtime-utils": "^0.33.5",
+				"@fluidframework/shared-object-base": "^0.33.5",
+				"@fluidframework/telemetry-utils": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1"
 			},
 			"dependencies": {
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -32435,54 +32435,54 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -32491,34 +32491,34 @@
 					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
 				},
 				"@fluidframework/map": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.4.tgz",
-					"integrity": "sha512-vnTbjXYvYLGwL9IE8Si3ZmpeDyxjcOcZ0XqxRuKxLHT7Z+SjbWTU/VgNyjseWPJ6IGF3pMfrtsF0ghP2n9AqkA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.5.tgz",
+					"integrity": "sha512-OYqYC2ltNeQkyaofrW47Poyz3Ey5GDZXlFJaMfY71ziFr/ZvEqpbg8LIIPeQF4K0DiGtftV+u/2OHwebfZfsLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.4",
+						"@fluidframework/shared-object-base": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
 					}
 				},
 				"@fluidframework/merge-tree": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.33.4.tgz",
-					"integrity": "sha512-8b7CRpGoV0RHHQtVCQLWKinQpO3EJ3+TkLxWUU02uoOpd6RbQSy2lDkZ46c7VJb7ZnFxxjt9hLAFR+IbJLw5yg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.33.5.tgz",
+					"integrity": "sha512-csN07krGDWPL5oj8UgH9npmx+xJeUBGdaTT9oZDjzhpGlzd/hFTVcHh/D0En4379LhwDPJsTvPG7KrH9R5QB4A==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
@@ -32543,59 +32543,59 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -32606,129 +32606,129 @@
 			}
 		},
 		"old-test-utils": {
-			"version": "npm:@fluidframework/test-utils@0.34.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.34.2.tgz",
-			"integrity": "sha512-bHZEwjys3hfeIlThUzD73dt//xEUfe0zKlMRmvPd/fvp0WF+g2j+M/zUhUnnRaQQFQBkK5AGn7s2C6DVPEGTaw==",
+			"version": "npm:@fluidframework/test-utils@0.34.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.34.3.tgz",
+			"integrity": "sha512-W9WJSy/xsLmZeaeQQ7ErDngV482dYin4h4u4e1be6NBz76GqDDPK0WpWqZvwxrDoSmgIEl2uZALh1B0R6aBzgQ==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.34.2",
-				"@fluidframework/container-definitions": "^0.34.2",
-				"@fluidframework/container-loader": "^0.34.2",
-				"@fluidframework/container-runtime": "^0.34.2",
-				"@fluidframework/core-interfaces": "^0.34.2",
-				"@fluidframework/datastore": "^0.34.2",
-				"@fluidframework/datastore-definitions": "^0.34.2",
-				"@fluidframework/driver-definitions": "^0.34.2",
-				"@fluidframework/local-driver": "^0.34.2",
-				"@fluidframework/map": "^0.34.2",
+				"@fluidframework/aqueduct": "^0.34.3",
+				"@fluidframework/container-definitions": "^0.34.3",
+				"@fluidframework/container-loader": "^0.34.3",
+				"@fluidframework/container-runtime": "^0.34.3",
+				"@fluidframework/core-interfaces": "^0.34.3",
+				"@fluidframework/datastore": "^0.34.3",
+				"@fluidframework/datastore-definitions": "^0.34.3",
+				"@fluidframework/driver-definitions": "^0.34.3",
+				"@fluidframework/local-driver": "^0.34.3",
+				"@fluidframework/map": "^0.34.3",
 				"@fluidframework/protocol-definitions": "^0.1019.0",
-				"@fluidframework/request-handler": "^0.34.2",
-				"@fluidframework/routerlicious-driver": "^0.34.2",
-				"@fluidframework/runtime-definitions": "^0.34.2",
-				"@fluidframework/runtime-utils": "^0.34.2",
+				"@fluidframework/request-handler": "^0.34.3",
+				"@fluidframework/routerlicious-driver": "^0.34.3",
+				"@fluidframework/runtime-definitions": "^0.34.3",
+				"@fluidframework/runtime-utils": "^0.34.3",
 				"@fluidframework/server-local-server": "^0.1019.0",
-				"@fluidframework/test-driver-definitions": "^0.34.2",
-				"@fluidframework/test-runtime-utils": "^0.34.2",
+				"@fluidframework/test-driver-definitions": "^0.34.3",
+				"@fluidframework/test-runtime-utils": "^0.34.3",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"old-test-utils2": {
-			"version": "npm:@fluidframework/test-utils@0.33.4",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.33.4.tgz",
-			"integrity": "sha512-dOx6aMfy/u3pOp7hVHUwAy6FXk/Oqic95ntMaUawaaAxI04gUkLj/IaHCZWNr0AphH/laG1YZkrwy5+Y/BpD3Q==",
+			"version": "npm:@fluidframework/test-utils@0.33.5",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-0.33.5.tgz",
+			"integrity": "sha512-+WP1YNp2S4geyfoGo5Ay+bOF333OxxqGmc1EvSlL/GaI6jHtKT7mhbtrJPdDv5zPpOufHrd1pRfK0j0zYP4sLA==",
 			"requires": {
-				"@fluidframework/aqueduct": "^0.33.4",
-				"@fluidframework/container-definitions": "^0.33.4",
-				"@fluidframework/container-loader": "^0.33.4",
-				"@fluidframework/container-runtime": "^0.33.4",
-				"@fluidframework/core-interfaces": "^0.33.4",
-				"@fluidframework/datastore": "^0.33.4",
-				"@fluidframework/datastore-definitions": "^0.33.4",
-				"@fluidframework/driver-definitions": "^0.33.4",
-				"@fluidframework/local-driver": "^0.33.4",
-				"@fluidframework/map": "^0.33.4",
+				"@fluidframework/aqueduct": "^0.33.5",
+				"@fluidframework/container-definitions": "^0.33.5",
+				"@fluidframework/container-loader": "^0.33.5",
+				"@fluidframework/container-runtime": "^0.33.5",
+				"@fluidframework/core-interfaces": "^0.33.5",
+				"@fluidframework/datastore": "^0.33.5",
+				"@fluidframework/datastore-definitions": "^0.33.5",
+				"@fluidframework/driver-definitions": "^0.33.5",
+				"@fluidframework/local-driver": "^0.33.5",
+				"@fluidframework/map": "^0.33.5",
 				"@fluidframework/protocol-definitions": "^0.1018.0",
-				"@fluidframework/request-handler": "^0.33.4",
-				"@fluidframework/routerlicious-driver": "^0.33.4",
-				"@fluidframework/runtime-definitions": "^0.33.4",
-				"@fluidframework/runtime-utils": "^0.33.4",
+				"@fluidframework/request-handler": "^0.33.5",
+				"@fluidframework/routerlicious-driver": "^0.33.5",
+				"@fluidframework/runtime-definitions": "^0.33.5",
+				"@fluidframework/runtime-utils": "^0.33.5",
 				"@fluidframework/server-local-server": "^0.1018.0",
-				"@fluidframework/test-drivers": "^0.33.4",
-				"@fluidframework/test-runtime-utils": "^0.33.4",
+				"@fluidframework/test-drivers": "^0.33.5",
+				"@fluidframework/test-runtime-utils": "^0.33.5",
 				"assert": "^2.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
 				"@fluidframework/agent-scheduler": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.4.tgz",
-					"integrity": "sha512-La5SOjQUoWKjzxMdgRMy9aIqArx1foHNVhc0pRsZ2AByPVWao58ac2bFa0xiSV7tbR65uYxpOBEdA8f/bNVRYA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.33.5.tgz",
+					"integrity": "sha512-4D11HLNUuH/SOAZlqB7+be1vmhOsNXCIrzNmelYf5R4mS2dTIase6XjcSTxIxZ6Yp/UjvcZJrP5oytufZTF4xQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/map": "^0.33.4",
-						"@fluidframework/register-collection": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/map": "^0.33.5",
+						"@fluidframework/register-collection": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/aqueduct": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.33.4.tgz",
-					"integrity": "sha512-G4SL0puCvFGqM1/38Q41woJA110twCrMwtWJuNKOS555ac6WjyxUrJC6+g7RBRFHFy9NDCDB+/5riQFvc54mqA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.33.5.tgz",
+					"integrity": "sha512-BgPZ9VAlM7XVBskl4gr7QbEG0W6luBnHENIz46Ej2YtZIZ6QWxc32lwVL3sxon35r7i1+Y1zE7COzLiCLJaDgg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-loader": "^0.33.4",
-						"@fluidframework/container-runtime": "^0.33.4",
-						"@fluidframework/container-runtime-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/map": "^0.33.4",
-						"@fluidframework/request-handler": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/synthesize": "^0.33.4",
-						"@fluidframework/view-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-loader": "^0.33.5",
+						"@fluidframework/container-runtime": "^0.33.5",
+						"@fluidframework/container-runtime-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/map": "^0.33.5",
+						"@fluidframework/request-handler": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/synthesize": "^0.33.5",
+						"@fluidframework/view-interfaces": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/container-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.4.tgz",
-					"integrity": "sha512-/5vZBv9ZaGfe+cmupuQmsEz4/wGXUGfsjKQj/hpfRuDgV6u7uBK+B6EeZ4shDxbxoCTB+W/lyAuek3KHXHLPMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.33.5.tgz",
+					"integrity": "sha512-2CzP0pqHNFqpplMU9Qecm2F0kCdMlkvqqucPq39LBBJGVt6KENM21bj+IuEr4O5TIUTVAVYkqZKJYs4HqXLXyg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/container-loader": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.4.tgz",
-					"integrity": "sha512-yZCiaeUAQNmEbKQzk38W99Qo0TpgRYmfDFdK7UIslmXPGSn2l+kPFpfi4LOV06X7kZCGmICrKf98sTQfQN18Cw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.33.5.tgz",
+					"integrity": "sha512-YPKXSpK2XvuEAKCSoTC0ss0wuQuggX9Kmmbfd9/XZr2F2uzbK6+zhod7NcnI1LkpLzRmhtvdKos7vaUeNnOChA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -32737,26 +32737,26 @@
 					}
 				},
 				"@fluidframework/container-runtime": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.4.tgz",
-					"integrity": "sha512-ud4/S+VgQj2XrSb+l6USV70Ef/pwgeG2P7r3B2vSqmtfEFD1D1sBTz/zvK4I/jNrLN/C18yYTXcSQ85ZpWzl0g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.33.5.tgz",
+					"integrity": "sha512-UdDvzszrq3OtshuDoMWjGjFGGA5dcDHbG7xPBpiq5MSmqpLS5TubQElzNzfJ/EcQyXq+zjzQBPhny92S8g1H3g==",
 					"requires": {
-						"@fluidframework/agent-scheduler": "^0.33.4",
+						"@fluidframework/agent-scheduler": "^0.33.5",
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-runtime-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-runtime-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"double-ended-queue": "^2.1.0-0",
@@ -32764,55 +32764,55 @@
 					}
 				},
 				"@fluidframework/container-runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-pwhzqukeXDTGmCaktzVKiJgDk9rKLDYRyzIXD7/XtJaHPnsEuT8tJP/+z18bk9re+n4XVRdsPCV1knll9Rd/FQ==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-jlDzxLGGQAnRKoR3VVQprYYN0yu2XflcA4BMfkVq6ODyYQW9mnd0sUp/BgIyOAYbpCcUMYdpaca4tpb+4FKcTw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/container-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.4.tgz",
-					"integrity": "sha512-wFQcgVhooP08yRNi0dStKwlpQuHz1hLcausRMoGPPkyLrxUPdfPHNdwLw0BXYKvcS4BjAM6jzM8r/UcHn9gNug==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.33.5.tgz",
+					"integrity": "sha512-mzh5nFIHoAQABIHi+c5v0KCZW20bSNA+NabsUVv6NNfw1c+Adi9cH/rF8mM0RDqvB5kCn4HEuoT0hey8jM0QwQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/core-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.4.tgz",
-					"integrity": "sha512-DQRfKuHdrwhVmkWcdbt547eRlZSPxKToxfmJff/Y8OW51JuCHkyczD/US8P0UpjBdn6tcNlmp1h7ZHm3XGxT9A=="
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.33.5.tgz",
+					"integrity": "sha512-JIXM9ildjBBq4/gHsVR6oE1D0za4iggUm0q4I342vzQ7n/TUjzfnjg8fgM7TI4cQfpbozZ0bhiP3Ohj5XRvTdQ=="
 				},
 				"@fluidframework/datastore": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.4.tgz",
-					"integrity": "sha512-DogideMpq6sDI7tV4s7WJIc2yHupTkjNEIx1T0jsgYbEwdDu5zqWhk4lJymxunX8pfZheypmv/foOC7U+G/W9g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.33.5.tgz",
+					"integrity": "sha512-cNpMUnZtIYxYfs/uSxBnrIcZTPg/FwpRJkxCoIG8CFB/O8ll4qUn6PUFkUBqO59Y2LyFEXngvDi1jzRsGEoXag==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/container-utils": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/container-utils": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"lodash": "^4.17.19",
@@ -32820,68 +32820,68 @@
 					}
 				},
 				"@fluidframework/datastore-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.4.tgz",
-					"integrity": "sha512-m24bFHly3XVm3tMS1iZcIjDpBH3MDFJBNgQJMVLapc352bNWBN7mWsL7NmVsfDSIE+15YjyY3JR0w19G/BSQBg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.33.5.tgz",
+					"integrity": "sha512-Vhups9i661X2TKYWuqGkwWvyCHLyzQxhCrbF2lVYoNN6/0Zmvr+qYlT1bKOKzcuEC5KiNyKS47VgA8KHfcmkYw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/driver-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.4.tgz",
-					"integrity": "sha512-xYhm31kUarmZbGNW7jlktUKGisMRIjZoFOk/9iev3X7WgfWF9ybPlRkRUOSbrWFUh7Jbl9ews/sFO160kP8gcw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.33.5.tgz",
+					"integrity": "sha512-c4b/50sEOkakuNu/yF15eIUP1TD8Z0JJRNVjkVzx3PtpADByOd2qQO6k7nExj4eKS+2COZ6o1lFgV8+oKqd+uQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/driver-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.4.tgz",
-					"integrity": "sha512-gh7Ik25S/vK/8m8DEjiNKdYVlknbAL5YW9uNHCeBuWhUer551w1KobB7zRndOQ0wCmezeKmzZ2YVUFyfDZFWIg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.33.5.tgz",
+					"integrity": "sha512-9+GZrimtvk3UgxJZg2uye+RoNUmEBHGls/j9AGj9ZKFcUMv965rpg5cUgpmmTfsIC7QOSxDlo383n05gf5qB+g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
-						"@fluidframework/core-interfaces": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0"
 					}
 				},
 				"@fluidframework/driver-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.4.tgz",
-					"integrity": "sha512-T4hOuedKSE/Pe4yJIQvI8wRkHoN47Wke4QhBjwJ/zmdQ5pKzJQclLthSfWJ9XN9klZL2ZWHMzNA6M5Td0jU3CA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.33.5.tgz",
+					"integrity": "sha512-I3axQQxJXeVoHm2WdBK80kfPb5MbpOUTLFykRcq5TH9SUs9hTGGnaliPSYNXqQx83+iVc8rVBfaOgHy4uRp4ZQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/garbage-collector": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.4.tgz",
-					"integrity": "sha512-qbVeeya640iY2NGz+ezSxV2GdDMWCdZEepH7iOqa/1PsAkvIngngqQvZmYx36+7Nh3UMiUJKJLfBpIXsrTPzGA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.33.5.tgz",
+					"integrity": "sha512-/0gTjxhniCr1SY7mNwe6VrKohNce9WBH3ScUCxEXbYvCwdH1NiGkjLi0+Up5MH3oQNBcCyO9th1j0dLeZs+hcg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/runtime-definitions": "^0.33.4"
+						"@fluidframework/runtime-definitions": "^0.33.5"
 					}
 				},
 				"@fluidframework/gitresources": {
@@ -32890,17 +32890,17 @@
 					"integrity": "sha512-g/bMx4Ligi8hWsqwu7CSB8/TvHh/KrULDS/F8BOZL7J9Z+IfTrwfLoLt/MD3n3WmNM5N8OYVx7YcNRkFO22nkQ=="
 				},
 				"@fluidframework/local-driver": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.4.tgz",
-					"integrity": "sha512-9c08KwFc4PFSb7oCO/bR4qW4jS4EFyRqNHGn8CA6aLyPr9p/tYSyK4ZD9hno2xjZ0p2tBxA4EaTCU9+q3waBbg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.33.5.tgz",
+					"integrity": "sha512-e1XYWk1Wj6TJKjVU5wXsqJWo98tb/VYyhD1OAlBt5iVNLXc2rN9sO4iWX7UY+EdQR2SKRxdkYMU3+p1GG/U9xw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.4",
+						"@fluidframework/routerlicious-driver": "^0.33.5",
 						"@fluidframework/server-local-server": "^0.1018.0",
 						"@fluidframework/server-services-client": "^0.1018.0",
 						"@fluidframework/server-services-core": "^0.1018.0",
@@ -32912,17 +32912,17 @@
 					}
 				},
 				"@fluidframework/map": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.4.tgz",
-					"integrity": "sha512-vnTbjXYvYLGwL9IE8Si3ZmpeDyxjcOcZ0XqxRuKxLHT7Z+SjbWTU/VgNyjseWPJ6IGF3pMfrtsF0ghP2n9AqkA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.33.5.tgz",
+					"integrity": "sha512-OYqYC2ltNeQkyaofrW47Poyz3Ey5GDZXlFJaMfY71ziFr/ZvEqpbg8LIIPeQF4K0DiGtftV+u/2OHwebfZfsLg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.4",
+						"@fluidframework/shared-object-base": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"path-browserify": "^1.0.1"
@@ -32949,48 +32949,48 @@
 					}
 				},
 				"@fluidframework/register-collection": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.4.tgz",
-					"integrity": "sha512-7wMGCDBxGrljYYmseHaIZ9aNopRNS04/L86YxrtvbeuXwh8b0agBhLNIiuPpwVJzq2hR9w6+/5Ij9G7SZWSbPA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.33.5.tgz",
+					"integrity": "sha512-FWIEBA6DpEKGT3QkORywBXRAwpG4jAKuZR6VQiFUfTtWZBgC62Wlr0yDiOEh3pOq8/edar/5VLJjZRerhJVpIQ==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/shared-object-base": "^0.33.4",
+						"@fluidframework/shared-object-base": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1"
 					}
 				},
 				"@fluidframework/request-handler": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.33.4.tgz",
-					"integrity": "sha512-+g6s8UzFir3jZqZZ7eq+c6/hMyolSy585VT47qFWqIyqrElOZY+rAdBpcxmGJqcDBe9b0zGVM053Ed7yboHsnA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.33.5.tgz",
+					"integrity": "sha512-g5VmxiVfpGIA8OXT/QC65wYj+WDbXHsqkqlDezsrLzNbXtrWok1io/MxQr3Uo0qc8O6BxMrrpztR+giWONT1TA==",
 					"requires": {
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-runtime-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
+						"@fluidframework/container-runtime-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
 				"@fluidframework/routerlicious-driver": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.4.tgz",
-					"integrity": "sha512-kW90xb/P88bqBwEPrGpvRlVzNsoJ9Oz4sPKn0Z1wtkMgyycjZLvpFu0rjPh5K+xNiC7b7/MKNcQni5a745tyWg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.33.5.tgz",
+					"integrity": "sha512-c2vUnr91ZmoNpckZD6drWehdaIjn9aZkS2kW+ka/B/SeXDDK0eVP4gWbcH+U4Ih94MHz6eRWQ3ghgpDdAvYwLA==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/driver-base": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/driver-base": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/gitresources": "^0.1018.0",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@fluidframework/server-services-client": "^0.1018.0",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"debug": "^4.1.1",
@@ -33002,32 +33002,32 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.4.tgz",
-					"integrity": "sha512-H+Dp7uXMGMnd1V2Q1AdmYv565FMfmSuVLMsDY61TWVqu7ww+IBKGSL6tOVKYuwRdZ+4hzqDNRL8LPH1KzAW6FA==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.33.5.tgz",
+					"integrity": "sha512-b8sDZE+IlnCEITZ9GdYnaexzkZJM9VLQrryTRct4zraKbfyvZyEJyYQutJp2kjm7AuGVtXO+vFhqVCCM98w3yg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
 						"@types/node": "^10.17.24"
 					}
 				},
 				"@fluidframework/runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-b37XTU5yq2JMNWJivFic+UBoC1LLDFYa5nafWIcWGSbahZvIqsAZtFnBF58kaUPsXLXFGXwFnTV4+/Q7GEyfMw==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-dMdvHcQUfGAwxNz3EJ2W4UnL/UO3aaLElJeYywFlL8YTlbF9WbyiEYJI14wXlLcpqam2H2dRpA5QdvxY8ObJqg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/garbage-collector": "^0.33.4",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/garbage-collector": "^0.33.5",
 						"@fluidframework/protocol-base": "^0.1018.0",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
 						"assert": "^2.0.0"
 					}
 				},
@@ -33170,37 +33170,37 @@
 					}
 				},
 				"@fluidframework/shared-object-base": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.4.tgz",
-					"integrity": "sha512-n9BdaDyei4GOuDuqN5cP/jo2HCkr9JIl31othUphGLdS8hQ072hqkWpk21Dm6KxxopFMB62ZO0zhJYOcYY/N1g==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.33.5.tgz",
+					"integrity": "sha512-i9NqH2nWZYmudpCBn7UUUNbW9b05ff6J1KvlrGMw+WKzyn6GGMfjIBCqYxH5bHAj3o/pZkjSLkAgLqL5lLfOEQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
 					}
 				},
 				"@fluidframework/synthesize": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.33.4.tgz",
-					"integrity": "sha512-m934TgKNbr1wRM7vhOtLRLv4Necmyu6STLzH5aQY3UGMD/AxC7RX6IZr65psM+QCe17oI7LLLYkO5Du8bMoYSQ==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.33.5.tgz",
+					"integrity": "sha512-EzJ4oeeJvMfNnFH16Vwas6RQfNnUUv6E8rJdweUNjSSooNPy3adLIQRLRB5KjSl0BDt4T9rSK2fVVIVzwwzc7A==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.4"
+						"@fluidframework/core-interfaces": "^0.33.5"
 					}
 				},
 				"@fluidframework/telemetry-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.4.tgz",
-					"integrity": "sha512-m++X78YZqW7rMztlOCP+amYjhMDXWW/IcRm4vTWKYCOFf1I22qMukwYSYdNNoTZm8YeRP0dqtXg3JU4REzt2Kg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.33.5.tgz",
+					"integrity": "sha512-E2U4eRED6o6qZC3pVT6WZW3v2y0ePfKYGz/GMeFC2nOUnvbQ0FJ6FEtEbIZmW732TsZ9cI2qy9iOcvk7dOaAmQ==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
@@ -33209,22 +33209,22 @@
 					}
 				},
 				"@fluidframework/test-runtime-utils": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.33.4.tgz",
-					"integrity": "sha512-sk3lSvhcKu2i10c4FwdLp4pOfIGs3aWyDVpJVTfp102Twch+WGCvRjb1nM791trfwjwgAZmmZtLpzigIJEzi5Q==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.33.5.tgz",
+					"integrity": "sha512-/g3UTeNWhhgDGAYnU7tNy+09ApMYPxIfKx5Asd+/v52d91foxf/sJQx+/4KymANkY3lSdgxn0XH69+KobvsyGw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.19.1",
 						"@fluidframework/common-utils": "^0.27.0",
-						"@fluidframework/container-definitions": "^0.33.4",
-						"@fluidframework/core-interfaces": "^0.33.4",
-						"@fluidframework/datastore-definitions": "^0.33.4",
-						"@fluidframework/driver-definitions": "^0.33.4",
-						"@fluidframework/driver-utils": "^0.33.4",
+						"@fluidframework/container-definitions": "^0.33.5",
+						"@fluidframework/core-interfaces": "^0.33.5",
+						"@fluidframework/datastore-definitions": "^0.33.5",
+						"@fluidframework/driver-definitions": "^0.33.5",
+						"@fluidframework/driver-utils": "^0.33.5",
 						"@fluidframework/protocol-definitions": "^0.1018.0",
-						"@fluidframework/routerlicious-driver": "^0.33.4",
-						"@fluidframework/runtime-definitions": "^0.33.4",
-						"@fluidframework/runtime-utils": "^0.33.4",
-						"@fluidframework/telemetry-utils": "^0.33.4",
+						"@fluidframework/routerlicious-driver": "^0.33.5",
+						"@fluidframework/runtime-definitions": "^0.33.5",
+						"@fluidframework/runtime-utils": "^0.33.5",
+						"@fluidframework/telemetry-utils": "^0.33.5",
 						"assert": "^2.0.0",
 						"axios": "^0.21.1",
 						"jsrsasign": "^10.0.2",
@@ -33232,11 +33232,11 @@
 					}
 				},
 				"@fluidframework/view-interfaces": {
-					"version": "0.33.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.33.4.tgz",
-					"integrity": "sha512-EEJ3V5JgZxxkZO1lDb7TLqHXJVAMU1oEDN8fxVgGlYhLJl9cu3yGOXO4b/nwX+Fe2NQ9kGL+iwjjbEJkI/J2Gg==",
+					"version": "0.33.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.33.5.tgz",
+					"integrity": "sha512-sIcbqDHQys43AIqv9ck1881GpAGJQHJFBKTnF4DpsQRkicLt4WDF+dr4CucXZjcpyuV4kJ/clHzAx4H1qxLzig==",
 					"requires": {
-						"@fluidframework/core-interfaces": "^0.33.4"
+						"@fluidframework/core-interfaces": "^0.33.5"
 					}
 				},
 				"ansi-regex": {

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/protocol-base": "^0.1019.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/merge-tree": "^0.35.4",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/protocol-base": "^0.1019.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/map": "^0.35.4",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore": "^0.35.4",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/odsp-driver": "^0.35.4",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-base": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-base": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-base": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/map": "^0.35.4",
     "@fluidframework/merge-tree": "^0.35.4",
     "@fluidframework/runtime-definitions": "^0.35.4",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-runtime-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/runtime-definitions": "^0.35.4",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-utils": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/telemetry-utils": "^0.35.4",
     "assert": "^2.0.0"

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/gitresources": "^0.1019.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0"
   },

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore": "^0.35.4",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.35.4",
     "@fluidframework/cell": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/agent-scheduler": "^0.35.4",
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-runtime-definitions": "^0.35.4",
     "@fluidframework/container-utils": "^0.35.4",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/protocol-definitions": "^0.1019.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-utils": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/runtime-definitions": "^0.35.4"
   },
   "devDependencies": {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",
     "@fluidframework/garbage-collector": "^0.35.4",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",
     "@fluidframework/datastore-definitions": "^0.35.4",

--- a/packages/test/end-to-end-tests/package.json
+++ b/packages/test/end-to-end-tests/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/base-host": "^0.35.4",
     "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/cell": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-internal/test-loader-utils": "^0.35.4",
     "@fluidframework/build-common": "^0.20.0",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/eslint-config-fluid": "^0.23.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/base-host": "^0.35.4",
     "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/cell": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/container-runtime": "^0.35.4",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluid-internal/replay-tool": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",
     "@fluidframework/file-driver": "^0.35.4",

--- a/packages/test/version-test-1/package.json
+++ b/packages/test/version-test-1/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.35.4",
     "@fluidframework/base-host": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/runtime-utils": "^0.35.4",
     "@fluidframework/view-interfaces": "^0.35.4",
     "react": "^16.10.2",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluid-internal/fluidapp-odsp-urlresolver": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/datastore": "^0.35.4",
     "@fluidframework/driver-definitions": "^0.35.4",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-runtime": "^0.35.4",
     "@fluidframework/file-driver": "^0.35.4",
     "@fluidframework/merge-tree": "^0.35.4",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluid-internal/client-api": "^0.35.4",
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.35.4",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/container-definitions": "^0.35.4",
     "@fluidframework/container-loader": "^0.35.4",
     "@fluidframework/core-interfaces": "^0.35.4",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/driver-definitions": "^0.35.4",
     "@fluidframework/driver-utils": "^0.35.4",
     "node-fetch": "^2.6.1"

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "debug": "^4.1.1",
     "events": "^3.1.0"
   },

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.27.0",
+    "@fluidframework/common-utils": "^0.27.2",
     "@fluidframework/odsp-doclib-utils": "^0.35.4",
     "@fluidframework/protocol-base": "^0.1019.0",
     "@fluidframework/protocol-definitions": "^0.1019.0",


### PR DESCRIPTION
Making sure that clients consuming release/0.35 are forced to pick up right version of common-utils - using older version in runtime code and running against old version of loader (ODSP driver) will result in failures due to a bug around how we handled ArrayBuffer / IsoBuffers.
For more details - please see https://github.com/microsoft/FluidFramework/pull/5378
