### PR TITLE
Add file logging to stress tests

### DIFF
--- a/packages/test/service-load-test/package.json
+++ b/packages/test/service-load-test/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@fluid-experimental/task-manager": "^0.37.0",
     "@fluidframework/aqueduct": "^0.37.0",
+    "@fluidframework/common-definitions": "^0.19.1",
     "@fluidframework/common-utils": "^0.29.0-0",
     "@fluidframework/container-definitions": "^0.37.0",
     "@fluidframework/container-loader": "^0.37.0",

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -31,12 +31,10 @@ async function main() {
         process.env.DEBUG = log;
     }
 
-    const result = await orchestratorProcess(
+    await orchestratorProcess(
         driver,
         { ...profile, name: profileArg },
         { testId, debug });
-
-    await safeExit(result);
 }
 /**
  * Implementation of the orchestrator process. Returns the return code to exit the process with.
@@ -45,7 +43,7 @@ async function orchestratorProcess(
     driver: TestDriverTypes,
     profile: ILoadTestConfig & { name: string },
     args: { testId?: string, debug?: true },
-): Promise<number> {
+) {
     const testDriver = await createTestDriver(driver);
 
     // Create a new file if a testId wasn't provided
@@ -75,8 +73,11 @@ async function orchestratorProcess(
         );
         p.push(new Promise((resolve) => process.on("close", resolve)));
     }
-    await Promise.all(p);
-    return 0;
+    try{
+        await Promise.all(p);
+    } finally{
+        await safeExit(0, testId);
+    }
 }
 
 main().catch(

--- a/packages/test/service-load-test/src/runner.ts
+++ b/packages/test/service-load-test/src/runner.ts
@@ -37,7 +37,7 @@ async function main() {
     }
     const result = await runnerProcess(driver, profile, runId, testId);
 
-    await safeExit(result);
+    await safeExit(result, testId, runId);
 }
 
 /**

--- a/packages/test/service-load-test/src/utils.ts
+++ b/packages/test/service-load-test/src/utils.ts
@@ -36,11 +36,13 @@ class FileLogger implements ITelemetryBufferedLogger {
                 fs.mkdirSync(path, {recursive: true});
             }
             const schema = [...this.schema];
+            const data = logs.reduce(
+                (file, event)=> `${file}\n${schema.reduce((line,k)=>`${line}${event[k] ?? ""},`,"")}`,
+                schema.join(","));
+
             fs.writeFileSync(
                 `${path}/${runInfo.runId ?? "orchestrator"}_${Date.now()}.csv`,
-                logs.reduce(
-                    (file, event)=> `${file}\n${schema.reduce((line,k)=>`${line}${event[k] ?? ""},`,"")}`,
-                    schema.join(",")));
+                data);
         }
 
         this.error = false;


### PR DESCRIPTION
Log to a file on every stress test iteration where there are errors. This will ease local debugging where we don't have the infra logger, and may be useful to partners to capture and collect errors.