### PR TITLE
Add option to include Loader in scope

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,20 @@
+## 0.37 Breaking changes
+- [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
+
+### Loader in data stores deprecated
+The `loader` property on the `IContainerRuntime`, `IFluidDataStoreRuntime`, and `IFluidDataStoreContext` interfaces is now deprecated and will be removed in an upcoming release.  Data store objects will no longer have access to an `ILoader` by default.  To replicate the same behavior, existing users can make the `ILoader` used to create a `Container` available on the `scope` property of these interfaces instead by setting the `provideScopeLoader` `ILoaderOptions` flag when creating the loader.
+```typescript
+const loader = new Loader({
+    urlResolver,
+    documentServiceFactory,
+    codeLoader,
+    options: { provideScopeLoader: true },
+    });
+```
+```typescript
+const loader: ILoader | undefined = this.context.scope.ILoader;
+```
+
 ## 0.36 Breaking changes
 - [Some `ILoader` APIs moved to `IHostLoader`](#Some-ILoader-APIs-moved-to-IHostLoader)
 - [TaskManager removed](#TaskManager-removed)

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -124,7 +124,7 @@ export class ProseMirror extends EventEmitter
 
     constructor(
         private readonly runtime: IFluidDataStoreRuntime,
-        /* Private */ context: IFluidDataStoreContext,
+        private readonly context: IFluidDataStoreContext,
     ) {
         super();
 
@@ -151,7 +151,10 @@ export class ProseMirror extends EventEmitter
         this.root = await this.runtime.getChannel("root") as ISharedMap;
         this.text = await this.root.get<IFluidHandle<SharedString>>("text")!.get();
 
-        this.collabManager = new FluidCollabManager(this.text, this.runtime.loader);
+        if (this.context.scope.ILoader === undefined) {
+            throw new Error("scope must include ILoader");
+        }
+        this.collabManager = new FluidCollabManager(this.text, this.context.scope.ILoader);
 
         // Access for debugging
         // eslint-disable-next-line @typescript-eslint/dot-notation

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -279,9 +279,13 @@ function initialize(
             }
             typingDetails.classList.remove("hidden");
 
+            if (context.scope.ILoader === undefined) {
+                throw new Error("scope must contain ILoader");
+            }
+
             // Start typing and register to update the UI
             const typeP = scribe.type(
-                context.loader,
+                context.scope.ILoader,
                 url,
                 root,
                 runtime,

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -232,6 +232,15 @@ export type ILoaderOptions = {
      * Defaults to true.
      */
     cache?: boolean;
+
+    /**
+     * Provide the current Loader through the scope object when creating Containers.  It is added
+     * as the `ILoader` property, and will overwrite an existing property of the same name on the
+     * scope.  Useful for when the host wants to provide the current Loader's functionality to
+     * individual Data Stores.
+     * Defaults to false.
+     */
+    provideScopeLoader?: boolean;
 };
 
 /**

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -282,7 +282,14 @@ export interface ILoaderHeader {
     [LoaderHeader.version]: string | undefined | null;
 }
 
+interface IProvideLoader {
+    readonly ILoader: ILoader;
+}
+
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IRequestHeader extends Partial<ILoaderHeader> { }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface IFluidObject extends Readonly<Partial<IProvideLoader>> { }
 }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -242,9 +242,9 @@ export class Loader extends EventEmitter implements IHostLoader {
     constructor(loaderProps: ILoaderProps) {
         super();
 
-        const scope = loaderProps.scope ?? {};
+        const scope = { ...loaderProps.scope };
         if (loaderProps.options?.provideScopeLoader === true) {
-            (scope as any).ILoader = this;
+            scope.ILoader = this;
         }
 
         this.services = {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -241,12 +241,18 @@ export class Loader extends EventEmitter implements IHostLoader {
 
     constructor(loaderProps: ILoaderProps) {
         super();
+
+        const scope = loaderProps.scope ?? {};
+        if (loaderProps.options?.provideScopeLoader === true) {
+            (scope as any).ILoader = this;
+        }
+
         this.services = {
             urlResolver: createCachedResolver(MultiUrlResolver.create(loaderProps.urlResolver)),
             documentServiceFactory: MultiDocumentServiceFactory.create(loaderProps.documentServiceFactory),
             codeLoader: loaderProps.codeLoader,
             options: loaderProps.options ?? {},
-            scope: loaderProps.scope ?? {},
+            scope,
             subLogger: DebugLogger.mixinDebugLogger("fluid:telemetry", loaderProps.logger, { loaderId: uuid() }),
             proxyLoaderFactories: loaderProps.proxyLoaderFactories ?? new Map<string, IProxyLoaderFactory>(),
         };

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -79,6 +79,10 @@ export interface IContainerRuntime extends
     readonly leader: boolean;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly storage: IDocumentStorageService;
+    /**
+     * @deprecated 0.37 Use the provideScopeLoader flag to make the loader
+     * available through scope instead
+     */
     readonly loader: ILoader;
     readonly flushMode: FlushMode;
     readonly scope: IFluidObject;

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -67,6 +67,10 @@ export interface IFluidDataStoreRuntime extends
 
     readonly connected: boolean;
 
+    /**
+     * @deprecated 0.37 Use the provideScopeLoader flag to make the loader
+     * available through scope instead
+     */
     readonly loader: ILoader;
 
     readonly logger: ITelemetryLogger;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -256,6 +256,10 @@ IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegi
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly storage: IDocumentStorageService;
     readonly baseSnapshot: ISnapshotTree | undefined;
+    /**
+     * @deprecated 0.37 Use the provideScopeLoader flag to make the loader
+     * available through scope instead
+     */
     readonly loader: ILoader;
     /**
      * Indicates the attachment state of the data store to a host service.

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -179,7 +179,10 @@ async function createWebLoader(
             new MultiUrlResolver(documentId, window.location.origin, options, true) : urlResolver,
         documentServiceFactory,
         codeLoader,
-        options: { hotSwapContext: options.hotSwapContext === "true" },
+        options: {
+            hotSwapContext: options.hotSwapContext === "true",
+            provideScopeLoader: true,
+        },
     });
 }
 


### PR DESCRIPTION
Fixes #5329 

Add a LoaderOption to add the created Loader into the scope object sent into the created Containers.  This allows data objects to access a Loader without using the loader property on the context, and allows us to remove the loader property later (thus making loader access off by default).

This exists as a loader option at creation rather than having the host add the loader to the scope because 1) it standardizes the access pattern, and 2) the scope is passed into the Loader that wants to be added, but the scope is readonly on the Loader.  Using a creation option seems easier for the consumer than creating a scope, passing it into the Loader, then editing the scope in the Loader after it has been created and forcing the data object to be aware of the property names the host is using.