### PR TITLE
Integrate OpProcessingController functionality into LoaderContainerTracker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,9 @@
                 "src/index.ts",
                 "--runInBand"
             ],
-            "env": { "TS_NODE_PROJECT": "tsconfig.json", },
+            "env": {
+                "TS_NODE_PROJECT": "tsconfig.json",
+            },
             // "skipFiles": ["<node_internals>/**"],
             "console": "integratedTerminal",
             "smartStep": true,
@@ -48,7 +50,9 @@
                 // "fail",
                 "--exit"
             ],
-            "env": { "TS_NODE_PROJECT": "tsconfig.json", },
+            "env": {
+                "TS_NODE_PROJECT": "tsconfig.json",
+            },
             // "skipFiles": ["<node_internals>/**"],
             "console": "integratedTerminal",
             "smartStep": true,
@@ -74,7 +78,7 @@
             "sourceMaps": true,
             "url": "localhost:3000/sharedText/oct18-3",
             "pathMapping": {
-                "/public/scripts/dist/src/" : "${workspaceFolder}/dist"
+                "/public/scripts/dist/src/": "${workspaceFolder}/dist"
             }
         },
         {
@@ -90,7 +94,9 @@
             "request": "launch",
             "name": "Beast",
             "sourceMaps": true,
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
             "protocol": "inspector",
             "program": "${workspaceFolder}/dist/test/merge-tree/beastTest.js"
         },
@@ -99,7 +105,9 @@
             "request": "launch",
             "name": "Farm",
             "sourceMaps": true,
-            "outFiles": [ "${workspaceFolder}/packages/runtime/sequence/dist/test/*.js" ],
+            "outFiles": [
+                "${workspaceFolder}/packages/runtime/sequence/dist/test/*.js"
+            ],
             "protocol": "inspector",
             "program": "${workspaceFolder}/packages/runtime/sequence/dist/test/testFarm.js"
         },
@@ -113,8 +121,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -127,8 +137,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceRoot}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -141,8 +153,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceRoot}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -155,8 +169,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceRoot}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -169,8 +185,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -183,8 +201,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -197,8 +217,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -211,8 +233,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -225,8 +249,10 @@
             "sourceMaps": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/server",
-            "outFiles": [ "${workspaceFolder}/dist/**/*.js" ],
-            "protocol":"inspector",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "protocol": "inspector",
             "trace": "sm"
         },
         {
@@ -250,7 +276,8 @@
             "skipFiles": [
                 "<node_internals>/**/*.js"
             ],
-            "preLaunchTask": "Build Current Tests"
+            "preLaunchTask": "Build Current Tests",
+            "internalConsoleOptions": "openOnSessionStart",
         },
         {
             "type": "node",
@@ -262,9 +289,12 @@
             "args": [
                 "--no-timeouts",
                 "--exit",
-                "../../dist/test/${fileBasenameNoExtension}.js", ],
+                "../../dist/test/${fileBasenameNoExtension}.js",
+            ],
             "cwd": "${fileDirname}",
-            "outFiles": ["${fileDirname}/../../dist/**/*.js"],
+            "outFiles": [
+                "${fileDirname}/../../dist/**/*.js"
+            ],
         }
     ]
 }

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,7 +1,13 @@
 ## 0.37 Breaking changes
+- [OpProcessingController marked for deprecation](#opprocessingcontroller-marked-for-deprecation)
 - [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
 - [TelemetryLogger Properties Format](#TelemetryLogger-Properties-Format)
 
+### OpProcessingController marked for deprecation
+`OpProcessingController` is marked for deprecation and we be removed in 0.38.
+`LoaderContainerTracker` is the replacement with better tracking.  The API differs from `OpProcessingController` in the following ways:
+- Loader is added for tracking and any Container created/loaded will be automatically tracked
+- The op control APIs accept Container instead of DeltaManager
 ### Loader in data stores deprecated
 The `loader` property on the `IContainerRuntime`, `IFluidDataStoreRuntime`, and `IFluidDataStoreContext` interfaces is now deprecated and will be removed in an upcoming release.  Data store objects will no longer have access to an `ILoader` by default.  To replicate the same behavior, existing users can make the `ILoader` used to create a `Container` available on the `scope` property of these interfaces instead by setting the `provideScopeLoader` `ILoaderOptions` flag when creating the loader.
 ```typescript

--- a/examples/data-objects/table-document/src/test/table.spec.ts
+++ b/examples/data-objects/table-document/src/test/table.spec.ts
@@ -5,9 +5,7 @@
 
 import { strict as assert } from "assert";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import {
-    ITestObjectProvider,
-} from "@fluidframework/test-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeLoaderCompat } from "@fluidframework/test-version-utils";
 import { TableDocument } from "../document";
 import { TableSlice } from "../slice";

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -152,6 +152,10 @@ describe("Document Dirty", () => {
         registerDirtyContainerHandler();
     });
 
+    afterEach(() => {
+        loaderContainerTracker.reset();
+    });
+
     function checkDirtyState(
         when: string,
         expectedDirty: boolean,

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -19,8 +19,8 @@ import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidf
 import {
     createAndAttachContainer,
     ITestFluidObject,
+    LoaderContainerTracker,
     LocalCodeLoader,
-    OpProcessingController,
     TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
 
@@ -34,7 +34,7 @@ describe("Document Dirty", () => {
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
     let documentServiceFactory: LocalDocumentServiceFactory;
-    let opProcessingController: OpProcessingController;
+    let loaderContainerTracker: LoaderContainerTracker;
     let container: Container;
     let dataObject: ITestFluidObject;
     let containerRuntime: IContainerRuntime;
@@ -119,6 +119,7 @@ describe("Document Dirty", () => {
             documentServiceFactory,
             codeLoader,
         });
+        loaderContainerTracker.add(loader);
 
         return createAndAttachContainer(
             codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
@@ -127,20 +128,19 @@ describe("Document Dirty", () => {
     beforeEach(async () => {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
+        loaderContainerTracker = new LoaderContainerTracker();
 
         // Create the first container, component and DDSes.
         container = await createContainer() as Container;
         dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
         containerRuntime = dataObject.context.containerRuntime as IContainerRuntime;
         sharedMap = await dataObject.getSharedObject<SharedMap>(mapId);
-        opProcessingController = new OpProcessingController();
-        opProcessingController.addDeltaManagers(container.deltaManager);
 
         // Set an initial key. The Container is in read-only mode so the first op it sends will get nack'd and is
         // re-sent. Do it here so that the extra events don't mess with rest of the test.
         sharedMap.set("setup", "done");
 
-        await opProcessingController.process();
+        await loaderContainerTracker.ensureSynchronized();
 
         wasMarkedDirtyRuntimeCount = 0;
         wasMarkedCleanRuntimeCount = 0;
@@ -177,7 +177,7 @@ describe("Document Dirty", () => {
             checkDirtyState("after value set", true, 0);
 
             // Wait for the ops to get processed which should mark the document clean after processing
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             // Document will have been marked clean on reconnection
 
@@ -193,7 +193,7 @@ describe("Document Dirty", () => {
             checkDirtyState("after batch value set", true, 0);
 
             // Wait for the ops to get processed which should mark the document clean after processing
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             checkDirtyState("after processing batch value set", false, 1);
         });
@@ -231,7 +231,7 @@ describe("Document Dirty", () => {
             // Document should still be dirty right after reconnection
             checkDirtyState("after reconnect and replayed ops", true, 0);
 
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             // Document will have been marked clean after process
             checkDirtyState("after processing replayed ops", false, 1);
@@ -258,7 +258,7 @@ describe("Document Dirty", () => {
                 checkDirtyState("after reconnect and replayed ops", true, 0);
 
                 // Wait for the ops to get processed.
-                await opProcessingController.process();
+                await loaderContainerTracker.ensureSynchronized();
 
                 // Document will have been marked clean after process
                 checkDirtyState("after processing replayed ops", false, 1);
@@ -286,7 +286,7 @@ describe("Document Dirty", () => {
             checkDirtyState("after reconnect and replayed ops", true, 0);
 
             // Wait for the ops to get processed.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             // Document will have been marked clean after process
             checkDirtyState("after processing replayed ops", false, 1);
@@ -317,7 +317,7 @@ describe("Document Dirty", () => {
                 checkDirtyState("after reconnect and replayed ops", true, 0);
 
                 // Wait for the ops to get processed.
-                await opProcessingController.process();
+                await loaderContainerTracker.ensureSynchronized();
 
                 // Document will have been marked clean after process
                 checkDirtyState("after processing replayed ops", false, 1);
@@ -332,7 +332,7 @@ describe("Document Dirty", () => {
             // Set values in DDSes in force read only state.
             sharedMap.set("key", "value");
 
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             // Document should have been marked dirty again due to pending DDS ops
             checkDirtyState("after value set while force readonly", true, 0);
@@ -343,7 +343,7 @@ describe("Document Dirty", () => {
             // Document should still be dirty right after turning off force readonly
             checkDirtyState("after clear readonly and replayed ops", true, 0);
 
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             // Document will have been marked clean after process
             checkDirtyState("after processing replayed ops", false, 1);
@@ -360,7 +360,7 @@ describe("Document Dirty", () => {
                 container.forceReadonly(true);
                 await ensureContainerConnected(container);
 
-                await opProcessingController.process();
+                await loaderContainerTracker.ensureSynchronized();
 
                 // Document should have been marked dirty again due to pending DDS ops
                 checkDirtyState("after value set while force readonly", true, 0);
@@ -371,7 +371,7 @@ describe("Document Dirty", () => {
                 // Document should still be dirty right after turning off force readonly
                 checkDirtyState("after reconnect and replayed ops", true, 0);
 
-                await opProcessingController.process();
+                await loaderContainerTracker.ensureSynchronized();
 
                 // Document will have been marked clean after process
                 checkDirtyState("after processing replayed ops", false, 1);

--- a/packages/test/local-server-tests/src/test/localTestServer.spec.ts
+++ b/packages/test/local-server-tests/src/test/localTestServer.spec.ts
@@ -91,6 +91,10 @@ describe("LocalTestServer", () => {
         sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
     });
 
+    afterEach(() => {
+        loaderContainerTracker.reset();
+    });
+
     describe("Document.existing", () => {
         it("Validate document is new for user1 1 and exists for client 2", () => {
             assert.equal(dataObject1.runtime.existing, false, "Document already exists");

--- a/packages/test/local-server-tests/src/test/localTestServer.spec.ts
+++ b/packages/test/local-server-tests/src/test/localTestServer.spec.ts
@@ -15,7 +15,7 @@ import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidf
 import {
     createAndAttachContainer,
     createLoader,
-    OpProcessingController,
+    LoaderContainerTracker,
     ITestFluidObject,
     TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
@@ -54,7 +54,7 @@ describe("LocalTestServer", () => {
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
     let urlResolver: LocalResolver;
-    let opProcessingController: OpProcessingController;
+    let loaderContainerTracker: LoaderContainerTracker;
     let container1: IContainer;
     let container2: IContainer;
     let dataObject1: ITestFluidObject;
@@ -64,18 +64,21 @@ describe("LocalTestServer", () => {
 
     async function createContainer(): Promise<IContainer> {
         const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
+        loaderContainerTracker.add(loader);
         return createAndAttachContainer(
             codeDetails, loader, urlResolver.createCreateNewRequest(documentId));
     }
 
     async function loadContainer(): Promise<IContainer> {
         const loader = createLocalLoader([[codeDetails, factory]], deltaConnectionServer, urlResolver);
+        loaderContainerTracker.add(loader);
         return loader.resolve({ url: documentLoadUrl });
     }
 
     beforeEach(async () => {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         urlResolver = new LocalResolver();
+        loaderContainerTracker = new LoaderContainerTracker();
 
         // Create a Container for the first client.
         container1 = await createContainer();
@@ -86,9 +89,6 @@ describe("LocalTestServer", () => {
         container2 = await loadContainer();
         dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-
-        opProcessingController = new OpProcessingController();
-        opProcessingController.addDeltaManagers(container1.deltaManager, container2.deltaManager);
     });
 
     describe("Document.existing", () => {
@@ -126,27 +126,27 @@ describe("LocalTestServer", () => {
                 }
             });
 
-            await opProcessingController.pauseProcessing();
+            await loaderContainerTracker.pauseProcessing();
 
             sharedString1.insertText(0, "A");
             sharedString2.insertText(0, "C");
             assert.equal(user1ReceivedMsgCount, 0, "User1 received message count is incorrect");
             assert.equal(user2ReceivedMsgCount, 0, "User2 received message count is incorrect");
 
-            await opProcessingController.process(container1.deltaManager);
+            await loaderContainerTracker.ensureSynchronized(container1);
             assert.equal(user1ReceivedMsgCount, 0, "User1 received message count is incorrect");
             assert.equal(user2ReceivedMsgCount, 0, "User2 received message count is incorrect");
 
-            await opProcessingController.process(container2.deltaManager);
+            await loaderContainerTracker.ensureSynchronized(container2);
             assert.equal(user1ReceivedMsgCount, 0, "User1 received message count is incorrect");
             assert.equal(user2ReceivedMsgCount, 1, "User2 received message count is incorrect");
 
-            await opProcessingController.processIncoming(container1.deltaManager);
+            await loaderContainerTracker.processIncoming(container1);
             assert.equal(user1ReceivedMsgCount, 1, "User1 received message count is incorrect");
             assert.equal(user2ReceivedMsgCount, 1, "User2 received message count is incorrect");
 
             sharedString1.insertText(0, "B");
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             assert.equal(sharedString1.getText(), sharedString2.getText(), "Shared string not synced");
             assert.equal(sharedString1.getText().length, 3, sharedString1.getText());

--- a/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
@@ -82,6 +82,10 @@ describe("No Delta Stream", () => {
         await loaderContainerTracker.ensureSynchronized();
     });
 
+    afterEach(() => {
+        loaderContainerTracker.reset();
+    });
+
     it("Validate Properties on Loaded Container With No Delta Stream", async () => {
         // Load the Container that was created by the first client.
         const container = await loadContainer(true) as Container;

--- a/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
@@ -10,7 +10,7 @@ import {
     createLocalResolverCreateNewRequest,
     LocalDocumentServiceFactory,
     LocalResolver,
- } from "@fluidframework/local-driver";
+} from "@fluidframework/local-driver";
 import { SharedString } from "@fluidframework/sequence";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
@@ -18,7 +18,7 @@ import {
     createAndAttachContainer,
     createLoader,
     ITestFluidObject,
-    OpProcessingController,
+    LoaderContainerTracker,
     TestContainerRuntimeFactory,
     TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
@@ -35,21 +35,21 @@ describe("No Delta Stream", () => {
     const factory = new TestContainerRuntimeFactory(
         "",
         new TestFluidObjectFactory([[stringId, SharedString.getFactory()]]),
-        {generateSummaries: true});
+        { generateSummaries: true });
 
     let deltaConnectionServer: ILocalDeltaConnectionServer;
-    let opc: OpProcessingController;
+    let loaderContainerTracker: LoaderContainerTracker;
 
     async function createContainer(): Promise<IContainer> {
         const loader = createLoader(
             [[codeDetails, factory]],
             new LocalDocumentServiceFactory(deltaConnectionServer),
             new LocalResolver());
+        loaderContainerTracker.add(loader);
         const container = await createAndAttachContainer(
             codeDetails,
             loader,
             createLocalResolverCreateNewRequest(documentId));
-        opc.addDeltaManagers(container.deltaManager);
         return container;
     }
 
@@ -58,14 +58,14 @@ describe("No Delta Stream", () => {
             [[codeDetails, factory]],
             new LocalDocumentServiceFactory(deltaConnectionServer, { storageOnly }),
             new LocalResolver());
+        loaderContainerTracker.add(loader);
         const container = await loader.resolve({ url: documentLoadUrl });
-        opc.addDeltaManagers(container.deltaManager);
         return container;
     }
 
     beforeEach(async () => {
         deltaConnectionServer = LocalDeltaConnectionServer.create();
-        opc = new OpProcessingController();
+        loaderContainerTracker = new LoaderContainerTracker();
 
         // Create a Container for the first client.
         const container = await createContainer();
@@ -79,7 +79,7 @@ describe("No Delta Stream", () => {
         assert.notStrictEqual(dataObject.runtime.clientId, undefined, "clientId");
 
         dataObject.root.set("test", "key");
-        await opc.process();
+        await loaderContainerTracker.ensureSynchronized();
     });
 
     it("Validate Properties on Loaded Container With No Delta Stream", async () => {

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -25,8 +25,8 @@ import { SharedString } from "@fluidframework/sequence";
 import {
     createAndAttachContainer,
     ITestFluidObject,
+    LoaderContainerTracker,
     LocalCodeLoader,
-    OpProcessingController,
     TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
 
@@ -45,7 +45,7 @@ describe("Ops on Reconnect", () => {
     let urlResolver: LocalResolver;
     let deltaConnectionServer: ILocalDeltaConnectionServer;
     let documentServiceFactory: LocalDocumentServiceFactory;
-    let opProcessingController: OpProcessingController;
+    let loaderContainerTracker: LoaderContainerTracker;
     let container1: Container;
     let container1Object1: ITestFluidObject & IFluidLoadable;
     let container1Object1Map1: SharedMap;
@@ -84,11 +84,13 @@ describe("Ops on Reconnect", () => {
 
         const codeLoader = new LocalCodeLoader([[codeDetails, runtimeFactory]]);
 
-        return new Loader({
+        const loader = new Loader({
             urlResolver,
             documentServiceFactory,
             codeLoader,
         });
+        loaderContainerTracker.add(loader);
+        return loader;
     }
 
     async function createContainer(): Promise<IContainer> {
@@ -130,7 +132,6 @@ describe("Ops on Reconnect", () => {
         const container2Object1 = await requestFluidObject<ITestFluidObject & IFluidLoadable>(
             container2,
             "default");
-        opProcessingController.addDeltaManagers(container2.deltaManager);
 
         return container2Object1;
     }
@@ -139,6 +140,7 @@ describe("Ops on Reconnect", () => {
         urlResolver = new LocalResolver();
         deltaConnectionServer = LocalDeltaConnectionServer.create();
         documentServiceFactory = new LocalDocumentServiceFactory(deltaConnectionServer);
+        loaderContainerTracker = new LoaderContainerTracker();
 
         // Create the first container, dataObject and DDSes.
         container1 = await createContainer() as Container;
@@ -150,11 +152,8 @@ describe("Ops on Reconnect", () => {
         container1Object1Directory = await container1Object1.getSharedObject<SharedDirectory>(directoryId);
         container1Object1String = await container1Object1.getSharedObject<SharedString>(stringId);
 
-        opProcessingController = new OpProcessingController();
-        opProcessingController.addDeltaManagers(container1.deltaManager);
-
         // Wait for the attach ops to get processed.
-        await opProcessingController.process();
+        await loaderContainerTracker.ensureSynchronized();
     });
 
     describe("Ops on Container reconnect", () => {
@@ -180,7 +179,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues = [
                 ["key1", "value1", undefined /* batch */],
@@ -214,7 +213,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues = [
                 ["key1", "value1", undefined /* batch */],
@@ -251,7 +250,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues = [
                 ["key1", "value1", undefined /* batch */],
@@ -279,7 +278,7 @@ describe("Ops on Reconnect", () => {
             container1Object1Map1.set("dataStore2Key", container1Object2.handle);
 
             // Wait for the set above to get processed.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             // Create a second container and set up a listener to store the received map / directory values.
             const container2Object1 = await setupSecondContainersDataObject();
@@ -314,7 +313,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues = [
                 ["key1", "value1", undefined /* batch */],
@@ -355,7 +354,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues = [
                 ["key1", "value1", undefined /* batch */],
@@ -383,7 +382,7 @@ describe("Ops on Reconnect", () => {
             container1Object1Map1.set("dataStore2Key", container1Object2.handle);
 
             // Wait for the set above to get processed.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             // Create a second container and set up a listener to store the received map / directory values.
             const container2Object1 = await setupSecondContainersDataObject();
@@ -417,7 +416,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues = [
                 ["key1", "value1", undefined /* batch */],
@@ -463,7 +462,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues: [string, string, boolean | undefined][] = [
                 ["key1", "value1", true /* batch */],
@@ -511,7 +510,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues: [string, string, boolean | undefined][] = [
                 ["key1", "value1", true /* batch */],
@@ -554,7 +553,7 @@ describe("Ops on Reconnect", () => {
             await waitForContainerReconnection(container1);
 
             // Wait for the ops to get processed by both the containers.
-            await opProcessingController.process();
+            await loaderContainerTracker.ensureSynchronized();
 
             const expectedValues: [string, string, boolean | undefined][] = [
                 ["key1", "value1", true /* batch */],

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -156,6 +156,10 @@ describe("Ops on Reconnect", () => {
         await loaderContainerTracker.ensureSynchronized();
     });
 
+    afterEach(() => {
+        loaderContainerTracker.reset();
+    });
+
     describe("Ops on Container reconnect", () => {
         it("can resend ops on reconnection that were sent in disconnected state", async () => {
             // Create a second container and set up a listener to store the received map / directory values.

--- a/packages/test/test-end-to-end-tests/src/test/gcDataStoreRequests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gcDataStoreRequests.spec.ts
@@ -10,18 +10,11 @@ import {
 } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import { IFluidCodeDetails, IRequest } from "@fluidframework/core-interfaces";
+import { IRequest } from "@fluidframework/core-interfaces";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import {
-    createAndAttachContainer,
-    createDocumentId,
-    createLoader,
-    ITestObjectProvider,
-    OpProcessingController,
-} from "@fluidframework/test-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
 
 class TestDataObject extends DataObject {
     public get _root() {
@@ -40,11 +33,6 @@ class TestDataObject extends DataObject {
 // REVIEW: enable compat testing?
 describeNoCompat("GC Data Store Requests", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    let documentId: string;
-    const codeDetails: IFluidCodeDetails = {
-        package: "garbageCollectionTestPackage",
-        config: {},
-    };
     const factory = new DataObjectFactory(
         "TestDataObject",
         TestDataObject,
@@ -72,29 +60,10 @@ describeNoCompat("GC Data Store Requests", (getTestObjectProvider) => {
         runtimeOptions,
     );
 
-    let opProcessingController: OpProcessingController;
     let container1: IContainer;
 
-    async function createContainer(): Promise<IContainer> {
-        const loader = createLoader(
-            [[codeDetails, runtimeFactory]],
-            provider.documentServiceFactory,
-            provider.urlResolver,
-            ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver?.type } }),
-        );
-        return createAndAttachContainer(
-            codeDetails, loader, provider.driver.createCreateNewRequest(documentId));
-    }
-
-    async function loadContainer(): Promise<IContainer> {
-        const loader = createLoader(
-            [[codeDetails, runtimeFactory]],
-            provider.documentServiceFactory,
-            provider.urlResolver,
-            ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver?.type } }),
-        );
-        return loader.resolve({ url: await provider.driver.createContainerUrl(documentId) });
-    }
+    const createContainer = async (): Promise<IContainer> => provider.createContainer(runtimeFactory);
+    const loadContainer = async (): Promise<IContainer> => provider.loadContainer(runtimeFactory);
 
     async function waitForSummary(container: IContainer): Promise<string | undefined> {
         let handle: string | undefined;
@@ -112,12 +81,9 @@ describeNoCompat("GC Data Store Requests", (getTestObjectProvider) => {
 
     beforeEach(async () => {
         provider = getTestObjectProvider();
-        documentId = createDocumentId();
-        opProcessingController = provider.opProcessingController;
 
         // Create a Container for the first client.
         container1 = await createContainer();
-        opProcessingController.addDeltaManagers(container1.deltaManager);
     });
 
     it("should fail requests with externalRequest flag for unreferenced data stores", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
@@ -12,17 +12,10 @@ import { assert, TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { Container } from "@fluidframework/container-loader";
-import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { SummaryType } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import {
-    createAndAttachContainer,
-    createDocumentId,
-    createLoader,
-    ITestObjectProvider,
-} from "@fluidframework/test-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
 
 class TestDataObject extends DataObject {
     public get _root() {
@@ -36,11 +29,6 @@ class TestDataObject extends DataObject {
 
 // REVIEW: enable compat testing?
 describeNoCompat("GC in summary", (getTestObjectProvider) => {
-    let documentId: string;
-    const codeDetails: IFluidCodeDetails = {
-        package: "garbageCollectionTestPackage",
-        config: {},
-    };
     const dataObjectFactory = new DataObjectFactory(
         "TestDataObject",
         TestDataObject,
@@ -63,16 +51,7 @@ describeNoCompat("GC in summary", (getTestObjectProvider) => {
     let containerRuntime: ContainerRuntime;
     let defaultDataStore: TestDataObject;
 
-    async function createContainer(): Promise<IContainer> {
-        const loader = createLoader(
-            [[codeDetails, runtimeFactory]],
-            provider.documentServiceFactory,
-            provider.urlResolver,
-            ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver?.type } }),
-        );
-        return createAndAttachContainer(
-            codeDetails, loader, provider.driver.createCreateNewRequest(documentId));
-    }
+    const createContainer = async (): Promise<IContainer> => provider.createContainer(runtimeFactory);
 
     // Summarizes the container and validates that the data store's reference state is correct in the summary.
     async function validateDataStoreReferenceState(dataStoreId: string, referenced: boolean) {
@@ -103,12 +82,9 @@ describeNoCompat("GC in summary", (getTestObjectProvider) => {
 
     beforeEach(async () => {
         provider = getTestObjectProvider();
-        documentId = createDocumentId();
-
         const container = await createContainer() as Container;
         defaultDataStore = await requestFluidObject<TestDataObject>(container, "/");
         containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
-        provider.opProcessingController.addDeltaManagers(containerRuntime.deltaManager);
 
         // Wait for the Container to get connected.
         if (!container.connected) {

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -12,21 +12,12 @@ import {
 } from "@fluidframework/aqueduct";
 import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
-import { IFluidCodeDetails, IRequest, IResponse } from "@fluidframework/core-interfaces";
-import {
-    createAndAttachContainer,
-    createDocumentId,
-    createLoader,
-    ITestObjectProvider,
-    OpProcessingController,
-} from "@fluidframework/test-utils";
+import { IRequest, IResponse } from "@fluidframework/core-interfaces";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
 
 class TestSharedDataObject1 extends DataObject {
-    public inspectRequest: boolean = false;
-
     public get _root() {
         return this.root;
     }
@@ -44,7 +35,7 @@ class TestSharedDataObject1 extends DataObject {
     public async request(request: IRequest): Promise<IResponse> {
         const url = request.url;
         const parsed = parse(url, true);
-        if (this.inspectRequest) {
+        if (parsed.query.inspect === "1") {
             // returning query params instead of the data object for testing purposes
             return { mimeType: "text/plain", status: 200, value: `${parsed.search}` };
         } else if (parsed?.pathname === "/") {
@@ -98,48 +89,31 @@ const testSharedDataObjectFactory2 = new DataObjectFactory(
 // REVIEW: enable compat testing?
 describeNoCompat("Loader.request", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    const codeDetails: IFluidCodeDetails = {
-        package: "loaderRequestTestPackage",
-        config: {},
-    };
 
     let dataStore1: TestSharedDataObject1;
     let dataStore2: TestSharedDataObject2;
     let loader: IHostLoader;
-    let opProcessingController: OpProcessingController;
 
-    async function createContainer(documentId: string): Promise<IContainer> {
-        const runtimeFactory =
-            new ContainerRuntimeFactoryWithDefaultDataStore(
-                testSharedDataObjectFactory1,
-                [
-                    [testSharedDataObjectFactory1.type, Promise.resolve(testSharedDataObjectFactory1)],
-                    [testSharedDataObjectFactory2.type, Promise.resolve(testSharedDataObjectFactory2)],
-                ],
-            );
-        loader = createLoader(
-            [[codeDetails, runtimeFactory]],
-            provider.documentServiceFactory,
-            provider.urlResolver,
-            ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver?.type } }),
+    const runtimeFactory =
+        new ContainerRuntimeFactoryWithDefaultDataStore(
+            testSharedDataObjectFactory1,
+            [
+                [testSharedDataObjectFactory1.type, Promise.resolve(testSharedDataObjectFactory1)],
+                [testSharedDataObjectFactory2.type, Promise.resolve(testSharedDataObjectFactory2)],
+            ],
         );
-        return createAndAttachContainer(
-            codeDetails, loader, provider.driver.createCreateNewRequest(documentId));
-    }
+    const createContainer = async (): Promise<IContainer> => provider.createContainer(runtimeFactory);
     let container: IContainer;
     beforeEach(async () => {
         provider = getTestObjectProvider();
-        const documentId = createDocumentId();
-        container = await createContainer(documentId);
+        container = await createContainer();
+        loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]]);
         dataStore1 = await requestFluidObject(container, "default");
 
         dataStore2 = await testSharedDataObjectFactory2.createInstance(dataStore1._context.containerRuntime);
 
         // this binds dataStore2 to dataStore1
         dataStore1._root.set("key", dataStore2.handle);
-
-        opProcessingController = provider.opProcessingController;
-        opProcessingController.addDeltaManagers(container.deltaManager);
     });
 
     it("can create the data objects with correct types", async () => {
@@ -185,7 +159,6 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
         const url = await container.getAbsoluteUrl("");
         assert(url, "url is undefined");
         const container2 = await loader.resolve({ url, headers });
-        opProcessingController.addDeltaManagers(container2.deltaManager);
 
         // create a new data store using the original container
         const newDataStore = await testSharedDataObjectFactory2.createInstance(dataStore1._context.containerRuntime);
@@ -218,7 +191,6 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
         assert(url, "url is undefined");
         // load the containers paused
         const container1 = await loader.resolve({ url, headers: { [LoaderHeader.pause]: true } });
-        opProcessingController.addDeltaManagers(container1.deltaManager);
         const container2 = await loader.resolve({ url, headers: { [LoaderHeader.pause]: true } });
 
         assert.strictEqual(container1, container2, "container not cached across multiple loader requests");
@@ -246,10 +218,9 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
     });
 
     it("can handle url with query params", async () => {
-        dataStore1.inspectRequest = true;
         const url = await container.getAbsoluteUrl("");
         assert(url, "url is undefined");
-        const testUrl = `${url}${url.includes("?") ? "&query1=1&query2=2" : "?query1=1&query2=2"}`;
+        const testUrl = `${url}${url.includes("?") ? "&query1=1&query2=2&inspect=1" : "?query1=1&query2=2&inspect=1"}`;
 
         const response = await loader.request({ url: testUrl });
         const searchParams = new URLSearchParams(response.value);

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -99,7 +99,11 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
         config: {},
     };
 
-    let loaderContainerTracker: LoaderContainerTracker;
+    const loaderContainerTracker = new LoaderContainerTracker();
+
+    afterEach(() => {
+        loaderContainerTracker.reset();
+    });
 
     async function createContainer(documentId: string, factory: IFluidDataStoreFactory): Promise<IContainer> {
         const loader = createLoader(
@@ -108,9 +112,7 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
             provider.urlResolver,
             ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver?.type } }),
         );
-        if (loaderContainerTracker) {
-            loaderContainerTracker.add(loader);
-        }
+        loaderContainerTracker.add(loader);
         return createAndAttachContainer(
             codeDetails, loader, provider.driver.createCreateNewRequest(documentId));
     }
@@ -122,9 +124,7 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
             provider.urlResolver,
             ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver?.type } }),
         );
-        if (loaderContainerTracker) {
-            loaderContainerTracker.add(loader);
-        }
+        loaderContainerTracker.add(loader);
         return loader.resolve({ url: await provider.driver.createContainerUrl(documentId) });
     }
 
@@ -144,10 +144,6 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
     });
 
     describe("2 dataObjects", () => {
-        beforeEach(async () => {
-            loaderContainerTracker = new LoaderContainerTracker();
-        });
-
         it("early open / late close", async () => {
             const documentId = createDocumentId();
 
@@ -225,7 +221,6 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
             let text2: SharedString;
 
             beforeEach(async () => {
-                loaderContainerTracker = new LoaderContainerTracker();
                 const documentId = createDocumentId();
                 const factory = new TestFluidObjectFactory([["text", SharedString.getFactory()]]);
 

--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -108,7 +108,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(await map2.wait(testKey), testValue);
     });
 
-    it.skip("doesn't resend successful op", async function() {
     it("doesn't resend successful op", async function() {
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {
             map.set(testKey, "something unimportant");

--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -44,7 +44,7 @@ const getPendingOps = async (args: ITestObjectProvider, send: boolean, cb: MapCa
         }
     });
     await args.ensureSynchronized();
-    await args.opProcessingController.pauseProcessing(container.deltaManager as any);
+    await args.opProcessingController.pauseProcessing(container);
     const dataStore = await requestFluidObject<ITestFluidObject>(container, "default");
     assert(dataStore.runtime.deltaManager.outbound.paused);
     const map = await dataStore.getSharedObject<SharedMap>(mapId);
@@ -90,7 +90,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
             provider.defaultCodeDetails,
             loader,
             provider.driver.createCreateNewRequest(provider.documentId));
-        provider.opProcessingController.addDeltaManagers((container1 as any).deltaManager);
         url = await container1.getAbsoluteUrl("");
         const dataStore1 = await requestFluidObject<ITestFluidObject>(container1, "default");
         map1 = await dataStore1.getSharedObject<SharedMap>(mapId);
@@ -109,6 +108,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(await map2.wait(testKey), testValue);
     });
 
+    it.skip("doesn't resend successful op", async function() {
     it("doesn't resend successful op", async function() {
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {
             map.set(testKey, "something unimportant");
@@ -119,7 +119,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 
         // load with pending ops, which it should not resend because they were already sent successfully
         const container2 = await loader.resolve({ url }, pendingOps);
-        provider.opProcessingController.addDeltaManagers(container2.deltaManager);
         const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         const map2 = await dataStore2.getSharedObject<SharedMap>(mapId);
 
@@ -154,7 +153,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
 
         // load container with pending ops, which should not resend the ops sent by previous container
         const container2 = await loader.resolve({ url }, pendingOps);
-        provider.opProcessingController.addDeltaManagers(container2.deltaManager);
         const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         const map2 = await dataStore2.getSharedObject<SharedMap>(mapId);
         if (!(container2 as any).connected) {
@@ -252,7 +250,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         });
 
         const container2 = await loader.resolve({ url }, pendingOps);
-        provider.opProcessingController.addDeltaManagers(container2.deltaManager);
         const dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
         const map2 = await dataStore2.getSharedObject<SharedMap>(mapId);
         if (!(container2 as any).connected) {

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -7,7 +7,6 @@ import { ContainerRuntimeFactoryWithDefaultDataStore, DataObject, DataObjectFact
 import { assert, bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { SharedDirectory, SharedMap } from "@fluidframework/map";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
@@ -15,14 +14,7 @@ import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { SharedObjectSequence } from "@fluidframework/sequence";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
-
-import {
-    ITestObjectProvider,
-    createAndAttachContainer,
-    createDocumentId,
-    createLoader,
-} from "@fluidframework/test-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
 
 const defaultDataStoreId = "default";
 
@@ -37,11 +29,6 @@ async function createContainer(
     provider: ITestObjectProvider,
     runtimeOptions: Omit<IContainerRuntimeOptions, "generateSummaries">,
 ): Promise<IContainer> {
-    const documentId = createDocumentId();
-    const codeDetails: IFluidCodeDetails = {
-        package: "summarizerTestPackage",
-    };
-
     const factory = new DataObjectFactory(TestDataObject.dataObjectName, TestDataObject, [
         SharedMap.getFactory(),
         SharedDirectory.getFactory(),
@@ -65,20 +52,7 @@ async function createContainer(
         thisRuntimeOptions,
     );
 
-    const loader = createLoader(
-        [[codeDetails, runtimeFactory]],
-        provider.documentServiceFactory,
-        provider.urlResolver,
-        ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver?.type } }),
-    );
-    const container = await createAndAttachContainer(
-        codeDetails,
-        loader,
-        provider.driver.createCreateNewRequest(documentId));
-
-    provider.opProcessingController.addDeltaManagers(container.deltaManager);
-
-    return container;
+    return provider.createContainer(runtimeFactory);
 }
 
 function readBlobContent(content: ISummaryBlob["content"]): unknown {

--- a/packages/test/test-end-to-end-tests/src/test/upgradeManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/upgradeManager.spec.ts
@@ -6,23 +6,11 @@
 import { strict as assert } from "assert";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { UpgradeManager } from "@fluidframework/base-host";
-import {
-    ICodeLoader,
-    IContainer,
-} from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
-import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Container } from "@fluidframework/container-loader";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import {
-    createAndAttachContainer,
-    createDocumentId,
-    ITestObjectProvider,
-    LocalCodeLoader,
-    OpProcessingController,
-} from "@fluidframework/test-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 
 class TestDataObject extends DataObject {
@@ -41,44 +29,16 @@ class TestDataObject extends DataObject {
 }
 
 describeNoCompat("UpgradeManager (hot-swap)", (getTestObjectProvider) => {
-    const codeDetails: IFluidCodeDetails = {
-        package: "localLoaderTestPackage",
-        config: {},
-    };
     let provider: ITestObjectProvider;
-    let opProcessingController: OpProcessingController;
 
-    async function createContainer(documentId: string, factory: IFluidDataStoreFactory): Promise<IContainer> {
-        const codeLoader: ICodeLoader = new LocalCodeLoader([[codeDetails, factory]]);
-        const loader = new Loader({
-            urlResolver: provider.urlResolver,
-            documentServiceFactory: provider.documentServiceFactory,
-            codeLoader,
-            options: { hotSwapContext: true },
-            logger: ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver.type } }),
-        });
+    const createContainer = async (): Promise<IContainer> =>
+        provider.createContainer(TestDataObject.getFactory(), { hotSwapContext: true });
 
-        return createAndAttachContainer(
-            codeDetails, loader, provider.driver.createCreateNewRequest(documentId));
-    }
-
-    async function loadContainer(documentId: string, factory: IFluidDataStoreFactory): Promise<IContainer> {
-        const codeLoader: ICodeLoader = new LocalCodeLoader([[codeDetails, factory]]);
-
-        const loader = new Loader({
-            urlResolver: provider.urlResolver,
-            documentServiceFactory: provider.documentServiceFactory,
-            codeLoader,
-            options: { hotSwapContext: true },
-            logger: ChildLogger.create(getTestLogger?.(), undefined, { all: { driverType: provider.driver.type } }),
-        });
-
-        return loader.resolve({ url: await provider.driver.createContainerUrl(documentId) });
-    }
+    const loadContainer = async (): Promise<IContainer> =>
+        provider.loadContainer(TestDataObject.getFactory(), { hotSwapContext: true });
 
     beforeEach(async () => {
         provider = getTestObjectProvider();
-        opProcessingController = provider.opProcessingController;
     });
 
     it("prevents multiple approved proposals", async () => {
@@ -87,22 +47,19 @@ describeNoCompat("UpgradeManager (hot-swap)", (getTestObjectProvider) => {
         const addCounts = Array(clients).fill(0);
         const approveCounts = Array(clients).fill(0);
         const containers: IContainer[] = [];
-        const documentId = createDocumentId();
 
         // Create the first Container.
-        const container1 = await createContainer(documentId, TestDataObject.getFactory());
+        const container1 = await createContainer();
         containers.push(container1);
 
         // Load rest of the Containers.
         const restOfContainersP =
-            Array(clients - 1).fill(undefined).map(async () => loadContainer(documentId, TestDataObject.getFactory()));
+            Array(clients - 1).fill(undefined).map(async () => loadContainer());
         const restOfContainers = await Promise.all(restOfContainersP);
         containers.push(...restOfContainers);
 
         const dataObjects = await Promise.all(containers.map(
             async (container) => requestFluidObject<TestDataObject>(container, "default")));
-
-        opProcessingController.addDeltaManagers(...containers.map((c) => c.deltaManager));
 
         dataObjects.map((c, i) => {
             c._runtime.getQuorum().on("addProposal", () => { ++addCounts[i]; });
@@ -124,7 +81,7 @@ describeNoCompat("UpgradeManager (hot-swap)", (getTestObjectProvider) => {
         }
 
         // upgrade all containers at once
-        const resultsP = upgradeManagers.map(async (u) => u.upgrade(codeDetails, true));
+        const resultsP = upgradeManagers.map(async (u) => u.upgrade(provider.defaultCodeDetails, true));
 
         await Promise.all(succeededP);
 
@@ -138,12 +95,9 @@ describeNoCompat("UpgradeManager (hot-swap)", (getTestObjectProvider) => {
     });
 
     it("1 client low priority is immediate", async () => {
-        const documentId = createDocumentId();
-
-        const container = await createContainer(documentId, TestDataObject.getFactory());
+        const container = await createContainer();
         const dataObject = await requestFluidObject<TestDataObject>(container, "default");
 
-        opProcessingController.addDeltaManagers(container.deltaManager);
         const upgradeManager = new UpgradeManager((container as any).context.runtime);
 
         const upgradeP = new Promise<void>((resolve) => {
@@ -159,19 +113,17 @@ describeNoCompat("UpgradeManager (hot-swap)", (getTestObjectProvider) => {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        upgradeManager.upgrade(codeDetails);
+        upgradeManager.upgrade(provider.defaultCodeDetails);
         await provider.ensureSynchronized();
         await upgradeP;
     });
 
     it("2 clients low priority is delayed", async () => {
-        const documentId = createDocumentId();
-
         // Create the first Container.
-        const container1 = await createContainer(documentId, TestDataObject.getFactory());
+        const container1 = await createContainer();
 
         // Load the second Container.
-        const container2 = await loadContainer(documentId, TestDataObject.getFactory()) as Container;
+        const container2 = await loadContainer() as Container;
 
         const upgradeManager = new UpgradeManager((container1 as any).context.runtime);
 
@@ -186,7 +138,6 @@ describeNoCompat("UpgradeManager (hot-swap)", (getTestObjectProvider) => {
         });
 
         const dataObject = await requestFluidObject<TestDataObject>(container1, "default");
-        opProcessingController.addDeltaManagers(container1.deltaManager);
 
         // Set a key in the root map of the first container's dataObject. The Container is created in "read" mode so the
         // first op it sends will get nack'd and it reconnects.
@@ -196,7 +147,7 @@ describeNoCompat("UpgradeManager (hot-swap)", (getTestObjectProvider) => {
             await provider.ensureSynchronized();
         }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        upgradeManager.upgrade(codeDetails);
+        upgradeManager.upgrade(provider.defaultCodeDetails);
 
         // disconnect one client, which should initiate upgrade
         assert(container2.clientId);

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -34,7 +34,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 
     /**
      * Add a loader to start to track any container created from them
-     * @param loader loader to start tracking any container created.
+     * @param loader - loader to start tracking any container created.
      */
     public add<LoaderType extends IHostLoader>(loader: LoaderType) {
         // TODO: Expose Loader API to able to intercept container creation
@@ -57,7 +57,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
     /**
      * Utility function to add container to be tracked.
      *
-     * @param container container to add
+     * @param container - container to add
      */
     private addContainer(container: IContainer) {
         // ignore summarizer
@@ -83,8 +83,8 @@ export class LoaderContainerTracker implements IOpProcessingController {
      * Keep track of the trailing NoOp that was sent so we can discount them in the clientSequenceNumber tracking.
      * The server might coalesce them with other ops, or a single NoOp, or delay it if it don't think it is necessary.
      *
-     * @param container the container to track
-     * @param record the record to update the trailing op information
+     * @param container - the container to track
+     * @param record - the record to update the trailing op information
      */
     private trackTrailingNoOps(container: IContainer, record: ContainerRecord) {
         container.deltaManager.outbound.on("op", (messages) => {
@@ -146,7 +146,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
      * - No isDirty (non-readonly) containers
      * - No extra clientId in quorum of any container that is not tracked and still opened.
      *      - i.e. no pending Join/Leave message.
-     * - No unresolved proposal (minSeqNum >= lastProposalSeqNum)
+     * - No unresolved proposal (minSeqNum \>= lastProposalSeqNum)
      * - lastSequenceNumber of all container is the same
      * - clientSequenceNumberObserved is the same as clientSequenceNumber sent
      *      - this overlaps with !isDirty, but include task scheduler ops.
@@ -204,10 +204,10 @@ export class LoaderContainerTracker implements IOpProcessingController {
     }
 
     /**
-     * Utilities to calculate the set of clientId per container in quorum that is NOT associated with
+     * Utility to calculate the set of clientId per container in quorum that is NOT associated with
      * any container we tracked, indicating there is a pending join or leave op that we need to wait.
      *
-     * @param containersToApply the set of containers to check
+     * @param containersToApply - the set of containers to check
      */
     private getPendingClients(containersToApply: IContainer[]) {
         // All the clientId we track should be a superset of the quorum, otherwise, we are missing
@@ -235,10 +235,10 @@ export class LoaderContainerTracker implements IOpProcessingController {
     }
 
     /**
-     * Utilities to check sequence number based synchronization.
+     * Utility to check synchronization based on sequence number
      * See ensureSynchronized for more detail
      *
-     * @param containersToApply the set of containers to check
+     * @param containersToApply - the set of containers to check
      */
     private isSequenceNumberSynchronized(containersToApply: IContainer[]) {
         // clientSequenceNumber check detects ops in flight, both on the wire and in the outbound queue
@@ -277,12 +277,12 @@ export class LoaderContainerTracker implements IOpProcessingController {
     }
 
     /**
-     * Utilities to wait for any clientId in quorum that is NOT associated with any container we
+     * Utility to wait for any clientId in quorum that is NOT associated with any container we
      * tracked, indicating there is a pending join or leave op that we need to wait.
      *
      * Note that this function doesn't account for container that got added after we started waiting
      *
-     * @param containersToApply the set of containers to wait for any inbound ops for
+     * @param containersToApply - the set of containers to wait for any inbound ops for
      */
     private async waitForPendingClients(pendingClients: [IContainer, Set<string>][]) {
         const unconnectedClients =
@@ -314,8 +314,8 @@ export class LoaderContainerTracker implements IOpProcessingController {
     }
 
     /**
-     * Utilities to wait for any inbound ops from a set of containers
-     * @param containersToApply the set of containers to wait for any inbound ops for
+     * Utility to wait for any inbound ops from a set of containers
+     * @param containersToApply - the set of containers to wait for any inbound ops for
      */
     private async waitForAnyInboundOps(containersToApply: IContainer[]) {
         return new Promise<void>((res) => {
@@ -426,11 +426,11 @@ export class LoaderContainerTracker implements IOpProcessingController {
     }
 
     /**
-     * Utilities to set up listener to track the outbound ops until it round trip back
+     * Utility to set up listener to track the outbound ops until it round trip back
      * Returns a function to remove the handler after it is done.
      *
-     * @param container the container to setup
-     * @param inflightTracker a map to track the clientSequenceNumber per container it expect to get ops back
+     * @param container - the container to setup
+     * @param inflightTracker - a map to track the clientSequenceNumber per container it expect to get ops back
      */
     private setupInOutTracker(container: IContainer, inflightTracker: Map<IContainer, number>) {
         const outHandler = (messages: IDocumentMessage[]) => {
@@ -513,7 +513,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 
     /**
      * Filter out the opened containers based on param.
-     * @param containers The container to filter to.  If the array is empty, it means don't filter and return
+     * @param containers - The container to filter to.  If the array is empty, it means don't filter and return
      * all open containers.
      */
     private getContainers(containers: IContainer[]) {

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -37,7 +37,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
      * @param loader - loader to start tracking any container created.
      */
     public add<LoaderType extends IHostLoader>(loader: LoaderType) {
-        // TODO: Expose Loader API to able to intercept container creation
+        // TODO: Expose Loader API to able to intercept container creation (See issue #5114)
         const patch = <T, C extends IContainer>(fn: (...args) => Promise<C>) => {
             const boundFn = fn.bind(loader);
             return async (...args: T[]) => {
@@ -121,9 +121,9 @@ export class LoaderContainerTracker implements IOpProcessingController {
     }
 
     private trackLastProposal(container: IContainer) {
-        container.deltaManager.inbound.on("op", (message) => {
-            if (message.type === MessageType.Propose && message.sequenceNumber > this.lastProposalSeqNum) {
-                this.lastProposalSeqNum = message.sequenceNumber;
+        container.getQuorum().on("addProposal", (proposal) => {
+            if (proposal.sequenceNumber > this.lastProposalSeqNum) {
+                this.lastProposalSeqNum = proposal.sequenceNumber;
             }
         });
     }

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -3,17 +3,36 @@
  * Licensed under the MIT License.
  */
 
-import { IContainer, IHostLoader } from "@fluidframework/container-definitions";
+import { IContainer, IDeltaQueue, IHostLoader } from "@fluidframework/container-definitions";
+import { Container } from "@fluidframework/container-loader";
+import { debug } from "./debug";
+
+const debugOp = debug.extend("ops");
 
 export class LoaderContainerTracker {
-    private readonly containers = new Set<IContainer>();
+    private readonly containers = new Map<IContainer, boolean>();
 
+    /**
+     * @internal Temporary exposing a list of containers for OpProcessingController shim
+     */
+    public get trackedContainers() {
+        return this.containers.keys();
+    }
+
+    /**
+     * Add a loader to start to track any container created from them
+     * @param loader loader to start tracking any container created.
+     */
     public add<LoaderType extends IHostLoader>(loader: LoaderType) {
+        // TODO: Expose Loader API to able to intercept container creation
         const patch = <T, C extends IContainer>(fn: (...args) => Promise<C>) => {
             const boundFn = fn.bind(loader);
             return async (...args: T[]) => {
                 const container = await boundFn(...args);
-                this.containers.add(container);
+                if (!this.containers.has(container)) {
+                    this.containers.set(container, false);
+                    this.setupTrace(container, this.containers.size);
+                }
                 return container;
             };
         };
@@ -25,35 +44,207 @@ export class LoaderContainerTracker {
         loader.rehydrateDetachedContainerFromSnapshot = patch(loader.rehydrateDetachedContainerFromSnapshot);
     }
 
+    /**
+     * Reset the tracker, closing all containers and stop tracking them.
+     */
     public reset() {
-        for (const container of this.containers) {
+        for (const container of this.containers.keys()) {
             container.close();
         }
         this.containers.clear();
+
+        // TODO: Unpatch the loaders?
     }
 
+    /**
+     * Make sure all the tracked containers are synchronized.
+     * That means all the opened containers
+     */
     public async ensureSynchronized() {
+        const resumed = this.resumeProcessing();
         // eslint-disable-next-line no-constant-condition
         while (true) {
-            const containers = Array.from(this.containers.values());
+            const containers = Array.from(this.containers.keys());
             const openedContainers = containers.filter((c) => !c.closed);
-            if (openedContainers.length === 0) { return; }
+            if (openedContainers.length === 0) { break; }
 
             const dirtyContainers = openedContainers.filter((c) => c.isDirty);
             if (dirtyContainers.length !== 0) {
+                // Wait for all the containers to be saved
                 await Promise.all(dirtyContainers.map(async (c) => new Promise((res) => c.once("saved", res))));
-                // Loop back and check again if we are dirty.
-                continue;
+            } else {
+                // Wait for all the leave messages
+                const pendingDisconnectedClients = this.getPendingDisconnectedClients(openedContainers);
+                if (pendingDisconnectedClients.length !== 0) {
+                    await this.waitForDisconnectedClients(pendingDisconnectedClients);
+                } else if (this.isSequenceNumberSynchronized(openedContainers)) {
+                    // done, we are in sync
+                    break;
+                }
             }
-            // Check to see if all the container has process the same number of ops.
-            const seqNum = openedContainers[0].deltaManager.lastSequenceNumber;
-            if (openedContainers.every((c) => c.deltaManager.lastSequenceNumber === seqNum)) {
-                // done, we are in sync
-                return;
+            // yield a turn to allow side effect of the ops we just processed execute before we check again
+            await new Promise<void>((res) => { setTimeout(res, 0); });
+        }
+
+        // Pause all container that was resumed
+        await this.pauseProcessing(resumed);
+    }
+
+    private getPendingDisconnectedClients(openedContainers: IContainer[]) {
+        // All the clientId we track should be a superset of the quorum, otherwise, we are missing
+        // leave messages
+        const openedClientId = openedContainers.map((container) => (container as Container).clientId);
+
+        const disconnectClients: [IContainer, Set<string>][] = [];
+        openedContainers.forEach((container) => {
+            const disconnectedClientId = new Set<string>();
+            const quorum = container.getQuorum();
+            quorum.getMembers().forEach((client, clientId) => {
+                if (!openedClientId.includes(clientId)) {
+                    disconnectedClientId.add(clientId);
+                }
+            });
+
+            if (disconnectedClientId.size !== 0) {
+                disconnectClients.push([container, disconnectedClientId]);
             }
-            // yield
-            await new Promise<void>((res) => {
-                setTimeout(res, 0);
+        });
+        return disconnectClients;
+    }
+
+    private async waitForDisconnectedClients(disconnectClients: [IContainer, Set<string>][]) {
+        return Promise.all(disconnectClients.map(async ([container, disconnectedClientId]) => {
+            return new Promise<void>((res) => {
+                const handler = (clientId: string) => {
+                    disconnectedClientId.delete(clientId);
+                    if (disconnectedClientId.size === 0) {
+                        container.getQuorum().off("removeMember", handler);
+                        res();
+                    }
+                };
+                container.getQuorum().on("removeMember", handler);
+                container.on("closed", () => {
+                    container.getQuorum().off("removeMember", handler);
+                    res();
+                });
+            });
+        }));
+    }
+
+    private isSequenceNumberSynchronized(openedContainers: IContainer[]) {
+        // TODO: Currently isDirty flag ignores ops for task scheduler.
+        // So we need to look into the deltamanager to use clientSequenceNumber.
+        const isClientSequenceNumberSynchronized = openedContainers.every((container) => {
+            const deltaManager = (container.deltaManager as any);
+            return deltaManager.clientSequenceNumber === deltaManager.clientSequenceNumberObserved;
+        });
+
+        if (!isClientSequenceNumberSynchronized) { return false; }
+
+        // Check to see if all the container has process the same number of ops.
+        const seqNum = openedContainers[0].deltaManager.lastSequenceNumber;
+        return openedContainers.every((c) => c.deltaManager.lastSequenceNumber === seqNum);
+    }
+
+    /**
+     * Resume all queue activities on all paused tracked containers and return them
+     */
+    private resumeProcessing() {
+        const resumed: IContainer[] = [];
+        for (const [container, paused] of this.containers.entries()) {
+            if (paused) {
+                container.deltaManager.inbound.resume();
+                container.deltaManager.outbound.resume();
+                resumed.push(container);
+                this.containers.set(container, false);
+            }
+        }
+        return resumed;
+    }
+
+    /**
+     * Pause all queue activities on the containers given, or all tracked containers
+     * Any containers given that is not tracked will be ignored.
+     */
+    public async pauseProcessing(containers?: IContainer[]) {
+        const pauseP: Promise<void>[] = [];
+        const containersToPause = containers ?? this.containers.keys();
+        for (const container of containersToPause) {
+            const paused = this.containers.get(container);
+            if (paused !== undefined && !paused) {
+                pauseP.push(container.deltaManager.inbound.pause());
+                pauseP.push(container.deltaManager.outbound.pause());
+                this.containers.set(container, true);
+            }
+        }
+        return Promise.all(pauseP);
+    }
+
+    /**
+     * Pause all queue activities on all tracked containers, and resume only
+     * inbound to process ops until it is idle. All queues are left in the paused state
+     * after the function
+     */
+    public async processIncoming() {
+        return this.processQueue((container) => container.deltaManager.inbound);
+    }
+
+    /**
+     * Pause all queue activities on all tracked containers, and resume only
+     * outbound to process ops until it is idle. All queues are left in the paused state
+     * after the function
+     */
+    public async processOutgoing() {
+        return this.processQueue((container) => container.deltaManager.outbound);
+    }
+
+    /**
+     * @deprecated Same as ensureSynchronized()
+     */
+    public async process() {
+        return this.ensureSynchronized();
+    }
+
+    /**
+     * Implementation of processIncoming and processOutgoing
+     */
+    private async processQueue<U>(getQueue: (container: IContainer) => IDeltaQueue<U>) {
+        await this.pauseProcessing();
+        const resumed: IDeltaQueue<U>[] = [];
+        for (const container of this.containers.keys()) {
+            const queue = getQueue(container);
+            queue.resume();
+            resumed.push(queue);
+        }
+
+        while (resumed.some((queue) => !queue.idle)) {
+            await new Promise<void>((res) => { setTimeout(res, 0); });
+        }
+
+        await Promise.all(resumed.map(async (queue) => queue.pause()));
+    }
+
+    /**
+     * Setup debug traces for connection and ops
+     */
+    private setupTrace(container: IContainer, index: number) {
+        if (debugOp.enabled) {
+            container.deltaManager.outbound.on("op", (messages) => {
+                for (const msg of messages) {
+                    debugOp(`${index}: OUT:         `
+                        + `clientSeq: ${msg.clientSequenceNumber} ${msg.type}`);
+                }
+            });
+            container.deltaManager.inbound.on("push", (msg) => {
+                debugOp(`${index}: IN : seq: ${msg.sequenceNumber} `
+                    + `clientSeq: ${msg.clientSequenceNumber.toString().padStart(3)} ${msg.type} `);
+            });
+
+            container.deltaManager.on("connect", (details) => {
+                debugOp(`${index}: CON: clientId: ${details.clientId}`);
+            });
+            container.deltaManager.on("disconnect", (reason) => {
+                debugOp(`${index}: DIS: ${reason}`);
             });
         }
     }

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -5,19 +5,32 @@
 
 import { IContainer, IDeltaQueue, IHostLoader } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
+import { IDocumentMessage, ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { debug } from "./debug";
+import { IOpProcessingController } from "./testObjectProvider";
 
 const debugOp = debug.extend("ops");
+const debugWait = debug.extend("wait");
 
-export class LoaderContainerTracker {
-    private readonly containers = new Map<IContainer, boolean>();
+interface ContainerRecord {
+    // A short number for debug output
+    index: number;
 
-    /**
-     * @internal Temporary exposing a list of containers for OpProcessingController shim
-     */
-    public get trackedContainers() {
-        return this.containers.keys();
-    }
+    // LoaderContainerTracker paused state
+    paused: boolean;
+
+    // Tracking trailing no-op that may or may be acked by the server so we can discount them
+    // See issue #5629
+    startTrailingNoOps: number;
+    trailingNoOps: number;
+
+    // Track last proposal to ensure no unresolved proposal
+    lastProposal: number;
+}
+
+export class LoaderContainerTracker implements IOpProcessingController {
+    private readonly containers = new Map<IContainer, ContainerRecord>();
+    private lastProposalSeqNum: number = 0;
 
     /**
      * Add a loader to start to track any container created from them
@@ -29,10 +42,7 @@ export class LoaderContainerTracker {
             const boundFn = fn.bind(loader);
             return async (...args: T[]) => {
                 const container = await boundFn(...args);
-                if (!this.containers.has(container)) {
-                    this.containers.set(container, false);
-                    this.setupTrace(container, this.containers.size);
-                }
+                this.addContainer(container);
                 return container;
             };
         };
@@ -45,118 +55,282 @@ export class LoaderContainerTracker {
     }
 
     /**
+     * Utility function to add container to be tracked.
+     *
+     * @param container container to add
+     */
+    private addContainer(container: IContainer) {
+        // ignore summarizer
+        if (!container.deltaManager.clientDetails.capabilities.interactive) { return; }
+
+        // don't add container that is already tracked
+        if (this.containers.has(container)) { return; }
+
+        const record = {
+            index: this.containers.size,
+            paused: false,
+            startTrailingNoOps: 0,
+            trailingNoOps: 0,
+            lastProposal: 0,
+        };
+        this.containers.set(container, record);
+        this.trackTrailingNoOps(container, record);
+        this.trackLastProposal(container);
+        this.setupTrace(container, record.index);
+    }
+
+    /**
+     * Keep track of the trailing NoOp that was sent so we can discount them in the clientSequenceNumber tracking.
+     * The server might coalesce them with other ops, or a single NoOp, or delay it if it don't think it is necessary.
+     *
+     * @param container the container to track
+     * @param record the record to update the trailing op information
+     */
+    private trackTrailingNoOps(container: IContainer, record: ContainerRecord) {
+        container.deltaManager.outbound.on("op", (messages) => {
+            for (const msg of messages) {
+                if (msg.type === MessageType.NoOp) {
+                    // Track the NoOp that was sent.
+                    if (record.startTrailingNoOps === 0) {
+                        record.startTrailingNoOps = msg.clientSequenceNumber;
+                    }
+                    record.trailingNoOps++;
+                } else {
+                    // Other ops has been sent. We would like to see those ack'ed, so no more need to track NoOps
+                    record.startTrailingNoOps = 0;
+                    record.trailingNoOps = 0;
+                }
+            }
+        });
+
+        container.deltaManager.inbound.on("push", (message) => {
+            // Received the no op back, update the record.
+            if (message.type === MessageType.NoOp
+                && message.clientId === (container as Container).clientId
+                && message.clientSequenceNumber === record.startTrailingNoOps) {
+                record.trailingNoOps--;
+                record.startTrailingNoOps++;
+            }
+        });
+
+        container.on("disconnected", () => {
+            // reset on disconnect.
+            record.startTrailingNoOps = 0;
+            record.trailingNoOps = 0;
+        });
+    }
+
+    private trackLastProposal(container: IContainer) {
+        container.deltaManager.inbound.on("op", (message) => {
+            if (message.type === MessageType.Propose && message.sequenceNumber > this.lastProposalSeqNum) {
+                this.lastProposalSeqNum = message.sequenceNumber;
+            }
+        });
+    }
+
+    /**
      * Reset the tracker, closing all containers and stop tracking them.
      */
     public reset() {
+        this.lastProposalSeqNum = 0;
         for (const container of this.containers.keys()) {
             container.close();
         }
         this.containers.clear();
 
-        // TODO: Unpatch the loaders?
+        // REVIEW: do we need to unpatch the loaders?
     }
 
     /**
      * Make sure all the tracked containers are synchronized.
-     * That means all the opened containers
+     * - No isDirty containers
+     * - No extra clientId in quorum of any container that is not tracked and still opened.
+     *      - i.e. no pending Join/Leave message.
+     * - No unresolved proposal (minSeqNum >= lastProposalSeqNum)
+     * - lastSequenceNumber of all container is the same
+     * - clientSequenceNumberObserved is the same as clientSequenceNumber sent
+     *      - this overlaps with !isDirty, but include task scheduler ops.
+     *      - Trailing NoOp is tracked and don't count as pending ops.
      */
-    public async ensureSynchronized() {
-        const resumed = this.resumeProcessing();
+    public async ensureSynchronized(...containers: IContainer[]) {
+        const resumed = this.resumeProcessing(...containers);
+
+        let waitingSequenceNumberSynchronized = false;
         // eslint-disable-next-line no-constant-condition
         while (true) {
-            const containers = Array.from(this.containers.keys());
-            const openedContainers = containers.filter((c) => !c.closed);
-            if (openedContainers.length === 0) { break; }
+            const containersToApply = this.getContainers(containers);
+            if (containersToApply.length === 0) { break; }
 
-            const dirtyContainers = openedContainers.filter((c) => c.isDirty);
-            if (dirtyContainers.length !== 0) {
-                // Wait for all the containers to be saved
-                await Promise.all(dirtyContainers.map(async (c) => new Promise((res) => c.once("saved", res))));
-            } else {
+            const dirtyContainers = containersToApply.filter((c) => c.isDirty);
+            if (dirtyContainers.length === 0) {
                 // Wait for all the leave messages
-                const pendingDisconnectedClients = this.getPendingDisconnectedClients(openedContainers);
-                if (pendingDisconnectedClients.length !== 0) {
-                    await this.waitForDisconnectedClients(pendingDisconnectedClients);
-                } else if (this.isSequenceNumberSynchronized(openedContainers)) {
-                    // done, we are in sync
-                    break;
+                const pendingClients = this.getPendingClients(containersToApply);
+                if (pendingClients.length === 0) {
+                    if (this.isSequenceNumberSynchronized(containersToApply)) {
+                        // done, we are in sync
+                        break;
+                    }
+                    if (!waitingSequenceNumberSynchronized) {
+                        // Only write it out once
+                        waitingSequenceNumberSynchronized = true;
+                        debugWait("Waiting for sequence number synchronized");
+                        await this.waitForAnyInboundOps(containersToApply);
+                    }
+                } else {
+                    waitingSequenceNumberSynchronized = false;
+                    await this.waitForPendingClients(pendingClients);
                 }
+            } else {
+                // Wait for all the containers to be saved
+                debugWait("Waiting container to be saved");
+                waitingSequenceNumberSynchronized = false;
+                await Promise.all(dirtyContainers.map(async (c) => new Promise((res) => c.once("saved", res))));
             }
+
             // yield a turn to allow side effect of the ops we just processed execute before we check again
             await new Promise<void>((res) => { setTimeout(res, 0); });
         }
 
         // Pause all container that was resumed
-        await this.pauseProcessing(resumed);
+        // don't call pause if resumed is empty and pause everything, which is not what we want
+        if (resumed.length !== 0) {
+            await this.pauseProcessing(...resumed);
+        }
+
+        debugWait("Synchronized");
     }
 
-    private getPendingDisconnectedClients(openedContainers: IContainer[]) {
+    /**
+     * Utilities to calculate the set of clientId per container in quorum that is NOT associated with
+     * any container we tracked, indicating there is a pending join or leave op that we need to wait.
+     *
+     * @param containersToApply the set of containers to check
+     */
+    private getPendingClients(containersToApply: IContainer[]) {
         // All the clientId we track should be a superset of the quorum, otherwise, we are missing
         // leave messages
-        const openedClientId = openedContainers.map((container) => (container as Container).clientId);
+        const openedDocuments = Array.from(this.containers.keys()).filter((c) => !c.closed);
+        const openedClientId = openedDocuments.map((container) => (container as Container).clientId);
 
-        const disconnectClients: [IContainer, Set<string>][] = [];
-        openedContainers.forEach((container) => {
-            const disconnectedClientId = new Set<string>();
+        const pendingClients: [IContainer, Set<string>][] = [];
+        containersToApply.forEach((container) => {
+            const pendingClientId = new Set<string>();
             const quorum = container.getQuorum();
             quorum.getMembers().forEach((client, clientId) => {
+                // ignore summarizer
+                if (!client.client.details.capabilities.interactive) { return; }
                 if (!openedClientId.includes(clientId)) {
-                    disconnectedClientId.add(clientId);
+                    pendingClientId.add(clientId);
                 }
             });
 
-            if (disconnectedClientId.size !== 0) {
-                disconnectClients.push([container, disconnectedClientId]);
+            if (pendingClientId.size !== 0) {
+                pendingClients.push([container, pendingClientId]);
             }
         });
-        return disconnectClients;
+        return pendingClients;
     }
 
-    private async waitForDisconnectedClients(disconnectClients: [IContainer, Set<string>][]) {
-        return Promise.all(disconnectClients.map(async ([container, disconnectedClientId]) => {
+    /**
+     * Utilities to check sequence number based synchronization.
+     * See ensureSynchronized for more detail
+     *
+     * @param containersToApply the set of containers to check
+     */
+    private isSequenceNumberSynchronized(containersToApply: IContainer[]) {
+        // TODO: Currently isDirty flag ignores ops for task scheduler.
+        // So we need to look into the deltamanager to use clientSequenceNumber.
+        const isClientSequenceNumberSynchronized = containersToApply.every((container) => {
+            const deltaManager = (container.deltaManager as any);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const { trailingNoOps } = this.containers.get(container)!;
+            return deltaManager.clientSequenceNumber ===
+                (deltaManager.clientSequenceNumberObserved as number) + trailingNoOps;
+        });
+
+        if (!isClientSequenceNumberSynchronized) {
+            return false;
+        }
+
+        const minSeqNum = containersToApply[0].deltaManager.minimumSequenceNumber;
+        if (minSeqNum < this.lastProposalSeqNum) {
+            // There is an unresolved proposal
+            return false;
+        }
+
+        // Check to see if all the container has process the same number of ops.
+        const seqNum = containersToApply[0].deltaManager.lastSequenceNumber;
+        return containersToApply.every((c) => c.deltaManager.lastSequenceNumber === seqNum);
+    }
+
+    /**
+     * Utilities to wait for any clientId in quorum that is NOT associated with any container we
+     * tracked, indicating there is a pending join or leave op that we need to wait.
+     *
+     * Note that this function doesn't account for container that got added after we started waiting
+     *
+     * @param containersToApply the set of containers to wait for any inbound ops for
+     */
+    private async waitForPendingClients(pendingClients: [IContainer, Set<string>][]) {
+        const unconnectedClients =
+            Array.from(this.containers.keys()).filter((c) => !c.closed && !(c as Container).connected);
+        return Promise.all(pendingClients.map(async ([container, pendingClientId]) => {
             return new Promise<void>((res) => {
+                const cleanup = () => {
+                    unconnectedClients.forEach((c) => c.off("connected", handler));
+                    container.getQuorum().off("removeMember", handler);
+                };
                 const handler = (clientId: string) => {
-                    disconnectedClientId.delete(clientId);
-                    if (disconnectedClientId.size === 0) {
-                        container.getQuorum().off("removeMember", handler);
+                    pendingClientId.delete(clientId);
+                    if (pendingClientId.size === 0) {
+                        cleanup();
                         res();
                     }
                 };
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const index = this.containers.get(container)!.index;
+                debugWait(`${index}: Waiting for pending clients ${Array.from(pendingClientId.keys())}`);
+                unconnectedClients.forEach((c) => c.on("connected", handler));
                 container.getQuorum().on("removeMember", handler);
                 container.on("closed", () => {
-                    container.getQuorum().off("removeMember", handler);
+                    cleanup();
                     res();
                 });
             });
         }));
     }
 
-    private isSequenceNumberSynchronized(openedContainers: IContainer[]) {
-        // TODO: Currently isDirty flag ignores ops for task scheduler.
-        // So we need to look into the deltamanager to use clientSequenceNumber.
-        const isClientSequenceNumberSynchronized = openedContainers.every((container) => {
-            const deltaManager = (container.deltaManager as any);
-            return deltaManager.clientSequenceNumber === deltaManager.clientSequenceNumberObserved;
+    /**
+     * Utilities to wait for any inbound ops from a set of containers
+     * @param containersToApply the set of containers to wait for any inbound ops for
+     */
+    private async waitForAnyInboundOps(containersToApply: IContainer[]) {
+        return new Promise<void>((res) => {
+            const handler = () => {
+                containersToApply.map((c) => {
+                    c.deltaManager.inbound.off("push", handler);
+                });
+                res();
+            };
+            containersToApply.map((c) => {
+                c.deltaManager.inbound.on("push", handler);
+            });
         });
-
-        if (!isClientSequenceNumberSynchronized) { return false; }
-
-        // Check to see if all the container has process the same number of ops.
-        const seqNum = openedContainers[0].deltaManager.lastSequenceNumber;
-        return openedContainers.every((c) => c.deltaManager.lastSequenceNumber === seqNum);
     }
 
     /**
      * Resume all queue activities on all paused tracked containers and return them
      */
-    private resumeProcessing() {
+    public resumeProcessing(...containers: IContainer[]) {
         const resumed: IContainer[] = [];
-        for (const [container, paused] of this.containers.entries()) {
-            if (paused) {
+        const containersToApply = this.getContainers(containers);
+        for (const container of containersToApply) {
+            const record = this.containers.get(container);
+            if (record !== undefined && record.paused) {
                 container.deltaManager.inbound.resume();
                 container.deltaManager.outbound.resume();
                 resumed.push(container);
-                this.containers.set(container, false);
+                record.paused = false;
             }
         }
         return resumed;
@@ -166,18 +340,18 @@ export class LoaderContainerTracker {
      * Pause all queue activities on the containers given, or all tracked containers
      * Any containers given that is not tracked will be ignored.
      */
-    public async pauseProcessing(containers?: IContainer[]) {
+    public async pauseProcessing(...containers: IContainer[]) {
         const pauseP: Promise<void>[] = [];
-        const containersToPause = containers ?? this.containers.keys();
-        for (const container of containersToPause) {
-            const paused = this.containers.get(container);
-            if (paused !== undefined && !paused) {
+        const containersToApply = this.getContainers(containers);
+        for (const container of containersToApply) {
+            const record = this.containers.get(container);
+            if (record !== undefined && !record.paused) {
                 pauseP.push(container.deltaManager.inbound.pause());
                 pauseP.push(container.deltaManager.outbound.pause());
-                this.containers.set(container, true);
+                record.paused = true;
             }
         }
-        return Promise.all(pauseP);
+        await Promise.all(pauseP);
     }
 
     /**
@@ -185,8 +359,8 @@ export class LoaderContainerTracker {
      * inbound to process ops until it is idle. All queues are left in the paused state
      * after the function
      */
-    public async processIncoming() {
-        return this.processQueue((container) => container.deltaManager.inbound);
+    public async processIncoming(...containers: IContainer[]) {
+        return this.processQueue(containers, (container) => container.deltaManager.inbound);
     }
 
     /**
@@ -194,34 +368,80 @@ export class LoaderContainerTracker {
      * outbound to process ops until it is idle. All queues are left in the paused state
      * after the function
      */
-    public async processOutgoing() {
-        return this.processQueue((container) => container.deltaManager.outbound);
-    }
-
-    /**
-     * @deprecated Same as ensureSynchronized()
-     */
-    public async process() {
-        return this.ensureSynchronized();
+    public async processOutgoing(...containers: IContainer[]) {
+        return this.processQueue(containers, (container) => container.deltaManager.outbound);
     }
 
     /**
      * Implementation of processIncoming and processOutgoing
      */
-    private async processQueue<U>(getQueue: (container: IContainer) => IDeltaQueue<U>) {
-        await this.pauseProcessing();
+    private async processQueue<U>(containers: IContainer[], getQueue: (container: IContainer) => IDeltaQueue<U>) {
+        await this.pauseProcessing(...containers);
         const resumed: IDeltaQueue<U>[] = [];
-        for (const container of this.containers.keys()) {
+
+        const containersToApply = this.getContainers(containers);
+        const inflightTracker = new Map<IContainer, number>();
+        const cleanup: (() => void)[] = [];
+        for (const container of containersToApply) {
             const queue = getQueue(container);
+
+            // track the outgoing ops (if any) to make sure they make the round trip to at least to the same client
+            // to make sure they are sequenced.
+            cleanup.push(this.setupInOutTracker(container, inflightTracker));
             queue.resume();
             resumed.push(queue);
         }
 
         while (resumed.some((queue) => !queue.idle)) {
+            debugWait("Wait until queue is idle");
             await new Promise<void>((res) => { setTimeout(res, 0); });
         }
 
+        // Make sure all the op that we sent out are acked first
+        // This is no op if we are processing incoming
+        if (inflightTracker.size) {
+            debugWait("Wait for inflight ops");
+            do {
+                await this.waitForAnyInboundOps(containersToApply);
+            } while (inflightTracker.size);
+        }
+
+        // remove the handlers
+        cleanup.forEach((clean) => clean());
+
         await Promise.all(resumed.map(async (queue) => queue.pause()));
+    }
+
+    /**
+     * Utilities to set up listener to track the outbound ops until it round trip back
+     * Returns a function to remove the handler after it is done.
+     *
+     * @param container the container to setup
+     * @param inflightTracker a map to track the clientSequenceNumber per container it expect to get ops back
+     */
+    private setupInOutTracker(container: IContainer, inflightTracker: Map<IContainer, number>) {
+        const outHandler = (messages: IDocumentMessage[]) => {
+            for (const message of messages) {
+                if (message.type !== MessageType.NoOp) {
+                    inflightTracker.set(container, message.clientSequenceNumber);
+                }
+            }
+        };
+        const inHandler = (message: ISequencedDocumentMessage) => {
+            if (message.type !== MessageType.NoOp
+                && message.clientId === (container as Container).clientId
+                && inflightTracker.get(container) === message.clientSequenceNumber) {
+                inflightTracker.delete(container);
+            }
+        };
+
+        container.deltaManager.outbound.on("op", outHandler);
+        container.deltaManager.inbound.on("push", inHandler);
+
+        return () => {
+            container.deltaManager.outbound.off("op", outHandler);
+            container.deltaManager.inbound.off("push", inHandler);
+        };
     }
 
     /**
@@ -229,15 +449,40 @@ export class LoaderContainerTracker {
      */
     private setupTrace(container: IContainer, index: number) {
         if (debugOp.enabled) {
+            const getContentsString = (msgContents: any) => {
+                let address = "";
+                let contents = JSON.parse(msgContents);
+                // eslint-disable-next-line no-null/no-null
+                while (contents !== undefined && contents !== null) {
+                    if (contents.contents?.address !== undefined) {
+                        address += `/${contents.contents.address}`;
+                        contents = contents.contents.contents;
+                    } else if (contents.content?.address !== undefined) {
+                        address += `/${contents.content.address}`;
+                        contents = contents.content.contents;
+                    } else {
+                        break;
+                    }
+                }
+                if (address) {
+                    return `addr=${address} contents=${JSON.stringify(contents)}`;
+                }
+                return JSON.stringify(contents);
+            };
+            debugOp(`${index}: ADD: clientId: ${(container as Container).clientId}`);
             container.deltaManager.outbound.on("op", (messages) => {
                 for (const msg of messages) {
-                    debugOp(`${index}: OUT:         `
-                        + `clientSeq: ${msg.clientSequenceNumber} ${msg.type}`);
+                    debugOp(`${index}: OUT:          `
+                        + `cli: ${msg.clientSequenceNumber.toString().padStart(3)} `
+                        + `         ${msg.type} ${getContentsString(msg.contents)}`);
                 }
             });
             container.deltaManager.inbound.on("push", (msg) => {
-                debugOp(`${index}: IN : seq: ${msg.sequenceNumber} `
-                    + `clientSeq: ${msg.clientSequenceNumber.toString().padStart(3)} ${msg.type} `);
+                const clientSeq = msg.clientId === (container as Container).clientId ?
+                    `cli: ${msg.clientSequenceNumber.toString().padStart(3)}` : "        ";
+                debugOp(`${index}: IN : seq: ${msg.sequenceNumber.toString().padStart(3)} `
+                    + `${clientSeq} min: ${msg.minimumSequenceNumber.toString().padStart(3)} `
+                    + `${msg.type} ${getContentsString(msg.contents)}`);
             });
 
             container.deltaManager.on("connect", (details) => {
@@ -247,5 +492,15 @@ export class LoaderContainerTracker {
                 debugOp(`${index}: DIS: ${reason}`);
             });
         }
+    }
+
+    /**
+     * Filter out the opened containers based on param.
+     * @param containers The container to filter to.  If the array is empty, it means don't filter and return
+     * all open containers.
+     */
+    private getContainers(containers: IContainer[]) {
+        const containersToApply = containers.length === 0 ? Array.from(this.containers.keys()) : containers;
+        return containersToApply.filter((container) => !container.closed);
     }
 }

--- a/packages/test/test-utils/src/opProcessingController.ts
+++ b/packages/test/test-utils/src/opProcessingController.ts
@@ -254,7 +254,7 @@ export interface IDeltaConnectionServerMonitor {
 /**
  * Class with access to the local delta connection server and delta managers that can control op processing.
  *
- * @deprecate Can be removed >=0.38. Replaced with LoaderContainerTracker
+ * @deprecated Can be removed \>=0.38. Replaced with LoaderContainerTracker
  */
 export class OpProcessingController {
     /**

--- a/packages/test/test-utils/src/opProcessingController.ts
+++ b/packages/test/test-utils/src/opProcessingController.ts
@@ -253,6 +253,8 @@ export interface IDeltaConnectionServerMonitor {
 
 /**
  * Class with access to the local delta connection server and delta managers that can control op processing.
+ *
+ * @deprecate Can be removed >=0.38. Replaced with LoaderContainerTracker
  */
 export class OpProcessingController {
     /**

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -236,7 +236,7 @@ export class ScribeLambda extends SequencedLambda {
                             }
                         } catch (ex) {
                             this.revertProtocolState(prevState.protocolState, prevState.pendingOps);
-                            // If this flag is set, we should ignore any storage speciic error and move forward
+                            // If this flag is set, we should ignore any storage specific error and move forward
                             // to process the next message.
                             if (this.serviceConfiguration.scribe.ignoreStorageException) {
                                 await this.sendSummaryNack(

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -369,7 +369,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     public setConnectionState(connected: boolean, clientId?: string) {
         if (!connected) {
             this.localProposals.forEach((deferral) => {
-                deferral.reject("Client got disconnected");
+                deferral.reject(new Error("Client got disconnected"));
             });
             this.localProposals.clear();
         }


### PR DESCRIPTION
Fully replace usage of `OpProcessingController` with `LoaderContainerTracker`
  - Container created by Loader added to it will be automatically tracked, removing explicity `addDeltaManager`
  - `OpProcessingController` manually track op outbound and inbound to keep track of inflight ops.  `LoaderContainerTracker` do less tracking, instead it use the follow condition to tell if the containers are in sync
    - No `isDirty` containers
    - No extra `clientId` in quorum of any container that is not tracked and still opened.
      - i.e. no pending Join/Leave message.
    - No unresolved proposal (`minSeqNum >= lastProposalSeqNum`)  [New in`LoaderContainerTracker`]
    - `lastSequenceNumber` of all container is the same
    - `clientSequenceNumberObserved` is the same as `clientSequenceNumber` sent
        - This overlaps with `!isDirty`, but include task scheduler ops that `isDirty` doesn't cover
        - Trailing `NoOp` is tracked and don't count as pending ops. See Issue #5629 

This fixes `pendingOps.spec.ts` test where there is a bad interaction between `OpProcessingController` and `LoaderContainerTracker` where `OpProcessingController` paused the `DeltaManager` while `LoaderContainerTracker` is waiting.

`OpProcessingController` is mark as deprecated and will be remove on the next release to allow a grace period for migration

Also:
- Using the debug package to trace ops and wait for debugging (set env DEBUG to `fluid:test-utils:ops` or `fluid:test-utils:wait`)
- Fixes #5572: listener with assert should be unregister after test in `leader.spec.ts`, as those condition would not be true .
- Convert more test to create and load containers with `TestObjectProvider` to get automatic tracking
- Quorum Proposal should throw a Error instead of a string when disconnected.