### PR TITLE
Handle errors in Alfred's connectDocument

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { inspect } from "util";
 import {
     ConnectionMode,
     IClient,
@@ -31,8 +32,6 @@ import {
     getRandomInt,
     generateClientId,
 } from "../utils";
-import { inspect } from "util";
-import { IOrdererConnection } from "@fluidframework/server-services-core";
 
 interface IRoom {
 
@@ -283,7 +282,7 @@ export function configureWebSocketServices(
 
             let connectedMessage: IConnected;
             if (isWriter(messageClient.scopes, details.existing, message.mode)) {
-                let connection: IOrdererConnection;
+                let connection: core.IOrdererConnection;
                 try {
                     const orderer = await orderManager.getOrderer(claims.tenantId, claims.documentId);
                     connection = await orderer.connect(socket, clientId, messageClient as IClient, details);

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -257,16 +257,16 @@ export function configureWebSocketServices(
             }
 
             const detailsP = storage.getOrCreateDocument(claims.tenantId, claims.documentId)
-            .catch(async (err) => {
-                const errMsg = `Failed to get or create document with error: ${safeStringify(err, undefined, 2)}`;
-                return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
-            });
+                .catch(async (err) => {
+                    const errMsg = `Failed to get or create document with error: ${safeStringify(err, undefined, 2)}`;
+                    return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
+                });
 
             const clientsP = clientManager.getClients(claims.tenantId, claims.documentId)
-            .catch(async (err) => {
-                const errMsg = `Failed to get clients due to error: ${safeStringify(err, undefined, 2)}`;
-                return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
-            });
+                .catch(async (err) => {
+                    const errMsg = `Failed to get clients due to error: ${safeStringify(err, undefined, 2)}`;
+                    return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
+                });
 
             const [details, clients] = await Promise.all([detailsP, clientsP]);
 
@@ -298,16 +298,16 @@ export function configureWebSocketServices(
             let connectedMessage: IConnected;
             if (isWriter(messageClient.scopes, details.existing, message.mode)) {
                 const orderer = await orderManager.getOrderer(claims.tenantId, claims.documentId)
-                .catch(async (err) => {
-                    const errMsg = `Failed to get orderer manager. Error: ${safeStringify(err, undefined, 2)}`;
-                    return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
-                });
+                    .catch(async (err) => {
+                        const errMsg = `Failed to get orderer manager. Error: ${safeStringify(err, undefined, 2)}`;
+                        return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
+                    });
 
                 const connection = await orderer.connect(socket, clientId, messageClient as IClient, details)
-                .catch(async (err) => {
-                    const errMsg = `Failed to connect to orderer. Error: ${safeStringify(err, undefined, 2)}`;
-                    return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
-                });
+                    .catch(async (err) => {
+                        const errMsg = `Failed to connect to orderer. Error: ${safeStringify(err, undefined, 2)}`;
+                        return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
+                    });
 
                 // Eventually we will send disconnect reason as headers to client.
                 connection.once("error", (error) => {
@@ -321,7 +321,11 @@ export function configureWebSocketServices(
                     socket.disconnect(true);
                 });
 
-                void connection.connect();
+                connection.connect()
+                    .catch(async (err) => {
+                        const errMsg = `Error connecting the orderer connection: ${safeStringify(err, undefined, 2)}`;
+                        return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
+                    });
 
                 connectionsMap.set(clientId, connection);
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -258,7 +258,7 @@ export function configureWebSocketServices(
 
             const detailsP = storage.getOrCreateDocument(claims.tenantId, claims.documentId)
                 .catch(async (err) => {
-                    const errMsg = `Failed to get or create document with error: ${safeStringify(err, undefined, 2)}`;
+                    const errMsg = `Failed to get or create document. Error: ${safeStringify(err, undefined, 2)}`;
                     return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
                 });
 
@@ -321,7 +321,8 @@ export function configureWebSocketServices(
 
                 connection.connect()
                     .catch(async (err) => {
-                        const errMsg = `Error connecting the orderer connection: ${safeStringify(err, undefined, 2)}`;
+                        // eslint-disable-next-line max-len
+                        const errMsg = `Failed to connect to the orderer connection. Error: ${safeStringify(err, undefined, 2)}`;
                         return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
                     });
 


### PR DESCRIPTION
Addressing #5665. In this PR:

1. Adding error handlers for multiple async operations that could possibly fail. If those operations fail, we would have a server error, so returning 500 to clients to indicate that
2. We were calling `connection.connect()` and only after that setting the listener to the `error` event. Switching the order (setting error listener first, calling `connect()` after) might help with possible race conditions.
3. `connection.connect()` was a floating promise and we had to disable ESLint errors. I fixed that by adding a `.catch()` to the promise.
