### PR TITLE
Better handling of pending ops in task-manager

### DIFF
--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -32,15 +32,15 @@ export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     abandon(taskId: string): void;
 
     /**
-     * Check whether this client is the current assignee for the task AND we don't anticipate that changing
-     * due to outstanding ops.
+     * Check whether this client is the current assignee for the task and there is no outstanding abandon op that
+     * would release the lock.
      * @param taskId - Identifier for the task
      */
     haveTaskLock(taskId: string): boolean;
 
     /**
-     * Check whether this client is either the current assignee for the task or is waiting in line AND we don't
-     * anticipate that changing due to outstanding ops.
+     * Check whether this client is either the current assignee for the task or is waiting in line or we expect they
+     * will be in line after outstanding ops have been ack'd.
      * @param taskId - Identifier for the task
      */
     queued(taskId: string): boolean;

--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -6,6 +6,10 @@
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 
 export interface ITaskManagerEvents extends ISharedObjectEvents {
+    /**
+     * Notifies when the local client has reached or left the front of the queue.  Does not account for known pending
+     * ops, but instead only reflects the current state.
+     */
     (event: "assigned" | "lost", listener: (taskId: string) => void);
 }
 
@@ -22,19 +26,21 @@ export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     lockTask(taskId: string): Promise<void>;
 
     /**
-     * Exit the queue immediately.
+     * Exit the queue, releasing the task if currently locked.
      * @param taskId - Identifier for the task
      */
     abandon(taskId: string): void;
 
     /**
-     * Check whether this client is the current assignee for the task.
+     * Check whether this client is the current assignee for the task AND we don't anticipate that changing
+     * due to outstanding ops.
      * @param taskId - Identifier for the task
      */
     haveTaskLock(taskId: string): boolean;
 
     /**
-     * Check whether this client is either the current assignee for the task or is waiting in line.
+     * Check whether this client is either the current assignee for the task or is waiting in line AND we don't
+     * anticipate that changing due to outstanding ops.
      * @param taskId - Identifier for the task
      */
     queued(taskId: string): boolean;

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -263,6 +263,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
      * @returns the snapshot of the current state of the task manager
      */
     protected snapshotCore(serializer: IFluidSerializer): ITree {
+        // TODO filter out tasks with no clients, some are still getting in.
         const content = [...this.taskQueues.entries()];
 
         // And then construct the tree for it

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -236,8 +236,8 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
     }
 
     public async lockTask(taskId: string) {
-        // If we have the lock and don't anticipate that changing due to pending ops, resolve immediately
-        if (this.haveTaskLock(taskId) && this.latestPendingOps.get(taskId) === undefined) {
+        // If we have the lock, resolve immediately
+        if (this.haveTaskLock(taskId)) {
             return;
         }
 
@@ -297,7 +297,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
         const currentAssignee = this.taskQueues.get(taskId)?.[0];
         return currentAssignee !== undefined
             && currentAssignee === this.runtime.clientId
-            && this.latestPendingOps.get(taskId) === undefined;
+            && !this.latestPendingOps.has(taskId);
     }
 
     public queued(taskId: string) {
@@ -307,7 +307,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
         return (
                 clientQueue !== undefined
                 && clientQueue.includes(this.runtime.clientId)
-                && this.latestPendingOps.get(taskId) === undefined
+                && !this.latestPendingOps.has(taskId)
             )
             || this.latestPendingOps.get(taskId)?.type === "volunteer";
     }

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -204,7 +204,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
                     res();
                 } else if (!this.queued(taskId)) {
                     this.queueWatcher.off("queueChange", checkIfAcquiredLock);
-                    rej(new Error(`Removed from queue: ${taskId}`));
+                    rej(new Error(`Removed from queue before acquiring lock: ${taskId}`));
                 }
             };
             this.queueWatcher.on("queueChange", checkIfAcquiredLock);

--- a/packages/dds/task-manager/src/test/taskManager.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.spec.ts
@@ -59,12 +59,12 @@ describe("TaskManager", () => {
         it("Can lock a task", async () => {
             const taskId = "taskId";
             const lockTaskP = taskManager1.lockTask(taskId);
-            assert.ok(taskManager1.queued(taskId), "Not queued");
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
             assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
             containerRuntimeFactory.processAllMessages();
             await lockTaskP;
-            assert.ok(taskManager1.queued(taskId), "Not queued");
-            assert.ok(taskManager1.haveTaskLock(taskId), "Don't have lock");
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.haveTaskLock(taskId), "Should have lock");
         });
 
         it("Can wait for a task", async () => {
@@ -72,27 +72,108 @@ describe("TaskManager", () => {
             const lockTaskP1 = taskManager1.lockTask(taskId);
             const lockTaskP2 = taskManager2.lockTask(taskId);
 
-            assert.ok(taskManager1.queued(taskId), "Task manager 1 not queued");
+            assert.ok(taskManager1.queued(taskId), "Task manager 1 should be queued");
             assert.ok(!taskManager1.haveTaskLock(taskId), "Task manager 1 should not have lock");
-            assert.ok(taskManager2.queued(taskId), "Task manager 2 not queued");
+            assert.ok(taskManager2.queued(taskId), "Task manager 2 should be queued");
             assert.ok(!taskManager2.haveTaskLock(taskId), "Task manager 2 should not have lock");
 
             containerRuntimeFactory.processAllMessages();
             await lockTaskP1;
 
-            assert.ok(taskManager1.queued(taskId), "Task manager 1 not queued");
+            assert.ok(taskManager1.queued(taskId), "Task manager 1 should be queued");
             assert.ok(taskManager1.haveTaskLock(taskId), "Task manager 1 does not have lock");
-            assert.ok(taskManager2.queued(taskId), "Task manager 2 not queued");
+            assert.ok(taskManager2.queued(taskId), "Task manager 2 should be queued");
             assert.ok(!taskManager2.haveTaskLock(taskId), "Task manager 2 should not have lock");
 
             taskManager1.abandon(taskId);
             containerRuntimeFactory.processAllMessages();
             await lockTaskP2;
 
-            assert.ok(!taskManager1.queued(taskId), "Task manager 1 not queued");
+            assert.ok(!taskManager1.queued(taskId), "Task manager 1 should be queued");
             assert.ok(!taskManager1.haveTaskLock(taskId), "Task manager 1 should not have lock");
-            assert.ok(taskManager2.queued(taskId), "Task manager 2 not queued");
+            assert.ok(taskManager2.queued(taskId), "Task manager 2 should be queued");
             assert.ok(taskManager2.haveTaskLock(taskId), "Task manager 2 should not have lock");
+        });
+
+        it("Can abandon and immediately attempt to reacquire a task", async () => {
+            const taskId = "taskId";
+            const lockTaskP = taskManager1.lockTask(taskId);
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            containerRuntimeFactory.processAllMessages();
+            await lockTaskP;
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.haveTaskLock(taskId), "Should have lock");
+
+            taskManager1.abandon(taskId);
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            const relockTaskP = taskManager1.lockTask(taskId);
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            containerRuntimeFactory.processAllMessages();
+            await relockTaskP;
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.haveTaskLock(taskId), "Should have lock");
+        });
+
+        it("Can attempt to lock twice and abandon twice (after ack)", async () => {
+            const taskId = "taskId";
+            const lockTaskP1 = taskManager1.lockTask(taskId);
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            containerRuntimeFactory.processAllMessages();
+            await lockTaskP1;
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.haveTaskLock(taskId), "Should have lock");
+
+            const lockTaskP2 = taskManager1.lockTask(taskId);
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.haveTaskLock(taskId), "Should have lock");
+            containerRuntimeFactory.processAllMessages();
+            await lockTaskP2;
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.haveTaskLock(taskId), "Should have lock");
+
+            taskManager1.abandon(taskId);
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            containerRuntimeFactory.processAllMessages();
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+
+            taskManager1.abandon(taskId);
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            containerRuntimeFactory.processAllMessages();
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+        });
+
+        it("Can attempt to lock twice and abandon twice (before ack)", async () => {
+            const taskId = "taskId";
+            const lockTaskP1 = taskManager1.lockTask(taskId);
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+
+            const lockTaskP2 = taskManager1.lockTask(taskId);
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            containerRuntimeFactory.processAllMessages();
+            await lockTaskP1;
+            await lockTaskP2;
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.haveTaskLock(taskId), "Should have lock");
+
+            taskManager1.abandon(taskId);
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            taskManager1.abandon(taskId);
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
+            containerRuntimeFactory.processAllMessages();
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.haveTaskLock(taskId), "Should not have lock");
         });
     });
 });


### PR DESCRIPTION
This change makes a few substantial changes in task-manager:

1. Changes the task queue tracking to reflect the consensus state (previously would remove self on abandon before ack).
2. Most importantly, tracks pending ops with `messageId` to better understand pending state.  This allows us to better understand if we anticipate a future abandon/volunteer when deciding whether to declare ourselves the lock holder.
3. Correctly handles abandon before the ack of a volunteer op by rejecting the promise.

@anthony-murphy found a bug when experimenting with the task-manager which I believe was (3) above -- if you're still able to try your scenario with this fix, I'd love to know if things are working as you expect now.