### PR TITLE
Use root data object rather than root data stores on the container for FluidStatic

### DIFF
--- a/examples/hosts/app-integration/external-controller/tests/index.ts
+++ b/examples/hosts/app-integration/external-controller/tests/index.ts
@@ -9,7 +9,6 @@ import {
     KeyValueInstantiationFactory
 } from "@fluid-experimental/data-objects";
 import { getSessionStorageContainer } from "@fluid-experimental/get-container";
-import { getObjectWithIdFromContainer } from "@fluidframework/aqueduct";
 
 import { DiceRollerController } from "../src/controller";
 import { DOProviderContainerRuntimeFactory } from "@fluid-experimental/fluid-static";
@@ -39,10 +38,11 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement,
 
     // Get the Default Object from the Container
     const dataObjectId = "dice";
+    const rootDataObject = (await container.request({ url: "/" })).value;
     if (createNewFlag) {
-        await container.request({ url: `/create/${KeyValueInstantiationFactory.type}/${dataObjectId}` });
+        await rootDataObject.createDataObject(KeyValueDataObject, dataObjectId);
     }
-    const kvPairDataObject = await getObjectWithIdFromContainer<KeyValueDataObject>(dataObjectId, container);
+    const kvPairDataObject = await rootDataObject.getDataObject(dataObjectId);
     const diceRollerController = new DiceRollerController(kvPairDataObject);
     await diceRollerController.initialize(createNewFlag);
 

--- a/experimental/framework/fluid-static/src/FluidStatic.ts
+++ b/experimental/framework/fluid-static/src/FluidStatic.ts
@@ -60,6 +60,13 @@ export class FluidContainer {
         dataObjectClass: IFluidStaticDataObjectClass,
         id: string,
     ) {
+        const type = dataObjectClass.factory.type;
+        // This is a runtime check to ensure the developer doesn't try to create something they have not defined.
+        if (!this.types.has(type)) {
+            throw new Error(
+                `Trying to create a DataObject with type ${type} that was not defined in Container initialization`);
+        }
+
         return this.rootDataObject.createDataObject<T>(dataObjectClass, id);
     }
 

--- a/experimental/framework/fluid-static/src/FluidStatic.ts
+++ b/experimental/framework/fluid-static/src/FluidStatic.ts
@@ -4,8 +4,8 @@
  */
 
 import { getContainer, IGetContainerService } from "@fluid-experimental/get-container";
+import { DataObject } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
-import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { NamedFluidDataStoreRegistryEntry } from "@fluidframework/runtime-definitions";
 import {
     DOProviderContainerRuntimeFactory,
@@ -56,7 +56,7 @@ export class FluidContainer {
             });
         }
 
-    public async createDataObject<T extends IFluidLoadable = IFluidLoadable>(
+    public async createDataObject<T extends DataObject>(
         dataObjectClass: IFluidStaticDataObjectClass,
         id: string,
     ) {
@@ -70,7 +70,7 @@ export class FluidContainer {
         return this.rootDataObject.createDataObject<T>(dataObjectClass, id);
     }
 
-    public async getDataObject<T extends IFluidLoadable = IFluidLoadable>(id: string) {
+    public async getDataObject<T extends DataObject>(id: string) {
         return this.rootDataObject.getDataObject<T>(id);
     }
 }

--- a/experimental/framework/fluid-static/src/FluidStatic.ts
+++ b/experimental/framework/fluid-static/src/FluidStatic.ts
@@ -4,13 +4,14 @@
  */
 
 import { getContainer, IGetContainerService } from "@fluid-experimental/get-container";
-import { DataObject, getObjectWithIdFromContainer } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
+import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { NamedFluidDataStoreRegistryEntry } from "@fluidframework/runtime-definitions";
 import {
-    IdToDataObjectCollection,
     DOProviderContainerRuntimeFactory,
+    IdToDataObjectCollection,
     IFluidStaticDataObjectClass,
+    RootDataObject,
 } from "./containerCode";
 
 export interface ContainerConfig {
@@ -41,36 +42,29 @@ export interface ContainerCreateConfig extends ContainerConfig {
 export class FluidContainer {
     private readonly types: Set<string>;
     public constructor(
-        private readonly container: IContainer,
+        container: IContainer, // we anticipate using this later, e.g. for Audience
         namedRegistryEntries: NamedFluidDataStoreRegistryEntry[],
+        private readonly rootDataObject: RootDataObject,
         public readonly createNew: boolean) {
-        this.types = new Set();
-        namedRegistryEntries.forEach((value: NamedFluidDataStoreRegistryEntry) => {
-            const type = value[0];
-            if (this.types.has(type)) {
-                throw new Error(`Multiple DataObjects share the same type identifier ${value}`);
-            }
-            this.types.add(type);
-        });
-    }
-
-    public async createDataObject<T extends DataObject>(
-        dataObjectClass: IFluidStaticDataObjectClass, id: string): Promise<T> {
-        const type = dataObjectClass.factory.type;
-        // This is a runtime check to ensure the developer doesn't try to create something they have not defined.
-        if (!this.types.has(type)) {
-            throw new Error(
-                `Trying to create a DataObject with type ${type} that was not defined in Container initialization`);
+            this.types = new Set();
+            namedRegistryEntries.forEach((value: NamedFluidDataStoreRegistryEntry) => {
+                const type = value[0];
+                if (this.types.has(type)) {
+                    throw new Error(`Multiple DataObjects share the same type identifier ${value}`);
+                }
+                this.types.add(type);
+            });
         }
 
-        await this.container.request({ url: `/create/${type}/${id}` });
-        const dataObject = await this.getDataObject<T>(id);
-        return dataObject;
+    public async createDataObject<T extends IFluidLoadable = IFluidLoadable>(
+        dataObjectClass: IFluidStaticDataObjectClass,
+        id: string,
+    ) {
+        return this.rootDataObject.createDataObject<T>(dataObjectClass, id);
     }
 
-    public async getDataObject<T extends DataObject>(id: string): Promise<T> {
-        const dataObject = await getObjectWithIdFromContainer<T>(id, this.container);
-        return dataObject;
+    public async getDataObject<T extends IFluidLoadable = IFluidLoadable>(id: string) {
+        return this.rootDataObject.getDataObject<T>(id);
     }
 }
 
@@ -98,7 +92,8 @@ export class FluidInstance {
             new DOProviderContainerRuntimeFactory(registryEntries, config.initialDataObjects),
             true, /* createNew */
         );
-        return new FluidContainer(container, registryEntries, true /* createNew */);
+        const rootDataObject = (await container.request({ url: "/" })).value;
+        return new FluidContainer(container, registryEntries, rootDataObject, true /* createNew */);
     }
 
     public async getContainer(id: string, config: ContainerConfig): Promise<FluidContainer> {
@@ -109,7 +104,8 @@ export class FluidInstance {
             new DOProviderContainerRuntimeFactory(registryEntries),
             false, /* createNew */
         );
-        return new FluidContainer(container, registryEntries, false /* createNew */);
+        const rootDataObject = (await container.request({ url: "/" })).value;
+        return new FluidContainer(container, registryEntries, rootDataObject, false /* createNew */);
     }
 
     private getRegistryEntries(dataObjects: IFluidStaticDataObjectClass[]) {

--- a/experimental/framework/fluid-static/src/containerCode.ts
+++ b/experimental/framework/fluid-static/src/containerCode.ts
@@ -70,10 +70,12 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
     }
 
     protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
-        const rootDataObject = await runtime.createRootDataStore(
+        await runtime.createRootDataStore(
             this.rootDataObjectFactory.type,
             rootDataStoreId,
         ) as RootDataObject;
+
+        const rootDataObject = (await runtime.request({ url: "/" })).value;
 
         const initialDataObjects: Promise<IFluidLoadable>[] = [];
         // If the developer provides additional DataObjects we will create them

--- a/experimental/framework/fluid-static/src/containerCode.ts
+++ b/experimental/framework/fluid-static/src/containerCode.ts
@@ -25,7 +25,7 @@ export class RootDataObject extends DataObject {
 
     protected async hasInitialized() { }
 
-    public async createDataObject<T extends IFluidLoadable = IFluidLoadable>(
+    public async createDataObject<T extends DataObject>(
         dataObjectClass: IFluidStaticDataObjectClass,
         id: string,
     ) {
@@ -37,7 +37,7 @@ export class RootDataObject extends DataObject {
         return object;
     }
 
-    public async getDataObject<T extends IFluidLoadable = IFluidLoadable>(id: string) {
+    public async getDataObject<T extends DataObject>(id: string) {
         const handle = await this.root.wait<IFluidHandle<T>>(id);
         return handle.get();
     }

--- a/experimental/framework/fluid-static/src/containerCode.ts
+++ b/experimental/framework/fluid-static/src/containerCode.ts
@@ -73,9 +73,9 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
         await runtime.createRootDataStore(
             this.rootDataObjectFactory.type,
             rootDataStoreId,
-        ) as RootDataObject;
+        );
 
-        const rootDataObject = (await runtime.request({ url: "/" })).value;
+        const rootDataObject: RootDataObject = (await runtime.request({ url: "/" })).value;
 
         const initialDataObjects: Promise<IFluidLoadable>[] = [];
         // If the developer provides additional DataObjects we will create them


### PR DESCRIPTION
This change lets us drop the request handler approach to create data objects, gives us better control over the ID namespace, and a good place for us to consolidate logic for e.g. singleton creation and task scheduling in the future.