### PR TITLE
Unify logging prop for test driverType

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -71,7 +71,7 @@ describe(`Attach/Bind Api Tests For Attached Container`, () => {
             urlResolver,
             documentServiceFactory,
             codeLoader,
-            logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+            logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
         });
         loaderContainerTracker.add(testLoader);
         return testLoader;

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -48,7 +48,7 @@ describe("Container", () => {
     async function loadContainer(props?: Partial<ILoaderProps>) {
         const loader = new Loader({
             ...props,
-            logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+            logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
             urlResolver: props?.urlResolver ?? driver.createUrlResolver(),
             documentServiceFactory:
                 props?.documentServiceFactory ?? driver.createDocumentServiceFactory(),

--- a/packages/test/test-end-to-end-tests/src/test/contextReload.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/contextReload.spec.ts
@@ -110,7 +110,7 @@ describe("context reload (hot-swap)", function() {
             options: { hotSwapContext: true },
             urlResolver: driver.createUrlResolver(),
             documentServiceFactory: driver.createDocumentServiceFactory(),
-            logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+            logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
         });
         loaderContainerTracker.add(loader);
         return createAndAttachContainer(
@@ -232,7 +232,7 @@ describe("context reload (hot-swap)", function() {
                 options: { hotSwapContext: true },
                 urlResolver: driver.createUrlResolver(),
                 documentServiceFactory: driver.createDocumentServiceFactory(),
-                logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+                logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
             });
             loaderContainerTracker.add(loader);
             return loader.resolve({ url: await driver.createContainerUrl(documentId) });

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -81,7 +81,7 @@ describe(`Dehydrate Rehydrate Container Test`, () => {
             urlResolver: driver.createUrlResolver(),
             documentServiceFactory,
             codeLoader,
-            logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+            logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
         });
         loaderContainerTracker.add(testLoader);
         return testLoader;

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -63,7 +63,7 @@ describe("Errors Types", () => {
             urlResolver,
             documentServiceFactory: mockFactory,
             codeLoader,
-            logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+            logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
         });
         loaderContainerTracker.add(loader);
 

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -36,7 +36,7 @@ describe("SharedString", () => {
         const text = "hello world";
         const documentId = createDocumentId();
         const driver = getFluidTestDriver();
-        const logger = ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}});
+        const logger = ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}});
 
         { // creating client
             const codeDetails = { package: "no-dynamic-pkg" };
@@ -141,7 +141,7 @@ describe("SharedString", () => {
         const text = "hello world";
         const documentId = createDocumentId();
         const driver = getFluidTestDriver();
-        const logger = ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}});
+        const logger = ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}});
 
         let initialText = "";
         { // creating client

--- a/packages/test/test-end-to-end-tests/src/test/upgradeManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/upgradeManager.spec.ts
@@ -53,7 +53,7 @@ describe("UpgradeManager (hot-swap)", () => {
             documentServiceFactory: driver.createDocumentServiceFactory(),
             codeLoader,
             options: { hotSwapContext: true },
-            logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+            logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
         });
 
         return createAndAttachContainer(
@@ -68,7 +68,7 @@ describe("UpgradeManager (hot-swap)", () => {
             documentServiceFactory: driver.createDocumentServiceFactory(),
             codeLoader,
             options: { hotSwapContext: true },
-            logger: ChildLogger.create(getTestLogger(), undefined, {all: {testDriverType: driver.type}}),
+            logger: ChildLogger.create(getTestLogger(), undefined, {all: {driverType: driver.type}}),
         });
 
         return loader.resolve({ url: await driver.createContainerUrl(documentId) });


### PR DESCRIPTION
Currently sometimes it's logged as `driverType` and sometimes `testDriverType`.