### PR TITLE
BumpVersion: fix renamed e2e test package and guard against common mistakes

### DIFF
--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-
 import { strict as assert } from "assert";
 import { Context, VersionChangeType } from "./context";
 import { getRepoStateChange } from "./versionBag";
@@ -12,12 +11,9 @@ import { MonoRepo, MonoRepoKind } from "../common/monoRepo";
 import { Package } from "../common/npmPackage";
 import * as semver from "semver";
 
-
 /**
  * Functions and utilities to update the package versions
  */
-
-
 export async function bumpVersion(context: Context, bump: string[], version: VersionChangeType, packageShortNames: string, commit?: string) {
     console.log(`Bumping ${packageShortNames} to ${version}`);
 
@@ -64,7 +60,6 @@ export async function bumpVersion(context: Context, bump: string[], version: Ver
     }
 }
 
-
 /**
  * Bump version of packages in the repo
  *
@@ -100,10 +95,11 @@ export async function bumpRepo(context: Context, versionBump: VersionChangeType,
     return context.collectVersions(true);
 }
 
-async function bumpLegacyDependencies(context:Context, versionBump: VersionChangeType) {
+async function bumpLegacyDependencies(context: Context, versionBump: VersionChangeType) {
     if (versionBump !== "patch") {
         // Assumes that we want N/N-1 testing
-        const pkg = context.fullPackageMap.get("@fluid-internal/end-to-end-tests");
+        const pkg = context.fullPackageMap.get("@fluidframework/test-end-to-end-tests")
+            || context.fullPackageMap.get("@fluid-internal/end-to-end-tests");
         if (!pkg) {
             fatal("Unable to find package @fluid-internal/end-to-end-tests");
         }

--- a/tools/build-tools/src/bumpVersion/context.ts
+++ b/tools/build-tools/src/bumpVersion/context.ts
@@ -33,6 +33,7 @@ export class Context {
 
     constructor(
         public readonly gitRepo: GitRepo,
+        public readonly originRemotePartialUrl: string,
         public readonly originalBranchName: string
     ) {
         this.timer = new Timer(commonOptions.timer);

--- a/tools/build-tools/src/bumpVersion/createBranch.ts
+++ b/tools/build-tools/src/bumpVersion/createBranch.ts
@@ -15,11 +15,16 @@ import * as semver from "semver";
  * Create release branch based on the repo state, bump minor version immediately
  * and push it to `main` and the new release branch to remote
  */
-export async function createReleaseBranch(context: Context, partialUrl: string) {
-    const url = "github.com/microsoft/FluidFramework";
-    const remote = await context.gitRepo.getRemote(partialUrl);
+export async function createReleaseBranch(context: Context) {
+    const remote = await context.gitRepo.getRemote(context.originRemotePartialUrl);
     if (!remote) {
-        fatal(`Unable to find remote for ${partialUrl}`)
+        fatal(`Unable to find remote for '${context.originRemotePartialUrl}'`)
+    }
+
+    if (context.originalBranchName !== "main") {
+        console.warn("WARNING: Bumping minor version outside of main branch is not normal!  Make sure you know what you are doing.")
+    } else if (!await context.gitRepo.isBranchUpToDate("main", remote)) {
+        fatal(`Local 'main' branch not up to date with remote. Please pull from '${remote}'.`);
     }
 
     // Create release branch based on client version


### PR DESCRIPTION
e2e test package changed, so we need to update the bumpVersion tools so it can update legacy versions.

Also:
- Restrict `--branch` to the main branch
- Make sure the repo is not dirty
- Make sure the branch `--branch` and `--release` operating on is up to date. 
  - Note that this can be improved to no dependent on local branch at all in the future