### PR TITLE
Fix deli ticketing no-ops incorrectly when reprocessing them in certain scenarios

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -82,6 +82,7 @@ export class CheckpointContext {
                 sequenceNumber: checkpoint.sequenceNumber,
                 epoch: checkpoint.epoch,
                 term: checkpoint.term,
+                lastSentMSN: checkpoint.lastSentMSN,
             };
 
             updateP = this.checkpointManager.writeCheckpoint(deliCheckpoint);

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -137,6 +137,8 @@ export class DeliLambda implements IPartitionLambda {
         this.term = lastCheckpoint.term;
         this.epoch = lastCheckpoint.epoch;
         this.durableSequenceNumber = lastCheckpoint.durableSequenceNumber;
+        this.lastSentMSN = lastCheckpoint.lastSentMSN ?? 0;
+
         const msn = this.clientSeqManager.getMinimumSequenceNumber();
         this.minimumSequenceNumber = msn === -1 ? this.sequenceNumber : msn;
 
@@ -716,6 +718,7 @@ export class DeliLambda implements IPartitionLambda {
             logOffset: this.logOffset,
             sequenceNumber: this.sequenceNumber,
             term: this.term,
+            lastSentMSN: this.lastSentMSN,
         };
     }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -40,6 +40,7 @@ const getDefaultCheckpooint = (epoch: number): IDeliState => {
         logOffset: -1,
         sequenceNumber: 0,
         term: 1,
+        lastSentMSN: 0,
     };
 };
 

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -25,6 +25,7 @@ describe("Routerlicious", () => {
                     logOffset,
                     sequenceNumber,
                     term: 1,
+                    lastSentMSN: 0,
                     queuedMessage: {
                         offset: logOffset,
                         partition: 1,

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -62,6 +62,7 @@ const DefaultDeli: IDeliState = {
     logOffset: -1,
     sequenceNumber: 0,
     term: 1,
+    lastSentMSN: 0,
 };
 
 class LocalSocketPublisher implements IPublisher {

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -67,6 +67,9 @@ export interface IDeliState {
 
     // Term at logOffset
     term: number;
+
+    // Last sent minimum sequence number
+    lastSentMSN: number | undefined;
 }
 
 // TODO: We should probably rename this to IScribeState

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -115,6 +115,7 @@ export class DocumentStorage implements IDocumentStorage {
             sequenceNumber,
             epoch: undefined,
             term: 1,
+            lastSentMSN: 0,
         };
 
         const scribe: IScribe = {

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -105,6 +105,7 @@ export class TestDocumentStorage implements IDocumentStorage {
             sequenceNumber,
             epoch: undefined,
             term: 1,
+            lastSentMSN: 0,
         };
 
         const scribe: IScribe = {


### PR DESCRIPTION
It's possible for deli to ticket server submitted no-op's incorrectly when reprocessing them because the `lastSentMSN` property is initially set to 0. `lastSentMSN` needs to be the same between the first time it processed the message and the second time.
The fix is to add that `lastSentMSN`  to the checkpoint.