### PR TITLE
Warn when duplicate messages are consumed

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -52,10 +52,21 @@ export class DocumentContextManager extends EventEmitter {
         this.contexts.delete(context);
     }
 
-    public setHead(head: IQueuedMessage) {
-        assert(head.offset > this.head.offset, `${head.offset} > ${this.head.offset}`);
+    public getHeadOffset() {
+        return this.head.offset;
+    }
 
-        this.head = head;
+    /**
+     * Updates the head to the new offset. The head offset will not be updated if it stays the same or moves backwards.
+     * @returns True if the head was update, false if it wasn't
+     */
+    public setHead(head: IQueuedMessage) {
+        if (head.offset > this.head.offset) {
+            this.head = head;
+            return true;
+        }
+
+        return false;
     }
 
     public setTail(tail: IQueuedMessage) {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -58,7 +58,7 @@ export class DocumentContextManager extends EventEmitter {
 
     /**
      * Updates the head to the new offset. The head offset will not be updated if it stays the same or moves backwards.
-     * @returns True if the head was update, false if it wasn't
+     * @returns True if the head was updated, false if it was not.
      */
     public setHead(head: IQueuedMessage) {
         if (head.offset > this.head.offset) {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -313,7 +313,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 	private processMessage(message: kafkaTypes.Message) {
 		const partition = message.partition;
 
-		if (this.assignedPartitions.has(partition) && this.isRebalancing) {
+		if (this.isRebalancing && this.assignedPartitions.has(partition)) {
 			/*
 				It is possible to receive messages while we have not yet finished rebalancing
 				due to how we wait for the fetchPartitionEpochs call to finish before emitting the rebalanced event.


### PR DESCRIPTION
Rdkafka is emitting duplicate messages in rare cases. It looks to be related to rebalancing/timeouts. All the cases seen so far is that it's a single duplicate message so the system should recover without needing to exit & restart.

- Instead of asserting and erroring when this happens, log a warning and ignore the duplicate message

Other changes:
- Order an if statement condition in rdkafka to not do a map lookup all the time