### PR TITLE
Disable blob deduping temporarily

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -247,6 +247,8 @@ export interface HostStoragePolicy {
      * Passing true results in faster loads and keeping cache more current, but it increases bandwidth consumption.
      */
     concurrentSnapshotFetch?: boolean;
+
+    blobDeduping?: boolean;
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -280,7 +280,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             docId: this.documentId,
         };
 
-        this.odspSummaryUploadManager = new OdspSummaryUploadManager(this.snapshotUrl, getStorageToken, logger, epochTracker);
+        this.odspSummaryUploadManager = new OdspSummaryUploadManager(this.snapshotUrl, getStorageToken, logger, epochTracker, this.hostPolicy);
     }
 
     public get repositoryUrl(): string {
@@ -476,7 +476,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             finalTree = this.combineProtocolAndAppSnapshotTree(appTree, protocolTree);
         }
 
-        if (this.hostPolicy.summarizerClient) {
+        if (this.hostPolicy.summarizerClient && this.hostPolicy.blobDeduping) {
             await this.odspSummaryUploadManager.buildCachesForDedup(finalTree, this.blobCache.value);
         }
         return finalTree;

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -387,7 +387,7 @@ export class OdspSummaryUploadManager {
                         blobs++;
                     } else {
                         if (!blobDedupingEnabled) {
-                            assert(false, "Blob deduping is disabled.")
+                            assert(false, "Blob deduping is disabled");
                         }
                         reusedBlobs++;
                         id = `${parentHandle}/${cachedPath}`;

--- a/packages/drivers/odsp-driver/src/test/odspSummaryUploadManagerTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspSummaryUploadManagerTests.spec.ts
@@ -31,6 +31,7 @@ describe("Odsp Summary Upload Manager Tests", () => {
             async (options: TokenFetchOptions, name?: string) => "token",
             logger,
             epochTracker,
+            { blobDeduping: true },
         );
     });
 


### PR DESCRIPTION
We can enable slowly in future. Allowing host to set policy so that it can be turned on without making changes at driver layer.
Currently we are facing Data corruption issue where directory blob is wrongly showing as map blob. We already disabled handle expansion but for now to be safe we are disabling entire blob deduping. Currently we are not facing the issue after disabling handle expansion but we can monitor telemetry before making any further conclusions.