### PR TITLE
r11s-driver: Add token refresh to delta stream connection

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -5,55 +5,11 @@
 
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
 import { IDocumentDeltaConnection, DriverError } from "@fluidframework/driver-definitions";
-import {
-    NetworkErrorBasic,
-    GenericNetworkError,
-    createGenericNetworkError,
-} from "@fluidframework/driver-utils";
 import { IClient, IConnect } from "@fluidframework/protocol-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-
-export enum R11sErrorType {
-    authorizationError = "authorizationError",
-    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
-}
+import { errorObjectFromSocketError } from "./errorUtils";
 
 const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
-
-function createNetworkError(
-    errorMessage: string,
-    canRetry: boolean,
-    statusCode: number,
-    retryAfterSeconds: number,
-) {
-    switch (statusCode) {
-        case 401:
-        case 403:
-            return new NetworkErrorBasic(
-                errorMessage, R11sErrorType.authorizationError, canRetry, statusCode);
-            break;
-        case 404:
-            return new NetworkErrorBasic(
-                errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, canRetry, statusCode);
-            break;
-        case 500:
-            return new GenericNetworkError(errorMessage, canRetry, statusCode);
-            break;
-        default:
-            return createGenericNetworkError(errorMessage, canRetry, retryAfterSeconds, statusCode);
-    }
-}
-
-/**
- * Returns specific network error based on error object.
- */
-const errorObjectFromSocketError = (socketError: {[key: string]: any}, handler: string, canRetry: boolean) => {
-    return createNetworkError(
-        `socket.io: ${handler}: ${socketError.message}`,
-        canRetry,
-        socketError.code,
-        socketError.retryAfter);
-};
 
 /**
  * Wrapper over the shared one for driver specific translation.
@@ -104,7 +60,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection impleme
         // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
         //   over it.
         if (canRetry && typeof error === "object" && error !== null) {
-            return errorObjectFromSocketError(error, handler, canRetry) as DriverError;
+            return errorObjectFromSocketError(error, handler) as DriverError;
         } else {
             return super.createErrorObject(handler, error, canRetry);
         }

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -129,8 +129,9 @@ export class DocumentService implements api.IDocumentService {
             const connection = await connect();
             return connection;
         } catch (error) {
-            if (error?.errorType === api.DriverErrorType.authorizationError) {
-                // Fetch new token and retry once
+            if (error?.statusCode === 401) {
+                // Fetch new token and retry once,
+                // otherwise 401 will be bubbled up as non-retriable AuthorizationError.
                 return connect();
             }
             throw error;

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -15,6 +15,29 @@ export enum R11sErrorType {
     fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
 }
 
+/**
+ * Interface for error responses for the WebSocket connection
+ */
+export interface IR11sSocketError {
+    /**
+     * An error code number for the error that occurred.
+     * It will be a valid HTTP status code.
+     */
+    code: number;
+
+    /**
+     * A message about the error that occurred for debugging / logging purposes.
+     * This should not be displayed to the user directly.
+     */
+    message: string;
+
+    /**
+     * Optional Retry-After time in seconds.
+     * The client should wait this many seconds before retrying its request.
+     */
+    retryAfter?: number;
+}
+
 export interface IR11sError {
     readonly errorType: R11sErrorType;
     readonly message: string;
@@ -58,4 +81,16 @@ export function throwR11sNetworkError(
 
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw networkError;
+}
+
+/**
+ * Returns network error based on error object from R11s socket (IR11sSocketError)
+ */
+export function errorObjectFromSocketError(socketError: IR11sSocketError, handler: string): R11sError {
+    const message = `socket.io: ${handler}: ${socketError.message}`;
+    return createR11sNetworkError(
+        message,
+        socketError.code,
+        socketError.retryAfter,
+    );
 }

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -5,7 +5,12 @@
 
 import assert from "assert";
 import { DriverErrorType, IThrottlingWarning } from "@fluidframework/driver-definitions";
-import { createR11sNetworkError, throwR11sNetworkError, R11sErrorType } from "../errorUtils";
+import {
+    createR11sNetworkError,
+    throwR11sNetworkError,
+    R11sErrorType,
+    errorObjectFromSocketError,
+} from "../errorUtils";
 
 describe("ErrorUtils", () => {
     describe("createR11sNetworkError()", () => {
@@ -117,6 +122,75 @@ describe("ErrorUtils", () => {
                 errorType: DriverErrorType.genericNetworkError,
                 canRetry: false,
             });
+        });
+    });
+    describe("errorObjectFromSocketError()", () => {
+        const handler = "test_handler";
+        const message = "test error";
+        const assertExpectedMessage = (actualMessage: string) => {
+            const expectedMessage = `socket.io: ${handler}: ${message}`;
+            assert.strictEqual(actualMessage, expectedMessage);
+        };
+        it("creates non-retriable authorization error on 401", () => {
+            const error = errorObjectFromSocketError({
+                code: 401,
+                message,
+            }, handler);
+            assertExpectedMessage(error.message);
+            assert.strictEqual(error.errorType, DriverErrorType.authorizationError);
+            assert.strictEqual(error.canRetry, false);
+            assert.strictEqual((error as any).statusCode, 401);
+        });
+        it("creates non-retriable authorization error on 403", () => {
+            const error = errorObjectFromSocketError({
+                code: 403,
+                message,
+            }, handler);
+            assertExpectedMessage(error.message);
+            assert.strictEqual(error.errorType, DriverErrorType.authorizationError);
+            assert.strictEqual(error.canRetry, false);
+            assert.strictEqual((error as any).statusCode, 403);
+        });
+        it("creates non-retriable not-found error on 404", () => {
+            const error = errorObjectFromSocketError({
+                code: 404,
+                message,
+            }, handler);
+            assertExpectedMessage(error.message);
+            assert.strictEqual(error.errorType, R11sErrorType.fileNotFoundOrAccessDeniedError);
+            assert.strictEqual(error.canRetry, false);
+            assert.strictEqual((error as any).statusCode, 404);
+        });
+        it("creates retriable error on 429 with retry-after", () => {
+            const error = errorObjectFromSocketError({
+                code: 429,
+                message,
+                retryAfter: 5,
+            }, handler);
+            assertExpectedMessage(error.message);
+            assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
+            assert.strictEqual(error.canRetry, true);
+            assert.strictEqual((error as IThrottlingWarning).retryAfterSeconds, 5);
+            assert.strictEqual((error as any).statusCode, 429);
+        });
+        it("creates retriable error on 429 without retry-after", () => {
+            const error = errorObjectFromSocketError({
+                code: 429,
+                message,
+            }, handler);
+            assertExpectedMessage(error.message);
+            assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
+            assert.strictEqual(error.canRetry, true);
+        });
+        it("creates retriable error on 500", () => {
+            const error = errorObjectFromSocketError({
+                code: 500,
+                message,
+            }, handler);
+            assertExpectedMessage(error.message);
+            assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
+            assert.strictEqual(error.canRetry, true);
+            assert.strictEqual((error as any).statusCode, 500);
         });
     });
 });


### PR DESCRIPTION
Refresh token and retry if the error thrown by the delta stream connection is a 401, otherwise pass error to DeltaManager for retry handling.

This also dedupes the network error logic in r11s-driver such that `R11sDocumentDeltaConnection` now uses the same network error logic as everything else.