### PR TITLE
Close and Reopen Containers in Stress Tests

### DIFF
--- a/packages/test/service-load-test/src/loadTestDataStore.ts
+++ b/packages/test/service-load-test/src/loadTestDataStore.ts
@@ -124,9 +124,7 @@ class LoadTestDataStoreModel {
         const halfClients = Math.floor(this.config.testConfig.numClients / 2);
         // The runners are paired up and each pair shares a single taskId
         this.taskId = `op_sender${config.runId % halfClients}`;
-        this.partnerId = this.config.runId < halfClients
-            ? this.config.runId + halfClients
-            : this.config.runId % halfClients;
+        this.partnerId = (this.config.runId + halfClients) % this.config.testConfig.numClients;
         const changed = (taskId)=>{
             if(taskId === this.taskId && this.taskStartTime !== 0) {
                 this.dir.set(taskTimeKey, this.totalTaskTime);

--- a/packages/test/service-load-test/src/runner.ts
+++ b/packages/test/service-load-test/src/runner.ts
@@ -5,9 +5,16 @@
 
 import commander from "commander";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
+import { TelemetryLogger } from "@fluidframework/telemetry-utils";
+import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
+import { Container } from "@fluidframework/container-loader";
 import { ILoadTestConfig } from "./testConfigFile";
 import { IRunConfig } from "./loadTestDataStore";
-import { createTestDriver, getProfile, load, safeExit } from "./utils";
+import { createTestDriver, getProfile, load, loggerP, safeExit } from "./utils";
+
+function logStatus(runId: number, message: string) {
+    console.log(`${runId.toString().padStart(3)}> ${message}`);
+}
 
 async function main() {
     commander
@@ -57,18 +64,88 @@ async function runnerProcess(
 
         const testDriver = await createTestDriver(driver);
 
-        const stressTest = await load(testDriver, url, runId);
-        await stressTest.run(runConfig, true);
-        console.log(`${runId.toString().padStart(3)}> exit`);
+        let reset = true;
+        let done = false;
+        while(!done) {
+            const {container, test} = await load(testDriver, url, runId);
+            scheduleContainerClose(container, runConfig);
+            try{
+                logStatus(runId, `running`);
+                done = await test.run(runConfig, reset);
+                logStatus(runId, done ?  `finished` : "closed");
+            }catch(error) {
+                const event: ITelemetryBaseEvent = {
+                    eventName:"RunnerFailed",
+                    category: "error",
+                };
+                TelemetryLogger.prepareErrorObject(event, error,false);
+                (await loggerP).send(event);
+                throw error;
+            }
+            finally{
+                reset = false;
+                if(!container.closed) {
+                    container.close();
+                }
+                await loggerP.then(async (l)=>l.flush({url, runId}));
+            }
+        }
         return 0;
     } catch (e) {
-        console.error(`${runId.toString().padStart(3)}> error: loading test`);
+        logStatus(runId, `error: loading test`);
         console.error(e);
         return -1;
     }
 }
 
-main().catch(
+function scheduleContainerClose(container: Container, runConfig: IRunConfig) {
+    new Promise<void>((res)=>{
+        // wait for the container to connect write
+        container.once("closed", res);
+        if(!container.deltaManager.active) {
+            container.once("connected", ()=>{
+                res();
+                container.off("closed", res);
+            });
+        }
+    }).then(()=>{
+        if(container.closed) {
+            return;
+        }
+        const quorum = container.getQuorum();
+        const scheduleLeave = ()=>{
+            const clientId = container.clientId;
+            if(clientId !== undefined && quorum.getMembers().has(clientId)) {
+                // calculate the clients quorum position
+                const quorumIndex = [... quorum.getMembers().entries()]
+                    .sort((a,b)=>b[1].sequenceNumber - a[1].sequenceNumber)
+                    .map((m)=>m[0])
+                    .indexOf(clientId);
+
+                // bucket the clients, with bias towards the summarizer aka index 0
+                if(quorumIndex >= 0 && quorumIndex <= runConfig.testConfig.numClients / 4) {
+                    quorum.off("removeMember",scheduleLeave);
+                    const leaveTime = runConfig.testConfig.readWriteCycleMs * 5 * Math.random();
+                    logStatus(runConfig.runId, `closing in ${leaveTime / 60000} min`);
+                    setTimeout(
+                        ()=>{
+                            if(!container.closed) {
+                                container.close();
+                            }
+                        },
+                        leaveTime);
+                }
+            }
+        };
+        quorum.on("removeMember", scheduleLeave);
+        scheduleLeave();
+    }).catch((e)=>{
+        logStatus(runConfig.runId, `Failed to schedule close: ${e}`);
+    });
+}
+
+main()
+.catch(
     (error) => {
         console.error(error);
         process.exit(-1);

--- a/packages/test/service-load-test/src/utils.ts
+++ b/packages/test/service-load-test/src/utils.ts
@@ -21,7 +21,7 @@ const packageName = `${pkgName}@${pkgVersion}`;
 
 class FileLogger implements ITelemetryBufferedLogger {
     private error: boolean = false;
-    private readonly schema = new Set<string>();
+    private readonly schema = new Map<string, number>();
     private  logs: ITelemetryBaseEvent[] = [];
 
     public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {}
@@ -31,20 +31,21 @@ class FileLogger implements ITelemetryBufferedLogger {
 
         if(this.error && runInfo !== undefined) {
             const logs = this.logs;
-            const path = `${__dirname}/output/${crypto.createHash("md5").update(runInfo.url).digest("hex")}/`;
-            if(!fs.existsSync(path)) {
-                fs.mkdirSync(path, {recursive: true});
+            const outputDir = `${__dirname}/output/${crypto.createHash("md5").update(runInfo.url).digest("hex")}`;
+            if(!fs.existsSync(outputDir)) {
+                fs.mkdirSync(outputDir, {recursive: true});
             }
-            const schema = [...this.schema];
+            // sort from most common column to least common
+            const schema = [...this.schema].sort((a,b)=>b[1] - a[1]).map((v)=>v[0]);
             const data = logs.reduce(
                 (file, event)=> `${file}\n${schema.reduce((line,k)=>`${line}${event[k] ?? ""},`,"")}`,
                 schema.join(","));
-
+            const filePath = `${outputDir}/${runInfo.runId ?? "orchestrator"}_${Date.now()}.csv`;
             fs.writeFileSync(
-                `${path}/${runInfo.runId ?? "orchestrator"}_${Date.now()}.csv`,
+                filePath,
                 data);
         }
-
+        this.schema.clear();
         this.error = false;
         this.logs = [];
         return baseFlushP;
@@ -53,7 +54,8 @@ class FileLogger implements ITelemetryBufferedLogger {
         this.baseLogger?.send(event);
 
         event.Event_Time = Date.now();
-        Object.keys(event).forEach((k)=>this.schema.add(k));
+        // keep track of the frequency of every log event, as we'll sort by most common on write
+        Object.keys(event).forEach((k)=>this.schema.set(k, (this.schema.get(k) ?? 0) + 1));
         if(event.category === "error") {
             this.error = true;
         }
@@ -108,7 +110,7 @@ export async function initialize(testDriver: ITestDriver) {
 export async function load(testDriver: ITestDriver, url: string, runId: number) {
     const loader = await createLoader(testDriver, runId);
     const container = await loader.resolve({ url });
-    return requestFluidObject<ILoadTest>(container,"/");
+    return {container, test: await requestFluidObject<ILoadTest>(container,"/")};
 }
 
 export const createTestDriver =

--- a/packages/test/service-load-test/src/utils.ts
+++ b/packages/test/service-load-test/src/utils.ts
@@ -11,7 +11,7 @@ import { ITestDriver, TestDriverTypes, ITelemetryBufferedLogger } from "@fluidfr
 import { createFluidTestDriver } from "@fluidframework/test-drivers";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { assert, LazyPromise } from "@fluidframework/common-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
+import { ChildLogger, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { pkgName, pkgVersion } from "./packageVersion";
 import { fluidExport, ILoadTest } from "./loadTestDataStore";
@@ -19,12 +19,14 @@ import { ILoadTestConfig, ITestConfig } from "./testConfigFile";
 
 const packageName = `${pkgName}@${pkgVersion}`;
 
-class FileLogger implements ITelemetryBufferedLogger {
+class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
     private error: boolean = false;
     private readonly schema = new Map<string, number>();
     private  logs: ITelemetryBaseEvent[] = [];
 
-    public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {}
+    public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {
+        super();
+    }
 
     async flush(runInfo?: {url: string,  runId?: number}): Promise<void> {
         const baseFlushP =  this.baseLogger?.flush();

--- a/packages/test/service-load-test/testConfig.json
+++ b/packages/test/service-load-test/testConfig.json
@@ -4,7 +4,7 @@
             "opRatePerMin": 10,
             "progressIntervalMs": 15000,
             "numClients": 120,
-            "totalSendCount": 1000,
+            "totalSendCount": 10000,
             "readWriteCycleMs": 30000
         },
         "full": {


### PR DESCRIPTION
- Return container and test from load, and schedule restart on loaded containers in runner.ts
- Return a boolean from the datastore; true if finished, false if it still has work to do.
- Integrate the latest changes from TaskManager
- Clean up logging a bit, both console, and output files

fixes #5058