### PR TITLE
Fix e2e legacy library install sequence

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.js
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.js
@@ -12,7 +12,7 @@ const testPackagesDir = `${packageDir}/..`;
 const requiredModules = [
     `${testPackagesDir}/mocha-test-setup`, // General mocha setup e.g. suppresses console.log
     `${testPackagesDir}/test-drivers`, // Inject implementation of getFluidTestDriver, configured via FLUID_TEST_DRIVER
-    `./dist/test/testApi`,
+    `${packageDir}/dist/test/testApi`,
 ];
 
 if (process.env.FLUID_TEST_LOGGER_PKG_PATH) {

--- a/packages/test/test-end-to-end-tests/src/test/compatUtils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compatUtils.ts
@@ -154,9 +154,14 @@ export const generateCompatTest = (
     // Run against all currently supported versions by default
     const compatVersions = [-1, -2];
     compatVersions.forEach((compatVersion: number) => {
-        const oldLoaderApi = getLoaderApi(compatVersion);
-        const oldContainerRuntimeApi = getContainerRuntimeApi(compatVersion);
-        const oldDataRuntimeApi = getDataRuntimeApi(compatVersion);
+        let oldLoaderApi: ReturnType<typeof getLoaderApi>;
+        let oldContainerRuntimeApi: ReturnType<typeof getContainerRuntimeApi>;
+        let oldDataRuntimeApi: ReturnType<typeof getDataRuntimeApi>;
+        before(async () => {
+            oldLoaderApi = getLoaderApi(compatVersion);
+            oldContainerRuntimeApi = getContainerRuntimeApi(compatVersion);
+            oldDataRuntimeApi = getDataRuntimeApi(compatVersion);
+        });
         describe(`compat N${compatVersion} - old loader, new runtime`, function() {
             tests(() => {
                 const driver = getFluidTestDriver();

--- a/packages/test/test-end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/contextReload.spec.ts
@@ -288,19 +288,25 @@ describe("context reload (hot-swap)", function() {
 
     const compatVersions = [-1, -2];
     compatVersions.forEach((compatVersion) => {
-        const oldLoaderApi = getLoaderApi(compatVersion);
-        const oldContainerRuntimeApi = getContainerRuntimeApi(compatVersion);
-        const oldDataStoreRuntimeApi = getDataRuntimeApi(compatVersion);
+        let oldLoaderApi: ReturnType<typeof getLoaderApi>;
+        let oldContainerRuntimeApi: ReturnType<typeof getContainerRuntimeApi>;
+        let oldDataRuntimeApi: ReturnType<typeof getDataRuntimeApi>;
+        let oldDataStoreClasses: ReturnType<typeof getTestDataStoreClasses>;
+        before(async () => {
+            oldLoaderApi = getLoaderApi(compatVersion);
+            oldContainerRuntimeApi = getContainerRuntimeApi(compatVersion);
+            oldDataRuntimeApi = getDataRuntimeApi(compatVersion);
+            oldDataStoreClasses = getTestDataStoreClasses(oldDataRuntimeApi);
+        });
         function createOldRuntimeFactory(dataStore): IRuntimeFactory {
             const type = TestDataObjectType;
-            const factory = new oldDataStoreRuntimeApi.DataObjectFactory(type, dataStore, [], {});
+            const factory = new oldDataRuntimeApi.DataObjectFactory(type, dataStore, [], {});
             return new oldContainerRuntimeApi.ContainerRuntimeFactoryWithDefaultDataStore(
                 factory,
-                [[type, Promise.resolve(new oldDataStoreRuntimeApi.DataObjectFactory(type, dataStore, [], {}))]],
+                [[type, Promise.resolve(new oldDataRuntimeApi.DataObjectFactory(type, dataStore, [], {}))]],
             );
         }
 
-        const oldDataStoreClasses = getTestDataStoreClasses(oldDataStoreRuntimeApi);
         describe(`compat N${compatVersions} - old loader, new runtime`, () => {
             beforeEach(async function() {
                 const documentId = createDocumentId();

--- a/packages/test/test-end-to-end-tests/src/test/testApi.ts
+++ b/packages/test/test-end-to-end-tests/src/test/testApi.ts
@@ -176,6 +176,8 @@ async function ensureInstalled(requested: string) {
                 ),
             );
         } catch (e) {
+            // rmdirSync recursive flags introduced in Node v12.10
+            // Remove the `as any` cast once node typing is updated.
             try { (rmdirSync as any)(modulePath, { recursive: true }); } catch (ex) { }
             throw new Error(`Unable to install version ${version}\n${e}`);
         }


### PR DESCRIPTION
mocha global fixture runs before the tests in parallel mode, but in non parallel mode it runs after.
So all the get legacy API happens before we have a chance to install.  
This break the r11s/odsp test pipeline, because it doesn't run the local test in parallel (and install) first.

Fix it by delaying getting the API until the "before" hook.

Also:
- Improve error reporting if install failed.
- Make sure we wait for both install to finish before returning (so that one doesn't get interrupted in the middle and leave it in a bad state)
- Clean up properly using rmdirSync with recursive.