### PR TITLE
fix flaky pending ops test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -68,6 +68,8 @@ const getPendingOps = async (args: ITestObjectProvider, send: boolean, cb: MapCa
         pendingState = container.closeAndGetPendingLocalState();
     }
 
+    args.opProcessingController.resumeProcessing();
+
     assert.ok(pendingState);
     return pendingState;
 };
@@ -107,8 +109,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(await map2.wait(testKey), testValue);
     });
 
-    // Skip this flaky test. See issue #5593
-    it.skip("doesn't resend successful op", async function() {
+    it("doesn't resend successful op", async function() {
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {
             map.set(testKey, "something unimportant");
         });


### PR DESCRIPTION
fix #5593

Calling opProcessingController.pauseProcessing() causes OpProcessingController to pause all delta managers when process() is called, which I didn't know. This led to a race condition where an op would sometimes not be observed during process() and then ensureSynchronized() would hang until test timeout.