### PR TITLE
create sort indexes for cosmosdb connection

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -22,7 +22,7 @@ data:
         "mongo": {
             "endpoint": "{{ .Values.mongodb.url }}",
             "expireAfterSeconds": "{{ .Values.mongodb.expireAfterSeconds }}",
-            "createSortIndexes": "{{ .Values.mongodb.createSortIndexes }}",
+            "createCosmosDBIndexes": "{{ .Values.mongodb.createCosmosDBIndexes }}",
             "collectionNames": {
                 "deltas": "deltas",
                 "documents": "documents",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -22,6 +22,7 @@ data:
         "mongo": {
             "endpoint": "{{ .Values.mongodb.url }}",
             "expireAfterSeconds": "{{ .Values.mongodb.expireAfterSeconds }}",
+            "createSortIndexes": "{{ .Values.mongodb.createSortIndexes }}",
             "collectionNames": {
                 "deltas": "deltas",
                 "documents": "documents",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -68,6 +68,7 @@ zookeeper:
 mongodb:
   url: mongodb_url
   expireAfterSeconds: -1
+  createSortIndexes: false
 
 rabbitmq:
   connectionString: ""

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -68,7 +68,7 @@ zookeeper:
 mongodb:
   url: mongodb_url
   expireAfterSeconds: -1
-  createSortIndexes: false
+  createCosmosDBIndexes: false
 
 rabbitmq:
   connectionString: ""

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -10,7 +10,7 @@
     "mongo": {
         "endpoint": "mongodb://mongodb:27017",
         "expireAfterSeconds": -1,
-        "createSortIndexes": false,
+        "createCosmosDBIndexes": false,
         "collectionNames": {
             "deltas": "deltas",
             "rawdeltas": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -10,6 +10,7 @@
     "mongo": {
         "endpoint": "mongodb://mongodb:27017",
         "expireAfterSeconds": -1,
+        "createSortIndexes": false,
         "collectionNames": {
             "deltas": "deltas",
             "rawdeltas": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -20,6 +20,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const mongoUrl = config.get("mongo:endpoint") as string;
     const documentsCollectionName = config.get("mongo:collectionNames:documents");
     const messagesCollectionName = config.get("mongo:collectionNames:scribeDeltas");
+    const createSortIndexes = config.get("mongo:createSortIndexes");
     const kafkaEndpoint = config.get("kafka:lib:endpoint");
     const kafkaLibrary = config.get("kafka:lib:name");
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
@@ -42,6 +43,10 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         client.collection<IDocument>(documentsCollectionName),
         client.collection<ISequencedOperationMessage>(messagesCollectionName),
     ]);
+
+    if (createSortIndexes) {
+        await scribeDeltas.createIndex({ "operation.sequenceNumber": 1 }, false);
+    }
 
     await scribeDeltas.createIndex(
         {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -54,15 +54,18 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
 
     if (createCosmosDBIndexes) {
         await scribeDeltas.createIndex({ "operation.sequenceNumber": 1 }, false);
-        await scribeDeltas.createTTLIndex({_ts:1}, mongoExpireAfterSeconds);
     }
 
     if (mongoExpireAfterSeconds > 0) {
-        await scribeDeltas.createTTLIndex(
-            {
-                mongoTimestamp: 1,
-            },
-            mongoExpireAfterSeconds);
+        if (createCosmosDBIndexes) {
+            await scribeDeltas.createTTLIndex({_ts:1}, mongoExpireAfterSeconds);
+        } else {
+            await scribeDeltas.createTTLIndex(
+                {
+                    mongoTimestamp: 1,
+                },
+                mongoExpireAfterSeconds);
+        }
     }
 
     const producer = createProducer(

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -20,7 +20,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const mongoUrl = config.get("mongo:endpoint") as string;
     const documentsCollectionName = config.get("mongo:collectionNames:documents");
     const messagesCollectionName = config.get("mongo:collectionNames:scribeDeltas");
-    const createSortIndexes = config.get("mongo:createSortIndexes");
+    const createCosmosDBIndexes = config.get("mongo:createCosmosDBIndexes");
     const kafkaEndpoint = config.get("kafka:lib:endpoint");
     const kafkaLibrary = config.get("kafka:lib:name");
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
@@ -52,8 +52,9 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         },
         true);
 
-    if (createSortIndexes) {
+    if (createCosmosDBIndexes) {
         await scribeDeltas.createIndex({ "operation.sequenceNumber": 1 }, false);
+        await scribeDeltas.createTTLIndex({_ts:1}, mongoExpireAfterSeconds);
     }
 
     if (mongoExpireAfterSeconds > 0) {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -44,10 +44,6 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         client.collection<ISequencedOperationMessage>(messagesCollectionName),
     ]);
 
-    if (createSortIndexes) {
-        await scribeDeltas.createIndex({ "operation.sequenceNumber": 1 }, false);
-    }
-
     await scribeDeltas.createIndex(
         {
             "documentId": 1,
@@ -55,6 +51,10 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
             "tenantId": 1,
         },
         true);
+
+    if (createSortIndexes) {
+        await scribeDeltas.createIndex({ "operation.sequenceNumber": 1 }, false);
+    }
 
     if (mongoExpireAfterSeconds > 0) {
         await scribeDeltas.createTTLIndex(

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -12,7 +12,7 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
     const mongoUrl = config.get("mongo:endpoint") as string;
     const mongoExpireAfterSeconds = config.get("mongo:expireAfterSeconds") as number;
     const deltasCollectionName = config.get("mongo:collectionNames:deltas");
-    const createSortIndexes = config.get("mongo:createSortIndexes");
+    const createCosmosDBIndexes = config.get("mongo:createCosmosDBIndexes");
     const mongoFactory = new services.MongoDbFactory(mongoUrl);
     const mongoManager = new MongoManager(mongoFactory, false);
 
@@ -27,7 +27,7 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
         },
         true);
 
-    if (createSortIndexes) {
+    if (createCosmosDBIndexes) {
         await opCollection.createIndex({
             "operation.term": 1,
             "operation.sequenceNumber": 1,
@@ -36,6 +36,8 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
         await opCollection.createIndex({
             "operation.sequenceNumber": 1,
         }, false);
+
+        await opCollection.createTTLIndex({_ts:1}, mongoExpireAfterSeconds);
     }
 
     if (mongoExpireAfterSeconds > 0) {

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -36,17 +36,19 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
         await opCollection.createIndex({
             "operation.sequenceNumber": 1,
         }, false);
-
-        await opCollection.createTTLIndex({_ts:1}, mongoExpireAfterSeconds);
     }
 
     if (mongoExpireAfterSeconds > 0) {
-        await opCollection.createTTLIndex(
-            {
-                mongoTimestamp: 1,
-            },
-            mongoExpireAfterSeconds,
-        );
+        if (createCosmosDBIndexes) {
+            await opCollection.createTTLIndex({_ts:1}, mongoExpireAfterSeconds);
+        } else {
+            await opCollection.createTTLIndex(
+                {
+                    mongoTimestamp: 1,
+                },
+                mongoExpireAfterSeconds,
+            );
+        }
     }
 
     return new ScriptoriumLambdaFactory(mongoManager, opCollection);

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -18,17 +18,6 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
 
     const db = await mongoManager.getDatabase();
     const opCollection = db.collection(deltasCollectionName);
-    if (createSortIndexes) {
-        await opCollection.createIndex({
-            "operation.sequenceNumber": 1,
-        }, false);
-
-        await opCollection.createIndex({
-            "operation.term": 1,
-            "operation.sequenceNumber": 1,
-        }, false);
-    }
-
     await opCollection.createIndex(
         {
             "documentId": 1,
@@ -37,6 +26,17 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
             "tenantId": 1,
         },
         true);
+
+    if (createSortIndexes) {
+        await opCollection.createIndex({
+            "operation.term": 1,
+            "operation.sequenceNumber": 1,
+        }, false);
+
+        await opCollection.createIndex({
+            "operation.sequenceNumber": 1,
+        }, false);
+    }
 
     if (mongoExpireAfterSeconds > 0) {
         await opCollection.createTTLIndex(


### PR DESCRIPTION
When we use CosmosDB mongo API instance instead of native mongo, clicker does not work and scribe crashes and restarts due to a MongoError: "The index path corresponding to the specified order-by item is excluded". 

This is because Cosmos DB API for MongoDB indexing works differently from native MongoDB. For sorting, you need to create an index that precisely matches the query that you plan to use for sorting:

https://docs.microsoft.com/en-us/azure/cosmos-db/mongodb-indexing#compound-indexes-mongodb-server-version-36

Adding the precise indexes in scribe and scriptorium fixes the issue. Put behind a config, so the current OSS implementation will be the same, unless the config is set to true.

Tested with diceroller in OSS with a default fluid tenant, works correctly both when config is set to true and set to false. 

EDIT: In addition, added new TTL index on the field "_ts" which is the only way to set TTL in CosmosDB:

https://docs.microsoft.com/en-us/azure/cosmos-db/mongodb-time-to-live

Changed config name to CreateCosmosDBIndexes and put the ttl index creation under the same config.
Will clean up the mongoTimeStamp TTL index in a separate PR after migrating to CosmosDB