### PR TITLE
Add delete method to KafkaOrdererFactory

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -227,7 +227,7 @@ export class KafkaOrdererFactory {
         return orderer;
     }
 
-    public async delete(tenantId: string, documentId: string): Promise<boolean> {
-        return this.ordererMap.delete(`${tenantId}/${documentId}`);
+    public delete(tenantId: string, documentId: string): void {
+        this.ordererMap.delete(`${tenantId}/${documentId}`);
     }
 }

--- a/server/routerlicious/packages/kafka-orderer/tsconfig.json
+++ b/server/routerlicious/packages/kafka-orderer/tsconfig.json
@@ -5,7 +5,6 @@
         "node_modules"
     ],
     "compilerOptions": {
-        "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },


### PR DESCRIPTION
- Add delete method to KafkaOrdererFactory - Things in `ordererMap` should be deleted eventually unless we want memory leaks
- Enable strict null checks in kafka orderer package