### PR TITLE
Fix failures while fetching too many ops (0.37)

### DIFF
--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -79,15 +79,13 @@ export class ParallelRequests<T> {
                 break;
             }
             this.results.delete(this.nextToDeliver);
+            assert(value.length <= this.payloadSize, "addRequestCore() should break into smaller chunks");
             this.nextToDeliver += value.length;
             this.responseCallback(value);
         }
 
         // Account for cancellation - state might be not in consistent state on cancelling operation
         if (this.working) {
-            assert(this.requestsInFlight !== 0 || this.results.size === 0,
-                0x106 /* "in unexpected state after dispatching results" */);
-
             if (this.requestsInFlight === 0) {
                 // we should have dispatched everything, no matter whether we knew about the end or not.
                 // see comment in addRequestCore() around throwing away chunk if it's above this.to
@@ -193,8 +191,29 @@ export class ParallelRequests<T> {
             }
 
             if (this.working) {
+                const fromOrig = from;
+                const payloadSize = payload.length;
+                let fullChunk = (requestedLength <= payloadSize); // we can possible get more than we asked.
+
                 if (payload.length !== 0) {
-                    this.results.set(from, payload);
+                    // We can get more than we asked for!
+                    // This can screw up logic in dispatch!
+                    // So push only batch size, and keep the rest for later - if conditions are favorable, we
+                    // will be able to use it. If not (parallel request overlapping these ops), it's easier to
+                    // discard them and wait for another (overlapping) request to come in later.
+                    if (requestedLength > payload.length) {
+                        // This is error in a sense that it's not expected and likely points bug in other layer.
+                        // This layer copes with this situation just fine.
+                        this.logger.sendErrorEvent({
+                            eventName: "ParallelRequests_Over",
+                            from,
+                            to,
+                            length: payload.length,
+                        });
+                    }
+                    const data = payload.splice(0, requestedLength);
+                    this.results.set(from, data);
+                    from += data.length;
                 } else {
                     // 1. empty (partial) chunks should not be returned by various caching / adapter layers -
                     //    they should fall back to next layer. This might be important invariant to hold to ensure
@@ -210,14 +229,10 @@ export class ParallelRequests<T> {
                         0x110 /* "callback should retry until valid fetch before it learns new boundary" */);
                 }
 
-                let fullChunk = (requestedLength <= payload.length); // we can possible get more than we asked.
-                from += payload.length;
-
                 if (!partial && !fullChunk) {
                     if (!this.knewTo) {
                         if (this.to === undefined || this.to > from) {
                             // The END
-                            assert(!this.knewTo, 0x111 /* "should not know futher boundary at end" */);
                             this.to = from;
                         }
                         break;
@@ -229,8 +244,8 @@ export class ParallelRequests<T> {
                     // catastrophic failure (see comment above on responsibility of callback to return something)
                     // This layer will just keep trying until it gets full set.
                     this.logger.sendErrorEvent({
-                        eventName: "ParallelRequestsPartial",
-                        from,
+                        eventName: "ParallelRequests_Partial",
+                        from: fromOrig,
                         to,
                         length: payload.length,
                     });
@@ -238,6 +253,12 @@ export class ParallelRequests<T> {
 
                 if (to === this.latestRequested) {
                     // we can go after full chunk at the end if we received partial chunk, or more than asked
+                    // Also if we got more than we asked to, we can actually use those ops!
+                    if (payload.length !== 0) {
+                        this.results.set(from, payload);
+                        from += payload.length;
+                    }
+
                     this.latestRequested = from;
                     fullChunk = true;
                 }

--- a/packages/loader/driver-utils/src/test/parallelRequests.spec.ts
+++ b/packages/loader/driver-utils/src/test/parallelRequests.spec.ts
@@ -5,7 +5,14 @@
 
 import { strict as assert } from "assert";
 import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { unreachableCase } from "@fluidframework/common-utils";
 import { ParallelRequests } from "../parallelRequests";
+
+enum HowMany {
+    Exact,
+    Partial,
+    TooMany,
+}
 
 describe("Parallel Requests", () => {
     async function test(
@@ -15,7 +22,7 @@ describe("Parallel Requests", () => {
         to: number,
         expectedRequests: number,
         knownTo: boolean,
-        partial = false)
+        howMany: HowMany = HowMany.Exact)
     {
         let nextElement = from;
         let requests = 0;
@@ -35,8 +42,17 @@ describe("Parallel Requests", () => {
                 assert(requests <= request);
                 assert(!knownTo || _to <= to);
 
-                if (partial) {
-                    length = Math.min(length, payloadSize / 2 + 1);
+                switch (howMany) {
+                    case HowMany.Partial:
+                        length = Math.min(length, payloadSize / 2 + 1);
+                        break;
+                    case HowMany.TooMany:
+                        length += 2;
+                        break;
+                    case HowMany.Exact:
+                        break;
+                    default:
+                        unreachableCase(howMany);
                 }
                 // covering knownTo === false case
                 const actualTo = Math.min(_from + length, to);
@@ -46,11 +62,12 @@ describe("Parallel Requests", () => {
                     payload.push(i);
                 }
 
-                return { partial: _from === to ? false : partial, cancel: false, payload};
+                return { partial: _from !== to && howMany === HowMany.Partial, cancel: false, payload};
             },
             (deltas: number[]) => {
                 dispatches++;
-                assert(dispatches <= requests);
+                // Big chunks are broken into smaller ones
+                assert(dispatches <= requests || howMany === HowMany.TooMany);
                 for (const el of deltas) {
                     assert(el === nextElement);
                     nextElement++;
@@ -61,9 +78,8 @@ describe("Parallel Requests", () => {
         await manager.run(concurrency);
 
         assert(nextElement === to);
-        assert(dispatches <= requests);
         assert(!knownTo || dispatches === requests);
-        assert(requests === expectedRequests);
+        assert.equal(requests, expectedRequests, "expected requests");
     }
 
     async function testCancel(
@@ -121,34 +137,42 @@ describe("Parallel Requests", () => {
     it("no concurrency, single request, over", async () => {
         await test(1, 100, 123, 156, 1, true);
         await test(1, 100, 123, 156, 1, false);
-        await test(1, 100, 123, 156, 1, true, true);
+        await test(1, 100, 123, 156, 1, true, HowMany.TooMany);
+        await test(1, 100, 123, 156, 1, true, HowMany.Partial);
     });
 
     it("no concurrency, single request, exact", async () => {
         await test(1, 156 - 123, 123, 156, 1, true);
         await test(1, 156 - 123, 123, 156, 2, false);
-        await test(1, 156 - 123, 123, 156, 2, true, true);
-        await test(1, 156 - 123, 123, 156, 3, false, true);
+        await test(1, 156 - 123, 123, 156, 1, true, HowMany.TooMany);
+        await test(1, 156 - 123, 123, 156, 2, true, HowMany.Partial);
+        await test(1, 156 - 123, 123, 156, 2, false, HowMany.TooMany);
+        await test(1, 156 - 123, 123, 156, 3, false, HowMany.Partial);
     });
 
     it("concurrency, single request, exact", async () => {
         await test(2, 156 - 123, 123, 156, 1, true);
-        await test(2, 156 - 123, 123, 156, 2, true, true);
+        await test(2, 156 - 123, 123, 156, 1, true, HowMany.TooMany);
+        await test(2, 156 - 123, 123, 156, 2, true, HowMany.Partial);
         // here, the number of actual requests is Ok to be 2..3
         await test(2, 156 - 123, 123, 156, 3, false);
-        await test(2, 156 - 123, 123, 156, 3, false, true);
+        await test(2, 156 - 123, 123, 156, 3, false, HowMany.TooMany);
+        await test(2, 156 - 123, 123, 156, 3, false, HowMany.Partial);
     });
 
     it("no concurrency, multiple requests", async () => {
         await test(1, 10, 123, 156, 4, true);
         await test(1, 10, 123, 156, 4, false);
+        await test(1, 10, 123, 156, 3, false, HowMany.TooMany);
     });
 
     it("two concurrent requests exact", async () => {
         await test(2, 10, 123, 153, 3, true);
-        await test(2, 10, 123, 153, 6, true, true);
+        await test(2, 10, 123, 153, 3, true, HowMany.TooMany);
+        await test(2, 10, 123, 153, 6, true, HowMany.Partial);
         await test(2, 10, 123, 153, 5, false);
-        await test(2, 10, 123, 153, 8, false, true);
+        await test(2, 10, 123, 153, 5, false, HowMany.TooMany);
+        await test(2, 10, 123, 153, 8, false, HowMany.Partial);
     });
 
     it("two concurrent requests one over", async () => {


### PR DESCRIPTION
Porting https://github.com/microsoft/FluidFramework/pull/5656 to 0.37

Couple bugs found via stress testing.
One was incorrect logging.
Another - code was not handling well case when storage returns more than asked.
This happens because caching layers are not "smart" and return all they've got, even if it's not asked for (ops in odsp snapshot is an example of that).

Adding a bunch of test cases to capture these scenarios.
And fixing them.
