### PR TITLE
Pairwise Generator: Fix bug and Remove Recursion For Better Type Support

### DIFF
--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -45,12 +45,12 @@ export const odspOpsCaching: OptionsMatrix<IOpsCachingPolicy> = {
     totalOpsToCache: numberCases,
 };
 
-export const odspHostPolicyMatrix: OptionsMatrix<HostStoragePolicy> = {
+export const odspHostPolicyMatrix = new Lazy<OptionsMatrix<HostStoragePolicy>> (()=>({
     blobDeduping: booleanCases,
     concurrentSnapshotFetch: booleanCases,
-    snapshotOptions:[undefined, odspSnapshotOptions],
-    opsCaching: [undefined, odspOpsCaching],
-};
+    snapshotOptions:[undefined, ...generatePairwiseOptions(odspSnapshotOptions)],
+    opsCaching: [undefined, ...generatePairwiseOptions(odspOpsCaching)],
+}));
 
 export const pairwiseOdspHostStoragePolicy = new Lazy(()=>
-    generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix));
+    generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix.value));

--- a/packages/test/test-pairwise-generator/src/index.ts
+++ b/packages/test/test-pairwise-generator/src/index.ts
@@ -11,13 +11,11 @@ import { assert } from "@fluidframework/common-utils";
 // of all property values
 export type OptionsMatrix<T extends Record<string, any>> =
     Required<{
-        [K in keyof T]: Exclude<T[K], undefined | boolean | number | string> extends  never
-            ? readonly (T[K])[]
-            : readonly (OptionsMatrix<T[K]>)[]
+        [K in keyof T]: readonly (T[K])[]
     }>;
 
 export const booleanCases: readonly (boolean)[] = [true, false];
-export const numberCases: readonly (number | undefined)[] = [undefined];
+export const numberCases: readonly (number | undefined)[] = [undefined,-1,0,1,1000];
 
 type PartialWithKeyCount<T extends Record<string, any>>= (Partial<T> & {__paritalKeyCount?: number});
 
@@ -28,14 +26,18 @@ function applyPairToPartial<T extends Record<string, any>>(
     let found: PartialWithKeyCount<T> | undefined;
     for(const partial of partials) {
         // the pair exists, so nothing to do
-        if(partial[pair.iKey] === pair.iVal && partial[pair.jKey] === pair.jVal) {
+        if(pair.iKey in partial
+            && pair.jKey in partial
+            && partial[pair.iKey] === pair.iVal
+            && partial[pair.jKey] === pair.jVal) {
             return;
         }
 
-        if(pair.iKey in partial && partial[pair.iKey] === pair.iVal && !(pair.jKey in partial)
-            || pair.jKey in partial && partial[pair.jKey] === pair.jVal && !(pair.iKey in partial)) {
-            found = partial;
-            break;
+        if(found === undefined) {
+            if((pair.iKey in partial && !(pair.jKey in partial) && partial[pair.iKey] === pair.iVal)
+                || (pair.jKey in partial && !(pair.iKey in partial) && partial[pair.jKey] === pair.jVal)) {
+                found = partial;
+            }
         }
     }
     if(found === undefined) {
@@ -56,37 +58,20 @@ function applyPairToPartial<T extends Record<string, any>>(
 }
 
 export function generatePairwiseOptions<T extends Record<string, any>>(optionsMatrix: OptionsMatrix<T>): T[] {
-    const valuesMap = new Map<keyof T, any[]>();
-    for(const key of Object.keys(optionsMatrix)) {
-        const matrixProp = optionsMatrix[key];
-        const values: any[] = [];
-        assert(Array.isArray(matrixProp), "matrix prop must be an array");
-        // if the only value is undefined, we can skip this property
-        if(matrixProp.length > 1 || matrixProp[0] !== undefined) {
-            for(const val of matrixProp) {
-                if(typeof val === "object") {
-                    const subOptions = generatePairwiseOptions<any>(val);
-                    if(subOptions.length > 1 || subOptions[0] !== undefined) {
-                        values.push(...subOptions);
-                    }
-                }else{
-                    values.push(val);
-                }
-            }
-            if(values.length > 1 || values[0] !== undefined) {
-                valuesMap.set(key, values);
-            }
-        }
-    }
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    // sort keys biggest to smallest, and prune those with only an undefined option
     const matrixKeys: (keyof T)[] =
-        Array.from(valuesMap.keys()).sort((a,b)=>valuesMap.get(b)!.length  - valuesMap.get(a)!.length);
-    // compute all the pairs of property values, and apply them
+        Object.keys(optionsMatrix)
+        .filter((k)=>optionsMatrix[k].length > 1 || optionsMatrix[k][0] !== undefined)
+        .sort((a,b)=>optionsMatrix[b].length  - optionsMatrix[a].length);
+
+    // compute all pairs, and apply them
     const partials: PartialWithKeyCount<T>[] = [];
-    for(const iKey of matrixKeys) {
-        for(const jKey of matrixKeys.slice(matrixKeys.indexOf(iKey) + 1)) {
-            for(const iVal of valuesMap.get(iKey)!) {
-                for(const jVal of valuesMap.get(jKey)!) {
+    for(let i = 0; i < matrixKeys.length - 1; i++) {
+        const iKey = matrixKeys[i];
+        for(let j = i + 1; j < matrixKeys.length; j++) {
+            const jKey = matrixKeys[j];
+            for(const iVal of  optionsMatrix[iKey]) {
+                for(const jVal of optionsMatrix[jKey]) {
                     applyPairToPartial(partials, {iKey, iVal, jKey, jVal});
                 }
             }
@@ -98,14 +83,14 @@ export function generatePairwiseOptions<T extends Record<string, any>>(optionsMa
         if(partial.__paritalKeyCount !== matrixKeys.length) {
             for(const key of matrixKeys) {
                 if(!(key in partial)) {
-                    const values = valuesMap.get(key)!;
-                    partial[key] = values[Math.floor(Math.random() * values.length)];
+                    const index = Math.floor(Math.random() * optionsMatrix[key].length);
+                    assert(partial[key] === undefined,"foo");
+                    partial[key] = optionsMatrix[key][index];
                 }
             }
         }
         delete partial.__paritalKeyCount;
     }
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     return partials as T[];
 }

--- a/packages/test/test-pairwise-generator/src/index.ts
+++ b/packages/test/test-pairwise-generator/src/index.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/common-utils";
-
 // converts all properties of an object to arrays of the
 // properties potential values. This will be used by generatePairwiseOptions
 // to compute original objects that contain pairwise combinations
@@ -84,7 +82,6 @@ export function generatePairwiseOptions<T extends Record<string, any>>(optionsMa
             for(const key of matrixKeys) {
                 if(!(key in partial)) {
                     const index = Math.floor(Math.random() * optionsMatrix[key].length);
-                    assert(partial[key] === undefined,"foo");
                     partial[key] = optionsMatrix[key][index];
                 }
             }

--- a/packages/test/test-pairwise-generator/src/index.ts
+++ b/packages/test/test-pairwise-generator/src/index.ts
@@ -15,7 +15,7 @@ export type OptionsMatrix<T extends Record<string, any>> =
     }>;
 
 export const booleanCases: readonly (boolean)[] = [true, false];
-export const numberCases: readonly (number | undefined)[] = [undefined,-1,0,1,1000];
+export const numberCases: readonly (number | undefined)[] = [undefined];
 
 type PartialWithKeyCount<T extends Record<string, any>>= (Partial<T> & {__paritalKeyCount?: number});
 

--- a/packages/test/test-pairwise-generator/src/test/examples.spec.ts
+++ b/packages/test/test-pairwise-generator/src/test/examples.spec.ts
@@ -44,7 +44,7 @@ describe("generatePairwiseOptions.examples",()=>{
         }
     });
 
-    it("Generate an Array",()=>{
+    it("Generate a fixed length Array",()=>{
         const arrayMatrix: OptionsMatrix<ArrayLike<number>> = {
             0:[3,6,9,12,15],
             1:[7,14,28],
@@ -61,6 +61,34 @@ describe("generatePairwiseOptions.examples",()=>{
         };
         for(const arrayLike of myArrayLikes) {
             runScenario(Array.from(arrayLike));
+        }
+    });
+
+    it("Generate an Complex object using nested options matrices",()=>{
+        const arrayMatrix: OptionsMatrix<ArrayLike<number>> = {
+            0: [3, 6, 9, 12, 15],
+            1: [7, 14, 28],
+            length: [2],
+        };
+
+        interface MyComplexObject {
+            numbers?: number[],
+            subObject: {str: string}
+        }
+        // in this example we generate pairwise options for keys on the main object to
+        // create the values which will then be pairwise matched with eachother
+        const complexObjectMatrix: OptionsMatrix<MyComplexObject> = {
+            numbers: [undefined, ... generatePairwiseOptions<ArrayLike<number>>(arrayMatrix).map((a)=>Array.from(a))],
+            subObject: generatePairwiseOptions<{str: string}>({str:["a","b","c"]}),
+        };
+
+        const complexObjects = generatePairwiseOptions<MyComplexObject>(complexObjectMatrix);
+
+        // use the array to drive a scenario
+        const runScenario = (complexObject: MyComplexObject)=>{
+        };
+        for(const complexObject of complexObjects) {
+            runScenario(complexObject);
         }
     });
 });

--- a/packages/test/test-pairwise-generator/src/test/examples.spec.ts
+++ b/packages/test/test-pairwise-generator/src/test/examples.spec.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "assert";
 import { generatePairwiseOptions, OptionsMatrix } from "../index";
 
 describe("generatePairwiseOptions.examples",()=>{
@@ -40,6 +41,26 @@ describe("generatePairwiseOptions.examples",()=>{
         const runScenario = (instance: MyObject)=>{};
         for(const instance of myObjects) {
             runScenario(instance);
+        }
+    });
+
+    it("Generate an Array",()=>{
+        const arrayMatrix: OptionsMatrix<ArrayLike<number>> = {
+            0:[3,6,9,12,15],
+            1:[7,14,28],
+            length: [2],
+        };
+
+        const myArrayLikes = generatePairwiseOptions<ArrayLike<number>>(arrayMatrix);
+
+        // use the array to drive a scenario
+        const runScenario = (numbers: number[])=>{
+            assert.strictEqual(numbers.length, 2);
+            assert(numbers[0] % 3 === 0);
+            assert(numbers[1] % 7 === 0);
+        };
+        for(const arrayLike of myArrayLikes) {
+            runScenario(Array.from(arrayLike));
         }
     });
 });

--- a/packages/test/test-pairwise-generator/src/test/generatePairwiseOptions.spec.ts
+++ b/packages/test/test-pairwise-generator/src/test/generatePairwiseOptions.spec.ts
@@ -58,7 +58,7 @@ interface ComplexOptions {
 const complexOptionsMatrix: OptionsMatrix<ComplexOptions> = {
     boolean: [undefined, true, false],
     oSimple: [undefined],
-    rSimple: [...simpleValues],
+    rSimple: simpleValues,
 };
 
 const complexValues = generatePairwiseOptions<ComplexOptions>(complexOptionsMatrix);

--- a/packages/test/test-pairwise-generator/src/test/generatePairwiseOptions.spec.ts
+++ b/packages/test/test-pairwise-generator/src/test/generatePairwiseOptions.spec.ts
@@ -11,6 +11,8 @@ interface SimpleOptions{
     rBoolean: boolean,
     number?: number,
     string?: string,
+    array?: number[];
+
 }
 const optionsToString = <T>(... options: T[]) =>
     options.map((o)=>JSON.stringify(o))
@@ -18,19 +20,31 @@ const optionsToString = <T>(... options: T[]) =>
 
 const simpleOptionsMatrix: OptionsMatrix<SimpleOptions> = {
     number:[undefined, 7],
-    oBoolean: [undefined, true],
+    oBoolean: [undefined, true, false],
     rBoolean: [true, false],
     string: [undefined],
+    array:[undefined, [0]],
 };
+
 function  validateSimpleOption(option: SimpleOptions) {
-    assert("number" in option, `number not defined:${option}`);
-    assert(option.number === undefined || option.number === 7, `number not expected value:${option}`);
+    assert("number" in option, `number not defined:${optionsToString(option)}`);
+    assert(option.number === undefined || option.number === 7,
+         `number not expected value:${optionsToString(option)}`);
+
     assert("oBoolean" in option, `oBoolean not defined:${option}`);
-    assert(option.oBoolean === undefined || option.oBoolean === true, `oBoolean not expected value:${option}`);
+    assert(option.oBoolean === undefined || option.oBoolean === true || option.oBoolean === false,
+         `oBoolean not expected value:${optionsToString(option)}`);
+
     assert("rBoolean" in option, `rBoolean not defined:${option}`);
-    assert(option.rBoolean === true || option.rBoolean === false, `rBoolean not expected value:${option}`);
+    assert(option.rBoolean === true || option.rBoolean === false,
+         `rBoolean not expected value:${optionsToString(option)}`);
+
     // string only has undefined as a value, so should be pruned from exploration
     assert(!("string" in option), `string is defined:${option}`);
+
+    assert("array" in option, `array not defined:${option}`);
+    assert(option.array === undefined || option.array[0] === 0,
+         `array not expected value:${optionsToString(option)}`);
 }
 
 const simpleValues = generatePairwiseOptions<SimpleOptions>(simpleOptionsMatrix);
@@ -44,7 +58,7 @@ interface ComplexOptions {
 const complexOptionsMatrix: OptionsMatrix<ComplexOptions> = {
     boolean: [undefined, true, false],
     oSimple: [undefined],
-    rSimple: [simpleOptionsMatrix],
+    rSimple: [...simpleValues],
 };
 
 const complexValues = generatePairwiseOptions<ComplexOptions>(complexOptionsMatrix);
@@ -62,17 +76,11 @@ function validateComplexOption(option: ComplexOptions) {
     assert(!("oSimple" in option), `oSimple is defined:${option}`);
 }
 
-// no-recursive type for validation
-export type ValuesMatrix<T extends Record<string, any>> =
-    Required<{
-        [K in keyof T]: readonly (T[K])[]
-    }>;
-
 /**
  * No pruning or optimizations, just calculate and validate all pairs
  */
 function  validatePairsExhaustively<T>(
-    matrix: ValuesMatrix<T>, values: T[]) {
+    matrix: OptionsMatrix<T>, values: T[]) {
     const keys = Object.keys(matrix);
     for(const i of keys) {
         for(const j of keys) {
@@ -83,8 +91,7 @@ function  validatePairsExhaustively<T>(
                 for(const jv of matrix[j]) {
                     let found = false;
                     for(const val of values) {
-                        if(JSON.stringify(val[i]) === JSON.stringify(iv)
-                            && JSON.stringify(val[j]) === JSON.stringify(jv)) {
+                        if(val[i] === iv && val[j] === jv) {
                             found = true;
                             break;
                         }
@@ -101,8 +108,7 @@ function  validatePairsExhaustively<T>(
 
 describe("generatePairwiseOptions",()=>{
     it("SimpleOptions",()=>{
-        assert.strictEqual(simpleValues.length, 6, optionsToString(...simpleValues));
-
+        assert.strictEqual(simpleValues.length, 10, optionsToString(...simpleValues));
         for(const option of simpleValues) {
             validateSimpleOption(option);
         }
@@ -110,19 +116,14 @@ describe("generatePairwiseOptions",()=>{
     });
 
     it("ComplexOptions",()=>{
-        assert.strictEqual(complexValues.length, 18, optionsToString(...complexValues));
+        assert.strictEqual(complexValues.length, 30, optionsToString(...complexValues));
 
         for(const option of complexValues) {
             validateComplexOption(option);
         }
 
-        validatePairsExhaustively<ComplexOptions>({
-            boolean: complexOptionsMatrix.boolean,
-            oSimple:  [undefined],
-            // this option is the pairwise set used on the simple test and is validate there
-            // reusing here validates we correctly compute the recursive matrix
-            rSimple: simpleValues,
-            },
+        validatePairsExhaustively<ComplexOptions>(
+            complexOptionsMatrix,
             complexValues);
     });
 });

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -39,17 +39,17 @@ const summaryConfigurationMatrix: OptionsMatrix<Partial<ISummaryConfiguration>> 
     maxTime: numberCases,
 };
 
-const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
+const summaryOptionsMatrix = new Lazy<OptionsMatrix<ISummaryRuntimeOptions>>(()=>({
     disableIsolatedChannels: booleanCases,
     generateSummaries: booleanCases,
     initialSummarizerDelayMs: numberCases,
-    summaryConfigOverrides:[undefined, summaryConfigurationMatrix],
-};
+    summaryConfigOverrides:[undefined, ...generatePairwiseOptions(summaryConfigurationMatrix)],
+}));
 
-const runtimeOptionsMatrix: OptionsMatrix<IContainerRuntimeOptions> = {
-    gcOptions: [undefined, gcOptionsMatrix],
-    summaryOptions: [undefined, summaryOptionsMatrix],
-};
+const runtimeOptionsMatrix = new Lazy<OptionsMatrix<IContainerRuntimeOptions>>(()=>({
+    gcOptions: [undefined, ...generatePairwiseOptions(gcOptionsMatrix)],
+    summaryOptions: [undefined, ...generatePairwiseOptions(summaryOptionsMatrix.value)],
+}));
 
 export const pairwiseRuntimeOptions = new Lazy<IContainerRuntimeOptions[]>(()=>
-    generatePairwiseOptions<IContainerRuntimeOptions>(runtimeOptionsMatrix));
+    generatePairwiseOptions<IContainerRuntimeOptions>(runtimeOptionsMatrix.value));


### PR DESCRIPTION
There was a bug which was leading to test instability where we were not checking if the object had the key before checking the value of the key, this led to the non-existent case and the undefined cases not being differentiated. This would incorrectly return from apply pair, and in cases where the key was unset it would later be overwritten leading to lost pairs.

Secondly, in trying to add support for arrays the typing and type handling was becoming unnecessarily complex. To reduce complexity, I removed recursive pairwise generation. The caller now needs to create their own sub matrices and generate them. This keeps both the types and generation code simple