### PR TITLE
Added GC tests when GC runs in test mode where unreferenced content is immediately deleted

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1577,6 +1577,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 // Remove this node's route ("/") and notify data stores of routes that are used in it.
                 const usedRoutes = referencedNodeIds.filter((id: string) => { return id !== "/"; });
                 this.dataStores.updateUsedRoutes(usedRoutes);
+
+                // If we are running in GC test mode, delete objects for unused routes. This enables testing
+                // scenarios involving access to deleted data.
+                if (this.options.runGCInTestMode) {
+                    this.dataStores.deleteUnusedRoutes(deletedNodeIds);
+                }
             } catch (error) {
                 event.cancel(gcStats, error);
                 throw error;

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -67,6 +67,12 @@ import { FluidDataStoreContext, LocalFluidDataStoreContext } from "./dataStoreCo
         return this._contexts.get(id);
     }
 
+    public delete(id: string): boolean {
+        this.deferredContexts.delete(id);
+        this.notBoundContexts.delete(id);
+        return this._contexts.delete(id);
+    }
+
     /**
      * Return the unbound local context with the given id,
      * or undefined if it's not found or not unbound.

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -507,6 +507,20 @@ export class DataStores implements IDisposable {
     }
 
     /**
+     * When running GC in test mode, this is called to delete objects whose routes are unused. This enables testing
+     * scenarios with accessing deleted content.
+     * @param unusedRoutes - The routes that are unused in all data stores in this Container.
+     */
+    public deleteUnusedRoutes(unusedRoutes: string[]) {
+        assert(this.runtime.options.runGCInTestMode, "Data stores should be deleted only in GC test mode");
+        for (const route of unusedRoutes) {
+            // Delete the contexts of unused data stores.
+            const dataStoreId = route.split("/")[1];
+            this.contexts.delete(dataStoreId);
+        }
+    }
+
+    /**
      * Returns the outbound routes of this channel. Only root data stores are considered referenced and their paths are
      * part of outbound routes.
      */

--- a/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
@@ -12,7 +12,7 @@ import { assert, TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { Container } from "@fluidframework/container-loader";
-import { SummaryType } from "@fluidframework/protocol-definitions";
+import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
@@ -29,128 +29,215 @@ class TestDataObject extends DataObject {
 }
 
 // REVIEW: enable compat testing?
-describeNoCompat("GC in summary", (getTestObjectProvider) => {
-    const dataObjectFactory = new DataObjectFactory(
-        "TestDataObject",
-        TestDataObject,
-        [],
-        []);
-    const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
-        gcOptions: { gcAllowed: true },
-    };
-    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-        dataObjectFactory,
-        [
-            [dataObjectFactory.type, Promise.resolve(dataObjectFactory)],
-        ],
-        undefined,
-        undefined,
-        flattenRuntimeOptions(runtimeOptions),
-    );
+describeNoCompat("Garbage Collection", (getTestObjectProvider) => {
+    // If deleteUnreferencedContent is true, GC is run in test mode where content that is not referenced is
+    // deleted after each GC run.
+    const tests = (deleteUnreferencedContent: boolean = false) => {
+        const dataObjectFactory = new DataObjectFactory(
+            "TestDataObject",
+            TestDataObject,
+            [],
+            []);
+        const runtimeOptions: IContainerRuntimeOptions = {
+            summaryOptions: { generateSummaries: false },
+            gcOptions: { gcAllowed: true },
+        };
+        const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+            dataObjectFactory,
+            [
+                [dataObjectFactory.type, Promise.resolve(dataObjectFactory)],
+            ],
+            undefined,
+            undefined,
+            flattenRuntimeOptions(runtimeOptions),
+        );
 
-    let provider: ITestObjectProvider;
-    let containerRuntime: ContainerRuntime;
-    let defaultDataStore: TestDataObject;
+        let provider: ITestObjectProvider;
+        let containerRuntime: ContainerRuntime;
+        let defaultDataStore: TestDataObject;
 
-    const createContainer = async (): Promise<IContainer> => provider.createContainer(runtimeFactory);
+        async function createContainer(): Promise<IContainer> {
+            // If deleteUnreferencedContent is true, set the `runGCInTestMode` loader option which will instruct GC to
+            // run in test mode.
+            const loaderOptions = deleteUnreferencedContent ? { runGCInTestMode: true } : undefined;
+            return provider.createContainer(runtimeFactory, loaderOptions);
+        }
 
-    // Summarizes the container and validates that the data store's reference state is correct in the summary.
-    async function validateDataStoreReferenceState(dataStoreId: string, referenced: boolean) {
-        await provider.ensureSynchronized();
-        const { summary } = await containerRuntime.summarize({
-            runGC: true,
-            fullTree: true,
-            trackState: false,
-            summaryLogger: new TelemetryNullLogger(),
-        });
-
-        // For unreferenced nodes, the unreferenced flag in its summary tree is undefined.
-        const expectedUnreferenced = referenced ? undefined : true;
-        let found = false;
-        for (const [id, summaryObject] of Object.entries(summary.tree)) {
-            if (id === dataStoreId) {
-                assert(summaryObject.type === SummaryType.Tree, `Data store ${dataStoreId}'s entry is not a tree`);
+        /**
+         * Validates that the summary trees of children have the given reference state.
+         */
+        function validateChildReferenceStates(summary: ISummaryTree, referenced: boolean) {
+            const expectedUnreferenced = referenced ? undefined : true;
+            for (const [ id, summaryObject ] of Object.entries(summary.tree)) {
+                if (summaryObject.type !== SummaryType.Tree) {
+                    continue;
+                }
                 assert(
                     summaryObject.unreferenced === expectedUnreferenced,
-                    `Data store ${dataStoreId} should be ${referenced ? "referenced" : "unreferenced"}`,
+                    `Summary tree ${id} should be ${ referenced ? "referenced" : "unreferenced" }`,
                 );
-                found = true;
-                break;
+                validateChildReferenceStates(summaryObject, referenced);
             }
         }
-        assert(found, `Data store ${dataStoreId} is not in the summary!`);
-    }
 
-    beforeEach(async () => {
-        provider = getTestObjectProvider();
-        const container = await createContainer() as Container;
-        defaultDataStore = await requestFluidObject<TestDataObject>(container, "/");
-        containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
+        /**
+         * Validates that the data store with the given id is represented correctly in the summary.
+         * For referenced data stores:
+         *   - The unreferenced property in its entry in the summary should be undefined.
+         * For unreferenced data stores:
+         *   - If deleteUnreferencedContent is true, its entry should not be in the summary.
+         *   - Otherwise, he unreferenced property in its entry in the summary should be true.
+         */
+        function validateDataStoreInSummary(summary: ISummaryTree, dataStoreId: string, referenced: boolean) {
+            let dataStoreTree: ISummaryTree | undefined;
+            for (const [ id, summaryObject ] of Object.entries(summary.tree)) {
+                if (id === dataStoreId) {
+                    assert(
+                        summaryObject.type === SummaryType.Tree,
+                        `Data store ${dataStoreId}'s entry is not a tree`,
+                    );
+                    dataStoreTree = summaryObject;
+                    break;
+                }
+            }
 
-        // Wait for the Container to get connected.
-        if (!container.connected) {
-            await new Promise<void>((resolve) => container.on("connected", () => resolve()));
+            // If deleteUnreferencedContent is true, unreferenced data stores are deleted in each summary. So,
+            // the summary should not contain the data store entry.
+            if (deleteUnreferencedContent && !referenced) {
+                assert(dataStoreTree === undefined, `Data store ${dataStoreId} should not be in the summary!`);
+            } else {
+                // For referenced data store, the unreferenced flag in its summary tree is undefined.
+                const expectedUnreferenced = referenced ? undefined : true;
+                assert(dataStoreTree !== undefined, `Data store ${dataStoreId} is not in the summary!`);
+                assert(
+                    dataStoreTree.unreferenced === expectedUnreferenced,
+                    `Data store ${dataStoreId} should be ${ referenced ? "referenced" : "unreferenced" }`,
+                );
+
+                // Validate that the summary trees of its children are marked as referenced. Currently, GC only runs
+                // at data store layer so everything below that layer is marked as referenced.
+                validateChildReferenceStates(dataStoreTree, true /* referenced */);
+            }
         }
+
+        /**
+         * Validates that the request to load the data store with the given id succeeds / fail as expected.
+         * For referenced data stores, we should always be able to load them.
+         * For unreferenced data store:
+         *   - If deleteUnreferencedContent is true, the load should fail with 404 because the data store is deleted.
+         *   - Otherwise, the load should pass because the data store exists.
+         */
+        async function validateDataStoreLoad(dataStoreId: string, referenced: boolean) {
+            const response = await containerRuntime.resolveHandle({
+                url: `/${dataStoreId}`, headers: { wait: false },
+            });
+            // If deleteUnreferencedContent is true, unreferenced data stores are deleted after GC runs. So, we should
+            // get a 404 response. Otherwise, we should get a 200.
+            const expectedStatus = deleteUnreferencedContent && !referenced ? 404 : 200;
+            assert(
+                response.status === expectedStatus,
+                `Data store ${dataStoreId} ${ referenced ? "should" : "should not" } have loaded`,
+            );
+        }
+
+        /**
+         * Summarizes the container and validates that the data store with the given id is correctly represented in
+         * the summary. Also validates that the data store load succeeds / fails as expected.
+         */
+        async function validateDataStoreReferenceState(dataStoreId: string, referenced: boolean) {
+            await provider.ensureSynchronized();
+            const { summary } = await containerRuntime.summarize({
+                runGC: true,
+                fullTree: true,
+                trackState: false,
+                summaryLogger: new TelemetryNullLogger(),
+            });
+
+            await validateDataStoreLoad(dataStoreId, referenced);
+            validateDataStoreInSummary(summary, dataStoreId, referenced);
+        }
+
+        beforeEach(async () => {
+            provider = getTestObjectProvider();
+            const container = await createContainer() as Container;
+            defaultDataStore = await requestFluidObject<TestDataObject>(container, "/");
+            containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
+
+            // Wait for the Container to get connected.
+            if (!container.connected) {
+                await new Promise<void>((resolve) => container.on("connected", () => resolve()));
+            }
+        });
+
+        it("marks default data store as referenced", async () => {
+            await validateDataStoreReferenceState(defaultDataStore.id, true /* referenced */);
+        });
+
+        it("marks root data stores as referenced", async () => {
+            const rootDataStore = await dataObjectFactory.createRootInstance("rootDataStore", containerRuntime);
+            await validateDataStoreReferenceState(rootDataStore.id, true /* referenced */);
+        });
+
+        it("marks non-root data stores as referenced / unreferenced correctly", async () => {
+            const dataStore = await dataObjectFactory.createInstance(containerRuntime);
+            // Add data store's handle in root component and verify its marked as referenced.
+            {
+                defaultDataStore._root.set("nonRootDS", dataStore.handle);
+                await validateDataStoreReferenceState(dataStore.id, true /* referenced */);
+            }
+
+            // Remove its handle and verify its marked as unreferenced.
+            {
+                defaultDataStore._root.delete("nonRootDS");
+                await validateDataStoreReferenceState(dataStore.id, false /* referenced */);
+            }
+
+            // Add data store's handle back in root component. If deleteUnreferencedContent is true, the data store
+            // should get deleted and should remain unreferenced. Otherwise, it should be referenced back.
+            {
+                defaultDataStore._root.set("nonRootDS", dataStore.handle);
+                await validateDataStoreReferenceState(
+                    dataStore.id, deleteUnreferencedContent ? false : true /* referenced */);
+            }
+        });
+
+        it("marks non-root data stores with handle in unreferenced data stores as unreferenced", async () => {
+            // Create a non-root data store - dataStore1.
+            const dataStore1 = await dataObjectFactory.createInstance(containerRuntime);
+            // Add dataStore1's handle in root component and verify its marked as referenced.
+            {
+                defaultDataStore._root.set("nonRootDS1", dataStore1.handle);
+                await validateDataStoreReferenceState(dataStore1.id, true /* referenced */);
+            }
+
+            // Remove dataStore1's handle and verify its marked as unreferenced.
+            {
+                defaultDataStore._root.delete("nonRootDS1");
+                await validateDataStoreReferenceState(dataStore1.id, false /* referenced */);
+            }
+
+            // Create another non-root data store - dataStore2.
+            const dataStore2 = await dataObjectFactory.createInstance(containerRuntime);
+            // Add dataStore2's handle in root component and verify its marked as referenced.
+            {
+                defaultDataStore._root.set("nonRootDS2", dataStore2.handle);
+                await validateDataStoreReferenceState(dataStore2.id, true /* referenced */);
+            }
+
+            // Remove dataStore2's handle from root component and add to dataStore1 (which is unreferenced).
+            {
+                defaultDataStore._root.delete("nonRootDS2");
+                dataStore1._root.set("nonRootDS2", dataStore2.handle);
+                await validateDataStoreReferenceState(dataStore2.id, false /* referenced */);
+            }
+        });
+    };
+
+    describe("Verify data store state when unreferenced content is marked", () => {
+        tests();
     });
 
-    it("marks default data store as referenced", async () => {
-        await validateDataStoreReferenceState(defaultDataStore.id, true /* referenced */);
-    });
-
-    it("marks root data stores as referenced", async () => {
-        const rootDataStore = await dataObjectFactory.createRootInstance("rootDataStore", containerRuntime);
-        await validateDataStoreReferenceState(rootDataStore.id, true /* referenced */);
-    });
-
-    it("marks non-root data stores as referenced / unreferenced correctly", async () => {
-        const dataStore = await dataObjectFactory.createInstance(containerRuntime);
-        // Add data store's handle in root component and verify its marked as referenced.
-        {
-            defaultDataStore._root.set("nonRootDS", dataStore.handle);
-            await validateDataStoreReferenceState(dataStore.id, true /* referenced */);
-        }
-
-        // Remove its handle and verify its marked as unreferenced.
-        {
-            defaultDataStore._root.delete("nonRootDS");
-            await validateDataStoreReferenceState(dataStore.id, false /* referenced */);
-        }
-
-        // Add data store's handle back in root component and verify its marked as referenced.
-        {
-            defaultDataStore._root.set("nonRootDS", dataStore.handle);
-            await validateDataStoreReferenceState(dataStore.id, true /* referenced */);
-        }
-    });
-
-    it("marks non-root data stores with handle in unreferenced data stores as unreferenced", async () => {
-        const dataStore1 = await dataObjectFactory.createInstance(containerRuntime);
-        // Add data store's handle in root component and verify its marked as referenced.
-        {
-            defaultDataStore._root.set("nonRootDS1", dataStore1.handle);
-            await validateDataStoreReferenceState(dataStore1.id, true /* referenced */);
-        }
-
-        // Remove its handle and verify its marked as unreferenced.
-        {
-            defaultDataStore._root.delete("nonRootDS1");
-            await validateDataStoreReferenceState(dataStore1.id, false /* referenced */);
-        }
-
-        // Create another non-root data store.
-        const dataStore2 = await dataObjectFactory.createInstance(containerRuntime);
-        // Add data store's handle in root component and verify its marked as referenced.
-        {
-            defaultDataStore._root.set("nonRootDS2", dataStore2.handle);
-            await validateDataStoreReferenceState(dataStore2.id, true /* referenced */);
-        }
-
-        // Remove its handle from root component and add to dataStore1 (which is unreferenced).
-        {
-            defaultDataStore._root.delete("nonRootDS2");
-            dataStore1._root.set("nonRootDS2", dataStore2.handle);
-            await validateDataStoreReferenceState(dataStore2.id, false /* referenced */);
-        }
+    describe("Verify data store state when unreferenced content is deleted", () => {
+        tests(true /* deleteUnreferencedContent */);
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
@@ -162,11 +162,6 @@ describeNoCompat("Garbage Collection", (getTestObjectProvider) => {
             const container = await createContainer() as Container;
             defaultDataStore = await requestFluidObject<TestDataObject>(container, "/");
             containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
-
-            // Wait for the Container to get connected.
-            if (!container.connected) {
-                await new Promise<void>((resolve) => container.on("connected", () => resolve()));
-            }
         });
 
         it("marks default data store as referenced", async () => {


### PR DESCRIPTION
- Added GC test mode - Every time GC runs, unused data stores are immediately removed from the container runtime's context list. This will enable us to test that we correctly handles scenarios where content is deleted. For example - the subsequent summary will not have an entry for deleted data stores, requests for deleted data stores will fail with 404.
- Added end-to-end tests with this mode enabled.
- Currently, the test mode can be enabled via `runGCInTestMode` loader option.