### PR TITLE
Update policy tool to allow @fluid-internal/test- to be not marked as private

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -29,7 +29,9 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 function packageShouldBePrivate(name: string): boolean {
     // See https://github.com/microsoft/FluidFramework/issues/2625
-    if (name === "@fluid-internal/client-api") {
+    if (name === "@fluid-internal/client-api"
+        || name.startsWith("@fluid-internal/test-")         // allow test packages to be packaged
+    ) {
         return false;
     }
 


### PR DESCRIPTION
These needs to be package up for internal use, but will not be published.
Needed by PR #5660 