### PR TITLE
Handle Kafka error events and improve runner error handling

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.28.0-0",
+    "@fluidframework/server-services-client": "^0.1022.0",
     "@fluidframework/server-services-core": "^0.1022.0",
     "@fluidframework/server-services-utils": "^0.1022.0",
     "async": "^2.6.1",

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -48,7 +48,6 @@ export class PartitionManager extends EventEmitter {
             this.rebalanced(partitions);
         });
 
-        // On any Kafka errors immediately stop processing
         this.consumer.on("error", (error, errorData: IContextErrorData) => {
             if (this.stopped) {
                 return;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -49,12 +49,12 @@ export class PartitionManager extends EventEmitter {
         });
 
         // On any Kafka errors immediately stop processing
-        this.consumer.on("error", (error) => {
+        this.consumer.on("error", (error, errorData: IContextErrorData) => {
             if (this.stopped) {
                 return;
             }
 
-            this.emit("error", error);
+            this.emit("error", error, errorData);
         });
     }
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { inspect } from "util";
 import { Deferred } from "@fluidframework/common-utils";
+import { promiseTimeout } from "@fluidframework/server-services-client";
 import { IConsumer, IContextErrorData, ILogger, IPartitionLambdaFactory } from "@fluidframework/server-services-core";
 import { IRunner } from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
@@ -12,6 +14,7 @@ import { PartitionManager } from "./partitionManager";
 export class KafkaRunner implements IRunner {
     private deferred: Deferred<void> | undefined;
     private partitionManager: PartitionManager | undefined;
+    private stopped: boolean = false;
 
     constructor(
         private readonly factory: IPartitionLambdaFactory,
@@ -39,8 +42,15 @@ export class KafkaRunner implements IRunner {
 
         this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, logger);
         this.partitionManager.on("error", (error, errorData: IContextErrorData) => {
-            deferred.reject(error);
+            if (errorData?.restart) {
+                deferred.reject(error);
+            } else {
+                logger?.error("KakfaRunner encountered an error that is not configured to trigger restart.");
+                logger?.error(inspect(error));
+            }
         });
+
+        this.stopped = false;
 
         return deferred.promise;
     }
@@ -49,15 +59,22 @@ export class KafkaRunner implements IRunner {
      * Signals to stop the service
      */
     public async stop(): Promise<void> {
-        if (!this.deferred) {
+        if (!this.deferred || this.stopped) {
             return;
         }
+
+        this.stopped = true;
 
         // Stop listening for new updates
         await this.consumer.pause();
 
         // Stop the partition manager
         await this.partitionManager?.stop();
+
+        await this.factory.dispose();
+
+        // Close the underlying consumer, but setting a timeout for safety
+        await promiseTimeout(30000, this.consumer.close());
 
         // Mark ourselves done once the partition manager has stopped
         this.deferred.resolve();

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -42,11 +42,11 @@ export class KafkaRunner implements IRunner {
 
         this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, logger);
         this.partitionManager.on("error", (error, errorData: IContextErrorData) => {
-            if (errorData?.restart) {
-                deferred.reject(error);
-            } else {
+            if (errorData && !errorData.restart) {
                 logger?.error("KakfaRunner encountered an error that is not configured to trigger restart.");
                 logger?.error(inspect(error));
+            } else {
+                deferred.reject(error);
             }
         });
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -71,6 +71,7 @@ export class KafkaRunner implements IRunner {
         // Stop the partition manager
         await this.partitionManager?.stop();
 
+        // Dispose the factory
         await this.factory.dispose();
 
         // Close the underlying consumer, but setting a timeout for safety

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -122,10 +122,6 @@ export class AlfredResourcesFactory implements utils.IResourcesFactory<AlfredRes
             kafkaNumberOfPartitions,
             kafkaReplicationFactor);
 
-        producer.on("error", (error) => {
-            winston.error(error);
-        });
-
         const redisConfig = config.get("redis");
         const webSocketLibrary = config.get("alfred:webSocketLib");
         const authEndpoint = config.get("auth:endpoint");

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -26,8 +26,8 @@
             "name": "kafka-node",
             "endpoint": "kafka:9092",
             "producerPollIntervalMs": 10,
-            "numberOfPartitions": 32,
-            "replicationFactor": 3
+            "numberOfPartitions": 8,
+            "replicationFactor": 1
         }
     },
     "zookeeper": {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -92,11 +92,11 @@ export abstract class RdkafkaBase extends EventEmitter {
 		});
 	}
 
-    protected error(error: any, restartOnError: boolean = false) {
-        const errorData: IContextErrorData = {
-            restart: restartOnError,
-        };
+	protected error(error: any, restartOnError: boolean = false) {
+		const errorData: IContextErrorData = {
+			restart: restartOnError,
+		};
 
-        this.emit("error", error, errorData);
-    }
+		this.emit("error", error, errorData);
+	}
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -4,6 +4,7 @@
  */
 
 import { EventEmitter } from "events";
+import { IContextErrorData } from "@fluidframework/server-services-core";
 import type * as kafkaTypes from "node-rdkafka";
 import { tryImportNodeRdkafka } from "./tryImport";
 
@@ -90,4 +91,12 @@ export abstract class RdkafkaBase extends EventEmitter {
 			});
 		});
 	}
+
+    protected error(error: any, restartOnError: boolean = false) {
+        const errorData: IContextErrorData = {
+            restart: restartOnError,
+        };
+
+        this.emit("error", error, errorData);
+    }
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -14,392 +14,392 @@ import { tryImportNodeRdkafka } from "./tryImport";
 const kafka = tryImportNodeRdkafka();
 
 export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
-	consumeTimeout: number;
-	consumeLoopTimeoutDelay: number;
-	optimizedRebalance: boolean;
-	commitRetryDelay: number;
-	automaticConsume: boolean;
-	additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
+    consumeTimeout: number;
+    consumeLoopTimeoutDelay: number;
+    optimizedRebalance: boolean;
+    commitRetryDelay: number;
+    automaticConsume: boolean;
+    additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
 }
 
 /**
  * Kafka consumer using the node-rdkafka library
  */
 export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
-	private readonly consumerOptions: IKafkaConsumerOptions;
-	private consumer?: kafkaTypes.KafkaConsumer;
-	private zooKeeperClient?: ZookeeperClient;
-	private closed = false;
-	private isRebalancing = true;
-	private assignedPartitions: Set<number> = new Set();
-	private readonly pendingCommits: Map<number, Deferred<void>> = new Map();
-	private readonly pendingMessages: Map<number, kafkaTypes.Message[]> = new Map();
-	private readonly latestOffsets: Map<number, number> = new Map();
+    private readonly consumerOptions: IKafkaConsumerOptions;
+    private consumer?: kafkaTypes.KafkaConsumer;
+    private zooKeeperClient?: ZookeeperClient;
+    private closed = false;
+    private isRebalancing = true;
+    private assignedPartitions: Set<number> = new Set();
+    private readonly pendingCommits: Map<number, Deferred<void>> = new Map();
+    private readonly pendingMessages: Map<number, kafkaTypes.Message[]> = new Map();
+    private readonly latestOffsets: Map<number, number> = new Map();
 
-	constructor(
-		endpoints: IKafkaEndpoints,
-		clientId: string,
-		topic: string,
-		public readonly groupId: string,
-		options?: Partial<IKafkaConsumerOptions>) {
-		super(endpoints, clientId, topic, options);
+    constructor(
+        endpoints: IKafkaEndpoints,
+        clientId: string,
+        topic: string,
+        public readonly groupId: string,
+        options?: Partial<IKafkaConsumerOptions>) {
+        super(endpoints, clientId, topic, options);
 
-		this.consumerOptions = {
-			...options,
-			consumeTimeout: options?.consumeTimeout ?? 1000,
-			consumeLoopTimeoutDelay: options?.consumeLoopTimeoutDelay ?? 100,
-			optimizedRebalance: options?.optimizedRebalance ?? false,
-			commitRetryDelay: options?.commitRetryDelay ?? 1000,
-			automaticConsume: options?.automaticConsume ?? true,
-		};
-	}
+        this.consumerOptions = {
+            ...options,
+            consumeTimeout: options?.consumeTimeout ?? 1000,
+            consumeLoopTimeoutDelay: options?.consumeLoopTimeoutDelay ?? 100,
+            optimizedRebalance: options?.optimizedRebalance ?? false,
+            commitRetryDelay: options?.commitRetryDelay ?? 1000,
+            automaticConsume: options?.automaticConsume ?? true,
+        };
+    }
 
-	protected connect() {
-		if (this.closed) {
-			return;
-		}
+    protected connect() {
+        if (this.closed) {
+            return;
+        }
 
-		const zookeeperEndpoints = this.endpoints.zooKeeper;
-		if (zookeeperEndpoints && zookeeperEndpoints.length > 0) {
-			const zooKeeperEndpoint = zookeeperEndpoints[Math.floor(Math.random() % zookeeperEndpoints.length)];
-			this.zooKeeperClient = new ZookeeperClient(zooKeeperEndpoint);
-		}
+        const zookeeperEndpoints = this.endpoints.zooKeeper;
+        if (zookeeperEndpoints && zookeeperEndpoints.length > 0) {
+            const zooKeeperEndpoint = zookeeperEndpoints[Math.floor(Math.random() % zookeeperEndpoints.length)];
+            this.zooKeeperClient = new ZookeeperClient(zooKeeperEndpoint);
+        }
 
-		const options: kafkaTypes.ConsumerGlobalConfig = {
-			"metadata.broker.list": this.endpoints.kafka.join(","),
-			"socket.keepalive.enable": true,
-			"socket.nagle.disable": true,
-			"client.id": this.clientId,
-			"group.id": this.groupId,
-			"enable.auto.commit": false,
-			"fetch.min.bytes": 1,
-			"fetch.max.bytes": 1024 * 1024,
-			"offset_commit_cb": true,
-			"rebalance_cb": this.consumerOptions.optimizedRebalance ? this.rebalance.bind(this) : true,
-			...this.consumerOptions.additionalOptions,
-		};
+        const options: kafkaTypes.ConsumerGlobalConfig = {
+            "metadata.broker.list": this.endpoints.kafka.join(","),
+            "socket.keepalive.enable": true,
+            "socket.nagle.disable": true,
+            "client.id": this.clientId,
+            "group.id": this.groupId,
+            "enable.auto.commit": false,
+            "fetch.min.bytes": 1,
+            "fetch.max.bytes": 1024 * 1024,
+            "offset_commit_cb": true,
+            "rebalance_cb": this.consumerOptions.optimizedRebalance ? this.rebalance.bind(this) : true,
+            ...this.consumerOptions.additionalOptions,
+        };
 
-		const consumer: kafkaTypes.KafkaConsumer = this.consumer =
-			new kafka.KafkaConsumer(options, { "auto.offset.reset": "latest" });
+        const consumer: kafkaTypes.KafkaConsumer = this.consumer =
+            new kafka.KafkaConsumer(options, { "auto.offset.reset": "latest" });
 
-		consumer.setDefaultConsumeTimeout(this.consumerOptions.consumeTimeout);
-		consumer.setDefaultConsumeLoopTimeoutDelay(this.consumerOptions.consumeLoopTimeoutDelay);
+        consumer.setDefaultConsumeTimeout(this.consumerOptions.consumeTimeout);
+        consumer.setDefaultConsumeLoopTimeoutDelay(this.consumerOptions.consumeLoopTimeoutDelay);
 
-		consumer.on("ready", () => {
-			consumer.subscribe([this.topic]);
+        consumer.on("ready", () => {
+            consumer.subscribe([this.topic]);
 
-			if (this.consumerOptions.automaticConsume) {
-				// start the consume loop
-				consumer.consume();
-			}
+            if (this.consumerOptions.automaticConsume) {
+                // start the consume loop
+                consumer.consume();
+            }
 
-			this.emit("connected", consumer);
-		});
+            this.emit("connected", consumer);
+        });
 
-		consumer.on("disconnected", () => {
-			this.emit("disconnected");
-		});
+        consumer.on("disconnected", () => {
+            this.emit("disconnected");
+        });
 
-		consumer.on("connection.failure", async (error) => {
-			await this.close(true);
+        consumer.on("connection.failure", async (error) => {
+            await this.close(true);
 
-			this.error(error);
-
-			this.connect();
-		});
-
-		consumer.on("data", this.processMessage.bind(this));
-
-		consumer.on("offset.commit", (err, offsets) => {
-			let shouldRetryCommit = false;
-
-			if (err) {
-				// a rebalance occurred while we were committing
-				// we can resubmit the commit if we still own the partition
-				shouldRetryCommit =
-					this.consumerOptions.optimizedRebalance &&
-					(err.code === kafka.CODES.ERRORS.ERR_REBALANCE_IN_PROGRESS ||
-						err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
-
-				if (!shouldRetryCommit) {
-					this.error(err);
-				}
-			}
-
-			for (const offset of offsets) {
-				const deferredCommit = this.pendingCommits.get(offset.partition);
-				if (deferredCommit) {
-					if (shouldRetryCommit) {
-						setTimeout(() => {
-							if (this.assignedPartitions.has(offset.partition)) {
-								// we still own this partition. checkpoint again
-								this.consumer?.commit(offset);
-							}
-						}, this.consumerOptions.commitRetryDelay);
-						continue;
-					}
-
-					this.pendingCommits.delete(offset.partition);
-
-					if (err) {
-						deferredCommit.reject(err);
-					} else {
-						deferredCommit.resolve();
-
-						this.emit("checkpoint", offset.partition, offset.offset);
-					}
-				} else {
-					this.error(new Error(`Unknown commit for partition ${offset.partition}`));
-				}
-			}
-		});
-
-		consumer.on("rebalance", async (err, topicPartitions) => {
-			if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS ||
-				err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-				const newAssignedPartitions = new Set<number>(topicPartitions.map((tp) => tp.partition));
-
-				if (newAssignedPartitions.size === this.assignedPartitions.size &&
-					Array.from(this.assignedPartitions).every((ap) => newAssignedPartitions.has(ap))) {
-					// the consumer is already up to date
-					return;
-				}
-
-				// clear pending messages
-				this.pendingMessages.clear();
-
-				if (!this.consumerOptions.optimizedRebalance) {
-					if (this.isRebalancing) {
-						this.isRebalancing = false;
-					} else {
-						this.emit("rebalancing", this.getPartitions(this.assignedPartitions), err.code);
-					}
-				}
-
-				const originalAssignedPartitions = this.assignedPartitions;
-				this.assignedPartitions = newAssignedPartitions;
-
-				try {
-					this.isRebalancing = true;
-					const partitions = this.getPartitions(this.assignedPartitions);
-					const partitionsWithEpoch = await this.fetchPartitionEpochs(partitions);
-					this.emit("rebalanced", partitionsWithEpoch, err.code);
-
-					// cleanup things left over from the lost partitions
-					for (const partition of originalAssignedPartitions) {
-						if (!newAssignedPartitions.has(partition)) {
-							// clear latest offset
-							this.latestOffsets.delete(partition);
-
-							// reject pending commit
-							const deferredCommit = this.pendingCommits.get(partition);
-							if (deferredCommit) {
-								this.pendingCommits.delete(partition);
-								deferredCommit.reject(new Error(`Partition for commit was unassigned. ${partition}`));
-							}
-						}
-					}
-
-					this.isRebalancing = false;
-
-					for (const pendingMessages of this.pendingMessages.values()) {
-						// process messages sent while we were rebalancing for each partition in order
-						for (const pendingMessage of pendingMessages) {
-							this.processMessage(pendingMessage);
-						}
-					}
-				} catch (ex) {
-					this.isRebalancing = false;
-					this.error(ex);
-				} finally {
-					this.pendingMessages.clear();
-				}
-			} else {
-				this.error(err);
-			}
-		});
-
-		consumer.on("rebalance.error", (error) => {
-			this.error(error);
-		});
-
-		consumer.on("event.error", (error) => {
             this.error(error);
-		});
 
-		consumer.on("event.throttle", (event) => {
-			this.emit("throttled", event);
-		});
+            this.connect();
+        });
 
-		consumer.connect();
-	}
+        consumer.on("data", this.processMessage.bind(this));
 
-	public async close(reconnecting: boolean = false): Promise<void> {
-		if (this.closed) {
-			return;
-		}
+        consumer.on("offset.commit", (err, offsets) => {
+            let shouldRetryCommit = false;
 
-		if (!reconnecting) {
-			// when closed outside of this class, disable reconnecting
-			this.closed = true;
-		}
+            if (err) {
+                // a rebalance occurred while we were committing
+                // we can resubmit the commit if we still own the partition
+                shouldRetryCommit =
+                    this.consumerOptions.optimizedRebalance &&
+                    (err.code === kafka.CODES.ERRORS.ERR_REBALANCE_IN_PROGRESS ||
+                        err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
 
-		await new Promise<void>((resolve) => {
-			if (this.consumer && this.consumer.isConnected()) {
-				this.consumer.disconnect(resolve);
-			} else {
-				resolve();
-			}
-		});
-		this.consumer = undefined;
+                if (!shouldRetryCommit) {
+                    this.error(err);
+                }
+            }
 
-		if (this.zooKeeperClient) {
-			this.zooKeeperClient.close();
-			this.zooKeeperClient = undefined;
-		}
+            for (const offset of offsets) {
+                const deferredCommit = this.pendingCommits.get(offset.partition);
+                if (deferredCommit) {
+                    if (shouldRetryCommit) {
+                        setTimeout(() => {
+                            if (this.assignedPartitions.has(offset.partition)) {
+                                // we still own this partition. checkpoint again
+                                this.consumer?.commit(offset);
+                            }
+                        }, this.consumerOptions.commitRetryDelay);
+                        continue;
+                    }
 
-		this.assignedPartitions.clear();
-		this.pendingCommits.clear();
-		this.latestOffsets.clear();
+                    this.pendingCommits.delete(offset.partition);
 
-		if (this.closed) {
-			this.emit("closed");
-			this.removeAllListeners();
-		}
-	}
+                    if (err) {
+                        deferredCommit.reject(err);
+                    } else {
+                        deferredCommit.resolve();
 
-	public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
-		if (!this.consumer) {
-			throw new Error("Invalid consumer");
-		}
+                        this.emit("checkpoint", offset.partition, offset.offset);
+                    }
+                } else {
+                    this.error(new Error(`Unknown commit for partition ${offset.partition}`));
+                }
+            }
+        });
 
-		if (this.pendingCommits.has(partitionId)) {
-			throw new Error(`There is already a pending commit for partition ${partitionId}`);
-		}
+        consumer.on("rebalance", async (err, topicPartitions) => {
+            if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS ||
+                err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+                const newAssignedPartitions = new Set<number>(topicPartitions.map((tp) => tp.partition));
 
-		// this will be resolved in the "offset.commit" event
-		const deferredCommit = new Deferred<void>();
-		this.pendingCommits.set(partitionId, deferredCommit);
+                if (newAssignedPartitions.size === this.assignedPartitions.size &&
+                    Array.from(this.assignedPartitions).every((ap) => newAssignedPartitions.has(ap))) {
+                    // the consumer is already up to date
+                    return;
+                }
 
-		// logs are replayed from the last checkpointed offset.
-		// to avoid reprocessing the last message twice, we checkpoint at offset + 1
-		this.consumer.commit({
-			topic: this.topic,
-			partition: partitionId,
-			offset: queuedMessage.offset + 1,
-		});
+                // clear pending messages
+                this.pendingMessages.clear();
 
-		return deferredCommit.promise;
-	}
+                if (!this.consumerOptions.optimizedRebalance) {
+                    if (this.isRebalancing) {
+                        this.isRebalancing = false;
+                    } else {
+                        this.emit("rebalancing", this.getPartitions(this.assignedPartitions), err.code);
+                    }
+                }
 
-	public async pause() {
-		this.consumer?.unsubscribe();
-		this.emit("paused");
-		return Promise.resolve();
-	}
+                const originalAssignedPartitions = this.assignedPartitions;
+                this.assignedPartitions = newAssignedPartitions;
 
-	public async resume() {
-		this.consumer?.subscribe([this.topic]);
-		this.emit("resumed");
-		return Promise.resolve();
-	}
+                try {
+                    this.isRebalancing = true;
+                    const partitions = this.getPartitions(this.assignedPartitions);
+                    const partitionsWithEpoch = await this.fetchPartitionEpochs(partitions);
+                    this.emit("rebalanced", partitionsWithEpoch, err.code);
 
-	/**
-	 * Saves the latest offset for the partition and emits the data event with the message.
-	 * If we are in the middle of rebalancing and the message was sent for a partition we will own,
-	 * the message will be saved and processed after rebalancing is completed.
-	 * @param message The message
-	 */
-	private processMessage(message: kafkaTypes.Message) {
-		const partition = message.partition;
+                    // cleanup things left over from the lost partitions
+                    for (const partition of originalAssignedPartitions) {
+                        if (!newAssignedPartitions.has(partition)) {
+                            // clear latest offset
+                            this.latestOffsets.delete(partition);
 
-		if (this.isRebalancing && this.assignedPartitions.has(partition)) {
-			/*
-				It is possible to receive messages while we have not yet finished rebalancing
-				due to how we wait for the fetchPartitionEpochs call to finish before emitting the rebalanced event.
-				This means that the PartitionManager has not yet created the partition,
-				so messages will be lost since they were sent to an "untracked partition".
-				To fix this, we should temporarily store the messages and emit them once we finish rebalancing.
-			*/
+                            // reject pending commit
+                            const deferredCommit = this.pendingCommits.get(partition);
+                            if (deferredCommit) {
+                                this.pendingCommits.delete(partition);
+                                deferredCommit.reject(new Error(`Partition for commit was unassigned. ${partition}`));
+                            }
+                        }
+                    }
 
-			let pendingMessages = this.pendingMessages.get(partition);
+                    this.isRebalancing = false;
 
-			if (!pendingMessages) {
-				pendingMessages = [];
-				this.pendingMessages.set(partition, pendingMessages);
-			}
+                    for (const pendingMessages of this.pendingMessages.values()) {
+                        // process messages sent while we were rebalancing for each partition in order
+                        for (const pendingMessage of pendingMessages) {
+                            this.processMessage(pendingMessage);
+                        }
+                    }
+                } catch (ex) {
+                    this.isRebalancing = false;
+                    this.error(ex);
+                } finally {
+                    this.pendingMessages.clear();
+                }
+            } else {
+                this.error(err);
+            }
+        });
 
-			pendingMessages.push(message);
+        consumer.on("rebalance.error", (error) => {
+            this.error(error);
+        });
 
-			return;
-		}
+        consumer.on("event.error", (error) => {
+            this.error(error);
+        });
 
-		this.latestOffsets.set(partition, message.offset);
-		this.emit("data", message as IQueuedMessage);
-	}
+        consumer.on("event.throttle", (event) => {
+            this.emit("throttled", event);
+        });
 
-	private getPartitions(partitions: Set<number>): IPartition[] {
-		return Array.from(partitions).map((partition) => ({
-			topic: this.topic,
-			partition,
-			offset: -1, // n/a
-		}));
-	}
+        consumer.connect();
+    }
 
-	/**
-	 * The default node-rdkafka consumer rebalance callback with the addition
-	 * of continuing from the last seen offset for assignments that have not changed
-	 */
-	private rebalance(err: kafkaTypes.LibrdKafkaError, assignments: kafkaTypes.Assignment[]) {
-		if (!this.consumer) {
-			return;
-		}
+    public async close(reconnecting: boolean = false): Promise<void> {
+        if (this.closed) {
+            return;
+        }
 
-		try {
-			if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
-				for (const assignment of assignments) {
-					const offset = this.latestOffsets.get(assignment.partition);
-					if (offset !== undefined) {
-						// this consumer is already assigned this partition
-						// ensure we continue reading from our current offset
-						// + 1 so we do not read the latest message again
-						(assignment as kafkaTypes.TopicPartitionOffset).offset = offset + 1;
-					}
-				}
+        if (!reconnecting) {
+            // when closed outside of this class, disable reconnecting
+            this.closed = true;
+        }
 
-				this.consumer.assign(assignments);
-			} else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-				this.consumer.unassign();
-			}
-		} catch (ex) {
-			if (this.consumer.isConnected()) {
-				this.consumer.emit("rebalance.error", ex);
-			}
-		}
-	}
+        await new Promise<void>((resolve) => {
+            if (this.consumer && this.consumer.isConnected()) {
+                this.consumer.disconnect(resolve);
+            } else {
+                resolve();
+            }
+        });
+        this.consumer = undefined;
 
-	private async fetchPartitionEpochs(partitions: IPartition[]): Promise<IPartitionWithEpoch[]> {
-		let epochs: number[];
+        if (this.zooKeeperClient) {
+            this.zooKeeperClient.close();
+            this.zooKeeperClient = undefined;
+        }
 
-		if (this.zooKeeperClient) {
-			const epochsP = new Array<Promise<number>>();
-			for (const partition of partitions) {
-				epochsP.push(this.zooKeeperClient.getPartitionLeaderEpoch(this.topic, partition.partition));
-			}
+        this.assignedPartitions.clear();
+        this.pendingCommits.clear();
+        this.latestOffsets.clear();
 
-			epochs = await Promise.all(epochsP);
-		} else {
-			epochs = new Array(partitions.length).fill(0);
-		}
+        if (this.closed) {
+            this.emit("closed");
+            this.removeAllListeners();
+        }
+    }
 
-		const partitionsWithEpoch: IPartitionWithEpoch[] = [];
+    public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
+        if (!this.consumer) {
+            throw new Error("Invalid consumer");
+        }
 
-		for (let i = 0; i < partitions.length; ++i) {
-			const partitionWithEpoch = partitions[i] as IPartitionWithEpoch;
-			partitionWithEpoch.leaderEpoch = epochs[i];
-			partitionsWithEpoch.push(partitionWithEpoch);
-		}
+        if (this.pendingCommits.has(partitionId)) {
+            throw new Error(`There is already a pending commit for partition ${partitionId}`);
+        }
 
-		return partitionsWithEpoch;
-	}
+        // this will be resolved in the "offset.commit" event
+        const deferredCommit = new Deferred<void>();
+        this.pendingCommits.set(partitionId, deferredCommit);
+
+        // logs are replayed from the last checkpointed offset.
+        // to avoid reprocessing the last message twice, we checkpoint at offset + 1
+        this.consumer.commit({
+            topic: this.topic,
+            partition: partitionId,
+            offset: queuedMessage.offset + 1,
+        });
+
+        return deferredCommit.promise;
+    }
+
+    public async pause() {
+        this.consumer?.unsubscribe();
+        this.emit("paused");
+        return Promise.resolve();
+    }
+
+    public async resume() {
+        this.consumer?.subscribe([this.topic]);
+        this.emit("resumed");
+        return Promise.resolve();
+    }
+
+    /**
+     * Saves the latest offset for the partition and emits the data event with the message.
+     * If we are in the middle of rebalancing and the message was sent for a partition we will own,
+     * the message will be saved and processed after rebalancing is completed.
+     * @param message The message
+     */
+    private processMessage(message: kafkaTypes.Message) {
+        const partition = message.partition;
+
+        if (this.isRebalancing && this.assignedPartitions.has(partition)) {
+            /*
+                It is possible to receive messages while we have not yet finished rebalancing
+                due to how we wait for the fetchPartitionEpochs call to finish before emitting the rebalanced event.
+                This means that the PartitionManager has not yet created the partition,
+                so messages will be lost since they were sent to an "untracked partition".
+                To fix this, we should temporarily store the messages and emit them once we finish rebalancing.
+            */
+
+            let pendingMessages = this.pendingMessages.get(partition);
+
+            if (!pendingMessages) {
+                pendingMessages = [];
+                this.pendingMessages.set(partition, pendingMessages);
+            }
+
+            pendingMessages.push(message);
+
+            return;
+        }
+
+        this.latestOffsets.set(partition, message.offset);
+        this.emit("data", message as IQueuedMessage);
+    }
+
+    private getPartitions(partitions: Set<number>): IPartition[] {
+        return Array.from(partitions).map((partition) => ({
+            topic: this.topic,
+            partition,
+            offset: -1, // n/a
+        }));
+    }
+
+    /**
+     * The default node-rdkafka consumer rebalance callback with the addition
+     * of continuing from the last seen offset for assignments that have not changed
+     */
+    private rebalance(err: kafkaTypes.LibrdKafkaError, assignments: kafkaTypes.Assignment[]) {
+        if (!this.consumer) {
+            return;
+        }
+
+        try {
+            if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
+                for (const assignment of assignments) {
+                    const offset = this.latestOffsets.get(assignment.partition);
+                    if (offset !== undefined) {
+                        // this consumer is already assigned this partition
+                        // ensure we continue reading from our current offset
+                        // + 1 so we do not read the latest message again
+                        (assignment as kafkaTypes.TopicPartitionOffset).offset = offset + 1;
+                    }
+                }
+
+                this.consumer.assign(assignments);
+            } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+                this.consumer.unassign();
+            }
+        } catch (ex) {
+            if (this.consumer.isConnected()) {
+                this.consumer.emit("rebalance.error", ex);
+            }
+        }
+    }
+
+    private async fetchPartitionEpochs(partitions: IPartition[]): Promise<IPartitionWithEpoch[]> {
+        let epochs: number[];
+
+        if (this.zooKeeperClient) {
+            const epochsP = new Array<Promise<number>>();
+            for (const partition of partitions) {
+                epochsP.push(this.zooKeeperClient.getPartitionLeaderEpoch(this.topic, partition.partition));
+            }
+
+            epochs = await Promise.all(epochsP);
+        } else {
+            epochs = new Array(partitions.length).fill(0);
+        }
+
+        const partitionsWithEpoch: IPartitionWithEpoch[] = [];
+
+        for (let i = 0; i < partitions.length; ++i) {
+            const partitionWithEpoch = partitions[i] as IPartitionWithEpoch;
+            partitionWithEpoch.leaderEpoch = epochs[i];
+            partitionsWithEpoch.push(partitionWithEpoch);
+        }
+
+        return partitionsWithEpoch;
+    }
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -103,7 +103,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		consumer.on("connection.failure", async (error) => {
 			await this.close(true);
 
-			this.emit("error", error);
+			this.error(error);
 
 			this.connect();
 		});
@@ -122,7 +122,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 						err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
 
 				if (!shouldRetryCommit) {
-					this.emit("error", err);
+					this.error(err);
 				}
 			}
 
@@ -149,7 +149,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 						this.emit("checkpoint", offset.partition, offset.offset);
 					}
 				} else {
-					this.emit("error", new Error(`Unknown commit for partition ${offset.partition}`));
+					this.error(new Error(`Unknown commit for partition ${offset.partition}`));
 				}
 			}
 		});
@@ -210,21 +210,21 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 					}
 				} catch (ex) {
 					this.isRebalancing = false;
-					this.emit("error", ex);
+					this.error(ex);
 				} finally {
 					this.pendingMessages.clear();
 				}
 			} else {
-				this.emit("error", err);
+				this.error(err);
 			}
 		});
 
 		consumer.on("rebalance.error", (error) => {
-			this.emit("error", error);
+			this.error(error);
 		});
 
 		consumer.on("event.error", (error) => {
-			this.emit("error", error);
+            this.error(error);
 		});
 
 		consumer.on("event.throttle", (event) => {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -14,392 +14,392 @@ import { tryImportNodeRdkafka } from "./tryImport";
 const kafka = tryImportNodeRdkafka();
 
 export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
-    consumeTimeout: number;
-    consumeLoopTimeoutDelay: number;
-    optimizedRebalance: boolean;
-    commitRetryDelay: number;
-    automaticConsume: boolean;
-    additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
+	consumeTimeout: number;
+	consumeLoopTimeoutDelay: number;
+	optimizedRebalance: boolean;
+	commitRetryDelay: number;
+	automaticConsume: boolean;
+	additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
 }
 
 /**
  * Kafka consumer using the node-rdkafka library
  */
 export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
-    private readonly consumerOptions: IKafkaConsumerOptions;
-    private consumer?: kafkaTypes.KafkaConsumer;
-    private zooKeeperClient?: ZookeeperClient;
-    private closed = false;
-    private isRebalancing = true;
-    private assignedPartitions: Set<number> = new Set();
-    private readonly pendingCommits: Map<number, Deferred<void>> = new Map();
-    private readonly pendingMessages: Map<number, kafkaTypes.Message[]> = new Map();
-    private readonly latestOffsets: Map<number, number> = new Map();
+	private readonly consumerOptions: IKafkaConsumerOptions;
+	private consumer?: kafkaTypes.KafkaConsumer;
+	private zooKeeperClient?: ZookeeperClient;
+	private closed = false;
+	private isRebalancing = true;
+	private assignedPartitions: Set<number> = new Set();
+	private readonly pendingCommits: Map<number, Deferred<void>> = new Map();
+	private readonly pendingMessages: Map<number, kafkaTypes.Message[]> = new Map();
+	private readonly latestOffsets: Map<number, number> = new Map();
 
-    constructor(
-        endpoints: IKafkaEndpoints,
-        clientId: string,
-        topic: string,
-        public readonly groupId: string,
-        options?: Partial<IKafkaConsumerOptions>) {
-        super(endpoints, clientId, topic, options);
+	constructor(
+		endpoints: IKafkaEndpoints,
+		clientId: string,
+		topic: string,
+		public readonly groupId: string,
+		options?: Partial<IKafkaConsumerOptions>) {
+		super(endpoints, clientId, topic, options);
 
-        this.consumerOptions = {
-            ...options,
-            consumeTimeout: options?.consumeTimeout ?? 1000,
-            consumeLoopTimeoutDelay: options?.consumeLoopTimeoutDelay ?? 100,
-            optimizedRebalance: options?.optimizedRebalance ?? false,
-            commitRetryDelay: options?.commitRetryDelay ?? 1000,
-            automaticConsume: options?.automaticConsume ?? true,
-        };
-    }
+		this.consumerOptions = {
+			...options,
+			consumeTimeout: options?.consumeTimeout ?? 1000,
+			consumeLoopTimeoutDelay: options?.consumeLoopTimeoutDelay ?? 100,
+			optimizedRebalance: options?.optimizedRebalance ?? false,
+			commitRetryDelay: options?.commitRetryDelay ?? 1000,
+			automaticConsume: options?.automaticConsume ?? true,
+		};
+	}
 
-    protected connect() {
-        if (this.closed) {
-            return;
-        }
+	protected connect() {
+		if (this.closed) {
+			return;
+		}
 
-        const zookeeperEndpoints = this.endpoints.zooKeeper;
-        if (zookeeperEndpoints && zookeeperEndpoints.length > 0) {
-            const zooKeeperEndpoint = zookeeperEndpoints[Math.floor(Math.random() % zookeeperEndpoints.length)];
-            this.zooKeeperClient = new ZookeeperClient(zooKeeperEndpoint);
-        }
+		const zookeeperEndpoints = this.endpoints.zooKeeper;
+		if (zookeeperEndpoints && zookeeperEndpoints.length > 0) {
+			const zooKeeperEndpoint = zookeeperEndpoints[Math.floor(Math.random() % zookeeperEndpoints.length)];
+			this.zooKeeperClient = new ZookeeperClient(zooKeeperEndpoint);
+		}
 
-        const options: kafkaTypes.ConsumerGlobalConfig = {
-            "metadata.broker.list": this.endpoints.kafka.join(","),
-            "socket.keepalive.enable": true,
-            "socket.nagle.disable": true,
-            "client.id": this.clientId,
-            "group.id": this.groupId,
-            "enable.auto.commit": false,
-            "fetch.min.bytes": 1,
-            "fetch.max.bytes": 1024 * 1024,
-            "offset_commit_cb": true,
-            "rebalance_cb": this.consumerOptions.optimizedRebalance ? this.rebalance.bind(this) : true,
-            ...this.consumerOptions.additionalOptions,
-        };
+		const options: kafkaTypes.ConsumerGlobalConfig = {
+			"metadata.broker.list": this.endpoints.kafka.join(","),
+			"socket.keepalive.enable": true,
+			"socket.nagle.disable": true,
+			"client.id": this.clientId,
+			"group.id": this.groupId,
+			"enable.auto.commit": false,
+			"fetch.min.bytes": 1,
+			"fetch.max.bytes": 1024 * 1024,
+			"offset_commit_cb": true,
+			"rebalance_cb": this.consumerOptions.optimizedRebalance ? this.rebalance.bind(this) : true,
+			...this.consumerOptions.additionalOptions,
+		};
 
-        const consumer: kafkaTypes.KafkaConsumer = this.consumer =
-            new kafka.KafkaConsumer(options, { "auto.offset.reset": "latest" });
+		const consumer: kafkaTypes.KafkaConsumer = this.consumer =
+			new kafka.KafkaConsumer(options, { "auto.offset.reset": "latest" });
 
-        consumer.setDefaultConsumeTimeout(this.consumerOptions.consumeTimeout);
-        consumer.setDefaultConsumeLoopTimeoutDelay(this.consumerOptions.consumeLoopTimeoutDelay);
+		consumer.setDefaultConsumeTimeout(this.consumerOptions.consumeTimeout);
+		consumer.setDefaultConsumeLoopTimeoutDelay(this.consumerOptions.consumeLoopTimeoutDelay);
 
-        consumer.on("ready", () => {
-            consumer.subscribe([this.topic]);
+		consumer.on("ready", () => {
+			consumer.subscribe([this.topic]);
 
-            if (this.consumerOptions.automaticConsume) {
-                // start the consume loop
-                consumer.consume();
-            }
+			if (this.consumerOptions.automaticConsume) {
+				// start the consume loop
+				consumer.consume();
+			}
 
-            this.emit("connected", consumer);
-        });
+			this.emit("connected", consumer);
+		});
 
-        consumer.on("disconnected", () => {
-            this.emit("disconnected");
-        });
+		consumer.on("disconnected", () => {
+			this.emit("disconnected");
+		});
 
-        consumer.on("connection.failure", async (error) => {
-            await this.close(true);
+		consumer.on("connection.failure", async (error) => {
+			await this.close(true);
 
+			this.error(error);
+
+			this.connect();
+		});
+
+		consumer.on("data", this.processMessage.bind(this));
+
+		consumer.on("offset.commit", (err, offsets) => {
+			let shouldRetryCommit = false;
+
+			if (err) {
+				// a rebalance occurred while we were committing
+				// we can resubmit the commit if we still own the partition
+				shouldRetryCommit =
+					this.consumerOptions.optimizedRebalance &&
+					(err.code === kafka.CODES.ERRORS.ERR_REBALANCE_IN_PROGRESS ||
+						err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
+
+				if (!shouldRetryCommit) {
+					this.error(err);
+				}
+			}
+
+			for (const offset of offsets) {
+				const deferredCommit = this.pendingCommits.get(offset.partition);
+				if (deferredCommit) {
+					if (shouldRetryCommit) {
+						setTimeout(() => {
+							if (this.assignedPartitions.has(offset.partition)) {
+								// we still own this partition. checkpoint again
+								this.consumer?.commit(offset);
+							}
+						}, this.consumerOptions.commitRetryDelay);
+						continue;
+					}
+
+					this.pendingCommits.delete(offset.partition);
+
+					if (err) {
+						deferredCommit.reject(err);
+					} else {
+						deferredCommit.resolve();
+
+						this.emit("checkpoint", offset.partition, offset.offset);
+					}
+				} else {
+					this.error(new Error(`Unknown commit for partition ${offset.partition}`));
+				}
+			}
+		});
+
+		consumer.on("rebalance", async (err, topicPartitions) => {
+			if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS ||
+				err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+				const newAssignedPartitions = new Set<number>(topicPartitions.map((tp) => tp.partition));
+
+				if (newAssignedPartitions.size === this.assignedPartitions.size &&
+					Array.from(this.assignedPartitions).every((ap) => newAssignedPartitions.has(ap))) {
+					// the consumer is already up to date
+					return;
+				}
+
+				// clear pending messages
+				this.pendingMessages.clear();
+
+				if (!this.consumerOptions.optimizedRebalance) {
+					if (this.isRebalancing) {
+						this.isRebalancing = false;
+					} else {
+						this.emit("rebalancing", this.getPartitions(this.assignedPartitions), err.code);
+					}
+				}
+
+				const originalAssignedPartitions = this.assignedPartitions;
+				this.assignedPartitions = newAssignedPartitions;
+
+				try {
+					this.isRebalancing = true;
+					const partitions = this.getPartitions(this.assignedPartitions);
+					const partitionsWithEpoch = await this.fetchPartitionEpochs(partitions);
+					this.emit("rebalanced", partitionsWithEpoch, err.code);
+
+					// cleanup things left over from the lost partitions
+					for (const partition of originalAssignedPartitions) {
+						if (!newAssignedPartitions.has(partition)) {
+							// clear latest offset
+							this.latestOffsets.delete(partition);
+
+							// reject pending commit
+							const deferredCommit = this.pendingCommits.get(partition);
+							if (deferredCommit) {
+								this.pendingCommits.delete(partition);
+								deferredCommit.reject(new Error(`Partition for commit was unassigned. ${partition}`));
+							}
+						}
+					}
+
+					this.isRebalancing = false;
+
+					for (const pendingMessages of this.pendingMessages.values()) {
+						// process messages sent while we were rebalancing for each partition in order
+						for (const pendingMessage of pendingMessages) {
+							this.processMessage(pendingMessage);
+						}
+					}
+				} catch (ex) {
+					this.isRebalancing = false;
+					this.error(ex);
+				} finally {
+					this.pendingMessages.clear();
+				}
+			} else {
+				this.error(err);
+			}
+		});
+
+		consumer.on("rebalance.error", (error) => {
+			this.error(error);
+		});
+
+		consumer.on("event.error", (error) => {
             this.error(error);
+		});
 
-            this.connect();
-        });
+		consumer.on("event.throttle", (event) => {
+			this.emit("throttled", event);
+		});
 
-        consumer.on("data", this.processMessage.bind(this));
+		consumer.connect();
+	}
 
-        consumer.on("offset.commit", (err, offsets) => {
-            let shouldRetryCommit = false;
+	public async close(reconnecting: boolean = false): Promise<void> {
+		if (this.closed) {
+			return;
+		}
 
-            if (err) {
-                // a rebalance occurred while we were committing
-                // we can resubmit the commit if we still own the partition
-                shouldRetryCommit =
-                    this.consumerOptions.optimizedRebalance &&
-                    (err.code === kafka.CODES.ERRORS.ERR_REBALANCE_IN_PROGRESS ||
-                        err.code === kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
+		if (!reconnecting) {
+			// when closed outside of this class, disable reconnecting
+			this.closed = true;
+		}
 
-                if (!shouldRetryCommit) {
-                    this.error(err);
-                }
-            }
+		await new Promise<void>((resolve) => {
+			if (this.consumer && this.consumer.isConnected()) {
+				this.consumer.disconnect(resolve);
+			} else {
+				resolve();
+			}
+		});
+		this.consumer = undefined;
 
-            for (const offset of offsets) {
-                const deferredCommit = this.pendingCommits.get(offset.partition);
-                if (deferredCommit) {
-                    if (shouldRetryCommit) {
-                        setTimeout(() => {
-                            if (this.assignedPartitions.has(offset.partition)) {
-                                // we still own this partition. checkpoint again
-                                this.consumer?.commit(offset);
-                            }
-                        }, this.consumerOptions.commitRetryDelay);
-                        continue;
-                    }
+		if (this.zooKeeperClient) {
+			this.zooKeeperClient.close();
+			this.zooKeeperClient = undefined;
+		}
 
-                    this.pendingCommits.delete(offset.partition);
+		this.assignedPartitions.clear();
+		this.pendingCommits.clear();
+		this.latestOffsets.clear();
 
-                    if (err) {
-                        deferredCommit.reject(err);
-                    } else {
-                        deferredCommit.resolve();
+		if (this.closed) {
+			this.emit("closed");
+			this.removeAllListeners();
+		}
+	}
 
-                        this.emit("checkpoint", offset.partition, offset.offset);
-                    }
-                } else {
-                    this.error(new Error(`Unknown commit for partition ${offset.partition}`));
-                }
-            }
-        });
+	public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
+		if (!this.consumer) {
+			throw new Error("Invalid consumer");
+		}
 
-        consumer.on("rebalance", async (err, topicPartitions) => {
-            if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS ||
-                err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-                const newAssignedPartitions = new Set<number>(topicPartitions.map((tp) => tp.partition));
+		if (this.pendingCommits.has(partitionId)) {
+			throw new Error(`There is already a pending commit for partition ${partitionId}`);
+		}
 
-                if (newAssignedPartitions.size === this.assignedPartitions.size &&
-                    Array.from(this.assignedPartitions).every((ap) => newAssignedPartitions.has(ap))) {
-                    // the consumer is already up to date
-                    return;
-                }
+		// this will be resolved in the "offset.commit" event
+		const deferredCommit = new Deferred<void>();
+		this.pendingCommits.set(partitionId, deferredCommit);
 
-                // clear pending messages
-                this.pendingMessages.clear();
+		// logs are replayed from the last checkpointed offset.
+		// to avoid reprocessing the last message twice, we checkpoint at offset + 1
+		this.consumer.commit({
+			topic: this.topic,
+			partition: partitionId,
+			offset: queuedMessage.offset + 1,
+		});
 
-                if (!this.consumerOptions.optimizedRebalance) {
-                    if (this.isRebalancing) {
-                        this.isRebalancing = false;
-                    } else {
-                        this.emit("rebalancing", this.getPartitions(this.assignedPartitions), err.code);
-                    }
-                }
+		return deferredCommit.promise;
+	}
 
-                const originalAssignedPartitions = this.assignedPartitions;
-                this.assignedPartitions = newAssignedPartitions;
+	public async pause() {
+		this.consumer?.unsubscribe();
+		this.emit("paused");
+		return Promise.resolve();
+	}
 
-                try {
-                    this.isRebalancing = true;
-                    const partitions = this.getPartitions(this.assignedPartitions);
-                    const partitionsWithEpoch = await this.fetchPartitionEpochs(partitions);
-                    this.emit("rebalanced", partitionsWithEpoch, err.code);
+	public async resume() {
+		this.consumer?.subscribe([this.topic]);
+		this.emit("resumed");
+		return Promise.resolve();
+	}
 
-                    // cleanup things left over from the lost partitions
-                    for (const partition of originalAssignedPartitions) {
-                        if (!newAssignedPartitions.has(partition)) {
-                            // clear latest offset
-                            this.latestOffsets.delete(partition);
+	/**
+	 * Saves the latest offset for the partition and emits the data event with the message.
+	 * If we are in the middle of rebalancing and the message was sent for a partition we will own,
+	 * the message will be saved and processed after rebalancing is completed.
+	 * @param message The message
+	 */
+	private processMessage(message: kafkaTypes.Message) {
+		const partition = message.partition;
 
-                            // reject pending commit
-                            const deferredCommit = this.pendingCommits.get(partition);
-                            if (deferredCommit) {
-                                this.pendingCommits.delete(partition);
-                                deferredCommit.reject(new Error(`Partition for commit was unassigned. ${partition}`));
-                            }
-                        }
-                    }
+		if (this.isRebalancing && this.assignedPartitions.has(partition)) {
+			/*
+				It is possible to receive messages while we have not yet finished rebalancing
+				due to how we wait for the fetchPartitionEpochs call to finish before emitting the rebalanced event.
+				This means that the PartitionManager has not yet created the partition,
+				so messages will be lost since they were sent to an "untracked partition".
+				To fix this, we should temporarily store the messages and emit them once we finish rebalancing.
+			*/
 
-                    this.isRebalancing = false;
+			let pendingMessages = this.pendingMessages.get(partition);
 
-                    for (const pendingMessages of this.pendingMessages.values()) {
-                        // process messages sent while we were rebalancing for each partition in order
-                        for (const pendingMessage of pendingMessages) {
-                            this.processMessage(pendingMessage);
-                        }
-                    }
-                } catch (ex) {
-                    this.isRebalancing = false;
-                    this.error(ex);
-                } finally {
-                    this.pendingMessages.clear();
-                }
-            } else {
-                this.error(err);
-            }
-        });
+			if (!pendingMessages) {
+				pendingMessages = [];
+				this.pendingMessages.set(partition, pendingMessages);
+			}
 
-        consumer.on("rebalance.error", (error) => {
-            this.error(error);
-        });
+			pendingMessages.push(message);
 
-        consumer.on("event.error", (error) => {
-            this.error(error);
-        });
+			return;
+		}
 
-        consumer.on("event.throttle", (event) => {
-            this.emit("throttled", event);
-        });
+		this.latestOffsets.set(partition, message.offset);
+		this.emit("data", message as IQueuedMessage);
+	}
 
-        consumer.connect();
-    }
+	private getPartitions(partitions: Set<number>): IPartition[] {
+		return Array.from(partitions).map((partition) => ({
+			topic: this.topic,
+			partition,
+			offset: -1, // n/a
+		}));
+	}
 
-    public async close(reconnecting: boolean = false): Promise<void> {
-        if (this.closed) {
-            return;
-        }
+	/**
+	 * The default node-rdkafka consumer rebalance callback with the addition
+	 * of continuing from the last seen offset for assignments that have not changed
+	 */
+	private rebalance(err: kafkaTypes.LibrdKafkaError, assignments: kafkaTypes.Assignment[]) {
+		if (!this.consumer) {
+			return;
+		}
 
-        if (!reconnecting) {
-            // when closed outside of this class, disable reconnecting
-            this.closed = true;
-        }
+		try {
+			if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
+				for (const assignment of assignments) {
+					const offset = this.latestOffsets.get(assignment.partition);
+					if (offset !== undefined) {
+						// this consumer is already assigned this partition
+						// ensure we continue reading from our current offset
+						// + 1 so we do not read the latest message again
+						(assignment as kafkaTypes.TopicPartitionOffset).offset = offset + 1;
+					}
+				}
 
-        await new Promise<void>((resolve) => {
-            if (this.consumer && this.consumer.isConnected()) {
-                this.consumer.disconnect(resolve);
-            } else {
-                resolve();
-            }
-        });
-        this.consumer = undefined;
+				this.consumer.assign(assignments);
+			} else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+				this.consumer.unassign();
+			}
+		} catch (ex) {
+			if (this.consumer.isConnected()) {
+				this.consumer.emit("rebalance.error", ex);
+			}
+		}
+	}
 
-        if (this.zooKeeperClient) {
-            this.zooKeeperClient.close();
-            this.zooKeeperClient = undefined;
-        }
+	private async fetchPartitionEpochs(partitions: IPartition[]): Promise<IPartitionWithEpoch[]> {
+		let epochs: number[];
 
-        this.assignedPartitions.clear();
-        this.pendingCommits.clear();
-        this.latestOffsets.clear();
+		if (this.zooKeeperClient) {
+			const epochsP = new Array<Promise<number>>();
+			for (const partition of partitions) {
+				epochsP.push(this.zooKeeperClient.getPartitionLeaderEpoch(this.topic, partition.partition));
+			}
 
-        if (this.closed) {
-            this.emit("closed");
-            this.removeAllListeners();
-        }
-    }
+			epochs = await Promise.all(epochsP);
+		} else {
+			epochs = new Array(partitions.length).fill(0);
+		}
 
-    public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
-        if (!this.consumer) {
-            throw new Error("Invalid consumer");
-        }
+		const partitionsWithEpoch: IPartitionWithEpoch[] = [];
 
-        if (this.pendingCommits.has(partitionId)) {
-            throw new Error(`There is already a pending commit for partition ${partitionId}`);
-        }
+		for (let i = 0; i < partitions.length; ++i) {
+			const partitionWithEpoch = partitions[i] as IPartitionWithEpoch;
+			partitionWithEpoch.leaderEpoch = epochs[i];
+			partitionsWithEpoch.push(partitionWithEpoch);
+		}
 
-        // this will be resolved in the "offset.commit" event
-        const deferredCommit = new Deferred<void>();
-        this.pendingCommits.set(partitionId, deferredCommit);
-
-        // logs are replayed from the last checkpointed offset.
-        // to avoid reprocessing the last message twice, we checkpoint at offset + 1
-        this.consumer.commit({
-            topic: this.topic,
-            partition: partitionId,
-            offset: queuedMessage.offset + 1,
-        });
-
-        return deferredCommit.promise;
-    }
-
-    public async pause() {
-        this.consumer?.unsubscribe();
-        this.emit("paused");
-        return Promise.resolve();
-    }
-
-    public async resume() {
-        this.consumer?.subscribe([this.topic]);
-        this.emit("resumed");
-        return Promise.resolve();
-    }
-
-    /**
-     * Saves the latest offset for the partition and emits the data event with the message.
-     * If we are in the middle of rebalancing and the message was sent for a partition we will own,
-     * the message will be saved and processed after rebalancing is completed.
-     * @param message The message
-     */
-    private processMessage(message: kafkaTypes.Message) {
-        const partition = message.partition;
-
-        if (this.isRebalancing && this.assignedPartitions.has(partition)) {
-            /*
-                It is possible to receive messages while we have not yet finished rebalancing
-                due to how we wait for the fetchPartitionEpochs call to finish before emitting the rebalanced event.
-                This means that the PartitionManager has not yet created the partition,
-                so messages will be lost since they were sent to an "untracked partition".
-                To fix this, we should temporarily store the messages and emit them once we finish rebalancing.
-            */
-
-            let pendingMessages = this.pendingMessages.get(partition);
-
-            if (!pendingMessages) {
-                pendingMessages = [];
-                this.pendingMessages.set(partition, pendingMessages);
-            }
-
-            pendingMessages.push(message);
-
-            return;
-        }
-
-        this.latestOffsets.set(partition, message.offset);
-        this.emit("data", message as IQueuedMessage);
-    }
-
-    private getPartitions(partitions: Set<number>): IPartition[] {
-        return Array.from(partitions).map((partition) => ({
-            topic: this.topic,
-            partition,
-            offset: -1, // n/a
-        }));
-    }
-
-    /**
-     * The default node-rdkafka consumer rebalance callback with the addition
-     * of continuing from the last seen offset for assignments that have not changed
-     */
-    private rebalance(err: kafkaTypes.LibrdKafkaError, assignments: kafkaTypes.Assignment[]) {
-        if (!this.consumer) {
-            return;
-        }
-
-        try {
-            if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
-                for (const assignment of assignments) {
-                    const offset = this.latestOffsets.get(assignment.partition);
-                    if (offset !== undefined) {
-                        // this consumer is already assigned this partition
-                        // ensure we continue reading from our current offset
-                        // + 1 so we do not read the latest message again
-                        (assignment as kafkaTypes.TopicPartitionOffset).offset = offset + 1;
-                    }
-                }
-
-                this.consumer.assign(assignments);
-            } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-                this.consumer.unassign();
-            }
-        } catch (ex) {
-            if (this.consumer.isConnected()) {
-                this.consumer.emit("rebalance.error", ex);
-            }
-        }
-    }
-
-    private async fetchPartitionEpochs(partitions: IPartition[]): Promise<IPartitionWithEpoch[]> {
-        let epochs: number[];
-
-        if (this.zooKeeperClient) {
-            const epochsP = new Array<Promise<number>>();
-            for (const partition of partitions) {
-                epochsP.push(this.zooKeeperClient.getPartitionLeaderEpoch(this.topic, partition.partition));
-            }
-
-            epochs = await Promise.all(epochsP);
-        } else {
-            epochs = new Array(partitions.length).fill(0);
-        }
-
-        const partitionsWithEpoch: IPartitionWithEpoch[] = [];
-
-        for (let i = 0; i < partitions.length; ++i) {
-            const partitionWithEpoch = partitions[i] as IPartitionWithEpoch;
-            partitionWithEpoch.leaderEpoch = epochs[i];
-            partitionsWithEpoch.push(partitionWithEpoch);
-        }
-
-        return partitionsWithEpoch;
-    }
+		return partitionsWithEpoch;
+	}
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -224,7 +224,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		});
 
 		consumer.on("event.error", (error) => {
-            this.error(error);
+			this.error(error);
 		});
 
 		consumer.on("event.throttle", (event) => {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -276,7 +276,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	private async handleError(error: any) {
 		await this.close(true);
 
-		this.emit("error", error);
+		this.error(error);
 
 		this.connect();
 	}

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -40,8 +40,8 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const lambdaFactory = await plugin.create(config) as IPartitionLambdaFactory;
 
         // Inbound Kafka configuration
-        const kafkaEndpoint = config.get("kafka:lib:endpoint");
-        const zookeeperEndpoint = config.get("zookeeper:endpoint");
+        const kafkaEndpoint: string = config.get("kafka:lib:endpoint");
+        const zookeeperEndpoint: string = config.get("zookeeper:endpoint");
         const numberOfPartitions = config.get("kafka:lib:numberOfPartitions");
         const replicationFactor = config.get("kafka:lib:replicationFactor");
 
@@ -53,7 +53,11 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 
         const clientId = moniker.choose();
 
-        const endpoints = { kafka: [kafkaEndpoint], zooKeeper: [zookeeperEndpoint] };
+        const endpoints = {
+            kafka: kafkaEndpoint ? kafkaEndpoint.split(",") : [],
+            zooKeeper: zookeeperEndpoint ? zookeeperEndpoint.split(",") : [],
+         };
+
         const consumer = new RdkafkaConsumer(
             endpoints,
             clientId,

--- a/server/routerlicious/packages/services-utils/src/runner.ts
+++ b/server/routerlicious/packages/services-utils/src/runner.ts
@@ -3,12 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { AssertionError } from "assert";
 import { inspect } from "util";
 import nconf from "nconf";
 import { ILogger } from "@fluidframework/server-services-core";
-
-import { NodeErrorTrackingService } from "./errorTrackingService";
 
 /**
  * A runner represents a task that starts once start is called. And ends when either start completes
@@ -56,11 +53,6 @@ export interface IRunnerFactory<T> {
     create(resources: T): Promise<IRunner>;
 }
 
-interface IErrorTrackingConfig {
-    track: boolean;
-    endpoint: string;
-}
-
 /**
  * Uses the provided factories to create and execute a runner.
  */
@@ -73,7 +65,17 @@ export async function run<T extends IResources>(
     const runner = await runnerFactory.create(resources);
 
     // Start the runner and then listen for the message to stop it
-    const runningP = runner.start(logger);
+    const runningP = runner
+        .start(logger)
+        .catch(async (error) => {
+            await runner
+                    .stop()
+                    .catch((innerError) => {
+                        logger?.error(`Could not stop runner due to error: ${innerError}`);
+                    });
+            return Promise.reject(error);
+        });
+
     process.on("SIGTERM", () => {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         runner.stop();
@@ -99,12 +101,7 @@ export function runService<T extends IResources>(
     // eslint-disable-next-line max-len
     const config = typeof configOrPath === "string" ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory") : configOrPath;
 
-    const errorTrackingConfig = config.get("error") as IErrorTrackingConfig;
     const runningP = run(config, resourceFactory, runnerFactory, logger);
-    let errorTracker: NodeErrorTrackingService;
-    if (errorTrackingConfig.track) {
-        errorTracker = new NodeErrorTrackingService(errorTrackingConfig.endpoint, group);
-    }
 
     runningP.then(
         () => {
@@ -114,19 +111,6 @@ export function runService<T extends IResources>(
         (error) => {
             logger?.error(`${group} service exiting due to error`);
             logger?.error(inspect(error));
-            if (errorTracker === undefined) {
-                process.exit(1);
-            } else {
-                if (group === "scribe" && error.error && error.error instanceof AssertionError) {
-                    errorTracker.captureException(error);
-                } else {
-                    errorTracker.captureException(error);
-                    errorTracker.flush(10000).then(() => {
-                        process.exit(1);
-                    }, () => {
-                        process.exit(1);
-                    });
-                }
-            }
+            process.exit(1);
         });
 }

--- a/server/routerlicious/packages/services/src/kafkaFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaFactory.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IConsumer, IProducer } from "@fluidframework/server-services-core";
+import { inspect } from "util";
+import winston from "winston";
+import { IConsumer, IContextErrorData, IProducer } from "@fluidframework/server-services-core";
 import { KafkaNodeConsumer, KafkaNodeProducer } from "@fluidframework/server-services-ordering-kafkanode";
 import { RdkafkaConsumer, RdkafkaProducer } from "@fluidframework/server-services-ordering-rdkafka";
 
@@ -33,13 +35,29 @@ export function createProducer(
     pollIntervalMs?: number,
     numberOfPartitions?: number,
     replicationFactor?: number): IProducer {
+    let producer: IProducer;
+
     if (type === "rdkafka") {
-        return new RdkafkaProducer(
+        producer = new RdkafkaProducer(
             { kafka: [kafkaEndPoint] },
             clientId,
             topic,
             { enableIdempotence, pollIntervalMs, numberOfPartitions, replicationFactor });
+
+        producer.on("error", (error, errorData: IContextErrorData) => {
+            if (errorData?.restart) {
+                throw new Error(error);
+            } else {
+                winston.error("Kafka Producer emitted an error that is not configured to restart the process.");
+                winston.error(inspect(error));
+            }
+        });
+    } else {
+        producer =  new KafkaNodeProducer({ kafkaHost: kafkaEndPoint }, clientId, topic);
+        producer.on("error", (error) => {
+            winston.error(error);
+        });
     }
 
-    return new KafkaNodeProducer({ kafkaHost: kafkaEndPoint }, clientId, topic);
+    return producer;
 }


### PR DESCRIPTION
When running the ordering service with the RdKafka library, if there is a Kafka error (example: brokers unavailable), microservices do not restart because of open handles related to Kafka, getting stuck and requiring manual intervention even after the Kafka service is stabilized. Also, RdKafka automatically retries requests, so we do not need to emit errors which would force the process to crash. This Pull Request addresses those two points:

1. Improve Kafka error event handling, skipping process restarts when not required
2. Improve the lambda runner infrastructure to call runner.stop() upon runner errors, and making sure we close Kafka consumers during that process

Other minor fixes include:

- fixing a bug in RdKafka ResourcesFactory (where we would populate the Kafka and ZooKeeper endpoints lists with `undefined` if the associated config was not found)
- making local setup only use 1 replica for Kafka partitions (since the local setup only uses one Kafka broker)
- removing obsolete `errorTracker` in `runner.ts`
- Adding default `on("error)` listeners for Kafka Producers in `kafkaFactory.ts`, centralizing the setup of those listeners. Before, we only had setup one listener for Alfred, so moving the logic over to `kafkaFactory.ts` makes sure that other lambdas that use Kafka Producers (Deli and Scribe) can benefit from those listeners

Validation:
- Built and ran the service both using RdKafka and Kafka-Node libraries. Stopped the Kafka service, and observed behavior in microservices.
- For RdKafka, the processes don't hang anymore on Kafka inssues. They do not crash since we let RdKafka resolve the problem internally.
- For RdKafka, When other dependency becomes unavailable (for example, after stopping MongoDB), services crash and restart since Kafka connections are closed properly by calling `runner.stop()`
- For Kafka-Node, the behavior remains consistent.
- In all cases, the system stabilizes when Kafka brokers become available again, and changes made by clients in the meantime are synchronized properly.
- Unit tests pass