### PR TITLE
Pass drive and item ids when requesting storage and websocket tokens

### DIFF
--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -106,7 +106,7 @@ async function getFileLinkCore(
             let additionalProps;
             const fileLink = await getWithRetryForTokenRefresh(async (options) => {
                 attempts++;
-                const token = await getToken({ ...options, siteUrl });
+                const token = await getToken({ ...options, siteUrl, driveId, itemId });
                 const { url, headers } = getUrlAndHeadersWithAuth(
                     `${siteUrl}/_api/web/GetFileByUrl(@a1)/ListItemAllFields/GetSharingInformation?@a1=${
                         encodeURIComponent(`'${fileItem.webDavUrl}'`)
@@ -156,7 +156,7 @@ async function getFileItemLite(
             let additionalProps;
             const fileItem = await getWithRetryForTokenRefresh(async (options) => {
                 attempts++;
-                const token = await getToken({ ...options, siteUrl });
+                const token = await getToken({ ...options, siteUrl, driveId, itemId });
                 const { url, headers } = getUrlAndHeadersWithAuth(
                     `${siteUrl}/_api/v2.0/drives/${driveId}/items/${itemId}?select=webUrl,webDavUrl`,
                     tokenFromResponse(token),

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -174,8 +174,12 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
                     hasClaims: !!options.claims,
                     hasTenantId: !!options.tenantId,
                 },
-                async (event) => tokenFetcher({ ...options, siteUrl: resolvedUrl.siteUrl })
-                .then((tokenResponse) => {
+                async (event) => tokenFetcher({
+                    ...options,
+                    siteUrl: resolvedUrl.siteUrl,
+                    driveId: resolvedUrl.driveId,
+                    itemId: resolvedUrl.itemId,
+                }).then((tokenResponse) => {
                     const token = tokenFromResponse(tokenResponse);
                     event.end({ fromCache: isTokenFromCache(tokenResponse), isNull: token === null ? true : false });
                     if (token === null && throwOnNullToken) {

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -44,6 +44,12 @@ export interface TokenFetchOptions {
 export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
     /** Site url representing ODSP resource location */
     siteUrl: string;
+
+    /** ODSP drive id where resource resides. Optional, used only when fetching token to access ODSP file */
+    driveId?: string;
+
+    /** ODSP item id representing resource. Optional, used only when fetching token to access ODSP file */
+    itemId?: string;
 }
 
 /**


### PR DESCRIPTION
Drive and item id needed to be added to facilitate the path where hashed proof token issued by ODSP is used instead of regular access token issued by AAD. This accounts for new scenario which allows ODSP to issue short-term access to a file (access is good until token expires). 