### PR TITLE
Make TokenFetcher optional for OdspDriverUrlResolverForShareLink to simplify usage for cases where ability to get share link is not essential

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -31,6 +31,18 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     private readonly logger: ITelemetryLogger;
     private readonly sharingLinkCache = new PromiseCache<string, string>();
     private readonly instrumentedTokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions> | undefined;
+    /**
+     * Creates url resolver instance
+     * @param tokenFetcher Function that returns access token used to fetch share link.
+     * Can be set as 'undefined' for cases where share link is not needed. Currently, only
+     * getAbsoluteUrl() method requires share link.
+     * @param identityType identity type for signed in user. This value determines the shape
+     * of share link as it differs for Enterprise and Consumer users
+     * @param logger logger object that is used as telemetry sink
+     * @param appName application name hint that is encoded with url produced by getAbsoluteUrl() method.
+     * This hint is used by link handling logic which determines which app to redirect to when user
+     * navigates directly to the link.
+     */
     public constructor(
         tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions> | undefined = undefined,
         private readonly identityType: IdentityType = "Enterprise",

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -33,13 +33,13 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     private readonly instrumentedTokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions> | undefined;
     /**
      * Creates url resolver instance
-     * @param tokenFetcher Function that returns access token used to fetch share link.
+     * @param tokenFetcher - Function that returns access token used to fetch share link.
      * Can be set as 'undefined' for cases where share link is not needed. Currently, only
      * getAbsoluteUrl() method requires share link.
-     * @param identityType identity type for signed in user. This value determines the shape
+     * @param identityType - identity type for signed in user. This value determines the shape
      * of share link as it differs for Enterprise and Consumer users
-     * @param logger logger object that is used as telemetry sink
-     * @param appName application name hint that is encoded with url produced by getAbsoluteUrl() method.
+     * @param logger - logger object that is used as telemetry sink
+     * @param appName - application name hint that is encoded with url produced by getAbsoluteUrl() method.
      * This hint is used by link handling logic which determines which app to redirect to when user
      * navigates directly to the link.
      */

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -25,10 +25,12 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     const sharelink = "https://microsoft.sharepoint-df.com/site/SHARELINK";
     // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1
     const urlWithNavParam = "https://microsoft.sharepoint-df.com/test?nav=cz0lMkZzaXRlVXJsJmQ9ZHJpdmVJZCZmPWZpbGVJZCZjPWRhdGFTdG9yZVBhdGgmZmx1aWQ9MQ%3D%3D";
-    let urlResolver: OdspDriverUrlResolverForShareLink;
+    let urlResolverWithTokenFetcher: OdspDriverUrlResolverForShareLink;
+    let urlResolverWithoutTokenFetcher: OdspDriverUrlResolverForShareLink;
 
     beforeEach(() => {
-        urlResolver = new OdspDriverUrlResolverForShareLink(async () => "SharingLinkToken");
+        urlResolverWithTokenFetcher = new OdspDriverUrlResolverForShareLink(async () => "SharingLinkToken");
+        urlResolverWithoutTokenFetcher = new OdspDriverUrlResolverForShareLink();
     });
 
     async function mockGetFileLink<T>(response: Promise<string>, callback: () => Promise<T>): Promise<T> {
@@ -42,53 +44,70 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     }
 
     it("resolve - Should resolve nav link correctly", async () => {
-        const resolvedUrl = await urlResolver.resolve({ url: urlWithNavParam });
-        assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
-        assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
-        assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be absent");
-        assert.strictEqual(resolvedUrl.hashedDocumentId, getHashedDocumentId(driveId, itemId), "Doc id should be equal");
-        assert(resolvedUrl.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
+        const runTest = async (resolver: OdspDriverUrlResolverForShareLink) => {
+            const resolvedUrl = await resolver.resolve({ url: urlWithNavParam });
+            assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
+            assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
+            assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be equal");
+            assert.strictEqual(resolvedUrl.hashedDocumentId, getHashedDocumentId(driveId, itemId), "Doc id should be equal");
+            assert(resolvedUrl.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
+        };
+        await runTest(urlResolverWithTokenFetcher);
+        await runTest(urlResolverWithoutTokenFetcher);
     });
 
     it("resolve - Should resolve odsp driver url correctly", async () => {
-        const resolvedUrl1 = await urlResolver.resolve({ url: urlWithNavParam });
-        const url: string = createOdspUrl(resolvedUrl1.siteUrl, resolvedUrl1.driveId, resolvedUrl1.itemId, dataStorePath);
-        const resolvedUrl2 = await urlResolver.resolve({ url });
-        assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
-        assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");
-        assert.strictEqual(resolvedUrl2.itemId, itemId, "Item id should be absent");
-        assert.strictEqual(resolvedUrl2.hashedDocumentId, getHashedDocumentId(driveId, itemId), "Doc id should be equal");
-        assert(resolvedUrl2.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
+        const runTest = async (resolver: OdspDriverUrlResolverForShareLink) => {
+            const resolvedUrl1 = await resolver.resolve({ url: urlWithNavParam });
+            const url: string = createOdspUrl(resolvedUrl1.siteUrl, resolvedUrl1.driveId, resolvedUrl1.itemId, dataStorePath);
+            const resolvedUrl2 = await resolver.resolve({ url });
+            assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
+            assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");
+            assert.strictEqual(resolvedUrl2.itemId, itemId, "Item id should be equal");
+            assert.strictEqual(resolvedUrl2.hashedDocumentId, getHashedDocumentId(driveId, itemId), "Doc id should be equal");
+            assert(resolvedUrl2.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
+        };
+        await runTest(urlResolverWithTokenFetcher);
+        await runTest(urlResolverWithoutTokenFetcher);
     });
 
     it("resolve - Check conversion in either direction", async () => {
         const resolvedUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
-            return urlResolver.resolve({ url: urlWithNavParam });
+            return urlResolverWithTokenFetcher.resolve({ url: urlWithNavParam });
         });
-        const absoluteUrl = await urlResolver.getAbsoluteUrl(resolvedUrl, dataStorePath);
+        const absoluteUrl = await urlResolverWithTokenFetcher.getAbsoluteUrl(resolvedUrl, dataStorePath);
         const actualNavParam = new URLSearchParams(absoluteUrl).get("nav");
         const expectedNavParam = new URLSearchParams(sharelink).get("nav");
         assert(actualNavParam !== undefined, "Nav param should be defined!!");
         assert.strictEqual(expectedNavParam, actualNavParam, "Nav param should match");
     });
 
-    it("resolve - Should generate sharelink and set it in shareLinkMap", async () => {
+    it("resolve - Should generate sharelink and set it in shareLinkMap if using resolver with TokenFetcher", async () => {
         const url: string = createOdspUrl(siteUrl, driveId, itemId, dataStorePath);
         await mockGetFileLink(Promise.resolve(sharelink), async () => {
-            return urlResolver.resolve({ url });
+            return urlResolverWithTokenFetcher.resolve({ url });
         });
-        const actualShareLink = await urlResolver["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
+        const actualShareLink = await urlResolverWithTokenFetcher["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
         return assert.strictEqual(actualShareLink, sharelink, "Sharing link should be equal!!");
+    });
+
+    it("resolve - Should not generate sharelink if using resolver without TokenFetcher", async () => {
+        const url: string = createOdspUrl(siteUrl, driveId, itemId, dataStorePath);
+        await mockGetFileLink(Promise.resolve(sharelink), async () => {
+            return urlResolverWithoutTokenFetcher.resolve({ url });
+        });
+        const actualShareLink = await urlResolverWithoutTokenFetcher["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
+        return assert.strictEqual(actualShareLink, undefined, "Sharing link should be undefined");
     });
 
     it("getAbsoluteUrl - Should generate sharelink if none was generated on resolve", async () => {
         const mockResolvedUrl = ({ siteUrl, driveId, itemId } as any) as IOdspResolvedUrl;
         const absoluteUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
-            return urlResolver.getAbsoluteUrl(mockResolvedUrl, dataStorePath);
+            return urlResolverWithTokenFetcher.getAbsoluteUrl(mockResolvedUrl, dataStorePath);
         });
 
         assert(absoluteUrl !== undefined, "Absolute url should be defined!!");
-        const actualShareLink = await urlResolver["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
+        const actualShareLink = await urlResolverWithTokenFetcher["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
         assert.strictEqual(actualShareLink, sharelink, "Sharing link should be equal!!");
 
         const url = new URL(sharelink);
@@ -100,39 +119,58 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
         const mockResolvedUrl = ({ siteUrl, driveId, itemId } as any) as IOdspResolvedUrl;
         let success = true;
         const absoluteUrl = await mockGetFileLink(Promise.reject(new Error("No Sharelink")), async () => {
-            return urlResolver.getAbsoluteUrl(mockResolvedUrl, dataStorePath);
+            return urlResolverWithTokenFetcher.getAbsoluteUrl(mockResolvedUrl, dataStorePath);
         }).catch((error) => {
             assert.strictEqual(error.message, "No Sharelink", "Error should be as expected.");
             success = false;
         });
 
         assert(absoluteUrl === undefined, "Absolute url should be undefined!!");
-        const actualShareLink = await urlResolver["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
+        const actualShareLink = await urlResolverWithTokenFetcher["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
         assert(actualShareLink === undefined, "Sharing link should be undefined!!");
         assert.strictEqual(success, false, "Error should be as expected!!");
     });
 
-    it("Should resolve createNew request", async () => {
-        const request: IRequest = urlResolver.createCreateNewRequest(siteUrl, driveId, dataStorePath, fileName);
-        const resolvedUrl = await urlResolver.resolve(request);
-        assert.strictEqual(resolvedUrl.fileName, fileName, "FileName should be equal");
-        assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
-        assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
-        assert.strictEqual(resolvedUrl.itemId, "", "Item id should be absent");
-        assert.strictEqual(resolvedUrl.hashedDocumentId, "", "No doc id should be present");
-        assert.strictEqual(resolvedUrl.endpoints.snapshotStorageUrl, "", "Snapshot url should be empty");
+    it("getAbsoluteUrl - Should throw if using resolver without TokenFetcher", async () => {
+        const mockResolvedUrl = ({ siteUrl, driveId, itemId } as any) as IOdspResolvedUrl;
+        let success = true;
+        const absoluteUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
+            return urlResolverWithoutTokenFetcher.getAbsoluteUrl(mockResolvedUrl, dataStorePath);
+        }).catch(() => {
+            success = false;
+        });
 
-        const [, queryString] = request.url.split("?");
-        const searchParams = new URLSearchParams(queryString);
-        assert.strictEqual(searchParams.get("path"), dataStorePath, "dataStorePath should match");
-        assert.strictEqual(searchParams.get("driveId"), driveId, "Drive id should match");
+        assert(absoluteUrl === undefined, "Absolute url should be undefined!!");
+        const actualShareLink = await urlResolverWithTokenFetcher["sharingLinkCache"].get(`${siteUrl},${driveId},${itemId}`);
+        assert(actualShareLink === undefined, "Sharing link should be undefined!!");
+        assert.strictEqual(success, false, "Error should be thrown!!");
+    });
+
+    it("Should resolve createNew request", async () => {
+        const runTest = async (resolver: OdspDriverUrlResolverForShareLink) => {
+            const request: IRequest = resolver.createCreateNewRequest(siteUrl, driveId, dataStorePath, fileName);
+            const resolvedUrl = await resolver.resolve(request);
+            assert.strictEqual(resolvedUrl.fileName, fileName, "FileName should be equal");
+            assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
+            assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
+            assert.strictEqual(resolvedUrl.itemId, "", "Item id should be absent");
+            assert.strictEqual(resolvedUrl.hashedDocumentId, "", "No doc id should be present");
+            assert.strictEqual(resolvedUrl.endpoints.snapshotStorageUrl, "", "Snapshot url should be empty");
+
+            const [, queryString] = request.url.split("?");
+            const searchParams = new URLSearchParams(queryString);
+            assert.strictEqual(searchParams.get("path"), dataStorePath, "dataStorePath should match");
+            assert.strictEqual(searchParams.get("driveId"), driveId, "Drive id should match");
+        };
+        await runTest(urlResolverWithTokenFetcher);
+        await runTest(urlResolverWithoutTokenFetcher);
     });
 
     it("Sharing link should be set when isSharingLinkToRedeem header is set", async () => {
         const resolvedUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
             const url = new URL(sharelink);
             storeLocatorInOdspUrl(url, { siteUrl, driveId, fileId: itemId, dataStorePath });
-            return urlResolver.resolve({ url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
+            return urlResolverWithTokenFetcher.resolve({ url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
         assert.strictEqual(resolvedUrl.sharingLinkToRedeem, sharelink, "Sharing link should be set in resolved url");
     });


### PR DESCRIPTION
Currently, only getAbsoluteUrl() requires share link. The rest of methods have no dependency on it. TokenFetcher callback must be specified to get access token that is used when calling API which returns share link. In cases where it is not essential to have share link, I see the usage pattern where resolver is instantiated like this: 
new OdspDriverUrlResolverForShareLink(async () => null)
The end result of this is failure to fetch share link but it gets logged as error. It happens as a result of perf optimization: OdspDriverUrlResolverForShareLink initiates share link fetching in its constructor so the error is logged even if created instance is never used to call getAbsoluteUrl(). The proposed change is to allow passing undefined for TokenFetcher as strong indicator that it is okay for share link fetch to fail. getAbsoluteUrl() will still fail with Error thrown but Error will not be logged internally. 

