### PR TITLE
Update remaining package that was left in 0.37 bump

### DIFF
--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/mocha-test-setup": "^0.36.0",
+    "@fluidframework/mocha-test-setup": "^0.37.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",


### PR DESCRIPTION
"@fluidframework/mocha-test-setup" was added in while the bump to 0.37.0 was happening and as such, the automatic merge still had it on 0.36.0