### PR TITLE
Fix replay tool

### DIFF
--- a/packages/drivers/file-driver/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentStorageService.ts
@@ -5,7 +5,11 @@
 
 import fs from "fs";
 import { assert, bufferToString } from "@fluidframework/common-utils";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions";
+import {
+    IDocumentStorageService,
+    IDocumentStorageServicePolicies,    // these are needed for api-extractor
+    ISummaryContext,                    // these are needed for api-extractor
+} from "@fluidframework/driver-definitions";
 import { buildSnapshotTree } from "@fluidframework/driver-utils";
 import * as api from "@fluidframework/protocol-definitions";
 import { IFileSnapshot, ReadDocumentStorageServiceBase } from "@fluidframework/replay-driver";

--- a/packages/drivers/file-driver/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentStorageService.ts
@@ -4,12 +4,8 @@
  */
 
 import fs from "fs";
-import { assert, bufferToString, IsoBuffer } from "@fluidframework/common-utils";
-import {
-    IDocumentStorageService,
-    IDocumentStorageServicePolicies,
-    ISummaryContext,
-} from "@fluidframework/driver-definitions";
+import { assert, bufferToString } from "@fluidframework/common-utils";
+import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { buildSnapshotTree } from "@fluidframework/driver-utils";
 import * as api from "@fluidframework/protocol-definitions";
 import { IFileSnapshot, ReadDocumentStorageServiceBase } from "@fluidframework/replay-driver";

--- a/packages/drivers/file-driver/src/fileDocumentStorageService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentStorageService.ts
@@ -4,7 +4,7 @@
  */
 
 import fs from "fs";
-import { assert, bufferToString } from "@fluidframework/common-utils";
+import { assert, bufferToString, IsoBuffer } from "@fluidframework/common-utils";
 import {
     IDocumentStorageService,
     IDocumentStorageServicePolicies,
@@ -53,9 +53,9 @@ export class FluidFetchReader extends ReadDocumentStorageServiceBase implements 
                 return null;
             }
             rootTree = true;
-            filename = `${this.path}/${this.versionName}/decoded/tree.json`;
+            filename = `${this.path}/${this.versionName}/tree.json`;
         } else {
-            filename = `${this.path}/${this.versionName}/decoded/${version.id}.json`;
+            filename = `${this.path}/${this.versionName}/${version.id}.json`;
         }
 
         if (!fs.existsSync(filename)) {
@@ -96,7 +96,7 @@ export class FluidFetchReader extends ReadDocumentStorageServiceBase implements 
 
     public async readBlob(sha: string): Promise<ArrayBufferLike> {
         if (this.versionName !== undefined) {
-            const fileName = `${this.path}/${this.versionName}/decoded/${sha}`;
+            const fileName = `${this.path}/${this.versionName}/${sha}`;
             if (fs.existsSync(fileName)) {
                 const data = fs.readFileSync(fileName);
                 return data;

--- a/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
@@ -5,7 +5,7 @@
 
 import fs from "fs";
 import util from "util";
-import { assert, bufferToString, stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
+import { assert, bufferToString, stringToBuffer, TelemetryNullLogger, IsoBuffer } from "@fluidframework/common-utils";
 import {
     IDocumentService,
     IDocumentStorageService,
@@ -243,10 +243,13 @@ async function saveSnapshot(name: string, fetchedData: IFetchedData[], saveDir: 
             console.error(`ERROR: Unable to get data for blob ${item.blobId}`);
             return;
         }
-        const data = bufferToString(buffer,"base64");
 
         if (!isFetchedTree(item)) {
-            fs.writeFileSync(`${outDir}/${item.filename}`, data);
+            // Just write the data as is.
+            fs.writeFileSync(`${outDir}/${item.filename}`, IsoBuffer.from(buffer));
+
+            // we assume that the buffer is utf8 here, which currently is true for
+            // all of our snapshot blobs.  It doesn't necessary be true in the future
             let decoded = bufferToString(buffer,"utf8");
             try {
                 if (!paramActualFormatting) {
@@ -257,11 +260,11 @@ async function saveSnapshot(name: string, fetchedData: IFetchedData[], saveDir: 
             fs.writeFileSync(
                 `${outDir}/decoded/${item.filename}.json`, decoded);
         } else {
-            // Write out same data for tree
-            fs.writeFileSync(`${outDir}/${item.filename}.json`, data);
-            const decoded = bufferToString(buffer,"utf8");
+            // Write out same data for tree decoded or not, except for formatting
+            const treeString = bufferToString(buffer,"utf8");
+            fs.writeFileSync(`${outDir}/${item.filename}.json`, treeString);
             fs.writeFileSync(`${outDir}/decoded/${item.filename}.json`,
-                paramActualFormatting ? decoded : JSON.stringify(JSON.parse(decoded), undefined, 2));
+                paramActualFormatting ? treeString : JSON.stringify(JSON.parse(treeString), undefined, 2));
         }
     }));
 }

--- a/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSnapshot.ts
@@ -5,7 +5,7 @@
 
 import fs from "fs";
 import util from "util";
-import { assert, bufferToString, stringToBuffer, TelemetryNullLogger, IsoBuffer } from "@fluidframework/common-utils";
+import { assert, bufferToString, stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
 import {
     IDocumentService,
     IDocumentStorageService,
@@ -246,7 +246,7 @@ async function saveSnapshot(name: string, fetchedData: IFetchedData[], saveDir: 
 
         if (!isFetchedTree(item)) {
             // Just write the data as is.
-            fs.writeFileSync(`${outDir}/${item.filename}`, IsoBuffer.from(buffer));
+            fs.writeFileSync(`${outDir}/${item.filename}`, Buffer.from(buffer));
 
             // we assume that the buffer is utf8 here, which currently is true for
             // all of our snapshot blobs.  It doesn't necessary be true in the future


### PR DESCRIPTION
Currently the file document service read the blob from the "decoded" directory, and looking for file without the `.json` extension, which the fluid fetch tool always write to.  So the replay-tool `--from` option is broken.

Ideally, the non-decoded version should be as unaltered as possible so that we can just return what is read on disk

So this change is for fluid fetch tool to write out the non-decoded blob as is (without encoding it in base64 first), and the replay tool revert back to reading those non-decoded blobs. 