### PR TITLE
Skip "doesn't resend successful op" test in e2e tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -109,7 +109,7 @@ describeNoCompat("stashed ops", (argsFactory: () => ITestObjectProvider) => {
         assert.strictEqual(await map2.wait(testKey), testValue);
     });
 
-    // TODO: Remove the skip for the following test once issue #5593 ("doesn't resend successful op" test 
+    // TODO: Remove the skip for the following test once issue #5593 ("doesn't resend successful op" test
     // in pendingOps.spec.ts is flaky) has been resolved
     it.skip("doesn't resend successful op", async function() {
         const pendingOps = await getPendingOps(args, true, (c, d, map) => {

--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -109,8 +109,7 @@ describeNoCompat("stashed ops", (argsFactory: () => ITestObjectProvider) => {
         assert.strictEqual(await map2.wait(testKey), testValue);
     });
 
-    // TODO: Remove the skip for the following test once issue #5593 ("doesn't resend successful op" test
-    // in pendingOps.spec.ts is flaky) has been resolved
+    // Skip this flaky test. See issue #5593
     it.skip("doesn't resend successful op", async function() {
         const pendingOps = await getPendingOps(args, true, (c, d, map) => {
             map.set(testKey, "something unimportant");

--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -109,7 +109,9 @@ describeNoCompat("stashed ops", (argsFactory: () => ITestObjectProvider) => {
         assert.strictEqual(await map2.wait(testKey), testValue);
     });
 
-    it("doesn't resend successful op", async function() {
+    // TODO: Remove the skip for the following test once issue #5593 ("doesn't resend successful op" test 
+    // in pendingOps.spec.ts is flaky) has been resolved
+    it.skip("doesn't resend successful op", async function() {
         const pendingOps = await getPendingOps(args, true, (c, d, map) => {
             map.set(testKey, "something unimportant");
         });


### PR DESCRIPTION
This would allow us to skip the test, since its intermittent errors was causing failures on the build pipeline. This skip can be removed once we understand the root cause for its flakiness