### PR TITLE
Bump build-tools deps to 0.2.18803

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3446,9 +3446,9 @@
 			"integrity": "sha512-m6Jcq7Qzj/xV97o0kV7ctC462bgqhcU0D/vjJi4Ah2gXOJ5+poVDxpXexQCnFWYKJRG3YqhH9OFMcpAX96TbgA=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.18168",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.18168.tgz",
-			"integrity": "sha512-O3Rbnd7Wo3n73jScLjzSaaCxQoR9+gAy/Lb1NpxZpZzNOLa/2L7qR7E5bgKXVPOi9iXfM0ypehclnf/5iZIOdw==",
+			"version": "0.2.18803",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.18803.tgz",
+			"integrity": "sha512-wOTy+MURZJlMVi5hUlWB9uGmjJj4uIAeNuwKRSsFpqqc3qZ/V15E7u74pps0b0YnBkx42qNDL4KyknmgJdVAsQ==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -4204,9 +4204,9 @@
 					"integrity": "sha512-u1Nnvd2Ld6lPMJLxb4ueDa28DUCApT1q0PA5yCc8I3Ii72NssaMOGmnzjDYQ2OeOlGly9YgYmDQZSAtjxxdtTg=="
 				},
 				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+					"version": "12.20.5",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+					"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -4504,9 +4504,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+					"version": "12.20.5",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+					"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -32104,9 +32104,9 @@
 					"integrity": "sha512-u1Nnvd2Ld6lPMJLxb4ueDa28DUCApT1q0PA5yCc8I3Ii72NssaMOGmnzjDYQ2OeOlGly9YgYmDQZSAtjxxdtTg=="
 				},
 				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+					"version": "12.20.5",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+					"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -32388,9 +32388,9 @@
 					"integrity": "sha512-u1Nnvd2Ld6lPMJLxb4ueDa28DUCApT1q0PA5yCc8I3Ii72NssaMOGmnzjDYQ2OeOlGly9YgYmDQZSAtjxxdtTg=="
 				},
 				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+					"version": "12.20.5",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+					"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 				},
 				"semver": {
 					"version": "6.3.0",
@@ -34106,9 +34106,9 @@
 					"integrity": "sha512-u1Nnvd2Ld6lPMJLxb4ueDa28DUCApT1q0PA5yCc8I3Ii72NssaMOGmnzjDYQ2OeOlGly9YgYmDQZSAtjxxdtTg=="
 				},
 				"@types/node": {
-					"version": "12.20.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-					"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+					"version": "12.20.5",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+					"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 				},
 				"jwt-decode": {
 					"version": "3.1.2",
@@ -34597,9 +34597,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.20.4",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-							"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+							"version": "12.20.5",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+							"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 						}
 					}
 				},
@@ -34622,9 +34622,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.20.4",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-							"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+							"version": "12.20.5",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+							"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 						},
 						"jwt-decode": {
 							"version": "3.1.2",
@@ -34649,9 +34649,9 @@
 					},
 					"dependencies": {
 						"@types/node": {
-							"version": "12.20.4",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-							"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+							"version": "12.20.5",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
+							"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg=="
 						}
 					}
 				},

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,9 +932,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.18168",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.18168.tgz",
-      "integrity": "sha512-O3Rbnd7Wo3n73jScLjzSaaCxQoR9+gAy/Lb1NpxZpZzNOLa/2L7qR7E5bgKXVPOi9iXfM0ypehclnf/5iZIOdw==",
+      "version": "0.2.18803",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.18803.tgz",
+      "integrity": "sha512-wOTy+MURZJlMVi5hUlWB9uGmjJj4uIAeNuwKRSsFpqqc3qZ/V15E7u74pps0b0YnBkx42qNDL4KyknmgJdVAsQ==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -956,12 +956,6 @@
         "sort-package-json": "1.40.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -5666,6 +5660,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -6552,12 +6552,6 @@
         "supports-hyperlinks": "^1.0.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
         "get-stdin": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -16212,9 +16206,9 @@
       }
     },
     "typed-rest-client": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.1.tgz",
-      "integrity": "sha512-7JbJFBZZuu3G64u6ksklN1xtVGfqBKiR5MQoTe5oLTi68OyB6pRuuIQCllfK/BdGjQtZYp62rgUOnEYDz4e9Xg==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.3.tgz",
+      "integrity": "sha512-gJoH7RE3trY77Bf5MNezVV+21O/WMmt9ps7w1bjFyLxrQqDymDWJSDacem1eM6R86zFM0FlE07F8dOupLmKLmQ==",
       "dev": true,
       "requires": {
         "qs": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.18168",
+    "@fluidframework/build-tools": "^0.2.18803",
     "@fluidframework/test-tools": "^0.2.3074",
     "@microsoft/api-documenter": "^7.12.7",
     "@microsoft/api-extractor": "^7.13.1",

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -42,7 +42,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.18168",
+    "@fluidframework/build-tools": "^0.2.18803",
     "@fluidframework/eslint-config-fluid": "^0.19.1",
     "@types/compression": "0.0.36",
     "@types/cors": "^2.8.4",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.18168",
+    "@fluidframework/build-tools": "^0.2.18803",
     "@microsoft/api-documenter": "^7.4.6",
     "@microsoft/api-extractor": "^7.13.1",
     "concurrently": "^5.2.0",


### PR DESCRIPTION
Update all packages in FF that refer to the @fluidframework/build-tools package to the newly released 0.2.18803 version