### PR TITLE
Pass data object classes rather than factories to FluidStatic methods

### DIFF
--- a/examples/apps/cra-demo/README.md
+++ b/examples/apps/cra-demo/README.md
@@ -112,10 +112,10 @@ Since we're working with async functions, we will need a place to store our KeyV
 const [dataObject, setDataObject] = React.useState<KeyValueDataObject>();
 ```
 
-### 6.b Create/Load the Fluid document and data object
+### 6.b Create/Load the Fluid container and data object
 Now that we have a setter method, we need to make sure that our create/get flow runs just once, on app load. Here we'll use React's `useEffect` because it allows code to be ran as soon as the component loads, and re-run only when specific values change, which by setting the dependency array to `[]`, means never.
 
-The bulk of this `useEffect` hooks is the async `load` function that starts by getting or creating the `fluidDocument`. The `FluidDocument` class then allows use to get or create one or more data objects. This could be multiple KVPairs, or other DataObjects that you define.
+The bulk of this `useEffect` hooks is the async `load` function that starts by getting or creating the `fluidContainer`. The `FluidContainer` class then allows use to get or create one or more data objects. This could be multiple KVPairs, or other DataObjects that you define.
 
 
 ```jsx
@@ -124,13 +124,13 @@ React.useEffect(() => {
     const { containerId, isNew } = getContainerId();
 
     const load = async () => {
-        const fluidDocument = isNew
-            ? await Fluid.createDocument(containerId, [KeyValueDataObject])
-            : await Fluid.getDocument(containerId, [KeyValueDataObject]);
+        const fluidContainer = isNew
+            ? await Fluid.createContainer(containerId, [KeyValueDataObject])
+            : await Fluid.getContainer(containerId, [KeyValueDataObject]);
 
         const keyValueDataObject: KeyValueDataObject = isNew
-            ? await fluidDocument.createDataObject(KeyValueDataObject, 'kvpairId')
-            : await fluidDocument.getDataObject('kvpairId');
+            ? await fluidContainer.createDataObject(KeyValueDataObject, 'kvpairId')
+            : await fluidContainer.getDataObject('kvpairId');
 
         setDataObject(keyValueDataObject);
     }

--- a/examples/apps/cra-demo/README.md
+++ b/examples/apps/cra-demo/README.md
@@ -28,12 +28,12 @@ Lastly, open up the `App.tsx` file, as that will be the only file we need to edi
 
 Fluid gives you access to methods to boostrap a new Fluid container and attach DataObjects to it.
 
-`KeyValueDataObject` will provide you with a fully scaffolded DDS to store your data and subscribe to change events. The `KeyValueInstantiationFactory` is required by `Fluid` to instantiate the `KeyValueDataObject`.
+`KeyValueDataObject` will provide you with a fully scaffolded DDS to store your data and subscribe to change events.
 
 ```js
 // App.tsx
 import { Fluid } from "@fluid-experimental/fluid-static";
-import { KeyValueDataObject, KeyValueInstantiationFactory } from "@fluid-experimental/data-objects";
+import { KeyValueDataObject } from "@fluid-experimental/data-objects";
 ```
 
 ### 3.a Add the `getContainerId` function
@@ -125,11 +125,11 @@ React.useEffect(() => {
 
     const load = async () => {
         const fluidDocument = isNew
-            ? await Fluid.createDocument(containerId, [KeyValueInstantiationFactory.registryEntry])
-            : await Fluid.getDocument(containerId, [KeyValueInstantiationFactory.registryEntry]);
+            ? await Fluid.createDocument(containerId, [KeyValueDataObject])
+            : await Fluid.getDocument(containerId, [KeyValueDataObject]);
 
         const keyValueDataObject: KeyValueDataObject = isNew
-            ? await fluidDocument.createDataObject(KeyValueInstantiationFactory.type, 'kvpairId')
+            ? await fluidDocument.createDataObject(KeyValueDataObject, 'kvpairId')
             : await fluidDocument.getDataObject('kvpairId');
 
         setDataObject(keyValueDataObject);

--- a/examples/apps/cra-demo/src/App.tsx
+++ b/examples/apps/cra-demo/src/App.tsx
@@ -31,13 +31,13 @@ function useKVPair(): [KVData, SetKVPair | undefined] {
 
         const load = async () => {
             const service = new TinyliciousService();
-            const fluidDocument = isNew
+            const fluidContainer = isNew
                 ? await Fluid.createContainer(service, containerId, [KeyValueDataObject])
                 : await Fluid.getContainer(service, containerId, [KeyValueDataObject]);
 
             const keyValueDataObject: KeyValueDataObject = isNew
-                ? await fluidDocument.createDataObject(KeyValueDataObject, 'kvpairId')
-                : await fluidDocument.getDataObject('kvpairId');
+                ? await fluidContainer.createDataObject(KeyValueDataObject, 'kvpairId')
+                : await fluidContainer.getDataObject('kvpairId');
 
             setDataObject(keyValueDataObject);
         }

--- a/examples/apps/cra-demo/src/App.tsx
+++ b/examples/apps/cra-demo/src/App.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { KeyValueDataObject, KeyValueInstantiationFactory } from "@fluid-experimental/data-objects";
+import { KeyValueDataObject } from "@fluid-experimental/data-objects";
 import { Fluid } from "@fluid-experimental/fluid-static";
 import { TinyliciousService } from "@fluid-experimental/get-container";
 
@@ -32,11 +32,11 @@ function useKVPair(): [KVData, SetKVPair | undefined] {
         const load = async () => {
             const service = new TinyliciousService();
             const fluidDocument = isNew
-                ? await Fluid.createDocument(service, containerId, [KeyValueInstantiationFactory.registryEntry])
-                : await Fluid.getDocument(service, containerId, [KeyValueInstantiationFactory.registryEntry]);
+                ? await Fluid.createContainer(service, containerId, [KeyValueDataObject])
+                : await Fluid.getContainer(service, containerId, [KeyValueDataObject]);
 
             const keyValueDataObject: KeyValueDataObject = isNew
-                ? await fluidDocument.createDataObject(KeyValueInstantiationFactory.type, 'kvpairId')
+                ? await fluidDocument.createDataObject(KeyValueDataObject, 'kvpairId')
                 : await fluidDocument.getDataObject('kvpairId');
 
             setDataObject(keyValueDataObject);

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -6,7 +6,6 @@
 import {
     IKeyValueDataObject,
     KeyValueDataObject,
-    KeyValueInstantiationFactory,
 } from "@fluid-experimental/data-objects";
 import { Fluid } from "@fluid-experimental/fluid-static";
 import { TinyliciousService } from "@fluid-experimental/get-container";
@@ -27,12 +26,12 @@ async function start(): Promise<void> {
     const service = new TinyliciousService();
     // Get or create the document
     const fluidContainer = createNew
-        ? await Fluid.createContainer(service, containerId, [KeyValueInstantiationFactory.registryEntry])
-        : await Fluid.getContainer(service, containerId, [KeyValueInstantiationFactory.registryEntry]);
+        ? await Fluid.createContainer(service, containerId, [KeyValueDataObject])
+        : await Fluid.getContainer(service, containerId, [KeyValueDataObject]);
 
     // We'll create the data object when we create the new document.
     const keyValueDataObject: IKeyValueDataObject = createNew
-        ? await fluidContainer.createDataObject<KeyValueDataObject>(KeyValueInstantiationFactory.type, dataObjectId)
+        ? await fluidContainer.createDataObject<KeyValueDataObject>(KeyValueDataObject, dataObjectId)
         : await fluidContainer.getDataObject<KeyValueDataObject>(dataObjectId);
 
     // Our controller manipulates the data object (model).

--- a/experimental/framework/data-objects/src/kvpair/DataObject.ts
+++ b/experimental/framework/data-objects/src/kvpair/DataObject.ts
@@ -44,6 +44,13 @@ export interface IKeyValueDataObject extends EventEmitter {
 export class KeyValueDataObject
     extends DataObject
     implements IKeyValueDataObject {
+    public static readonly factory = new DataObjectFactory(
+        "keyvalue-dataobject",
+        KeyValueDataObject,
+        [],
+        {},
+    );
+
     /**
      * hasInitialized is run by each client as they load the DataObject.  Here we use it to set up usage of the
      * DataObject, by registering an event listener for changes in data.
@@ -89,9 +96,4 @@ export class KeyValueDataObject
  * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
-export const KeyValueInstantiationFactory = new DataObjectFactory(
-    "keyvalue-dataobject",
-    KeyValueDataObject,
-    [],
-    {},
-);
+export const KeyValueInstantiationFactory = KeyValueDataObject.factory;

--- a/experimental/framework/fluid-static/src/FluidStatic.ts
+++ b/experimental/framework/fluid-static/src/FluidStatic.ts
@@ -10,7 +10,7 @@ import { IFluidDataStoreFactory, NamedFluidDataStoreRegistryEntry } from "@fluid
 import { DOProviderContainerRuntimeFactory } from "./containerCode";
 
 export interface IFluidStaticDataObjectClass {
-    factory: IFluidDataStoreFactory;
+    readonly factory: IFluidDataStoreFactory;
 }
 
 export class FluidContainer {


### PR DESCRIPTION
This change establishes a new convention that the DataObjects to be used with FluidStatic must include a static member `factory` providing the factory to instantiate them.  This then allows FluidStatic to unpack the factory from the DataObject class, so the consumer never needs to worry about the factory concept.

This isn't really a new convention -- most of our example DataObjects already follow this convention, though it's not formalized in an interface across them.