### PR TITLE
Overriding Axios default maxBodyLenght in RestWrapper

### DIFF
--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -12,6 +12,7 @@ export abstract class RestWrapper {
     constructor(
         protected readonly baseurl?: string,
         protected defaultQueryString: Record<string, unknown> = {},
+        protected readonly maxBodyLength = 1000 * 1024 * 1024,
         protected readonly maxContentLength = 1000 * 1024 * 1024,
     ) {
     }
@@ -24,6 +25,7 @@ export abstract class RestWrapper {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
             headers,
+            maxBodyLength: this.maxBodyLength,
             maxContentLength: this.maxContentLength,
             method: "GET",
             url: `${url}${this.generateQueryString(queryString)}`,
@@ -41,6 +43,7 @@ export abstract class RestWrapper {
             baseURL: this.baseurl,
             data: requestBody,
             headers,
+            maxBodyLength: this.maxBodyLength,
             maxContentLength: this.maxContentLength,
             method: "POST",
             url: `${url}${this.generateQueryString(queryString)}`,
@@ -56,6 +59,7 @@ export abstract class RestWrapper {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
             headers,
+            maxBodyLength: this.maxBodyLength,
             maxContentLength: this.maxContentLength,
             method: "DELETE",
             url: `${url}${this.generateQueryString(queryString)}`,
@@ -73,6 +77,7 @@ export abstract class RestWrapper {
             baseURL: this.baseurl,
             data: requestBody,
             headers,
+            maxBodyLength: this.maxBodyLength,
             maxContentLength: this.maxContentLength,
             method: "PATCH",
             url: `${url}${this.generateQueryString(queryString)}`,
@@ -100,6 +105,7 @@ export class BasicRestWrapper extends RestWrapper {
     constructor(
         baseurl?: string,
         defaultQueryString: Record<string, unknown> = {},
+        maxBodyLength = 1000 * 1024 * 1024,
         maxContentLength = 1000 * 1024 * 1024,
         private defaultHeaders: Record<string, unknown> = {},
         private readonly axios: AxiosInstance = Axios,
@@ -107,7 +113,7 @@ export class BasicRestWrapper extends RestWrapper {
         private readonly refreshDefaultHeaders?: () => Record<string, unknown>,
         private readonly getCorrelationId?: () => string | undefined,
     ) {
-        super(baseurl, defaultQueryString, maxContentLength);
+        super(baseurl, defaultQueryString, maxBodyLength, maxContentLength);
     }
 
     protected async request<T>(requestConfig: AxiosRequestConfig, statusCode: number, canRetry = true): Promise<T> {

--- a/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
@@ -14,7 +14,7 @@ describe("BasicRestWrapper", () => {
     const requestUrl = "/fakerequesturl/";
     const correlationIdHeader = "x-correlation-id";
     const headerCount = 1;
-    const maxBodyLenght = 1000 * 1024 * 1024;
+    const maxBodyLength = 1000 * 1024 * 1024;
     const maxContentLength = 1000 * 1024 * 1024;
     let axiosMock: Partial<AxiosInstance>;
     let axiosErrorMock: Partial<AxiosInstance>;
@@ -148,7 +148,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -161,7 +161,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -174,7 +174,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -188,7 +188,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -201,7 +201,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.get(requestUrl);
@@ -221,7 +221,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -247,7 +247,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -268,7 +268,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -281,7 +281,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -294,7 +294,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -307,7 +307,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -320,7 +320,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.post(requestUrl, {});
@@ -339,7 +339,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -363,7 +363,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -388,7 +388,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -401,7 +401,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -414,7 +414,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -427,7 +427,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -440,7 +440,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.delete(requestUrl);
@@ -459,7 +459,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -483,7 +483,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -508,7 +508,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -521,7 +521,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -534,7 +534,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -547,7 +547,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -560,7 +560,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLength, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.patch(requestUrl, {});
@@ -579,7 +579,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -603,7 +603,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
-                maxBodyLenght,
+                maxBodyLength,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,

--- a/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
@@ -14,6 +14,7 @@ describe("BasicRestWrapper", () => {
     const requestUrl = "/fakerequesturl/";
     const correlationIdHeader = "x-correlation-id";
     const headerCount = 1;
+    const maxBodyLenght = 1000 * 1024 * 1024;
     const maxContentLength = 1000 * 1024 * 1024;
     let axiosMock: Partial<AxiosInstance>;
     let axiosErrorMock: Partial<AxiosInstance>;
@@ -147,7 +148,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -160,7 +161,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -173,7 +174,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -187,7 +188,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.get(requestUrl).then(
@@ -200,7 +201,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.get(requestUrl);
@@ -220,6 +221,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -245,6 +247,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -265,7 +268,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -278,7 +281,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -291,7 +294,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -304,7 +307,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.post(requestUrl, {}).then(
@@ -317,7 +320,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.post(requestUrl, {});
@@ -336,6 +339,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -359,6 +363,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -383,7 +388,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -396,7 +401,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -409,7 +414,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -422,7 +427,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.delete(requestUrl, {}).then(
@@ -435,7 +440,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.delete(requestUrl);
@@ -454,6 +459,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -477,6 +483,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -501,7 +508,7 @@ describe("BasicRestWrapper", () => {
 
         it("Invalid Response Code should reject Promise", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosErrorMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosErrorMock as AxiosInstance);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -514,7 +521,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with 0 retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorZeroRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -527,7 +534,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should reject Promise with negative retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, axiosTooManyRequestsErrorNegativeRetryAfterMock as AxiosInstance);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -540,7 +547,7 @@ describe("BasicRestWrapper", () => {
 
         it("429 Response Code should not reject Promise with positive retryAfter", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, {}, Axios);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, {}, Axios);
 
             // act/assert
             await rw.patch(requestUrl, {}).then(
@@ -553,7 +560,7 @@ describe("BasicRestWrapper", () => {
 
         it("Standard properties should not change", async () => {
             // arrange
-            const rw = new BasicRestWrapper(baseurl, {}, maxContentLength, undefined, axiosMock as AxiosInstance);
+            const rw = new BasicRestWrapper(baseurl, {}, maxBodyLenght, maxContentLength, undefined, axiosMock as AxiosInstance);
 
             // act
             await rw.patch(requestUrl, {});
@@ -572,6 +579,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,
@@ -595,6 +603,7 @@ describe("BasicRestWrapper", () => {
             const rw = new BasicRestWrapper(
                 baseurl,
                 defaultQueryString,
+                maxBodyLenght,
                 maxContentLength,
                 defaultHeaders,
                 axiosMock as AxiosInstance,

--- a/server/routerlicious/packages/services-client/src/test/historian.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/historian.spec.ts
@@ -137,6 +137,7 @@ describe.only("Historian", () => {
             endpoint,
             initialQueryString,
             undefined,
+            undefined,
             initialHeaders,
             undefined,
             undefined,

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -69,6 +69,7 @@ export class TenantManager implements core.ITenantManager {
             baseUrl,
             defaultQueryString,
             undefined,
+            undefined,
             defaultHeaders,
             undefined,
             undefined,


### PR DESCRIPTION
We've seen errors in Scribe that look like this:

```
{"message":"fluid:services-client [post]
request to [/git/blobs?token=******] failed with [ERR_FR_MAX_BODY_LENGTH_EXCEEDED] [Request body larger than maxBodyLength limit]","level":"info","label":"winston"}
{"message":"scribe service exiting due to error","level":"error","label":"winston"}
```

In some occasions when blobs are reasonably large, service-initiated REST calls through Axios can fail because we are not overriding the default `maxBodyLength ` property in Axios. From the [Axios docs](https://github.com/axios/axios):

```
// `maxBodyLength` (Node only option) defines the max size of the http request content in bytes allowed
  maxBodyLength: 2000,
```

We already overwrite `maxContentLenght`, which is similar to `maxBodyLenght` but applies to the http response. The goal of this PR is to follow the same pattern, now for `maxBodyLenght` and avoid the errors similar to the above.