### PR TITLE
Allow op processing in paused state

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,3 +1,10 @@
+## 0.37 Breaking changes
+- [Paused container](#Paused-container)
+
+### Paused container
+When host passes "pause" header (LoaderHeader.pause), Container used to not process any ops until Container.resume() is called. Behavior and semantics of this header changed. Op processing is not paused and container will process all incoming ops, however it will wait to connect to ordering service until Container.resume() is called. This means that Container will catch up to latest state using ops from storage, but once it reaches the end of the log, it will not process any more ops until Container.resume() is called. This ensures that Container is as close (and gets there as fast as possible) to latest state as observed in storage, but does not collaborate with other clients until resumed.
+Please note that this adds a bit of variability into when ops are processed. This may result in some bugs being discovered where async code may not expect that state might change.
+
 ## 0.36 Breaking changes
 - [Some `ILoader` APIs moved to `IHostLoader`](#Some-ILoader-APIs-moved-to-IHostLoader)
 - [TaskManager removed](#TaskManager-removed)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -770,6 +770,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             // Propagate current connection state through the system.
             this.propagateConnectionState();
             if (!this.closed) {
+                this._deltaManager.inbound.resume();
+                this._deltaManager.outbound.resume();
+                this._deltaManager.inboundSignal.resume();
                 this.resumeInternal({ fetchOpsFromStorage: false, reason: "createDetached" });
             }
         } finally {
@@ -1177,10 +1180,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // Propagate current connection state through the system.
         this.propagateConnectionState();
 
-        if (!pause) {
-            this.resume();
-        }
-
         // Internal context is fully loaded at this point
         this.loaded = true;
 
@@ -1191,6 +1190,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this._deltaManager.inbound.resume();
             this._deltaManager.outbound.resume();
             this._deltaManager.inboundSignal.resume();
+            if (!pause) {
+                this.resume();
+            }
         }
 
         return {


### PR DESCRIPTION
This is first (and possible the only) step to resolve https://github.com/microsoft/FluidFramework/issues/5477
Please see breaking.md - there is substantial change in behavior.

The reason I believe it's good direction - it allows ops to trickle in sooner, including from storage (we make proactive request to storage as part of booting DeltaManager). I think it was original behavior, but our oldest release (0.10) already has pause/resume implemented.

It may expose bugs in existing code that may incorrectly assume that state of the universe does not change through initial loading / rendering. These bugs would show up in any other place where we would do virtualization (delay loading components). And to some extent, that's already what happens even today in Bohemia if we hit timeout and resume() is called before rendering is done. That said, if any bugs exists in existing components, with this change chances of hitting them goes way up.

Alternative is to apply ops before Container.load() returns, but pause right before returning. I do not like that direction, but it's an option.

Feedback?