### PR TITLE
Make token claims errors in r11s more specific

### DIFF
--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -1,14 +1,66 @@
 > **Note:** These breaking changes are only relevant to the server packages and images released from `./routerlicious`.
 
+## 0.1022 Breaking Changes
+
+- [@fluidframework/server-services-client@0.1022](#@fluidframework/server-services-client@0.1022)
+  - [`client.validateTokenClaims` no longer contains token expiration logic](#`client.validateTokenClaims`-no-longer-contains-token-expiration-logic)
+  - [`client.validateTokenClaims` throws on invalid claims](#`client.validateTokenClaims`-throws-on-invalid-claims)
+- [@fluidframework/server-services-utils@0.1022](#@fluidframework/server-services-utils@0.1022)
+  - [`utils.validateTokenClaims` no longer contains token expiration logic](#`utils.validateTokenClaims`-no-longer-contains-token-expiration-logic)
+  - [`utils.validateTokenClaims` throws on invalid claims](#`utils.validateTokenClaims`-throws-on-invalid-claims)
+
+### @fluidframework/server-services-client@0.1022
+
+#### `client.validateTokenClaims` no longer contains token expiration logic
+
+Token expiration logic has been moved from `validateTokenClaims` to `validateTokenClaimsExpiration`. To maintain functionality, use the two in succession. For example,
+
+```ts
+import {
+    validateTokenClaims,
+    validateTokenClaimsExpiration,
+} from "@fluidframework/server-services-client";
+
+const claims = validateTokenClaims(token, tenantId, documentId);
+if (isTokenExpiryEnabled) {
+    validateTokenClaimsExpiration(claims, maxTokenLifetimeSec)
+}
+```
+
+#### `client.validateTokenClaims` throws on invalid claims
+
+`validateTokenClaims` previously returned `undefined` if claims were invalid. Now, instead, it will throw a NetworkError that contains a status code (i.e. 401 or 403).
+
+### @fluidframework/server-services-utils@0.1022
+
+#### `utils.validateTokenClaims` no longer contains token expiration logic
+
+Token expiration logic has been moved from `validateTokenClaims` to @fluidframework/server-services-client's `validateTokenClaimsExpiration`. To maintain functionality, use the two in succession. For example,
+
+```ts
+import { validateTokenClaims } from "@fluidframework/server-services-utils";
+import { validateTokenClaimsExpiration } from "@fluidframework/server-services-client";
+
+const claims = validateTokenClaims(token, tenantId, documentId);
+if (isTokenExpiryEnabled) {
+    validateTokenClaimsExpiration(claims, maxTokenLifetimeSec)
+}
+```
+
+
+#### `utils.validateTokenClaims` throws on invalid claims
+
+`validateTokenClaims` previously returned `undefined` if claims were invalid. Now, instead, it will throw a NetworkError that contains a status code (i.e. 401 or 403).
+
 ## 0.1020 Breaking Changes
 
-- [@fluidframework/server-services-client](#@fluidframework/server-services-client)
+- [@fluidframework/server-services-client@0.1020](#@fluidframework/server-services-client@0.1020)
   - [`RestWrapper` is now an abstract class](#`restwrapper`-is-now-an-abstract-class)
   - [`Historian` class no longer handles request headers](#`historian`-class-no-longer-handles-request-headers)
-- [@fluidframework/server-routerlicious-base](#@fluidframework/server-routerlicious-base)
+- [@fluidframework/server-routerlicious-base@0.1020](#@fluidframework/server-routerlicious-base@0.1020)
   - [`Alfred` endpoints deltas/ and documents/ now validate token for every incoming request](#`alfred`-endpoints-deltas-and-documents-now-validate-token-for-every-incoming-request)
 
-### @fluidframework/server-services-client
+### @fluidframework/server-services-client@0.1020
 
 #### `RestWrapper` is now an abstract class
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -16,7 +16,12 @@ import {
     MessageType,
     NackErrorType,
 } from "@fluidframework/protocol-definitions";
-import { canSummarize, canWrite, validateTokenClaims } from "@fluidframework/server-services-client";
+import {
+    canSummarize,
+    canWrite,
+    validateTokenClaims,
+    validateTokenClaimsExpiration,
+} from "@fluidframework/server-services-client";
 
 import safeStringify from "json-stringify-safe";
 import * as semver from "semver";
@@ -197,13 +202,7 @@ export function configureWebSocketServices(
             const token = message.token;
             const claims = validateTokenClaims(token,
                 message.id,
-                message.tenantId,
-                maxTokenLifetimeSec,
-                isTokenExpiryEnabled);
-            if (!claims) {
-                // eslint-disable-next-line prefer-promise-reject-errors
-                return Promise.reject({ code: 401, message: "Invalid claims" });
-            }
+                message.tenantId);
 
             try {
                 await tenantManager.verifyToken(claims.tenantId, token);
@@ -267,17 +266,9 @@ export function configureWebSocketServices(
                 clientId,
                 messageClient as IClient);
 
-            if (isTokenExpiryEnabled && claims.exp) {
-                const lifeTimeMSec = (claims.exp * 1000) - Math.round((new Date()).getTime());
-                if (lifeTimeMSec > 0) {
-                    setExpirationTimer(lifeTimeMSec);
-                } else {
-                    // eslint-disable-next-line prefer-promise-reject-errors
-                    return Promise.reject({
-                        code: 401,
-                        message: "Invalid token expiry",
-                    });
-                }
+            if (isTokenExpiryEnabled) {
+                const lifeTimeMSec = validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
+                setExpirationTimer(lifeTimeMSec);
             }
 
             let connectedMessage: IConnected;

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -6,6 +6,7 @@
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import { IClient, IClientJoin, ScopeType } from "@fluidframework/protocol-definitions";
+import { validateTokenClaimsExpiration } from "@fluidframework/server-services-client";
 import * as core from "@fluidframework/server-services-core";
 import {
     validateTokenClaims,
@@ -172,9 +173,9 @@ async function verifyToken(request: Request, tenantManager: core.ITenantManager,
     }
     const tenantId = getParam(request.params, "tenantId");
     const documentId = getParam(request.params, "id");
-    const claims = validateTokenClaims(token, documentId, tenantId, maxTokenLifetimeSec, isTokenExpiryEnabled);
-    if (!claims) {
-        return Promise.reject(new Error("Invalid access token"));
+    const claims = validateTokenClaims(token, documentId, tenantId);
+    if (isTokenExpiryEnabled) {
+        validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
     }
     return tenantManager.verifyToken(claims.tenantId, token);
 }

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -190,7 +190,7 @@ describe("Routerlicious", () => {
                     });
                     it("/:tenantId/:id-invalidToken", async () => {
                         await supertest.get(`/documents/${appTenant1.id}/${document1._id}`)
-                            .expect(401);
+                            .expect(403);
                     });
                     it("/:tenantId", async () => {
                         await supertest.post(`/documents/${appTenant1.id}`)
@@ -198,31 +198,32 @@ describe("Routerlicious", () => {
                             .send({id: document1._id})
                             .expect((res) => {
                                 assert.notStrictEqual(res.status, 401);
+                                assert.notStrictEqual(res.status, 403);
                             });
                     });
                     it("/:tenantId-invalidtoken", async () => {
                         await supertest.post(`/documents/${appTenant1.id}`)
                             .send({id: document1._id})
-                            .expect(401);
+                            .expect(403);
                     });
                 });
 
                 describe("/deltas-invalidToken", () => {
                     it("/raw/:tenantId/:id", async () => {
                         await supertest.get(`/deltas/raw/${appTenant2.id}/${document1._id}`)
-                            .expect(401);
+                            .expect(403);
                     });
                     it("/:tenantId/:id", async () => {
                         await supertest.get(`/deltas/${appTenant2.id}/${document1._id}`)
-                            .expect(401);
+                            .expect(403);
                     });
                     it("/v1/:tenantId/:id", async () => {
                         await supertest.get(`/deltas/v1/${appTenant2.id}/${document1._id}`)
-                            .expect(401);
+                            .expect(403);
                     });
                     it("/:tenantId/:id/v1", async () => {
                         await supertest.get(`/deltas/${appTenant2.id}/${document1._id}/v1`)
-                            .expect(401);
+                            .expect(403);
                     });
                 });
             });

--- a/server/routerlicious/packages/services-client/src/auth.ts
+++ b/server/routerlicious/packages/services-client/src/auth.ts
@@ -7,35 +7,44 @@ import { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definit
 import { KJUR as jsrsasign } from "jsrsasign";
 import jwtDecode from "jwt-decode";
 import { v4 as uuid } from "uuid";
+import { NetworkError } from "./error";
 
 /**
- * Validates a JWT token to authorize routerlicious and returns decoded claims.
- * An undefined return value indicates invalid claims.
+ * Validates a JWT token to authorize routerlicious.
+ * @returns decoded claims.
+ * @throws {NetworkError} if claims are invalid.
  */
 export function validateTokenClaims(
     token: string,
     documentId: string,
-    tenantId: string,
-    maxTokenLifetimeSec: number,
-    isTokenExpiryEnabled: boolean): ITokenClaims {
+    tenantId: string): ITokenClaims {
     const claims = jwtDecode<ITokenClaims>(token);
 
     if (!claims || claims.documentId !== documentId || claims.tenantId !== tenantId) {
-        return undefined;
+        throw new NetworkError(403, "DocumentId and/or TenantId in token claims do not match requested resource");
     }
 
     if (claims.scopes === undefined || claims.scopes.length === 0) {
-        return undefined;
-    }
-
-    if (isTokenExpiryEnabled && claims.exp && claims.iat) {
-        const now = Math.round((new Date()).getTime() / 1000);
-        if (now >= claims.exp || claims.exp - claims.iat > maxTokenLifetimeSec) {
-            return undefined;
-        }
+        throw new NetworkError(403, "Missing scopes in token claims");
     }
 
     return claims;
+}
+
+/**
+ * Validates token claims' iat and exp properties to ensure valid token expiration.
+ * @returns token lifetime in milliseconds.
+ * @throws {NetworkError} if expiry is invalid.
+ */
+export function validateTokenClaimsExpiration(claims: ITokenClaims, maxTokenLifetimeSec: number): number {
+    if (!claims.exp || !claims.iat || claims.exp - claims.iat > maxTokenLifetimeSec) {
+        throw new NetworkError(403, "Invalid token expiry");
+    }
+    const lifeTimeMSec = (claims.exp * 1000) - (new Date()).getTime();
+    if (lifeTimeMSec < 0) {
+        throw new NetworkError(401, "Expired token");
+    }
+    return lifeTimeMSec;
 }
 
 /**

--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class NetworkError extends Error {
+    constructor(
+        /**
+         * HTTP status code that describes the error.
+         */
+        public readonly code: number,
+        message: string,
+    ) {
+        super(message);
+    }
+}

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from "./auth";
+export * from "./error";
 export * from "./generateNames";
 export * from "./gitManager";
 export * from "./historian";

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@fluidframework/protocol-definitions": "^0.1022.0",
+    "@fluidframework/server-services-client": "^0.1022.0",
     "@fluidframework/server-services-core": "^0.1022.0",
     "@sentry/node": "^5.6.2",
     "debug": "^4.1.1",

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -9,35 +9,28 @@ import { Params } from "express-serve-static-core";
 import { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";
 import * as jwt from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
-import { ITenantManager } from "@fluidframework/server-services-core";
-import { RequestHandler } from "express";
-import { Provider } from "nconf";
+import { NetworkError, validateTokenClaimsExpiration } from "@fluidframework/server-services-client";
+import type { ITenantManager } from "@fluidframework/server-services-core";
+import type { RequestHandler } from "express";
+import type { Provider } from "nconf";
 
 /**
- * Validates a JWT token to authorize routerlicious and returns decoded claims.
- * An undefined return value indicates invalid claims.
+ * Validates a JWT token to authorize routerlicious.
+ * @returns decoded claims.
+ * @throws {NetworkError} if claims are invalid.
  */
 export function validateTokenClaims(
     token: string,
     documentId: string,
-    tenantId: string,
-    maxTokenLifetimeSec: number,
-    isTokenExpiryEnabled: boolean): ITokenClaims | undefined {
+    tenantId: string): ITokenClaims {
     const claims = jwt.decode(token) as ITokenClaims;
 
     if (!claims || claims.documentId !== documentId || claims.tenantId !== tenantId) {
-        return undefined;
+        throw new NetworkError(403, "DocumentId and/or TenantId in token claims do not match request.");
     }
 
     if (claims.scopes === undefined || claims.scopes.length === 0) {
-        return undefined;
-    }
-
-    if (isTokenExpiryEnabled && claims.exp && claims.iat) {
-        const now = Math.round((new Date()).getTime() / 1000);
-        if (now >= claims.exp || claims.exp - claims.iat > maxTokenLifetimeSec) {
-            return undefined;
-        }
+        throw new NetworkError(403, "Missing scopes in token claims.");
     }
 
     return claims;
@@ -96,29 +89,37 @@ export function verifyStorageToken(tenantManager: ITenantManager, config: Provid
         const isTokenExpiryEnabled = config.get("auth:enableTokenExpiration") as boolean;
         const authorizationHeader = request.header("Authorization");
         if (!authorizationHeader) {
-            return res.status(401).send("Authorization header is missing.");
+            return res.status(403).send("Missing Authorization header.");
         }
         const regex = /Basic (.+)/;
         const tokenMatch = regex.exec(authorizationHeader);
         if (!tokenMatch || !tokenMatch[1]) {
-            return res.status(401).send("Missing access token.");
+            return res.status(403).send("Missing access token.");
         }
         const token = tokenMatch[1];
         const tenantId = getParam(request.params, "tenantId");
         const documentId = getParam(request.params, "id") || request.body.id;
         if (!tenantId || !documentId) {
-            return res.status(401).send("TenantId or DocumentId is missing in the access token.");
+            return res.status(403).send("Missing tenantId or documentId in request.");
         }
-        const claims = validateTokenClaims(token, documentId, tenantId, maxTokenLifetimeSec, isTokenExpiryEnabled);
-        if (!claims) {
-            return res.status(401).send("Invalid access token.");
+        let claims: ITokenClaims;
+        try {
+            claims = validateTokenClaims(token, documentId, tenantId);
+            if (isTokenExpiryEnabled) {
+                validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
+            }
+        } catch (error) {
+            if (error instanceof NetworkError) {
+                return res.status(error.code).send(error.message);
+            }
+            throw error;
         }
         tenantManager.verifyToken(claims.tenantId, token)
             .then(() => {
                 next();
             })
             .catch((error) => {
-                return res.status(401).json(error);
+                return res.status(403).json(error);
             });
     };
 }


### PR DESCRIPTION
Follow-up to #5509. Splits token expiration logic out of `validateTokenClaims` from services-client and services-utils into `validateTokenClaimsExpiration` in services-client. Also, instead of returning undefined for invalid claims or expiration, both functions simply throw errors with an HTTP error code attached.

Bonus improvement: return 403s for non-retriable errors from `verifyStorageToken` middleware