### PR TITLE
r11s-driver: fix: make generic errors retriable

### DIFF
--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -65,7 +65,7 @@ export function createR11sNetworkError(
             return new GenericNetworkError(errorMessage, true, statusCode);
         default:
             return createGenericNetworkError(
-                errorMessage, false, retryAfterSeconds, statusCode);
+                errorMessage, retryAfterSeconds !== undefined, retryAfterSeconds, statusCode);
     }
 }
 


### PR DESCRIPTION
Sometimes 400s have retryAfter defined. Those should be retriable.