### PR TITLE
Handle r11s-driver requests and errors in custom RestWrapper

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -12894,6 +12894,27 @@
 				}
 			}
 		},
+		"axios-mock-adapter": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+			"integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
+			"requires": {
+				"fast-deep-equal": "^3.1.3",
+				"is-buffer": "^2.0.3"
+			},
+			"dependencies": {
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+				},
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+				}
+			}
+		},
 		"axobject-query": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/packages/drivers/routerlicious-driver/.eslintrc.js
+++ b/packages/drivers/routerlicious-driver/.eslintrc.js
@@ -7,6 +7,9 @@ module.exports = {
     "extends": [
         "@fluidframework/eslint-config-fluid/eslint7"
     ],
+    "parserOptions": {
+        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    },
     "rules": {
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -12,20 +12,46 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "npm run build:genver && concurrently npm:build:compile npm:lint",
-    "build:compile": "concurrently npm:tsc npm:build:esnext",
+    "build:commonjs": "npm run tsc && npm run build:test",
+    "build:compile": "concurrently npm:build:commonjs npm:build:esnext",
     "build:docs": "api-extractor run --local && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",
     "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:genver": "gen-version",
+    "build:test": "tsc --project ./src/test/tsconfig.json",
     "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
     "eslint": "eslint --format stylish src",
     "eslint:fix": "eslint --format stylish src --fix",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "test": "npm run test:mocha",
+    "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
+    "test:mocha": "mocha --recursive dist/test -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
+    "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"
+  },
+  "nyc": {
+    "all": true,
+    "cache-dir": "nyc/.cache",
+    "exclude": [
+      "src/test/**/*.ts",
+      "dist/test/**/*.js"
+    ],
+    "exclude-after-remap": false,
+    "include": [
+      "src/**/*.ts",
+      "dist/**/*.js"
+    ],
+    "report-dir": "nyc/report",
+    "reporter": [
+      "cobertura",
+      "html",
+      "text"
+    ],
+    "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.19.1",
@@ -42,6 +68,7 @@
     "axios": "^0.21.1",
     "debug": "^4.1.1",
     "isomorphic-ws": "^4.0.1",
+    "json-stringify-safe": "5.0.1",
     "socket.io-client": "^2.1.1",
     "uuid": "^8.3.1",
     "ws": "^6.1.2"
@@ -49,6 +76,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@fluidframework/mocha-test-setup": "^0.36.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
@@ -59,8 +87,10 @@
     "@types/ws": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
+    "axios-mock-adapter": "1.19.0",
     "concurrently": "^5.2.0",
     "copyfiles": "^2.1.0",
+    "cross-env": "^7.0.2",
     "eslint": "~7.18.0",
     "eslint-plugin-eslint-comments": "~3.2.0",
     "eslint-plugin-import": "~2.22.1",
@@ -70,6 +100,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.1.1",
     "nock": "^10.0.1",
+    "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "typescript": "~4.1.3",
     "typescript-formatter": "7.1.0"

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -72,8 +72,8 @@ export class DeltaStorageService implements IDeltaStorageService {
         id: string,
         from: number,
         to: number): Promise<IDeltasFetchResult> {
-        const ordererRestWrapper = new RouterliciousOrdererRestWrapper(tenantId, id, this.tokenProvider, this.logger);
-        await ordererRestWrapper.load();
+        const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
+            tenantId, id, this.tokenProvider, this.logger);
         const ops = await ordererRestWrapper.get<ISequencedDocumentMessage[]>(this.url, { from, to });
 
         // It is assumed that server always returns all the ops that it has in the range that was requested.

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -3,20 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { OutgoingHttpHeaders } from "http";
-import querystring from "querystring";
 import {
     IDeltaStorageService,
     IDocumentDeltaStorageService,
     IDeltasFetchResult,
 } from "@fluidframework/driver-definitions";
-import Axios from "axios";
-import { v4 as uuid } from "uuid";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ITokenProvider } from "./tokens";
 import { DocumentStorageService } from "./documentStorageService";
+import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 
 const MaxBatchDeltas = 2000; // Maximum number of ops we can fetch at a time
 
@@ -75,31 +72,12 @@ export class DeltaStorageService implements IDeltaStorageService {
         id: string,
         from: number,
         to: number): Promise<IDeltasFetchResult> {
-        const query = querystring.stringify({ from, to });
-
-        const headers: OutgoingHttpHeaders = {
-            "x-correlation-id": uuid(),
-        };
-
-        const storageToken = await this.tokenProvider.fetchStorageToken(
-            tenantId,
-            id,
-        );
-
-        if (storageToken) {
-            headers.Authorization = `Basic ${storageToken.jwt}`;
-        }
-
-        const ops = await Axios.get<ISequencedDocumentMessage[]>(
-            `${this.url}?${query}`, { headers });
-
-        this.logger.sendTelemetryEvent({
-            eventName: "R11sDriverToServer",
-            correlationId: headers["x-correlation-id"] as string,
-        });
+        const ordererRestWrapper = new RouterliciousOrdererRestWrapper(tenantId, id, this.tokenProvider, this.logger);
+        await ordererRestWrapper.load();
+        const ops = await ordererRestWrapper.get<ISequencedDocumentMessage[]>(this.url, { from, to });
 
         // It is assumed that server always returns all the ops that it has in the range that was requested.
         // This may change in the future, if so, we need to adjust and receive "end" value from server in such case.
-        return {messages: ops.data, partialResult: false };
+        return {messages: ops, partialResult: false };
     }
 }

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -50,7 +50,7 @@ export class DocumentService implements api.IDocumentService {
             return new NullBlobStorageService();
         }
 
-        const storageRestWrapper = new RouterliciousStorageRestWrapper(
+        const storageRestWrapper = await RouterliciousStorageRestWrapper.load(
             this.tenantId,
             this.documentId,
             this.tokenProvider,
@@ -58,7 +58,6 @@ export class DocumentService implements api.IDocumentService {
             this.gitUrl,
             this.directCredentials,
         );
-        await storageRestWrapper.load();
         const historian = new Historian(
             this.gitUrl,
             this.historianApi,

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -6,14 +6,7 @@
 import assert from "assert";
 import * as api from "@fluidframework/driver-definitions";
 import { IClient, IErrorTrackingService } from "@fluidframework/protocol-definitions";
-import {
-    BasicRestWrapper,
-    getAuthorizationTokenFromCredentials,
-    GitManager,
-    Historian,
-    ICredentials,
-    IGitCache,
-} from "@fluidframework/server-services-client";
+import { GitManager, Historian, ICredentials, IGitCache } from "@fluidframework/server-services-client";
 import io from "socket.io-client";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { DeltaStorageService, DocumentDeltaStorageService } from "./deltaStorageService";
@@ -21,6 +14,7 @@ import { DocumentStorageService } from "./documentStorageService";
 import { R11sDocumentDeltaConnection } from "./documentDeltaConnection";
 import { NullBlobStorageService } from "./nullBlobStorageService";
 import { ITokenProvider } from "./tokens";
+import { RouterliciousStorageRestWrapper } from "./restWrapper";
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
@@ -56,35 +50,20 @@ export class DocumentService implements api.IDocumentService {
             return new NullBlobStorageService();
         }
 
-        const storageToken = await this.tokenProvider.fetchStorageToken(
+        const storageRestWrapper = new RouterliciousStorageRestWrapper(
             this.tenantId,
             this.documentId,
-        );
-        // Craft credentials - either use the direct credentials (i.e. a GitHub user + PAT) - or make use of our
-        // tenant token
-        let credentials: ICredentials | undefined;
-        if (this.directCredentials) {
-            credentials = this.directCredentials;
-        } else {
-            credentials = {
-                password: storageToken.jwt,
-                user: this.tenantId,
-            };
-        }
-
-        const restWrapper = new BasicRestWrapper(
+            this.tokenProvider,
+            this.logger,
             this.gitUrl,
-            {},
-            undefined,
-            {
-                Authorization: getAuthorizationTokenFromCredentials(credentials),
-            },
+            this.directCredentials,
         );
+        await storageRestWrapper.load();
         const historian = new Historian(
             this.gitUrl,
             this.historianApi,
             this.disableCache,
-            restWrapper);
+            storageRestWrapper);
         const gitManager = new GitManager(historian);
 
         // Insert cached seed data

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -63,14 +63,13 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         const quorumValues = getQuorumValuesFromProtocolSummary(protocolSummary);
 
         const logger2 = ChildLogger.create(logger, "RouterliciousDriver");
-        const ordererRestWrapper = new RouterliciousOrdererRestWrapper(
+        const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
             tenantId,
             id,
             this.tokenProvider,
             logger2,
             resolvedUrl.endpoints.ordererUrl,
         );
-        await ordererRestWrapper.load();
         await ordererRestWrapper.post(
             `/documents/${tenantId}`,
             {

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -35,11 +35,14 @@ export function createR11sNetworkError(
         case 404:
             return new NetworkErrorBasic(
                 errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, false, statusCode);
+        case 429:
+            return createGenericNetworkError(
+                errorMessage, true, retryAfterSeconds, statusCode);
         case 500:
             return new GenericNetworkError(errorMessage, true, statusCode);
         default:
             return createGenericNetworkError(
-                errorMessage, true, retryAfterSeconds, statusCode);
+                errorMessage, false, retryAfterSeconds, statusCode);
     }
 }
 

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DriverError } from "@fluidframework/driver-definitions";
+import {
+    NetworkErrorBasic,
+    GenericNetworkError,
+    createGenericNetworkError,
+    AuthorizationError,
+} from "@fluidframework/driver-utils";
+
+export enum R11sErrorType {
+    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
+}
+
+export interface IR11sError {
+    readonly errorType: R11sErrorType;
+    readonly message: string;
+    canRetry: boolean;
+}
+
+export type R11sError = DriverError | IR11sError;
+
+export function createR11sNetworkError(
+    errorMessage: string,
+    statusCode?: number,
+    retryAfterSeconds?: number,
+): R11sError {
+    switch (statusCode) {
+        case 401:
+        case 403:
+            return new AuthorizationError(errorMessage, undefined, undefined, statusCode);
+        case 404:
+            return new NetworkErrorBasic(
+                errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, false, statusCode);
+        case 500:
+            return new GenericNetworkError(errorMessage, true, statusCode);
+        default:
+            return createGenericNetworkError(
+                errorMessage, true, retryAfterSeconds, statusCode);
+    }
+}
+
+export function throwR11sNetworkError(
+    errorMessage: string,
+    statusCode?: number,
+    retryAfterSeconds?: number,
+): never {
+    const networkError = createR11sNetworkError(
+        errorMessage,
+        statusCode,
+        retryAfterSeconds);
+
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal
+    throw networkError;
+}

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -140,6 +140,7 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
             logger.sendErrorEvent({
                 eventName: "R11sRestWrapperLoadFailure",
             }, e);
+            await restWrapper.load();
         }
         return restWrapper;
     }
@@ -177,6 +178,7 @@ export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
             logger.sendErrorEvent({
                 eventName: "R11sRestWrapperLoadFailure",
             }, e);
+            await restWrapper.load();
         }
         return restWrapper;
     }

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -93,6 +93,15 @@ export class RouterliciousRestWrapper extends RestWrapper {
 }
 
 export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
+    private constructor(
+        logger: ITelemetryLogger,
+        getAuthorizationHeader: AuthorizationHeaderGetter,
+        baseurl?: string,
+        defaultQueryString: Record<string, unknown> = {},
+    ) {
+        super(logger, getAuthorizationHeader, baseurl, defaultQueryString);
+    }
+
     public static async load(
         tenantId: string,
         documentId: string,
@@ -137,6 +146,15 @@ export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
 }
 
 export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
+    private constructor(
+        logger: ITelemetryLogger,
+        getAuthorizationHeader: AuthorizationHeaderGetter,
+        baseurl?: string,
+        defaultQueryString: Record<string, unknown> = {},
+    ) {
+        super(logger, getAuthorizationHeader, baseurl, defaultQueryString);
+    }
+
     public static async load(
         tenantId: string,
         documentId: string,

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -1,0 +1,146 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
+import {
+    getAuthorizationTokenFromCredentials,
+    ICredentials,
+    RestWrapper,
+} from "@fluidframework/server-services-client";
+import Axios, { AxiosError, AxiosRequestConfig } from "axios";
+import safeStringify from "json-stringify-safe";
+import { v4 as uuid } from "uuid";
+import { throwR11sNetworkError } from "./errorUtils";
+import { ITokenProvider } from "./tokens";
+
+type AuthorizationHeaderGetter = (refresh?: boolean) => Promise<string | undefined>;
+
+export class RouterliciousRestWrapper extends RestWrapper {
+    private authorizationHeader: string | undefined;
+
+    constructor(
+        private readonly logger: ITelemetryLogger,
+        private readonly getAuthorizationHeader: AuthorizationHeaderGetter,
+        baseurl?: string,
+        defaultQueryString: Record<string, unknown> = {},
+    ) {
+        super(baseurl, defaultQueryString);
+    }
+
+    public async load() {
+        this.authorizationHeader = await this.getAuthorizationHeader();
+    }
+
+    protected async request<T>(requestConfig: AxiosRequestConfig, statusCode: number, canRetry = true): Promise<T> {
+        const config = {
+            ...requestConfig,
+            headers: this.generateHeaders(requestConfig.headers),
+        };
+
+        try {
+            const response = await Axios.request<T>(config);
+            return response.data;
+        } catch (reason: any) {
+            if (!reason || !reason?.isAxiosError) {
+                // Unknown error, treat as critical error and immediately throw as non-retriable
+                this.logger.sendErrorEvent({
+                    eventName: "CriticalRequestError",
+                    correlationId: config.headers["x-correlation-id"] as string,
+                }, reason);
+                throwR11sNetworkError(`Unknown Error on [${config.method}] to [${config.url}]: ${
+                    safeStringify(reason)
+                }`);
+            }
+
+            const axiosError = reason as AxiosError;
+            if (axiosError.response?.status === statusCode) {
+                // Axios misinterpreted as error, return as successful response
+                return axiosError.response.data as T;
+            }
+
+            if (axiosError.response?.status === 401 && canRetry) {
+                // Refresh Authorization header and retry once
+                this.authorizationHeader = await this.getAuthorizationHeader(true);
+                return this.request<T>(config, statusCode, false);
+            }
+
+            if (axiosError.response?.status === 429 && axiosError.response.data?.retryAfter > 0) {
+                // Retry based on retryAfter[Seconds]
+                return new Promise<T>((resolve, reject) => setTimeout(() => {
+                    this.request<T>(config, statusCode)
+                        .then(resolve)
+                        .catch(reject);
+                }, axiosError.response!.data.retryAfter * 1000));
+            }
+
+            // Allow anything else to be handled upstream
+            throwR11sNetworkError(axiosError.message, axiosError.response?.status);
+        }
+    }
+
+    private generateHeaders(requestHeaders?: Record<string, unknown>): Record<string, unknown> {
+        const correlationId = requestHeaders?.["x-correlation-id"] || uuid();
+
+        return {
+            "x-correlation-id": correlationId,
+            "Authorization": this.authorizationHeader,
+            ...requestHeaders,
+        };
+    }
+}
+
+export class RouterliciousStorageRestWrapper extends RouterliciousRestWrapper {
+    constructor(
+        tenantId: string,
+        documentId: string,
+        tokenProvider: ITokenProvider,
+        logger: ITelemetryLogger,
+        baseurl?: string,
+        directCredentials?: ICredentials,
+    ) {
+        const defaultQueryString = {
+            token: `${fromUtf8ToBase64(directCredentials?.user || tenantId)}`,
+        };
+        const getAuthorizationHeader: AuthorizationHeaderGetter = async (): Promise<string> => {
+            // Craft credentials - either use the direct credentials (i.e. a GitHub user + PAT) - or make use of our
+            // tenant token
+            let credentials: ICredentials;
+            if (directCredentials) {
+                credentials = directCredentials;
+            } else {
+                const storageToken = await tokenProvider.fetchStorageToken(
+                    tenantId,
+                    documentId,
+                );
+                credentials = {
+                    password: storageToken.jwt,
+                    user: tenantId,
+                };
+            }
+            return getAuthorizationTokenFromCredentials(credentials);
+        };
+        super(logger, getAuthorizationHeader, baseurl, defaultQueryString);
+    }
+}
+
+export class RouterliciousOrdererRestWrapper extends RouterliciousRestWrapper {
+    constructor(
+        tenantId: string,
+        documentId: string,
+        tokenProvider: ITokenProvider,
+        logger: ITelemetryLogger,
+        baseurl?: string,
+    ) {
+        const getAuthorizationHeader: AuthorizationHeaderGetter = async (): Promise<string> => {
+            const ordererToken = await tokenProvider.fetchOrdererToken(
+                tenantId,
+                documentId,
+            );
+            return `Basic ${ordererToken.jwt}`;
+        };
+        super(logger, getAuthorizationHeader, baseurl);
+    }
+}

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -1,0 +1,122 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { DriverErrorType, IThrottlingWarning } from "@fluidframework/driver-definitions";
+import { createR11sNetworkError, throwR11sNetworkError, R11sErrorType } from "../errorUtils";
+
+describe("ErrorUtils", () => {
+    describe("createR11sNetworkError()", () => {
+        it("creates non-retriable authorization error on 401", () => {
+            const message = "test error";
+            const error = createR11sNetworkError(message, 401);
+            assert.strictEqual(error.errorType, DriverErrorType.authorizationError);
+            assert.strictEqual(error.canRetry, false);
+        });
+        it("creates non-retriable authorization error on 403", () => {
+            const message = "test error";
+            const error = createR11sNetworkError(message, 403);
+            assert.strictEqual(error.errorType, DriverErrorType.authorizationError);
+            assert.strictEqual(error.canRetry, false);
+        });
+        it("creates non-retriable not-found error on 404", () => {
+            const message = "test error";
+            const error = createR11sNetworkError(message, 404);
+            assert.strictEqual(error.errorType, R11sErrorType.fileNotFoundOrAccessDeniedError);
+            assert.strictEqual(error.canRetry, false);
+        });
+        it("creates retriable error on 429 with retry-after", () => {
+            const message = "test error";
+            const error = createR11sNetworkError(message, 429, 5);
+            assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
+            assert.strictEqual(error.canRetry, true);
+            assert.strictEqual((error as IThrottlingWarning).retryAfterSeconds, 5);
+        });
+        it("creates retriable error on 429 without retry-after", () => {
+            const message = "test error";
+            const error = createR11sNetworkError(message, 429);
+            assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
+            assert.strictEqual(error.canRetry, true);
+        });
+        it("creates retriable error on 500", () => {
+            const message = "test error";
+            const error = createR11sNetworkError(message, 500);
+            assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
+            assert.strictEqual(error.canRetry, true);
+        });
+        it("creates retriable error on anything else", () => {
+            const message = "test error";
+            const error = createR11sNetworkError(message);
+            assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
+            assert.strictEqual(error.canRetry, true);
+        });
+    });
+    describe("throwR11sNetworkError()", () => {
+        it("throws non-retriable authorization error on 401", () => {
+            const message = "test error";
+            assert.throws(() => {
+                throwR11sNetworkError(message, 401);
+            }, {
+                errorType: DriverErrorType.authorizationError,
+                canRetry: false,
+            });
+        });
+        it("throws non-retriable authorization error on 403", () => {
+            const message = "test error";
+            assert.throws(() => {
+                throwR11sNetworkError(message, 403);
+            }, {
+                errorType: DriverErrorType.authorizationError,
+                canRetry: false,
+            });
+        });
+        it("throws non-retriable not-found error on 404", () => {
+            const message = "test error";
+            assert.throws(() => {
+                throwR11sNetworkError(message, 404);
+            }, {
+                errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+                canRetry: false,
+            });
+        });
+        it("throws retriable error on 429 with retry-after", () => {
+            const message = "test error";
+            assert.throws(() => {
+                throwR11sNetworkError(message, 429, 5);
+            }, {
+                errorType: DriverErrorType.throttlingError,
+                canRetry: true,
+                retryAfterSeconds: 5,
+            });
+        });
+        it("throws retriable error on 429 without retry-after", () => {
+            const message = "test error";
+            assert.throws(() => {
+                throwR11sNetworkError(message, 429);
+            }, {
+                errorType: DriverErrorType.genericNetworkError,
+                canRetry: true,
+            });
+        });
+        it("throws retriable error on 500", () => {
+            const message = "test error";
+            assert.throws(() => {
+                throwR11sNetworkError(message, 500);
+            }, {
+                errorType: DriverErrorType.genericNetworkError,
+                canRetry: true,
+            });
+        });
+        it("throws retriable error on anything else", () => {
+            const message = "test error";
+            assert.throws(() => {
+                throwR11sNetworkError(message);
+            }, {
+                errorType: DriverErrorType.genericNetworkError,
+                canRetry: true,
+            });
+        });
+    });
+});

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -46,11 +46,11 @@ describe("ErrorUtils", () => {
             assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
             assert.strictEqual(error.canRetry, true);
         });
-        it("creates retriable error on anything else", () => {
+        it("creates non-retriable error on anything else", () => {
             const message = "test error";
             const error = createR11sNetworkError(message);
             assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
-            assert.strictEqual(error.canRetry, true);
+            assert.strictEqual(error.canRetry, false);
         });
     });
     describe("throwR11sNetworkError()", () => {
@@ -109,13 +109,13 @@ describe("ErrorUtils", () => {
                 canRetry: true,
             });
         });
-        it("throws retriable error on anything else", () => {
+        it("throws non-retriable error on anything else", () => {
             const message = "test error";
             assert.throws(() => {
                 throwR11sNetworkError(message);
             }, {
                 errorType: DriverErrorType.genericNetworkError,
-                canRetry: true,
+                canRetry: false,
             });
         });
     });

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -1,0 +1,244 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
+import Axios, { AxiosRequestConfig } from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { RouterliciousRestWrapper } from "../restWrapper";
+import { R11sErrorType } from "../errorUtils";
+
+describe("RouterliciousDriverRestWrapper", () => {
+    const axiosMockAdapter = new AxiosMockAdapter(Axios);
+    const testUrl = "/api/protected";
+
+    // Set up mock request authentication
+    let validToken: string | undefined;
+    const token1 = "1234-auth-token-abcd";
+    const token2 = "9876-auth-token-zyxw";
+    const token3 = "abc-auth-token-123";
+    let tokenQueue: string[] = [];
+    // Pop a token off tokenQueue to generate an auth header
+    const getAuthHeader = async () => `Bearer ${tokenQueue.shift() || ""}`;
+    // Check if auth header token value matches current validToken
+    const isValidAuthHeader = (header: string) => header.replace(/^Bearer /, "") === validToken;
+    // Returns 200 on valid Authorization header; otherwise returns 401
+    const replyWithAuth = (requestConfig: AxiosRequestConfig) => {
+        if (isValidAuthHeader(requestConfig.headers?.Authorization)) {
+            return [200, "OK"];
+        }
+        return [401, "Not Allowed"];
+    };
+
+    // Set up mock throttling
+    let throttleDurationInMs: number;
+    let throttledAt: number;
+    const throttle = () => {
+        throttledAt = Date.now();
+    };
+    const replyWithThrottling = () => {
+        const retryAfterSeconds = (throttleDurationInMs - Date.now() - throttledAt) / 1000;
+        const throttled = retryAfterSeconds > 0;
+        if (throttled) {
+            return [429, { retryAfter: retryAfterSeconds }];
+        }
+        return [200, "OK"];
+    };
+
+    let restWrapper: RouterliciousRestWrapper;
+
+    beforeEach(async () => {
+        // reset auth mocking
+        validToken = undefined;
+        tokenQueue = [token1, token2, token3];
+        // reset throttling mocking
+        throttledAt = 0;
+        throttleDurationInMs = 50;
+
+        axiosMockAdapter.reset();
+        restWrapper = new RouterliciousRestWrapper(
+            new TelemetryNullLogger(),
+            getAuthHeader,
+        );
+        await restWrapper.load();
+    });
+
+    describe("get()", () => {
+        it("sends a request with auth headers", async () => {
+            validToken = token1;
+            axiosMockAdapter.onGet(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.get(testUrl));
+        });
+        it("retries a request with fresh auth headers on 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onGet(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.get(testUrl));
+        });
+        it("throws a non-retriable error on 2nd 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onGet(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.get(testUrl));
+        });
+        it("throws a retriable error on 500", async () => {
+            axiosMockAdapter.onGet(testUrl).reply(500);
+            await assert.rejects(restWrapper.get(testUrl), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("retries with delay on 429 with retryAfter", async () => {
+            throttle();
+            axiosMockAdapter.onGet(testUrl).reply(replyWithThrottling);
+            await assert.doesNotReject(restWrapper.get(testUrl));
+        });
+        it("throws a retriable error on 429 without retryAfter", async () => {
+            axiosMockAdapter.onGet(testUrl).reply(429, { retryAfter: undefined });
+            await assert.rejects(restWrapper.get(testUrl), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("throws a non-retriable error on 404", async () => {
+            axiosMockAdapter.onGet(testUrl).reply(404);
+            await assert.rejects(restWrapper.get(testUrl), {
+                canRetry: false,
+                errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+            });
+        });
+    });
+
+    describe("post()", () => {
+        it("sends a request with auth headers", async () => {
+            validToken = token1;
+            axiosMockAdapter.onPost(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
+        });
+        it("retries a request with fresh auth headers on 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onPost(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
+        });
+        it("throws a non-retriable error on 2nd 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onPost(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
+        });
+        it("throws a retriable error on 500", async () => {
+            axiosMockAdapter.onPost(testUrl).reply(500);
+            await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("retries with delay on 429 with retryAfter", async () => {
+            throttle();
+            axiosMockAdapter.onPost(testUrl).reply(replyWithThrottling);
+            await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
+        });
+        it("throws a retriable error on 429 without retryAfter", async () => {
+            axiosMockAdapter.onPost(testUrl).reply(429, { retryAfter: undefined });
+            await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("throws a non-retriable error on 404", async () => {
+            axiosMockAdapter.onPost(testUrl).reply(404);
+            await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
+                canRetry: false,
+                errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+            });
+        });
+    });
+
+    describe("patch()", () => {
+        it("sends a request with auth headers", async () => {
+            validToken = token1;
+            axiosMockAdapter.onPatch(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
+        });
+        it("retries a request with fresh auth headers on 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onPatch(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
+        });
+        it("throws a non-retriable error on 2nd 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onPatch(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
+        });
+        it("throws a retriable error on 500", async () => {
+            axiosMockAdapter.onPatch(testUrl).reply(500);
+            await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("retries with delay on 429 with retryAfter", async () => {
+            throttle();
+            axiosMockAdapter.onPatch(testUrl).reply(replyWithThrottling);
+            await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
+        });
+        it("throws a retriable error on 429 without retryAfter", async () => {
+            axiosMockAdapter.onPatch(testUrl).reply(429, { retryAfter: undefined });
+            await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("throws a non-retriable error on 404", async () => {
+            axiosMockAdapter.onPatch(testUrl).reply(404);
+            await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
+                canRetry: false,
+                errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+            });
+        });
+    });
+
+    describe("delete()", () => {
+        it("sends a request with auth headers", async () => {
+            validToken = token1;
+            axiosMockAdapter.onDelete(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.delete(testUrl));
+        });
+        it("retries a request with fresh auth headers on 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onDelete(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.delete(testUrl));
+        });
+        it("throws a non-retriable error on 2nd 401", async () => {
+            validToken = token1;
+            axiosMockAdapter.onDelete(testUrl).reply(replyWithAuth);
+            await assert.doesNotReject(restWrapper.delete(testUrl));
+        });
+        it("throws a retriable error on 500", async () => {
+            axiosMockAdapter.onDelete(testUrl).reply(500);
+            await assert.rejects(restWrapper.delete(testUrl), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("retries with delay on 429 with retryAfter", async () => {
+            throttle();
+            axiosMockAdapter.onDelete(testUrl).reply(replyWithThrottling);
+            await assert.doesNotReject(restWrapper.delete(testUrl));
+        });
+        it("throws a retriable error on 429 without retryAfter", async () => {
+            axiosMockAdapter.onDelete(testUrl).reply(429, { retryAfter: undefined });
+            await assert.rejects(restWrapper.delete(testUrl), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
+        it("throws a non-retriable error on 404", async () => {
+            axiosMockAdapter.onDelete(testUrl).reply(404);
+            await assert.rejects(restWrapper.delete(testUrl), {
+                canRetry: false,
+                errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+            });
+        });
+    });
+});

--- a/packages/drivers/routerlicious-driver/src/test/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/src/test/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "extends": "@fluidframework/build-common/ts-common-config.json",
+    "compilerOptions": {
+        "rootDir": "./",
+        "outDir": "../../dist/test",
+        "types": [
+            "mocha"
+        ],
+        "declaration": false,
+        "declarationMap": false
+    },
+    "include": [
+        "./**/*"
+    ],
+    "references": [
+        {
+            "path": "../.."
+        }
+    ]
+}

--- a/packages/drivers/routerlicious-driver/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/tsconfig.json
@@ -2,11 +2,13 @@
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
-        "node_modules"
+        "node_modules",
+        "src/test/**/*"
     ],
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "composite": true
     },
     "include": [
         "src/**/*"

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "assert";
 import {
-    ContainerErrorType,
     LoaderHeader,
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
@@ -86,7 +85,7 @@ describe("Errors Types", () => {
 
             assert.fail("Error expected");
         } catch (error) {
-            assert.equal(error.errorType, ContainerErrorType.genericError, "Error should be a genericError");
+            assert.equal(error.errorType, DriverErrorType.genericNetworkError, "Error should be a genericNetworkError");
         }
     });
 

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 import {
+    ContainerErrorType,
     LoaderHeader,
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
@@ -85,7 +86,10 @@ describe("Errors Types", () => {
 
             assert.fail("Error expected");
         } catch (error) {
-            assert.equal(error.errorType, DriverErrorType.genericNetworkError, "Error should be a genericNetworkError");
+            assert(
+                [DriverErrorType.genericNetworkError, ContainerErrorType.genericError].includes(error.errorType),
+                `${error.errorType} should be genericError or genericNetworkError`,
+            );
         }
     });
 


### PR DESCRIPTION
This is a redo of #5200 with request error handling happening as close to the HTTP request as possible