### PR TITLE
[0.35] Build esmodules for some projects

### DIFF
--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -12,7 +12,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "concurrently npm:build:compile npm:lint",
-    "build:compile": "npm run tsc",
+    "build:commonjs": "npm run tsc",
+    "build:compile": "concurrently npm:build:commonjs npm:build:esnext",
+    "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "clean": "rimraf dist *.tsbuildinfo *.build.log",

--- a/experimental/framework/fluid-static/package.json
+++ b/experimental/framework/fluid-static/package.json
@@ -12,7 +12,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "concurrently npm:build:compile npm:lint",
-    "build:compile": "npm run tsc",
+    "build:commonjs": "npm run tsc",
+    "build:compile": "concurrently npm:build:commonjs npm:build:esnext",
+    "build:esnext": "tsc --project ./tsconfig.esnext.json",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "clean": "rimraf dist *.tsbuildinfo *.build.log",


### PR DESCRIPTION
This is a port of PR #5612 to the 0.35 release branch. This will let us publish 0.35 packages with esmodules without waiting for the 0.37 release.

Main branch: #5612 
0.36 branch: #5613
0.35 branch: #5614