### PR TITLE
Examples: Minor boilerplate reduction

### DIFF
--- a/examples/data-objects/codemirror/src/codemirror.ts
+++ b/examples/data-objects/codemirror/src/codemirror.ts
@@ -25,7 +25,7 @@ import {
     Marker,
 } from "@fluidframework/merge-tree";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/datastore-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { SharedString, SequenceDeltaEvent } from "@fluidframework/sequence";
 import { IFluidHTMLOptions, IFluidHTMLView } from "@fluidframework/view-interfaces";
 import CodeMirror from "codemirror";
@@ -266,20 +266,16 @@ class SmdeFactory implements IFluidDataStoreFactory {
     public get IFluidDataStoreFactory() { return this; }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
-        const dataTypes = new Map<string, IChannelFactory>();
-        const mapFactory = SharedMap.getFactory();
-        const sequenceFactory = SharedString.getFactory();
-
-        dataTypes.set(mapFactory.type, mapFactory);
-        dataTypes.set(sequenceFactory.type, sequenceFactory);
-
         const runtimeClass = mixinRequestHandler(
             async (request: IRequest) => {
                 const router = await routerP;
                 return router.request(request);
             });
 
-        const runtime = new runtimeClass(context, dataTypes);
+        const runtime = new runtimeClass(context, new Map([
+            SharedMap.getFactory(),
+            SharedString.getFactory(),
+        ].map((factory) => [factory.type, factory])));
         const routerP = CodeMirrorComponent.load(runtime, context);
         return runtime;
     }

--- a/examples/data-objects/key-value-cache/src/index.ts
+++ b/examples/data-objects/key-value-cache/src/index.ts
@@ -23,7 +23,6 @@ import {
 } from "@fluidframework/runtime-definitions";
 import {
     IFluidDataStoreRuntime,
-    IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import {
     innerRequestHandler,
@@ -110,17 +109,15 @@ export class KeyValueFactoryComponent implements IRuntimeFactory, IFluidDataStor
     public get IFluidDataStoreFactory() { return this; }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
-        const dataTypes = new Map<string, IChannelFactory>();
-        const mapFactory = SharedMap.getFactory();
-        dataTypes.set(mapFactory.type, mapFactory);
-
         const runtimeClass = mixinRequestHandler(
             async (request: IRequest) => {
                 const router = await routerP;
                 return router.request(request);
             });
 
-        const runtime = new runtimeClass(context, dataTypes);
+        const runtime = new runtimeClass(context, new Map([
+            SharedMap.getFactory(),
+        ].map((factory) => [factory.type, factory])));
         const routerP = KeyValue.load(runtime, context);
 
         return runtime;

--- a/examples/data-objects/progress-bars/src/progressBars.ts
+++ b/examples/data-objects/progress-bars/src/progressBars.ts
@@ -16,7 +16,7 @@ import {
 import { FluidObjectHandle, mixinRequestHandler } from "@fluidframework/datastore";
 import { IFluidObjectCollection } from "@fluid-example/fluid-object-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/datastore-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 
@@ -223,17 +223,15 @@ class ProgressBarsFactory implements IFluidDataStoreFactory {
     public get IFluidDataStoreFactory() { return this; }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
-        const dataTypes = new Map<string, IChannelFactory>();
-        const mapFactory = SharedMap.getFactory();
-        dataTypes.set(mapFactory.type, mapFactory);
-
         const runtimeClass = mixinRequestHandler(
             async (request: IRequest) => {
                 const router = await routerP;
                 return router.request(request);
             });
 
-        const runtime = new runtimeClass(context, dataTypes);
+        const runtime = new runtimeClass(context, new Map([
+            SharedMap.getFactory(),
+        ].map((factory) => [factory.type, factory])));
         const routerP = ProgressCollection.load(runtime, context);
 
         return runtime;

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -24,7 +24,7 @@ import {
     createMap,
 } from "@fluidframework/merge-tree";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/datastore-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { IFluidHTMLOptions, IFluidHTMLView } from "@fluidframework/view-interfaces";
 import { EditorView } from "prosemirror-view";
@@ -176,20 +176,16 @@ class ProseMirrorFactory implements IFluidDataStoreFactory {
     public get IFluidDataStoreFactory() { return this; }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
-        const dataTypes = new Map<string, IChannelFactory>();
-        const mapFactory = SharedMap.getFactory();
-        const sequenceFactory = SharedString.getFactory();
-
-        dataTypes.set(mapFactory.type, mapFactory);
-        dataTypes.set(sequenceFactory.type, sequenceFactory);
-
         const runtimeClass = mixinRequestHandler(
             async (request: IRequest) => {
                 const router = await routerP;
                 return router.request(request);
             });
 
-        const runtime = new runtimeClass(context, dataTypes);
+        const runtime = new runtimeClass(context, new Map([
+            SharedMap.getFactory(),
+            SharedString.getFactory(),
+        ].map((factory) => [factory.type, factory])));
         const routerP = ProseMirror.load(runtime, context);
 
         return runtime;

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -26,7 +26,6 @@ import { IDocumentFactory } from "@fluid-example/host-service-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import {
     IFluidDataStoreRuntime,
-    IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import {
     IFluidDataStoreContext,
@@ -483,17 +482,15 @@ class ScribeFactory implements IFluidDataStoreFactory, IRuntimeFactory {
     }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
-        const dataTypes = new Map<string, IChannelFactory>();
-        const mapFactory = SharedMap.getFactory();
-        dataTypes.set(mapFactory.type, mapFactory);
-
         const runtimeClass = mixinRequestHandler(
             async (request: IRequest) => {
                 const router = await routerP;
                 return router.request(request);
             });
 
-        const runtime = new runtimeClass(context, dataTypes);
+        const runtime = new runtimeClass(context, new Map([
+            SharedMap.getFactory(),
+        ].map((factory) => [factory.type, factory])));
         const routerP = Scribe.load(runtime, context);
 
         return runtime;

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -294,28 +294,19 @@ class TaskScheduler {
 }
 
 export function instantiateDataStore(context: IFluidDataStoreContext) {
-    const modules = new Map<string, any>();
-
-    // Create channel factories
-    const mapFactory = SharedMap.getFactory();
-    const sharedStringFactory = SharedString.getFactory();
-    const cellFactory = SharedCell.getFactory();
-    const objectSequenceFactory = SharedObjectSequence.getFactory();
-    const numberSequenceFactory = SharedNumberSequence.getFactory();
-
-    modules.set(mapFactory.type, mapFactory);
-    modules.set(sharedStringFactory.type, sharedStringFactory);
-    modules.set(cellFactory.type, cellFactory);
-    modules.set(objectSequenceFactory.type, objectSequenceFactory);
-    modules.set(numberSequenceFactory.type, numberSequenceFactory);
-
     const runtimeClass = mixinRequestHandler(
         async (request: IRequest) => {
             const router = await routerP;
             return router.request(request);
         });
 
-    const runtime = new runtimeClass(context, modules);
+    const runtime = new runtimeClass(context, new Map([
+        SharedMap.getFactory(),
+        SharedString.getFactory(),
+        SharedCell.getFactory(),
+        SharedObjectSequence.getFactory(),
+        SharedNumberSequence.getFactory(),
+    ].map((factory) => [factory.type, factory])));
     const routerP = SharedTextRunner.load(runtime, context);
 
     return runtime;

--- a/examples/data-objects/smde/src/smde.ts
+++ b/examples/data-objects/smde/src/smde.ts
@@ -24,7 +24,7 @@ import {
     Marker,
 } from "@fluidframework/merge-tree";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/datastore-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { IFluidHTMLOptions, IFluidHTMLView } from "@fluidframework/view-interfaces";
 import SimpleMDE from "simplemde";
@@ -213,20 +213,16 @@ class SmdeFactory implements IFluidDataStoreFactory {
     public get IFluidDataStoreFactory() { return this; }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
-        const dataTypes = new Map<string, IChannelFactory>();
-        const mapFactory = SharedMap.getFactory();
-        const sequenceFactory = SharedString.getFactory();
-
-        dataTypes.set(mapFactory.type, mapFactory);
-        dataTypes.set(sequenceFactory.type, sequenceFactory);
-
         const runtimeClass = mixinRequestHandler(
             async (request: IRequest) => {
                 const router = await routerP;
                 return router.request(request);
             });
 
-        const runtime = new runtimeClass(context, dataTypes);
+        const runtime = new runtimeClass(context, new Map([
+            SharedMap.getFactory(),
+            SharedString.getFactory(),
+        ].map((factory) => [factory.type, factory])));
         const routerP = Smde.load(runtime, context);
 
         return runtime;

--- a/packages/runtime/client-api/src/api/codeLoader.ts
+++ b/packages/runtime/client-api/src/api/codeLoader.ts
@@ -47,33 +47,6 @@ export class Chaincode implements IFluidDataStoreFactory {
     { }
 
     public async instantiateDataStore(context: IFluidDataStoreContext) {
-        // Create channel factories
-        const mapFactory = map.SharedMap.getFactory();
-        const sharedStringFactory = sequence.SharedString.getFactory();
-        const inkFactory = ink.Ink.getFactory();
-        const cellFactory = cell.SharedCell.getFactory();
-        const objectSequenceFactory = sequence.SharedObjectSequence.getFactory();
-        const numberSequenceFactory = sequence.SharedNumberSequence.getFactory();
-        const consensusQueueFactory = ConsensusQueue.getFactory();
-        const sparseMatrixFactory = sequence.SparseMatrix.getFactory();
-        const directoryFactory = map.SharedDirectory.getFactory();
-        const sharedIntervalFactory = sequence.SharedIntervalCollection.getFactory();
-        const sharedMatrixFactory = SharedMatrix.getFactory();
-
-        // Register channel factories
-        const modules = new Map<string, any>();
-        modules.set(mapFactory.type, mapFactory);
-        modules.set(sharedStringFactory.type, sharedStringFactory);
-        modules.set(inkFactory.type, inkFactory);
-        modules.set(cellFactory.type, cellFactory);
-        modules.set(objectSequenceFactory.type, objectSequenceFactory);
-        modules.set(numberSequenceFactory.type, numberSequenceFactory);
-        modules.set(consensusQueueFactory.type, consensusQueueFactory);
-        modules.set(sparseMatrixFactory.type, sparseMatrixFactory);
-        modules.set(directoryFactory.type, directoryFactory);
-        modules.set(sharedIntervalFactory.type, sharedIntervalFactory);
-        modules.set(sharedMatrixFactory.type, sharedMatrixFactory);
-
         const runtimeClass = mixinRequestHandler(
             async (request: IRequest) => {
                 const document = await routerP;
@@ -89,7 +62,19 @@ export class Chaincode implements IFluidDataStoreFactory {
             },
             this.dataStoreFactory);
 
-        const runtime = new runtimeClass(context, modules);
+        const runtime = new runtimeClass(context, new Map([
+            map.SharedMap.getFactory(),
+            sequence.SharedString.getFactory(),
+            ink.Ink.getFactory(),
+            cell.SharedCell.getFactory(),
+            sequence.SharedObjectSequence.getFactory(),
+            sequence.SharedNumberSequence.getFactory(),
+            ConsensusQueue.getFactory(),
+            sequence.SparseMatrix.getFactory(),
+            map.SharedDirectory.getFactory(),
+            sequence.SharedIntervalCollection.getFactory(),
+            SharedMatrix.getFactory(),
+        ].map((factory) => [factory.type, factory])));
 
         // Initialize core data structures
         let root: map.ISharedMap;


### PR DESCRIPTION
No framework change, just updating some copy/pasted sample code to be a bit less verbose.

(Was experimenting with a different change.  This minor boilerplate reduction fell out.  Thought why not keep it?)