### PR TITLE
Move Stress Runner Api Back to Url from TestId

### DIFF
--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -78,7 +78,7 @@ async function orchestratorProcess(
     try{
         await Promise.all(p);
     } finally{
-        await safeExit(0, testId);
+        await safeExit(0, url);
     }
 }
 

--- a/packages/test/service-load-test/src/nodeStressTest.ts
+++ b/packages/test/service-load-test/src/nodeStressTest.ts
@@ -49,10 +49,12 @@ async function orchestratorProcess(
     const testDriver = await createTestDriver(driver);
 
     // Create a new file if a testId wasn't provided
-    const testId = args.testId ?? await initialize(testDriver);
+    const url = args.testId !== undefined
+        ? await testDriver.createContainerUrl(args.testId)
+        : await initialize(testDriver);
 
     const estRunningTimeMin = Math.floor(2 * profile.totalSendCount / (profile.opRatePerMin * profile.numClients));
-    console.log(`Connecting to ${args.testId ? "existing" : "new"} Container targeting with testId:\n${testId }`);
+    console.log(`Connecting to ${args.testId ? "existing" : "new"} Container targeting with url:\n${url }`);
     console.log(`Selected test profile: ${profile.name}`);
     console.log(`Estimated run time: ${estRunningTimeMin} minutes\n`);
 
@@ -63,7 +65,7 @@ async function orchestratorProcess(
             "--driver", driver,
             "--profile", profile.name,
             "--runId", i.toString(),
-            "--testId", testId];
+            "--url", url];
         if (args.debug) {
             const debugPort = 9230 + i; // 9229 is the default and will be used for the root orchestrator process
             childArgs.unshift(`--inspect-brk=${debugPort}`);

--- a/packages/test/service-load-test/src/runner.ts
+++ b/packages/test/service-load-test/src/runner.ts
@@ -14,14 +14,14 @@ async function main() {
         .version("0.0.1")
         .requiredOption("-d, --driver <driver>", "Which test driver info to use", "odsp")
         .requiredOption("-p, --profile <profile>", "Which test profile to use from testConfig.json", "ci")
-        .requiredOption("-id, --testId <testId>", "Load an existing data store rather than creating new")
-        .requiredOption("-r, --runId <runId>", "run a child process with the given id. Requires --testId option.")
+        .requiredOption("-u --url <url>", "Load an existing data store from the url")
+        .requiredOption("-r, --runId <runId>", "run a child process with the given id. Requires --url option.")
         .option("-l, --log <filter>", "Filter debug logging. If not provided, uses DEBUG env variable.")
         .parse(process.argv);
 
     const driver: TestDriverTypes = commander.driver;
     const profileArg: string = commander.profile;
-    const testId: string = commander.testId;
+    const url: string = commander.url;
     const runId: number  = commander.runId;
     const log: string | undefined = commander.log;
 
@@ -31,11 +31,11 @@ async function main() {
         process.env.DEBUG = log;
     }
 
-    if (testId === undefined) {
-        console.error("Missing --testId argument needed to run child process");
+    if (url === undefined) {
+        console.error("Missing --url argument needed to run child process");
         process.exit(-1);
     }
-    const result = await runnerProcess(driver, profile, runId, testId);
+    const result = await runnerProcess(driver, profile, runId, url);
 
     await safeExit(result);
 }
@@ -47,7 +47,7 @@ async function runnerProcess(
     driver: TestDriverTypes,
     profile: ILoadTestConfig,
     runId: number,
-    testId: string,
+    url: string,
 ): Promise<number> {
     try {
         const runConfig: IRunConfig = {
@@ -57,7 +57,7 @@ async function runnerProcess(
 
         const testDriver = await createTestDriver(driver);
 
-        const stressTest = await load(testDriver, testId, runId);
+        const stressTest = await load(testDriver, url, runId);
         await stressTest.run(runConfig, true);
         console.log(`${runId.toString().padStart(3)}> exit`);
         return 0;

--- a/packages/test/service-load-test/src/runner.ts
+++ b/packages/test/service-load-test/src/runner.ts
@@ -37,7 +37,7 @@ async function main() {
     }
     const result = await runnerProcess(driver, profile, runId, url);
 
-    await safeExit(result, testId, runId);
+    await safeExit(result, url, runId);
 }
 
 /**

--- a/packages/test/service-load-test/src/utils.ts
+++ b/packages/test/service-load-test/src/utils.ts
@@ -59,12 +59,11 @@ export async function initialize(testDriver: ITestDriver) {
     await container.attach(request);
     container.close();
 
-    return testId;
+    return testDriver.createContainerUrl(testId);
 }
 
-export async function load(testDriver: ITestDriver, testId: string, runId: number) {
+export async function load(testDriver: ITestDriver, url: string, runId: number) {
     const loader = await createLoader(testDriver, runId);
-    const url =  await testDriver.createContainerUrl(testId);
     const container = await loader.resolve({ url });
     return requestFluidObject<ILoadTest>(container,"/");
 }

--- a/packages/test/service-load-test/src/utils.ts
+++ b/packages/test/service-load-test/src/utils.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-
+import crypto from "crypto";
 import fs from "fs";
 import { Loader } from "@fluidframework/container-loader";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
@@ -26,12 +26,12 @@ class FileLogger implements ITelemetryBufferedLogger {
 
     public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {}
 
-    async flush(runInfo?: {testId: string,  runId?: number}): Promise<void> {
+    async flush(runInfo?: {url: string,  runId?: number}): Promise<void> {
         const baseFlushP =  this.baseLogger?.flush();
 
         if(this.error && runInfo !== undefined) {
             const logs = this.logs;
-            const path = `${__dirname}/output/${runInfo.testId}/`;
+            const path = `${__dirname}/output/${crypto.createHash("md5").update(runInfo.url).digest("hex")}/`;
             if(!fs.existsSync(path)) {
                 fs.mkdirSync(path, {recursive: true});
             }
@@ -136,11 +136,11 @@ export function getProfile(profileArg: string) {
     return profile;
 }
 
-export async function safeExit(code: number, testId: string, runId?: number) {
+export async function safeExit(code: number, url: string, runId?: number) {
     // There seems to be at least one dangling promise in ODSP Driver, give it a second to resolve
     await(new Promise((res) => { setTimeout(res, 1000); }));
     // Flush the logs
-    await loggerP.then(async (l)=>l.flush({testId, runId}));
+    await loggerP.then(async (l)=>l.flush({url, runId}));
 
     process.exit(code);
 }


### PR DESCRIPTION
When the stress test was moved to use the test driver, we moved the api to testid. Now that the runner and orchestrator are split i'm moving the runner api back to url. this should make the api more consumable for partners