### PR TITLE
r11s-driver: Prevent jsrsasign bundle

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -28,7 +28,7 @@ import {
     SummaryObject,
     SummaryType,
 } from "@fluidframework/protocol-definitions";
-import * as gitStorage from "@fluidframework/server-services-client";
+import { GitManager } from "@fluidframework/server-services-client";
 
 /**
  * Document access to underlying storage for routerlicious driver.
@@ -49,7 +49,7 @@ export class DocumentStorageService implements IDocumentStorageService {
 
     constructor(
         public readonly id: string,
-        public manager: gitStorage.GitManager,
+        public manager: GitManager,
         public readonly policies?: IDocumentStorageServicePolicies) {
     }
 


### PR DESCRIPTION
`import * as gitStorage from "@fluidframework/server-services-client` pulls in `jsrsasign` (~64.5kb) which is unused be r11s-driver.

In local testing, Webpack 4 correctly treeshakes and omits `jsrsasign`, but tools like [bundlephobia](https://bundlephobia.com/result?p=@fluidframework/routerlicious-driver@0.36.0) assume `jsrsasign` is included, which makes our little driver look ~twice its size.