### PR TITLE
TaskManager only add valid clients

### DIFF
--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -440,20 +440,22 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
     }
 
     private addClientToQueue(taskId: string, clientId: string) {
-        // Create the queue if it doesn't exist, and push the client on the back.
-        let clientQueue = this.taskQueues.get(taskId);
-        if (clientQueue === undefined) {
-            clientQueue = [];
-            this.taskQueues.set(taskId, clientQueue);
+        if(this.runtime.getQuorum().has(clientId)) {
+            // Create the queue if it doesn't exist, and push the client on the back.
+            let clientQueue = this.taskQueues.get(taskId);
+            if (clientQueue === undefined) {
+                clientQueue = [];
+                this.taskQueues.set(taskId, clientQueue);
+            }
+
+            const oldLockHolder = clientQueue[0];
+            clientQueue.push(clientId);
+            const newLockHolder = clientQueue[0];
+            this.queueWatcher.emit("queueChange", taskId, oldLockHolder, newLockHolder);
+
+            // TODO remove, just for debugging
+            this.emit("changed");
         }
-
-        const oldLockHolder = clientQueue[0];
-        clientQueue.push(clientId);
-        const newLockHolder = clientQueue[0];
-        this.queueWatcher.emit("queueChange", taskId, oldLockHolder, newLockHolder);
-
-        // TODO remove, just for debugging
-        this.emit("changed");
     }
 
     private removeClientFromQueue(taskId: string, clientId: string) {

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -440,7 +440,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
     }
 
     private addClientToQueue(taskId: string, clientId: string) {
-        if(this.runtime.getQuorum().has(clientId)) {
+        if(this.runtime.getQuorum().getMembers().has(clientId)) {
             // Create the queue if it doesn't exist, and push the client on the back.
             let clientQueue = this.taskQueues.get(taskId);
             if (clientQueue === undefined) {

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -120,8 +120,10 @@ export class MockContainerRuntime {
         this.deltaManager = new MockDeltaManager();
         // Set FluidDataStoreRuntime's deltaManager to ours so that they are in sync.
         this.dataStoreRuntime.deltaManager = this.deltaManager;
+        this.dataStoreRuntime.quorum = factory.quorum;
         // FluidDataStoreRuntime already creates a clientId, reuse that so they are in sync.
         this.clientId = this.dataStoreRuntime.clientId;
+        factory.quorum.addMember(this.clientId, {});
     }
 
     public createDeltaConnection(): MockDeltaConnection {
@@ -194,6 +196,7 @@ export class MockContainerRuntime {
 export class MockContainerRuntimeFactory {
     public sequenceNumber = 0;
     public minSeq = new Map<string, number>();
+    public readonly quorum = new MockQuorum();
     protected messages: ISequencedDocumentMessage[] = [];
     protected readonly runtimes: MockContainerRuntime[] = [];
 
@@ -388,7 +391,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter
     public deltaManager = new MockDeltaManager();
     public readonly loader: ILoader;
     public readonly logger: ITelemetryLogger = DebugLogger.create("fluid:MockFluidDataStoreRuntime");
-    public readonly quorum = new MockQuorum();
+    public quorum = new MockQuorum();
 
     public get absolutePath() {
         return `/${this.id}`;


### PR DESCRIPTION
Due to the way we delay load datastores and dds it's possible for them to be out of sync with the client until they are fully loaded. Specifically, they can see ops older than that latest quorum. The quorum will not contain the clients that these ops are from, as they have already been removed. This leads to zombie clients owning tasks in task manager