### PR TITLE
Basic FluidDataStoreRuntime unit tests

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/common-definitions";
+import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IFluidObject,
     IRequest,
@@ -29,6 +29,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import { BlobTreeEntry } from "@fluidframework/protocol-base";
 import {
+    IClientDetails,
     IDocumentMessage,
     IQuorum,
     ISequencedDocumentMessage,
@@ -134,6 +135,14 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         return this._containerRuntime.clientId;
     }
 
+    public get clientDetails(): IClientDetails {
+        return this._containerRuntime.clientDetails;
+    }
+
+    public get logger(): ITelemetryLogger {
+        return this._containerRuntime.logger;
+    }
+
     public get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
         return this._containerRuntime.deltaManager;
     }
@@ -148,6 +157,10 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
     public get loader(): ILoader {
         return this._containerRuntime.loader;
+    }
+
+    public get IFluidHandleContext() {
+        return this._containerRuntime.IFluidHandleContext;
     }
 
     public get containerRuntime(): IContainerRuntime {
@@ -243,7 +256,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
             this.channelDeferred.promise.then((runtime) => {
                 runtime.dispose();
             }).catch((error) => {
-                this._containerRuntime.logger.sendErrorEvent(
+                this.logger.sendErrorEvent(
                     { eventName: "ChannelDisposeError", fluidDataStoreId: this.id },
                     error);
             });

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -78,6 +78,7 @@
     "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.38.0",
+    "@fluidframework/test-runtime-utils": "^0.38.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -130,7 +130,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public get clientDetails(): IClientDetails {
-        return this.dataStoreContext.containerRuntime.clientDetails;
+        return this.dataStoreContext.clientDetails;
     }
 
     public get loader(): ILoader {
@@ -150,7 +150,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public get routeContext(): IFluidHandleContext {
-        return this.dataStoreContext.containerRuntime.IFluidHandleContext;
+        return this.dataStoreContext.IFluidHandleContext;
     }
 
     private readonly serializer = new FluidSerializer(this.IFluidHandleContext);
@@ -201,7 +201,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         super();
 
         this.logger = ChildLogger.create(
-            dataStoreContext.containerRuntime.logger, undefined, {all:{ dataStoreId: uuid() }});
+            dataStoreContext.logger, undefined, {all:{ dataStoreId: uuid() }});
         this.documentId = dataStoreContext.documentId;
         this.id = dataStoreContext.id;
         this.existing = dataStoreContext.existing;
@@ -213,9 +213,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         const tree = dataStoreContext.baseSnapshot;
 
         this.initialChannelUsedRoutesP = new LazyPromise(async () => {
-            // back-compat: 0.35.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.35.0. Remove
-            // undefined check when N > 0.36.0.
-            const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails?.();
+            const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails();
             if (gcDetailsInInitialSummary?.usedRoutes !== undefined) {
                 // Remove the route to this data store, if it exists.
                 const usedRoutes = gcDetailsInInitialSummary.usedRoutes.filter(
@@ -227,9 +225,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         });
 
         this.initialChannelGCDataP = new LazyPromise(async () => {
-            // back-compat: 0.35.0. getInitialGCSummaryDetails is added to IFluidDataStoreContext in 0.35.0. Remove
-            // undefined check when N > 0.36.0.
-            const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails?.();
+            const gcDetailsInInitialSummary = await this.dataStoreContext.getInitialGCSummaryDetails();
             if (gcDetailsInInitialSummary?.gcData !== undefined) {
                 const gcData = cloneGCData(gcDetailsInInitialSummary.gcData);
                 // Remove GC node for this data store, if any.

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -130,7 +130,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public get clientDetails(): IClientDetails {
-        return this.dataStoreContext.clientDetails;
+        // back-compat 0.38 - clientDetails is added to IFluidDataStoreContext in 0.38.
+        return this.dataStoreContext.clientDetails ?? this.dataStoreContext.containerRuntime.clientDetails;
     }
 
     public get loader(): ILoader {
@@ -150,7 +151,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public get routeContext(): IFluidHandleContext {
-        return this.dataStoreContext.IFluidHandleContext;
+        // back-compat 0.38 - IFluidHandleContext is added to IFluidDataStoreContext in 0.38.
+        return this.dataStoreContext.IFluidHandleContext ?? this.dataStoreContext.containerRuntime.IFluidHandleContext;
     }
 
     private readonly serializer = new FluidSerializer(this.IFluidHandleContext);
@@ -201,7 +203,11 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         super();
 
         this.logger = ChildLogger.create(
-            dataStoreContext.logger, undefined, {all:{ dataStoreId: uuid() }});
+            // back-compat 0.38 - logger is added to IFluidDataStoreContext in 0.38.
+            dataStoreContext.logger ?? dataStoreContext.containerRuntime.logger,
+            undefined,
+            {all:{ dataStoreId: uuid() }},
+        );
         this.documentId = dataStoreContext.documentId;
         this.id = dataStoreContext.id;
         this.existing = dataStoreContext.existing;

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { SummaryType } from "@fluidframework/protocol-definitions";
+import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
+import { MockFluidDataStoreContext } from "@fluidframework/test-runtime-utils";
+import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
+
+describe("FluidDataStoreRuntime Tests", () => {
+    let dataStoreContext: MockFluidDataStoreContext;
+    let sharedObjectRegistry: ISharedObjectRegistry;
+
+    beforeEach(() => {
+        dataStoreContext = new MockFluidDataStoreContext();
+        sharedObjectRegistry = {
+            get(name: string) {
+                throw new Error("Not implemented");
+            },
+        };
+    });
+
+    it("can create a data store runtime", () => {
+        let failed: boolean = false;
+        let dataStoreRuntime: FluidDataStoreRuntime | undefined;
+        try {
+            dataStoreRuntime = new FluidDataStoreRuntime(dataStoreContext, sharedObjectRegistry);
+        } catch (error) {
+            failed = true;
+        }
+        assert.strictEqual(failed, false, "Data store runtime creation failed");
+        assert.strictEqual(dataStoreRuntime?.id, dataStoreContext.id, "Data store runtime's id in incorrect");
+    });
+
+    it("can summarize an empty data store runtime", async () => {
+        const dataStoreRuntime = new FluidDataStoreRuntime(dataStoreContext, sharedObjectRegistry);
+        const summarizeResult = await dataStoreRuntime.summarize(true, false);
+        assert(summarizeResult.summary.type === SummaryType.Tree, "Data store runtime did not return a summary tree");
+        assert(Object.keys(summarizeResult.summary.tree).length === 0, "The summary should be empty");
+    });
+
+    it("can get GC data of an empty data store runtime", async () => {
+        // The GC data should have a single node for the data store runtime with empty outbound routes.
+        const expectedGCData: IGarbageCollectionData = {
+            gcNodes: { "/": [] },
+        };
+        const dataStoreRuntime = new FluidDataStoreRuntime(dataStoreContext, sharedObjectRegistry);
+        const gcData = await dataStoreRuntime.getGCData();
+        assert.deepStrictEqual(gcData, expectedGCData, "The GC data is incorrect");
+    });
+});

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { SummaryType } from "@fluidframework/protocol-definitions";
-import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
+import { IContainerRuntimeBase, IGarbageCollectionData } from "@fluidframework/runtime-definitions";
 import { MockFluidDataStoreContext } from "@fluidframework/test-runtime-utils";
 import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
 
@@ -15,6 +15,9 @@ describe("FluidDataStoreRuntime Tests", () => {
 
     beforeEach(() => {
         dataStoreContext = new MockFluidDataStoreContext();
+        // back-compat 0.38 - DataStoreRuntime looks in container runtime for certain properties that are unavailable
+        // in the data store context.
+        dataStoreContext.containerRuntime = {} as unknown as IContainerRuntimeBase;
         sharedObjectRegistry = {
             get(name: string) {
                 throw new Error("Not implemented");

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -69,8 +69,7 @@ export interface IContainerRuntimeBaseEvents extends IEvent{
  */
 export interface IContainerRuntimeBase extends
     IEventProvider<IContainerRuntimeBaseEvents>,
-    IProvideFluidHandleContext
-{
+    IProvideFluidHandleContext {
 
     readonly logger: ITelemetryLogger;
     readonly clientDetails: IClientDetails;
@@ -236,7 +235,9 @@ export interface IFluidDataStoreContextEvents extends IEvent {
  * get information and call functionality to the container.
  */
 export interface IFluidDataStoreContext extends
-IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegistry> {
+    IEventProvider<IFluidDataStoreContextEvents>,
+    Partial<IProvideFluidDataStoreRegistry>,
+    IProvideFluidHandleContext {
     readonly documentId: string;
     readonly id: string;
     /**
@@ -263,6 +264,8 @@ IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegi
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly storage: IDocumentStorageService;
     readonly baseSnapshot: ISnapshotTree | undefined;
+    readonly logger: ITelemetryLogger;
+    readonly clientDetails: IClientDetails;
     /**
      * @deprecated 0.37 Use the provideScopeLoader flag to make the loader
      * available through scope instead

--- a/packages/runtime/test-runtime-utils/src/index.ts
+++ b/packages/runtime/test-runtime-utils/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./insecureTokenProvider";
 export * from "./insecureUrlResolver";
+export * from "./mocksDataStoreContext";
 export * from "./mockDeltas";
 export * from "./mockLogger";
 export * from "./mocks";

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -1,0 +1,144 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import {
+    IFluidHandle,
+    IFluidHandleContext,
+    IFluidObject,
+} from "@fluidframework/core-interfaces";
+import {
+    IAudience,
+    IDeltaManager,
+    ContainerWarning,
+    ILoader,
+    AttachState,
+    ILoaderOptions,
+} from "@fluidframework/container-definitions";
+
+import { DebugLogger } from "@fluidframework/telemetry-utils";
+import {
+    IClientDetails,
+    IDocumentMessage,
+    IQuorum,
+    ISequencedDocumentMessage,
+    ISnapshotTree,
+} from "@fluidframework/protocol-definitions";
+import {
+    CreateChildSummarizerNodeFn,
+    CreateChildSummarizerNodeParam,
+    IContainerRuntimeBase,
+    IFluidDataStoreContext,
+    IFluidDataStoreRegistry,
+    IGarbageCollectionSummaryDetails,
+} from "@fluidframework/runtime-definitions";
+import { v4 as uuid } from "uuid";
+import { IDocumentStorageService } from "@fluidframework/driver-definitions";
+
+export class MockFluidDataStoreContext implements IFluidDataStoreContext {
+    public documentId: string;
+    public isLocalDataStore: boolean = true;
+    public packagePath: readonly string[];
+    public options: ILoaderOptions;
+    public clientId: string | undefined = uuid();
+    public clientDetails: IClientDetails;
+    public connected: boolean = true;
+    public leader: boolean;
+    public baseSnapshot: ISnapshotTree | undefined;
+    public deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    public containerRuntime: IContainerRuntimeBase;
+    public storage: IDocumentStorageService;
+    public IFluidDataStoreRegistry: IFluidDataStoreRegistry;
+    public IFluidHandleContext: IFluidHandleContext;
+
+    /**
+     * @deprecated 0.37 Use the provideScopeLoader flag to make the loader
+     * available through scope instead
+     */
+    public loader: ILoader;
+    /**
+     * Indicates the attachment state of the data store to a host service.
+     */
+    public attachState: AttachState;
+
+    /**
+     * @deprecated 0.16 Issue #1635, #3631
+     */
+    public createProps?: any;
+    public scope: IFluidObject;
+
+    constructor(
+        public readonly id: string = uuid(),
+        public readonly existing: boolean = false,
+        public readonly logger: ITelemetryLogger = DebugLogger.create("fluid:MockFluidDataStoreContext"),
+    ) {}
+
+    on(event: string | symbol, listener: (...args: any[]) => void): this {
+        switch (event) {
+            case "leader":
+            case "notleader":
+            case "attaching":
+            case "attached":
+                return this;
+            default:
+                throw new Error("Method not implemented.");
+        }
+    }
+
+    once(event: string | symbol, listener: (...args: any[]) => void): this {
+        return this;
+    }
+
+    off(event: string | symbol, listener: (...args: any[]) => void): this {
+        throw new Error("Method not implemented.");
+    }
+
+    public getQuorum(): IQuorum {
+        return;
+    }
+
+    public getAudience(): IAudience {
+        return;
+    }
+
+    public raiseContainerWarning(warning: ContainerWarning): void {
+        throw new Error("Method not implemented.");
+    }
+
+    public submitMessage(type: string, content: any, localOpMetadata: unknown): void {
+        throw new Error("Method not implemented.");
+    }
+
+    public submitSignal(type: string, content: any): void {
+        throw new Error("Method not implemented.");
+    }
+
+    public bindToContext(): void {
+        throw new Error("Method not implemented.");
+    }
+
+    public setChannelDirty(address: string): void {
+        throw new Error("Method not implemented.");
+    }
+
+    public async getAbsoluteUrl(relativeUrl: string): Promise<string | undefined> {
+        throw new Error("Method not implemented.");
+    }
+
+    public getCreateChildSummarizerNodeFn(
+        id: string,
+        createParam: CreateChildSummarizerNodeParam,
+    ): CreateChildSummarizerNodeFn {
+        throw new Error("Method not implemented.");
+    }
+
+    public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
+        throw new Error("Method not implemented.");
+    }
+
+    public async getInitialGCSummaryDetails(): Promise<IGarbageCollectionSummaryDetails> {
+        throw new Error("Method not implemented.");
+    }
+}


### PR DESCRIPTION
Added basic unit tests for FluidDataStoreRuntime that validates that it can be created and summarize, getGCData can be called on it.
The main goal here was to add a mock FluidDataStoreContext that can be used to create and test a real FluidDataStoreRuntime. Once this is in, we can keep adding more tests and updating the mock context as needed.

I also removed the usages of container runtime from data store runtime because it ideally should not know about it and talk only to the context. And also, it made mocking the FluidDataStoreContext harder.