### PR TITLE
Remove back-compat and deprecated getTaskManager

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -6,7 +6,6 @@
 import { EventEmitter } from "events";
 import {
     AgentSchedulerFactory,
-    IProvideAgentScheduler,
     IAgentScheduler,
 } from "@fluidframework/agent-scheduler";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -1996,20 +1995,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 this.closeFn(CreateContainerError(err));
             });
         }
-    }
-
-    /**
-     * @deprecated starting in 0.36. The AgentScheduler can be requested directly, though this will also be removed in
-     * a future release when an alternative is available: containerRuntime.request(\{ url: "/_scheduler" \}).
-     * getTaskManager should be removed in 0.38.
-     */
-    public async getTaskManager(): Promise<IProvideAgentScheduler> {
-        console.error("getTaskManager is deprecated.");
-        const agentScheduler = await this.getScheduler();
-        // Prior versions would return a TaskManager, which was an IProvideAgentScheduler -- returning this for back
-        // compat.  Wrapping the agentScheduler in an IProvideAgentScheduler will help catch any cases where customers
-        // try to call other TaskManager functionality.
-        return { IAgentScheduler: agentScheduler };
     }
 
     private async getScheduler(): Promise<IAgentScheduler> {

--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -24,10 +24,7 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
 
         beforeEach(async () => {
             const container = await provider.makeTestContainer();
-            // Back-compat: querying for IAgentScheduler since this request would return an ITaskManager prior to 0.36.
-            // Remove the query in 0.38 when back compat is no longer a concern.
-            scheduler = await requestFluidObject<IAgentScheduler>(container, agentSchedulerId)
-                .then((agentScheduler) => agentScheduler.IAgentScheduler);
+            scheduler = await requestFluidObject<IAgentScheduler>(container, agentSchedulerId);
 
             const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
 
@@ -106,10 +103,7 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
         beforeEach(async () => {
             // Create a new Container for the first document.
             container1 = await provider.makeTestContainer();
-            // Back-compat: querying for IAgentScheduler since this request would return an ITaskManager prior to 0.36.
-            // Remove the query in 0.38 when back compat is no longer a concern.
-            scheduler1 = await requestFluidObject<IAgentScheduler>(container1, agentSchedulerId)
-                .then((agentScheduler) => agentScheduler.IAgentScheduler);
+            scheduler1 = await requestFluidObject<IAgentScheduler>(container1, agentSchedulerId);
             const dataObject1 = await requestFluidObject<ITestDataObject>(container1, "default");
 
             // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick
@@ -123,10 +117,7 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
             }
             // Load existing Container for the second document.
             container2 = await provider.loadTestContainer();
-            // Back-compat: querying for IAgentScheduler since this request would return an ITaskManager prior to 0.36.
-            // Remove the query in 0.38 when back compat is no longer a concern.
-            scheduler2 = await requestFluidObject<IAgentScheduler>(container2, agentSchedulerId)
-                .then((agentScheduler) => agentScheduler.IAgentScheduler);
+            scheduler2 = await requestFluidObject<IAgentScheduler>(container2, agentSchedulerId);
             const dataObject2 = await requestFluidObject<ITestDataObject>(container2, "default");
 
             // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick


### PR DESCRIPTION
`TaskManager` was removed in 0.36, this removes the leftover deprecated method and leftover back compat.