### PR TITLE
ODSP Driver: Reduce Redundancy and Improve Consistency of Contracts

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,11 +1,62 @@
 ## 0.38 Breaking changes
 - [IPersistedCache changes](#IPersistedCache-changes)
+- [ODSP Driver Type Unification](#ODSP-Driver-Type-Unification)
 
 ### IPersistedCache changes
 IPersistedCache implementation no longer needs to implement updateUsage() method (removed form interface).
 Same goes for sequence number / maxOpCount arguments.
 put() changed from fire-and-forget to promise, with intention of returning write errors back to caller. Driver could use this information to stop recording any data about given file if driver needs to follow all-or-nothing strategy in regards to info about a file.
 Please note that format of data stored by driver changed. It will ignore cache entries recorded by previous versions of driver.
+
+## ODSP Driver Type Unification
+This change reuses existing contracts to reduce redundancy improve consistency.
+
+The breaking protion of  this change does rename some parameters to some helper functions, but the change are purely mechanical. In most cases you will likely find you are pulling properties off an object individually to pass them as params, whereas now you can just pass the object itself.
+
+``` typescript
+// before:
+createOdspUrl(
+    siteUrl,
+    driveId,
+    fileId,
+    "/",
+    containerPackageName,
+);
+fetchJoinSession(
+    driveId,
+    itemId,
+    siteUrl,
+    ...
+)
+getFileLink(
+    getToken,
+    something.driveId,
+    something.itemId,
+    something.siteUrl,
+    ...
+)
+
+// After:
+createOdspUrl({
+    siteUrl,
+    driveId,
+    itemId: fileId,
+    dataStorePath: "/",
+    containerPackageName,
+});
+
+fetchJoinSession(
+    {driveId, itemId, siteUrl},
+    ...
+);
+
+getFileLink(
+    getToken,
+    something,
+    ...
+)
+```
+
 
 ## 0.37 Breaking changes
 

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/urlResolver.ts
@@ -6,7 +6,7 @@
 import { assert , fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
-import { createOdspUrl, OdspDriverUrlResolver } from "@fluidframework/odsp-driver";
+import { createOdspUrl, IOdspUrlParts, OdspDriverUrlResolver } from "@fluidframework/odsp-driver";
 
 const fluidOfficeAndOneNoteServers = [
     "dev.fluidpreview.office.net",
@@ -18,7 +18,7 @@ export class FluidAppOdspUrlResolver implements IUrlResolver {
     public async resolve(request: IRequest): Promise<IResolvedUrl | undefined> {
         const reqUrl = new URL(request.url);
         const server = reqUrl.hostname.toLowerCase();
-        let contents: { drive: string; item: string; site: string } | undefined;
+        let contents: IOdspUrlParts | undefined;
         if (fluidOfficeAndOneNoteServers.includes(server)) {
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             contents = await initializeFluidOfficeOrOneNote(reqUrl);
@@ -29,9 +29,9 @@ export class FluidAppOdspUrlResolver implements IUrlResolver {
                 return value;
             };
             contents = {
-                drive: getRequiredParam("drive"),
-                item: getRequiredParam("item"),
-                site: getRequiredParam("siteUrl"),
+                driveId: getRequiredParam("drive"),
+                itemId: getRequiredParam("item"),
+                siteUrl: getRequiredParam("siteUrl"),
             };
         } else {
             return undefined;
@@ -39,7 +39,7 @@ export class FluidAppOdspUrlResolver implements IUrlResolver {
         if (!contents) {
             return undefined;
         }
-        const urlToBeResolved = createOdspUrl(contents.site, contents.drive, contents.item, "");
+        const urlToBeResolved = createOdspUrl({...contents, dataStorePath:""});
         const odspDriverUrlResolver: IUrlResolver = new OdspDriverUrlResolver();
         return odspDriverUrlResolver.resolve({ url: urlToBeResolved });
     }
@@ -53,7 +53,7 @@ export class FluidAppOdspUrlResolver implements IUrlResolver {
     }
 }
 
-async function initializeFluidOfficeOrOneNote(urlSource: URL) {
+async function initializeFluidOfficeOrOneNote(urlSource: URL): Promise<IOdspUrlParts | undefined> {
     const pathname = urlSource.pathname;
     // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
     const siteDriveItemMatch = pathname.match(/\/(p|preview|meetingnotes)\/([^/]*)\/([^/]*)\/([^/]*)/);
@@ -77,7 +77,7 @@ async function initializeFluidOfficeOrOneNote(urlSource: URL) {
 
     // Since we have the drive and item, only take the host ignore the rest
     const siteUrl = decodedSite.substring(storageType.length + 1);
-    const drive = decodeURIComponent(siteDriveItemMatch[3]);
-    const item = decodeURIComponent(siteDriveItemMatch[4]);
-    return { site: siteUrl, drive, item };
+    const driveId = decodeURIComponent(siteDriveItemMatch[3]);
+    const itemId = decodeURIComponent(siteDriveItemMatch[4]);
+    return { siteUrl, driveId, itemId };
 }

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -6,7 +6,13 @@
 import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
 
-export interface IOdspResolvedUrl extends IFluidResolvedUrl {
+export interface IOdspUrlParts {
+    siteUrl: string;
+    driveId: string;
+    itemId: string;
+}
+
+export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     type: "fluid";
     odspResolvedUrl: true;
 
@@ -15,12 +21,6 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl {
 
     // A hashed identifier that is unique to this document
     hashedDocumentId: string;
-
-    siteUrl: string;
-
-    driveId: string;
-
-    itemId: string;
 
     endpoints: {
         snapshotStorageUrl: string;
@@ -210,12 +210,6 @@ export interface IOdspSnapshot {
     ops?: ISequencedDeltaOpMessage[];
 }
 
-export interface IOdspUrlParts {
-    site: string;
-    drive: string;
-    item: string;
-}
-
 export interface ISnapshotOptions {
     blobs?: number;
     deltas?: number;
@@ -269,17 +263,12 @@ export interface ICreateFileResponse {
     sequenceNumber: number;
 }
 
-export interface OdspDocumentInfo {
-    siteUrl: string;
-    driveId: string;
-    fileId: string;
-    dataStorePath: string;
-}
+/**
+ * @deprecated - use OdspFluidDataStoreLocator
+ */
+export type OdspDocumentInfo = OdspFluidDataStoreLocator;
 
-export interface OdspFluidDataStoreLocator {
-    siteUrl: string;
-    driveId: string;
-    fileId: string;
+export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     dataStorePath: string;
     appName?: string;
     containerPackageName?: string;

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -97,7 +97,7 @@ export async function createNewFluidFile(
             { cancel: "error" });
     });
 
-    const odspUrl = createOdspUrl(newFileInfo.siteUrl, newFileInfo.driveId, itemId, "/");
+    const odspUrl = createOdspUrl({... newFileInfo, itemId, dataStorePath: "/"});
     const resolver = new OdspDriverUrlResolver();
     return resolver.resolve({ url: odspUrl });
 }

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -3,34 +3,26 @@
  * Licensed under the MIT License.
  */
 
+import {  OdspFluidDataStoreLocator } from "./contracts";
+
 /*
  * Per https://github.com/microsoft/FluidFramework/issues/1556, isolating createOdspUrl() in its own file.
  */
 
 /**
  * Encodes ODC/SPO information into a URL format that can be handled by the Loader
- * @param siteUrl - The site where the container is hosted
- * @param driveId - The id of the drive with the container
- * @param itemId - The id of the container
- * @param path - A path that corresponds to a request that will be handled by the container
- * @param containerPackageName - A string representing the container package name to be used for preloading scripts
  */
 export function createOdspUrl(
-    siteUrl: string,
-    driveId: string,
-    itemId: string,
-    path: string,
-    containerPackageName?: string,
-    fileVersion?: string,
+    l: OdspFluidDataStoreLocator,
 ): string {
-    let odspUrl = `${siteUrl}?driveId=${encodeURIComponent(driveId)}&itemId=${encodeURIComponent(
-        itemId,
-    )}&path=${encodeURIComponent(path)}`;
-    if (containerPackageName) {
-        odspUrl += `&containerPackageName=${encodeURIComponent(containerPackageName)}`;
+    let odspUrl = `${l.siteUrl}?driveId=${encodeURIComponent(l.driveId)}&itemId=${encodeURIComponent(
+        l.itemId,
+    )}&path=${encodeURIComponent(l.dataStorePath)}`;
+    if (l.containerPackageName) {
+        odspUrl += `&containerPackageName=${encodeURIComponent(l.containerPackageName)}`;
     }
-    if (fileVersion) {
-        odspUrl += `&fileVersion=${encodeURIComponent(fileVersion)}`;
+    if (l.fileVersion) {
+        odspUrl += `&fileVersion=${encodeURIComponent(l.fileVersion)}`;
     }
 
     return odspUrl;

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -11,6 +11,7 @@ import {  OdspFluidDataStoreLocator } from "./contracts";
 
 /**
  * Encodes ODC/SPO information into a URL format that can be handled by the Loader
+ * @param l -The property bag of necessary properties to locate a Fluid data store and craft a url for it
  */
 export function createOdspUrl(
     l: OdspFluidDataStoreLocator,

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -296,9 +296,7 @@ export class OdspDocumentService implements IDocumentService {
     private async joinSession(): Promise<ISocketStorageDiscovery> {
         const executeFetch = async () =>
             fetchJoinSession(
-                this.odspResolvedUrl.driveId,
-                this.odspResolvedUrl.itemId,
-                this.odspResolvedUrl.siteUrl,
+                this.odspResolvedUrl,
                 "opStream/joinSession",
                 "POST",
                 this.logger,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -129,24 +129,25 @@ export class OdspDriverUrlResolver implements IUrlResolver {
         relativeUrl: string,
         codeDetails?: IFluidCodeDetails,
     ): Promise<string> {
-        let url = relativeUrl;
-        if (url.startsWith("/")) {
-            url = url.substr(1);
+        let dataStorePath = relativeUrl;
+        if (dataStorePath.startsWith("/")) {
+            dataStorePath = dataStorePath.substr(1);
         }
         const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
-        const packageName = isFluidPackage(codeDetails?.package) ? codeDetails?.package.name : codeDetails?.package ??
-             odspResolvedUrl.codeHint?.containerPackageName;
+        const containerPackageName =
+            isFluidPackage(codeDetails?.package) ? codeDetails?.package.name : codeDetails?.package ??
+            odspResolvedUrl.codeHint?.containerPackageName;
 
-        return createOdspUrl(
-            odspResolvedUrl.siteUrl,
-            odspResolvedUrl.driveId,
-            odspResolvedUrl.itemId,
-            url,
-            packageName,
-            odspResolvedUrl.fileVersion,
-        );
+        return createOdspUrl({
+            ... odspResolvedUrl,
+            containerPackageName,
+            dataStorePath,
+        });
     }
 
+    /**
+     * @deprecated - use createOdspCreateContainerRequest
+     */
     public createCreateNewRequest(
         siteUrl: string,
         driveId: string,

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -11,7 +11,7 @@ const fluidSignature = "1";
 const fluidSignatureParamName = "fluid";
 const fluidSitePathParamName = "s";
 const fluidDriveIdParamName = "d";
-const fluidFileIdParamName = "f";
+const fluidItemIdParamName = "f";
 const fluidDataStorePathParamName = "c";
 const fluidAppNameParamName = "a";
 const fluidContainerPackageNameParamName = "p";
@@ -26,11 +26,11 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
     const siteUrl = new URL(locator.siteUrl);
     const sitePath = encodeURIComponent(siteUrl.pathname);
     const driveId = encodeURIComponent(locator.driveId);
-    const fileId = encodeURIComponent(locator.fileId);
+    const itemId = encodeURIComponent(locator.itemId);
     const dataStorePath = encodeURIComponent(locator.dataStorePath);
 
     let locatorSerialized = `${fluidSitePathParamName}=${sitePath}&${fluidDriveIdParamName}=${driveId}&${
-        fluidFileIdParamName}=${fileId}&${fluidDataStorePathParamName}=${dataStorePath}&${
+        fluidItemIdParamName}=${itemId}&${fluidDataStorePathParamName}=${dataStorePath}&${
         fluidSignatureParamName}=${fluidSignature}`;
     if (locator.appName) {
         locatorSerialized += `&${fluidAppNameParamName}=${encodeURIComponent(locator.appName)}`;
@@ -67,14 +67,14 @@ function decodeOdspFluidDataStoreLocator(
 
     const sitePath = locatorInfo.get(fluidSitePathParamName);
     const driveId = locatorInfo.get(fluidDriveIdParamName);
-    const fileId = locatorInfo.get(fluidFileIdParamName);
+    const itemId = locatorInfo.get(fluidItemIdParamName);
     const dataStorePath = locatorInfo.get(fluidDataStorePathParamName);
     const appName = locatorInfo.get(fluidAppNameParamName) ?? undefined;
     const containerPackageName = locatorInfo.get(fluidContainerPackageNameParamName) ?? undefined;
     const fileVersion = locatorInfo.get(fluidFileVersionParamName) ?? undefined;
     // "" is a valid value for dataStorePath so simply check for absence of the param;
     // the rest of params must be present and non-empty
-    if (!sitePath || !driveId || !fileId || dataStorePath === null) {
+    if (!sitePath || !driveId || !itemId || dataStorePath === null) {
         return undefined;
     }
 
@@ -92,7 +92,7 @@ function decodeOdspFluidDataStoreLocator(
     return {
         siteUrl: siteUrl.href,
         driveId,
-        fileId,
+        itemId,
         dataStorePath,
         appName,
         containerPackageName,

--- a/packages/drivers/odsp-driver/src/odspUrlHelper.ts
+++ b/packages/drivers/odsp-driver/src/odspUrlHelper.ts
@@ -104,19 +104,19 @@ export async function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefin
             }
         }
 
-        const drive = joinSessionMatch[3] || joinSessionMatch[5];
-        const item = joinSessionMatch[4];
+        const driveId = joinSessionMatch[3] || joinSessionMatch[5];
+        const itemId = joinSessionMatch[4];
 
-        return { site: `${url.origin}${url.pathname}`, drive, item };
+        return { siteUrl: `${url.origin}${url.pathname}`, driveId, itemId };
     } else {
         joinSessionMatch = /(.*)\/_api\/v2.1\/drives\/([^/]*)\/items\/([^/]*)(.*)/.exec(pathname);
 
         if (joinSessionMatch === null) {
             return undefined;
         }
-        const drive = joinSessionMatch[2];
-        const item = joinSessionMatch[3];
+        const driveId = joinSessionMatch[2];
+        const itemId = joinSessionMatch[3];
 
-        return { site: `${url.origin}${url.pathname}`, drive, item };
+        return { siteUrl: `${url.origin}${url.pathname}`, driveId, itemId };
     }
 }

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -26,7 +26,7 @@ const createUtLocalCache = () => new LocalPersistentCache(2000);
 describe("Tests for Epoch Tracker", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
     const driveId = "driveId";
-    const itemId = "fileId";
+    const itemId = "itemId";
     let epochTracker: EpochTracker;
     let localCache: LocalPersistentCache;
     const hashedDocumentId = getHashedDocumentId(driveId, itemId);

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -39,7 +39,7 @@ class DeferralWithCallback extends Deferred<void> {
 describe("Tests for Epoch Tracker With Redemption", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
     const driveId = "driveId";
-    const itemId = "fileId";
+    const itemId = "itemId";
     let epochTracker: EpochTrackerWithRedemption;
     const hashedDocumentId = getHashedDocumentId(driveId, itemId);
     let epochCallback: DeferralWithCallback;

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -20,7 +20,7 @@ describe("getFileLink", () => {
 
     it("should return web url for Consumer user", async () => {
         const result = await mockFetchOk(
-            async () => getFileLink(storageTokenFetcher, siteUrl, driveId, "itemId1", "Consumer", logger),
+            async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId1"}, "Consumer", logger),
             fileItemResponse,
         );
         assert.strictEqual(result, fileItemResponse.webUrl, "File link for Consumer user should match webUrl");
@@ -28,14 +28,14 @@ describe("getFileLink", () => {
 
     it("should return undefined for Consumer user if file web url is missing", async () => {
         const result = await mockFetchOk(
-            async () => getFileLink(storageTokenFetcher, siteUrl, driveId, "itemId2", "Consumer", logger),
+            async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId2"}, "Consumer", logger),
         );
         assert.strictEqual(result, undefined, "File link should be undefined");
     });
 
     it("should return undefined for Consumer user if file item is not found", async () => {
         const result = await mockFetchSingle(async () => {
-                return getFileLink(storageTokenFetcher, siteUrl, driveId, "itemId3", "Consumer", logger);
+                return getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId3"}, "Consumer", logger);
             },
             notFound,
         );
@@ -44,7 +44,7 @@ describe("getFileLink", () => {
 
     it("should return share link with existing access for Enterprise user", async () => {
         const result = await mockFetchMultiple(
-            async () => getFileLink(storageTokenFetcher, siteUrl, driveId, "itemId4", "Enterprise", logger),
+            async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId4"}, "Enterprise", logger),
             [
                 async () => okResponse({}, fileItemResponse),
                 async () => okResponse({}, { d: { directUrl: "sharelink" } }),
@@ -56,14 +56,14 @@ describe("getFileLink", () => {
 
     it("should return undefined for Enterprise user if file web dav url is missing", async () => {
         const result = await mockFetchOk(
-            async () => getFileLink(storageTokenFetcher, siteUrl, driveId, "itemId5", "Enterprise", logger),
+            async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId5"}, "Enterprise", logger),
         );
         assert.strictEqual(result, undefined, "File link should be undefined");
     });
 
     it("should return undefined for Enterprise user if file item is not found", async () => {
         const result = await mockFetchSingle(async () => {
-            return getFileLink(storageTokenFetcher, siteUrl, driveId, "itemId6", "Enterprise", logger);
+            return getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId6"}, "Enterprise", logger);
             },
             notFound);
         assert.strictEqual(result, undefined, "File link should be undefined");

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -19,11 +19,11 @@ import { IOdspResolvedUrl, SharingLinkHeader } from "../contracts";
 describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
     const driveId = "driveId";
-    const itemId = "fileId";
+    const itemId = "itemId";
     const dataStorePath = "dataStorePath";
     const fileName = "fileName";
     const sharelink = "https://microsoft.sharepoint-df.com/site/SHARELINK";
-    // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1
+    // Base64 encoded and then URI encoded string: d=driveId&f=itemId&c=dataStorePath&s=siteUrl&fluid=1
     const urlWithNavParam = "https://microsoft.sharepoint-df.com/test?nav=cz0lMkZzaXRlVXJsJmQ9ZHJpdmVJZCZmPWZpbGVJZCZjPWRhdGFTdG9yZVBhdGgmZmx1aWQ9MQ%3D%3D";
     let urlResolverWithTokenFetcher: OdspDriverUrlResolverForShareLink;
     let urlResolverWithoutTokenFetcher: OdspDriverUrlResolverForShareLink;
@@ -111,7 +111,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
         assert.strictEqual(actualShareLink, sharelink, "Sharing link should be equal!!");
 
         const url = new URL(sharelink);
-        storeLocatorInOdspUrl(url, { siteUrl, driveId, fileId: itemId, dataStorePath });
+        storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId: itemId, dataStorePath });
         assert.strictEqual(absoluteUrl, url.toString(), "Absolute url should be equal!!");
     });
 
@@ -167,7 +167,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     it("Sharing link should be set when isSharingLinkToRedeem header is set", async () => {
         const resolvedUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
             const url = new URL(sharelink);
-            storeLocatorInOdspUrl(url, { siteUrl, driveId, fileId: itemId, dataStorePath });
+            storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId: itemId, dataStorePath });
             return urlResolverWithTokenFetcher.resolve({ url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
         assert.strictEqual(resolvedUrl.sharingLinkToRedeem, sharelink, "Sharing link should be set in resolved url");
@@ -175,11 +175,11 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 
     it("Encode and decode nav param", async () => {
         const encodedUrl = new URL(sharelink);
-        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, fileId: itemId, dataStorePath });
+        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, itemId: itemId, dataStorePath });
 
         const locator = getLocatorFromOdspUrl(encodedUrl);
         assert.strictEqual(locator?.driveId, driveId, "Drive id should be equal");
-        assert.strictEqual(locator?.fileId, itemId, "Item id should be equal");
+        assert.strictEqual(locator?.itemId, itemId, "Item id should be equal");
         assert.strictEqual(locator?.dataStorePath, dataStorePath, "DataStore path should be equal");
         assert.strictEqual(locator?.siteUrl, siteUrl, "SiteUrl should be equal");
     });

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -20,11 +20,11 @@ import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRe
 describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
     const driveId = "driveId";
-    const itemId = "itemId";
+    const itemId = "fileId";
     const dataStorePath = "dataStorePath";
     const fileName = "fileName";
     const sharelink = "https://microsoft.sharepoint-df.com/site/SHARELINK";
-    // Base64 encoded and then URI encoded string: d=driveId&f=itemId&c=dataStorePath&s=siteUrl&fluid=1
+    // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1
     const urlWithNavParam = "https://microsoft.sharepoint-df.com/test?nav=cz0lMkZzaXRlVXJsJmQ9ZHJpdmVJZCZmPWZpbGVJZCZjPWRhdGFTdG9yZVBhdGgmZmx1aWQ9MQ%3D%3D";
     let urlResolverWithTokenFetcher: OdspDriverUrlResolverForShareLink;
     let urlResolverWithoutTokenFetcher: OdspDriverUrlResolverForShareLink;

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -15,6 +15,7 @@ import { createOdspUrl } from "../createOdspUrl";
 import * as fileLinkImport from "../getFileLink";
 import { getLocatorFromOdspUrl, storeLocatorInOdspUrl } from "../odspFluidFileLink";
 import { IOdspResolvedUrl, SharingLinkHeader } from "../contracts";
+import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest";
 
 describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
@@ -60,7 +61,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     it("resolve - Should resolve odsp driver url correctly", async () => {
         const runTest = async (resolver: OdspDriverUrlResolverForShareLink) => {
             const resolvedUrl1 = await resolver.resolve({ url: urlWithNavParam });
-            const url: string = createOdspUrl(resolvedUrl1.siteUrl, resolvedUrl1.driveId, resolvedUrl1.itemId, dataStorePath);
+            const url: string = createOdspUrl({... resolvedUrl1, dataStorePath});
             const resolvedUrl2 = await resolver.resolve({ url });
             assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
             assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");
@@ -84,7 +85,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     });
 
     it("resolve - Should generate sharelink and set it in shareLinkMap if using resolver with TokenFetcher", async () => {
-        const url: string = createOdspUrl(siteUrl, driveId, itemId, dataStorePath);
+        const url: string = createOdspUrl({siteUrl, driveId, itemId, dataStorePath});
         await mockGetFileLink(Promise.resolve(sharelink), async () => {
             return urlResolverWithTokenFetcher.resolve({ url });
         });
@@ -93,7 +94,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     });
 
     it("resolve - Should not generate sharelink if using resolver without TokenFetcher", async () => {
-        const url: string = createOdspUrl(siteUrl, driveId, itemId, dataStorePath);
+        const url: string = createOdspUrl({siteUrl, driveId, itemId, dataStorePath});
         await mockGetFileLink(Promise.resolve(sharelink), async () => {
             return urlResolverWithoutTokenFetcher.resolve({ url });
         });
@@ -111,7 +112,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
         assert.strictEqual(actualShareLink, sharelink, "Sharing link should be equal!!");
 
         const url = new URL(sharelink);
-        storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId: itemId, dataStorePath });
+        storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId, dataStorePath });
         assert.strictEqual(absoluteUrl, url.toString(), "Absolute url should be equal!!");
     });
 
@@ -146,7 +147,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 
     it("Should resolve createNew request", async () => {
         const runTest = async (resolver: OdspDriverUrlResolverForShareLink) => {
-            const request: IRequest = resolver.createCreateNewRequest(siteUrl, driveId, dataStorePath, fileName);
+            const request: IRequest = createOdspCreateContainerRequest(siteUrl, driveId, dataStorePath, fileName);
             const resolvedUrl = await resolver.resolve(request);
             assert.strictEqual(resolvedUrl.fileName, fileName, "FileName should be equal");
             assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
@@ -167,7 +168,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     it("Sharing link should be set when isSharingLinkToRedeem header is set", async () => {
         const resolvedUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
             const url = new URL(sharelink);
-            storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId: itemId, dataStorePath });
+            storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId, dataStorePath });
             return urlResolverWithTokenFetcher.resolve({ url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
         assert.strictEqual(resolvedUrl.sharingLinkToRedeem, sharelink, "Sharing link should be set in resolved url");
@@ -175,7 +176,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 
     it("Encode and decode nav param", async () => {
         const encodedUrl = new URL(sharelink);
-        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, itemId: itemId, dataStorePath });
+        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, itemId, dataStorePath });
 
         const locator = getLocatorFromOdspUrl(encodedUrl);
         assert.strictEqual(locator?.driveId, driveId, "Drive id should be equal");

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -5,7 +5,7 @@
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { ISocketStorageDiscovery } from "./contracts";
+import { IOdspUrlParts, ISocketStorageDiscovery } from "./contracts";
 import { getWithRetryForTokenRefresh, getOrigin } from "./odspUtils";
 import { getApiRoot } from "./odspUrlHelper";
 import { TokenFetchOptions } from "./tokenFetch";
@@ -23,9 +23,7 @@ import { EpochTracker } from "./epochTracker";
  * @param epochTracker - fetch wrapper which incorporates epoch logic around joisSession call.
  */
 export async function fetchJoinSession(
-    driveId: string,
-    itemId: string,
-    siteUrl: string,
+    urlParts: IOdspUrlParts,
     path: string,
     method: string,
     logger: ITelemetryLogger,
@@ -47,7 +45,7 @@ export async function fetchJoinSession(
             async (event) =>
         {
             // TODO Extract the auth header-vs-query logic out
-            const siteOrigin = getOrigin(siteUrl);
+            const siteOrigin = getOrigin(urlParts.siteUrl);
             let queryParams = `access_token=${token}`;
             let headers = {};
             if (queryParams.length > 2048) {
@@ -56,7 +54,7 @@ export async function fetchJoinSession(
             }
 
             const response = await epochTracker.fetchAndParseAsJSON<ISocketStorageDiscovery>(
-                `${getApiRoot(siteOrigin)}/drives/${driveId}/items/${itemId}/${path}?${queryParams}`,
+                `${getApiRoot(siteOrigin)}/drives/${urlParts.driveId}/items/${urlParts.itemId}/${path}?${queryParams}`,
                 { method, headers },
                 "joinSession",
             );

--- a/packages/drivers/odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/odsp-urlResolver/src/urlResolver.ts
@@ -21,7 +21,7 @@ export class OdspUrlResolver implements IUrlResolver {
             if (!contents) {
                 return undefined;
             }
-            const urlToBeResolved = createOdspUrl(contents.site, contents.drive, contents.item, "");
+            const urlToBeResolved = createOdspUrl({...contents, dataStorePath: "" });
             const odspDriverUrlResolver: IUrlResolver = new OdspDriverUrlResolver();
             return odspDriverUrlResolver.resolve({ url: urlToBeResolved, headers: request.headers });
         }

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -145,11 +145,11 @@ export class OdspTestDriver implements ITestDriver {
 
             this.testIdToUrl.set(
                 testId,
-                this.api.createOdspUrl(
+                this.api.createOdspUrl({
+                    ... driveItem,
                     siteUrl,
-                    driveItem.drive,
-                    driveItem.item,
-                    "/"));
+                    dataStorePath: "/",
+                }));
         }
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return this.testIdToUrl.get(testId)!;

--- a/packages/tools/fetch-tool/src/fluidFetch.ts
+++ b/packages/tools/fetch-tool/src/fluidFetch.ts
@@ -32,16 +32,16 @@ async function fluidFetchOneFile(urlStr: string, name?: string) {
 }
 
 async function tryFluidFetchOneSharePointFile(server: string, driveItem: IOdspDriveItem) {
-    const { path, name, drive, item } = driveItem;
+    const { path, name, driveId, itemId } = driveItem;
     console.log(`File: ${path}/${name}`);
-    await fluidFetchOneFile(`https://${server}/_api/v2.1/drives/${drive}/items/${item}`, name);
+    await fluidFetchOneFile(`https://${server}/_api/v2.1/drives/${driveId}/items/${itemId}`, name);
 }
 
-function getSharePointSpecificDriveItem(url: URL): { drive: string; item: string } | undefined {
+function getSharePointSpecificDriveItem(url: URL): { driveId: string; itemId: string } | undefined {
     if (url.searchParams.has("driveId") && url.searchParams.has("itemId")) {
         return {
-            drive: url.searchParams.get("driveId") as string,
-            item: url.searchParams.get("itemId") as string,
+            driveId: url.searchParams.get("driveId") as string,
+            itemId: url.searchParams.get("itemId") as string,
         };
     }
 }
@@ -77,7 +77,7 @@ async function fluidFetchMain() {
         // See if the url already has the specific item
         const driveItem = getSharePointSpecificDriveItem(url);
         if (driveItem) {
-            const file = await getSingleSharePointFile(server, driveItem.drive, driveItem.item);
+            const file = await getSingleSharePointFile(server, driveItem.driveId, driveItem.itemId);
             await tryFluidFetchOneSharePointFile(server, file);
             return;
         }

--- a/packages/tools/webpack-fluid-loader/src/odspUrlResolver.ts
+++ b/packages/tools/webpack-fluid-loader/src/odspUrlResolver.ts
@@ -29,21 +29,22 @@ export class OdspUrlResolver implements IUrlResolver {
 
         const fullPath = url.pathname.substr(1);
         const documentId = fullPath.split("/")[0];
-        const documentRelativePath = fullPath.slice(documentId.length + 1);
+        const dataStorePath = fullPath.slice(documentId.length + 1);
         const filePath = this.formFilePath(documentId);
 
-        const { drive, item } = await getDriveItemByRootFileName(
+        const { driveId, itemId } = await getDriveItemByRootFileName(
             this.server,
             "",
             filePath,
             this.authRequestInfo,
             true);
 
-        const odspUrl = createOdspUrl(
-            `https://${this.server}`,
-            drive,
-            item,
-            documentRelativePath);
+        const odspUrl = createOdspUrl({
+            siteUrl:`https://${this.server}`,
+            driveId,
+            itemId,
+            dataStorePath,
+        });
 
         return this.driverUrlResolver.resolve({ url: odspUrl, headers: request.headers });
     }
@@ -66,6 +67,6 @@ export class OdspUrlResolver implements IUrlResolver {
             this.authRequestInfo,
             false);
         return this.driverUrlResolver.createCreateNewRequest(
-            `https://${this.server}`, driveItem.drive, filePath, `${fileName}.fluid`);
+            `https://${this.server}`, driveItem.driveId, filePath, `${fileName}.fluid`);
     }
 }

--- a/packages/utils/odsp-doclib-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDrives.ts
@@ -49,8 +49,8 @@ interface IOdspDriveInfo {
 export interface IOdspDriveItem {
     path: string;
     name: string;
-    drive: string;
-    item: string;
+    driveId: string;
+    itemId: string;
     isFolder: boolean;
 }
 
@@ -119,7 +119,7 @@ export async function getChildrenByDriveItem(
     authRequestInfo: IOdspAuthRequestInfo,
 ): Promise<IOdspDriveItem[]> {
     if (!driveItem.isFolder) { return []; }
-    let url = `https://${server}/_api/v2.1/drives/${driveItem.drive}/items/${driveItem.item}/children`;
+    let url = `https://${server}/_api/v2.1/drives/${driveItem.driveId}/items/${driveItem.itemId}/children`;
     let children: any[] = [];
     do {
         const response = await getAsync(url, authRequestInfo);
@@ -223,8 +223,8 @@ function toIODSPDriveItem(parsedDriveItemBody: any): IOdspDriveItem {
     return {
         path,
         name: parsedDriveItemBody.name,
-        drive: parsedDriveItemBody.parentReference.driveId,
-        item: parsedDriveItemBody.id,
+        driveId: parsedDriveItemBody.parentReference.driveId,
+        itemId: parsedDriveItemBody.id,
         isFolder: !!parsedDriveItemBody.folder,
     };
 }


### PR DESCRIPTION
This change was spurred by a missed property, fileVersion on OdspDocumentInfo which wasn't plumbed through. This contract is redundant and just add complexity to making changes. On fixing I identified a number of contract issues, so decided to do a bunch of cleanup that should make the api easier to use with each other, and reduce to the need to manually spread objects into parameters repeatedly. No fluid contracts are affected by this change, only helper functions may change