### PR TITLE
Logging client summary failure reason in Scribe and insertOp failure in Scriptorium

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -221,9 +221,11 @@ export class ScribeLambda extends SequencedLambda {
                                         },
                                     );
                                 } else {
-                                    await this.sendSummaryNack(summaryResponse.message as ISummaryNack);
+                                    const nackMessage = summaryResponse.message as ISummaryNack;
+                                    await this.sendSummaryNack(nackMessage);
                                     this.context.log?.error(
-                                        `Client summary failure @${value.operation.sequenceNumber}`,
+                                        `Client summary failure @${value.operation.sequenceNumber}. `
+                                        + `Error: ${JSON.stringify(nackMessage, undefined, 2)}`,
                                         {
                                             messageMetaData: {
                                                 documentId: this.documentId,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -225,7 +225,7 @@ export class ScribeLambda extends SequencedLambda {
                                     await this.sendSummaryNack(nackMessage);
                                     this.context.log?.error(
                                         `Client summary failure @${value.operation.sequenceNumber}. `
-                                        + `Error: ${JSON.stringify(nackMessage, undefined, 2)}`,
+                                        + `Error: ${nackMessage.errorMessage}`,
                                         {
                                             messageMetaData: {
                                                 documentId: this.documentId,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -6,6 +6,7 @@
 /* eslint-disable no-null/no-null */
 
 import assert from "assert";
+import { inspect } from "util";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import {
     IDocumentMessage,
@@ -237,6 +238,7 @@ export class ScribeLambda extends SequencedLambda {
                                 }
                             }
                         } catch (ex) {
+                            this.context.log?.error(`Failed to summarize the document. Exception: ${inspect(ex)}`);
                             this.revertProtocolState(prevState.protocolState, prevState.pendingOps);
                             // If this flag is set, we should ignore any storage specific error and move forward
                             // to process the next message.

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -101,11 +101,11 @@ export class ScriptoriumLambda implements IPartitionLambda {
         return this.opCollection
             .insertMany(dbOps, false)
             .catch(async (error) => {
+                this.context.log?.error(`Error inserting operation in the database: ${inspect(error)}`);
+
                 // Duplicate key errors are ignored since a replay may cause us to insert twice into Mongo.
                 // All other errors result in a rejected promise.
                 if (error.code !== 11000) {
-                    this.context.log?.error(`Error inserting operation in the database: ${inspect(error)}`);
-
                     // Needs to be a full rejection here
                     return Promise.reject(error);
                 }

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { inspect } from "util";
 import {
     extractBoxcar,
     ICollection,
@@ -103,6 +104,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
                 // Duplicate key errors are ignored since a replay may cause us to insert twice into Mongo.
                 // All other errors result in a rejected promise.
                 if (error.code !== 11000) {
+                    this.context.log?.error(`Error inserting operation in the database: ${inspect(error)}`);
+
                     // Needs to be a full rejection here
                     return Promise.reject(error);
                 }


### PR DESCRIPTION
We currently do not log the error message from `ISummaryWriteResponse` returned from `writeClientSummary` in `SummaryWriter`, which makes it hard to investigate client summary failures. I'm addressing that in this PR.

We also have no logs in Scriptorium lambda to indicate when inserting the op into the database fails. I addressed that in this PR.