### PR TITLE
Add isRoot option to _createDataStoreWithProps for apps still using it to mark root components

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1335,10 +1335,14 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this.dataStores.createDetachedDataStoreCore(pkg, false);
     }
 
-    public async _createDataStoreWithProps(pkg: string | string[], props?: any, id = uuid()):
-        Promise<IFluidDataStoreChannel> {
+    public async _createDataStoreWithProps(
+        pkg: string | string[],
+        props?: any,
+        id = uuid(),
+        isRoot = false,
+    ): Promise<IFluidDataStoreChannel> {
         return this.dataStores._createFluidDataStoreContext(
-            Array.isArray(pkg) ? pkg : [pkg], id, false /* isRoot */, props).realize();
+            Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
     }
 
     private async _createDataStore(

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -102,7 +102,12 @@ export interface IContainerRuntimeBase extends
      * @deprecated 0.16 Issue #1537, #3631
      * @internal
      */
-    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string): Promise<IFluidRouter>;
+    _createDataStoreWithProps(
+        pkg: string | string[],
+        props?: any,
+        id?: string,
+        isRoot?: boolean,
+    ): Promise<IFluidRouter>;
 
     /**
      * Creates data store. Returns router of data store. Data store is not bound to container,


### PR DESCRIPTION
Fixes #5269.

_createDataStoreWithProps is deprecated and we want to remove its support. However, there are still consumers of it and they want to be able to mark "root" components as such. For enabling GC, we need to make sure that these consumers can mark root components so that we don't end up deleting them (and the rest of the components referenced from root).

To unblock GC, I have added a flag in this API to mark root components. In parallel, we are working on helping consumers move away from this API by providing alternate solutions / guidance.