### PR TITLE
Harden the service by rejecting invalid messages from client

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -26,14 +26,13 @@ import {
     LoaderCachingPolicy,
     IDocumentDeltaConnectionEvents,
 } from "@fluidframework/driver-definitions";
-import { isSystemType, isSystemMessage } from "@fluidframework/protocol-base";
+import { isSystemMessage } from "@fluidframework/protocol-base";
 import {
     ConnectionMode,
     IClient,
     IClientConfiguration,
     IClientDetails,
     IDocumentMessage,
-    IDocumentSystemMessage,
     INack,
     INackContent,
     ISequencedDocumentMessage,
@@ -761,18 +760,17 @@ export class DeltaManager
             type,
         };
 
-        const outbound = this.createOutboundMessage(type, message);
         this.emit("submitOp", message);
 
         if (!batch) {
             this.flush();
-            this.messageBuffer.push(outbound);
+            this.messageBuffer.push(message);
             this.flush();
         } else {
-            this.messageBuffer.push(outbound);
+            this.messageBuffer.push(message);
         }
 
-        return outbound.clientSequenceNumber;
+        return message.clientSequenceNumber;
     }
 
     public submitSignal(content: any) {
@@ -993,24 +991,6 @@ export class DeltaManager
         this.emit("closed", error);
 
         this.removeAllListeners();
-    }
-
-    // Specific system level message attributes are need to be looked at by the server.
-    // Hence they are separated and promoted as top level attributes.
-    private createOutboundMessage(
-        type: MessageType,
-        coreMessage: IDocumentMessage): IDocumentMessage {
-        if (isSystemType(type)) {
-            const data = coreMessage.contents as string;
-            coreMessage.contents = null;
-            const outboundMessage: IDocumentSystemMessage = {
-                ...coreMessage,
-                data,
-            };
-            return outboundMessage;
-        } else {
-            return coreMessage;
-        }
     }
 
     public refreshDelayInfo(id: string) {

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -4,14 +4,12 @@
  * Licensed under the MIT License.
  */
 
-import { isSystemType } from "@fluidframework/protocol-base";
 import {
     ConnectionMode,
     IClient,
     IConnect,
     IConnected,
     IDocumentMessage,
-    IDocumentSystemMessage,
     INack,
     ISignalMessage,
     MessageType,
@@ -75,13 +73,7 @@ function sanitizeMessage(message: any): IDocumentMessage {
         type: message.type,
     };
 
-    if (isSystemType(sanitizedMessage.type)) {
-        const systemMessage = sanitizedMessage as IDocumentSystemMessage;
-        systemMessage.data = message.data;
-        return systemMessage;
-    } else {
-        return sanitizedMessage;
-    }
+    return sanitizedMessage;
 }
 
 const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -498,7 +498,7 @@ export class DeliLambda implements IPartitionLambda {
         if (message.clientId) {
             return isServiceMessageType(message.operation.type);
         } else {
-            return true;
+            return false;
         }
     }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -265,6 +265,14 @@ export class DeliLambda implements IPartitionLambda {
                 `Gap detected in incoming op`);
         }
 
+        if (this.isInvalidMessage(message)) {
+            return this.createNackMessage(
+                message,
+                400,
+                NackErrorType.BadRequestError,
+                `Op not allowed`);
+        }
+
         // Handle client join/leave messages.
         if (!message.clientId) {
             if (message.operation.type === MessageType.ClientLeave) {
@@ -482,6 +490,16 @@ export class DeliLambda implements IPartitionLambda {
                 return JSON.parse(operation.data);
             }
         }
+    }
+
+    private isInvalidMessage(message: IRawOperationMessage) {
+        return message.clientId && (
+            message.operation.type === MessageType.ClientJoin ||
+            message.operation.type === MessageType.ClientLeave ||
+            message.operation.type === MessageType.SummaryAck ||
+            message.operation.type === MessageType.SummaryNack ||
+            message.operation.type === MessageType.NoClient ||
+            message.operation.type === MessageType.Control);
     }
 
     private createOutputMessage(

--- a/server/routerlicious/packages/protocol-base/src/utils.ts
+++ b/server/routerlicious/packages/protocol-base/src/utils.ts
@@ -6,14 +6,17 @@
 import { MessageType } from "@fluidframework/protocol-definitions";
 
 /**
- * Check if the string is a system message type, which includes
- * MessageType.RemoteHelp, MessageType.ClientJoin, MessageType.ClientLeave
+ * Check if the string is a service message type, which includes
+ * MessageType.ClientJoin, MessageType.ClientLeave, MessageType.Control,
+ * MessageType.NoClient, MessageType.SummaryAck, and MessageType.SummaryNack
  *
  * @param type - the type to check
  * @returns true if it is a system message type
  */
-export const isSystemType = (type: string) => (
-    type === MessageType.RemoteHelp ||
+export const isServiceMessageType = (type: string) => (
     type === MessageType.ClientJoin ||
     type === MessageType.ClientLeave ||
-    type === MessageType.Control);
+    type === MessageType.Control ||
+    type === MessageType.NoClient ||
+    type === MessageType.SummaryAck ||
+    type === MessageType.SummaryNack);


### PR DESCRIPTION
Tackles #5488. Will follow up with another PR with tests once service packages are published.

1. We are leveraging an invariant that any op sent by client should always have a valid client id. Currently, both r11s and push enforces this. Keeping that in mind, we introduced 'isServiceMessageType', which includes every op type that should only be sent by services. Since message sent by service does not have a clientId, we should be able to discard invalid ops quickly.

2. Removed code from deltaManager to promote certain op type data. That should not be necessary anymore.

3. Fixed 'sanitizeMessage' in Alfred. So even if client sends wrong fields, Alfred throws them away.