### PR TITLE
r11s: add SummaryTreeUploadManager to services-client

### DIFF
--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -11,6 +11,7 @@ export * from "./historian";
 export * from "./interfaces";
 export * from "./restWrapper";
 export * from "./storage";
+export * from "./summaryTreeUploadManager";
 export * from "./utils";
 export * from "./scopes";
 export * from "./promiseTimeout";

--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -101,3 +101,16 @@ export interface IGitManager {
     upsertRef(branch: string, commitSha: string): Promise<git.IRef>;
     write(branch: string, inputTree: api.ITree, parents: string[], message: string): Promise<git.ICommit>;
 }
+
+/**
+ * Uploads a summary to storage.
+ */
+export interface ISummaryUploadManager {
+    /**
+     * Writes summary tree to storage.
+     * @param summaryTree Summary tree to write to storage
+     * @param parentHandle Parent summary acked handle (from summary ack)
+     * @returns Id of created tree.
+     */
+    writeSummaryTree(summaryTree: api.ISummaryTree, parentHandle: string): Promise<string>;
+}

--- a/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
@@ -1,0 +1,141 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert, gitHashFile, IsoBuffer, Uint8ArrayToString, unreachableCase } from "@fluidframework/common-utils";
+import { ICreateTreeEntry } from "@fluidframework/gitresources";
+import { getGitMode, getGitType } from "@fluidframework/protocol-base";
+import {
+    ISnapshotTreeEx,
+    ISummaryTree,
+    SummaryObject,
+    SummaryType,
+} from "@fluidframework/protocol-definitions";
+import { ISummaryUploadManager, IGitManager } from "./storage";
+
+/**
+ * Recursively writes summary tree as individual summary blobs.
+ */
+export class SummaryTreeUploadManager implements ISummaryUploadManager {
+    constructor(
+        private readonly manager: IGitManager,
+        private readonly blobsShaCache: Map<string, string>,
+        private readonly getPreviousFullSnapshot:
+            (parentHandle: string) => Promise<ISnapshotTreeEx | null | undefined>,
+    ) {
+    }
+
+    public async writeSummaryTree(
+        summaryTree: ISummaryTree,
+        parentHandle: string,
+    ): Promise<string> {
+        const previousFullSnapshot = await this.getPreviousFullSnapshot(parentHandle);
+        return this.writeSummaryTreeCore(summaryTree, previousFullSnapshot ?? undefined);
+    }
+
+    private async writeSummaryTreeCore(
+        summaryTree: ISummaryTree,
+        previousFullSnapshot: ISnapshotTreeEx | undefined,
+    ): Promise<string> {
+        const entries = await Promise.all(Object.keys(summaryTree.tree).map(async (key) => {
+            const entry = summaryTree.tree[key];
+            const pathHandle = await this.writeSummaryTreeObject(entry, previousFullSnapshot);
+            const treeEntry: ICreateTreeEntry = {
+                mode: getGitMode(entry),
+                path: encodeURIComponent(key),
+                sha: pathHandle,
+                type: getGitType(entry),
+            };
+            return treeEntry;
+        }));
+
+        const treeHandle = await this.manager.createGitTree({ tree: entries });
+        return treeHandle.sha;
+    }
+
+    private async writeSummaryTreeObject(
+        object: SummaryObject,
+        previousFullSnapshot: ISnapshotTreeEx | undefined,
+    ): Promise<string> {
+        switch (object.type) {
+            case SummaryType.Blob: {
+                return this.writeSummaryBlob(object.content);
+            }
+            case SummaryType.Handle: {
+                if (previousFullSnapshot === undefined) {
+                    throw Error("Parent summary does not exist to reference by handle.");
+                }
+                return this.getIdFromPath(object.handleType, object.handle, previousFullSnapshot);
+            }
+            case SummaryType.Tree: {
+                return this.writeSummaryTreeCore(object, previousFullSnapshot);
+            }
+            case SummaryType.Attachment: {
+                return object.id;
+            }
+
+            default:
+                unreachableCase(object, `Unknown type: ${(object as any).type}`);
+        }
+    }
+
+    private async writeSummaryBlob(content: string | Uint8Array): Promise<string> {
+        const { parsedContent, encoding } = typeof content === "string"
+            ? { parsedContent: content, encoding: "utf-8" }
+            : { parsedContent: Uint8ArrayToString(content, "base64"), encoding: "base64" };
+
+        // The gitHashFile would return the same hash as returned by the server as blob.sha
+        const hash = await gitHashFile(IsoBuffer.from(parsedContent, encoding));
+        if (!this.blobsShaCache.has(hash)) {
+            this.blobsShaCache.set(hash, "");
+            const blob = await this.manager.createBlob(parsedContent, encoding);
+            assert(hash === blob.sha, 0x0b6 /* "Blob.sha and hash do not match!!" */);
+        }
+        return hash;
+    }
+
+    private getIdFromPath(
+        handleType: SummaryType,
+        handlePath: string,
+        previousFullSnapshot: ISnapshotTreeEx,
+    ): string {
+        const path = handlePath.split("/").map((part) => decodeURIComponent(part));
+        if (path[0] === "") {
+            // root of tree should be unnamed
+            path.shift();
+        }
+        if (path.length === 0) {
+            return previousFullSnapshot.id;
+        }
+
+        return this.getIdFromPathCore(handleType, path, previousFullSnapshot);
+    }
+
+    private getIdFromPathCore(
+        handleType: SummaryType,
+        path: string[],
+        /** Previous snapshot, subtree relative to this path part */
+        previousSnapshot: ISnapshotTreeEx,
+    ): string {
+        assert(path.length > 0, 0x0b3 /* "Expected at least 1 path part" */);
+        const key = path[0];
+        if (path.length === 1) {
+            switch (handleType) {
+                case SummaryType.Blob: {
+                    const tryId = previousSnapshot.blobs[key];
+                    assert(!!tryId, 0x0b4 /* "Parent summary does not have blob handle for specified path." */);
+                    return tryId;
+                }
+                case SummaryType.Tree: {
+                    const tryId = previousSnapshot.trees[key]?.id;
+                    assert(!!tryId, 0x0b5 /* "Parent summary does not have tree handle for specified path." */);
+                    return tryId;
+                }
+                default:
+                    throw Error(`Unexpected handle summary object type: "${handleType}".`);
+            }
+        }
+        return this.getIdFromPathCore(handleType, path.slice(1), previousSnapshot.trees[key]);
+    }
+}

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -3,17 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { ICommit, ICommitDetails, ICreateCommitParams, ICreateTreeEntry } from "@fluidframework/gitresources";
+import { ICommit, ICommitDetails, ICreateCommitParams } from "@fluidframework/gitresources";
 import {
     ITreeEntry,
     ICommittedProposal,
     ISequencedDocumentMessage,
     ISummaryTree,
-    SummaryType,
-    SummaryObject,
-    ISnapshotTreeEx,
 } from "@fluidframework/protocol-definitions";
-import { IGitCache, IGitManager } from "@fluidframework/server-services-client";
+import { IGitCache, SummaryTreeUploadManager } from "@fluidframework/server-services-client";
 import {
     ICollection,
     IDeliState,
@@ -28,12 +25,10 @@ import {
 import {
     getQuorumTreeEntries,
     IQuorumSnapshot,
-    getGitType,
-    getGitMode,
     mergeAppAndProtocolTree,
 } from "@fluidframework/protocol-base";
 import * as winston from "winston";
-import { gitHashFile, IsoBuffer, toUtf8, Uint8ArrayToString } from "@fluidframework/common-utils";
+import { toUtf8 } from "@fluidframework/common-utils";
 
 export class DocumentStorage implements IDocumentStorage {
     constructor(
@@ -66,8 +61,9 @@ export class DocumentStorage implements IDocumentStorage {
         const tenant = await this.tenantManager.getTenant(tenantId);
         const gitManager = tenant.gitManager;
 
-        const blobsShaCache = new Set<string>();
-        const handle = await writeSummaryTree(gitManager, summary, blobsShaCache, undefined);
+        const blobsShaCache = new Map<string, string>();
+        const summaryTreeUploadManager = new SummaryTreeUploadManager(gitManager, blobsShaCache, () => undefined);
+        const handle = await summaryTreeUploadManager.writeSummaryTree(summary, "");
 
         // At this point the summary op and its data are all valid and we can perform the write to history
         const quorumSnapshot: IQuorumSnapshot = {
@@ -313,113 +309,4 @@ export class DocumentStorage implements IDocumentStorage {
             return false;
         }
     }
-}
-
-/**
- * Writes the summary tree to storage.
- * @param manager - Git manager to write.
- * @param summaryTree - summary tree to be written to storage.
- * @param blobsShaCache - cache so that duplicate blobs are written only once.
- * @param snapshot - snapshot tree.
- */
-export async function writeSummaryTree(
-    manager: IGitManager,
-    summaryTree: ISummaryTree,
-    blobsShaCache: Set<string>,
-    snapshot: ISnapshotTreeEx | undefined,
-): Promise<string> {
-    const entries = await Promise.all(Object.keys(summaryTree.tree).map(async (key) => {
-        const entry = summaryTree.tree[key];
-        const pathHandle = await writeSummaryTreeObject(manager, blobsShaCache, key, entry, snapshot);
-        const treeEntry: ICreateTreeEntry = {
-            mode: getGitMode(entry),
-            path: encodeURIComponent(key),
-            sha: pathHandle,
-            type: getGitType(entry),
-        };
-        return treeEntry;
-    }));
-
-    const treeHandle = await manager.createGitTree({ tree: entries });
-    return treeHandle.sha;
-}
-
-async function writeSummaryTreeObject(
-    manager: IGitManager,
-    blobsShaCache: Set<string>,
-    key: string,
-    object: SummaryObject,
-    snapshot: ISnapshotTreeEx | undefined,
-    currentPath = "",
-): Promise<string> {
-    switch (object.type) {
-        case SummaryType.Blob: {
-            return writeSummaryBlob(object.content, blobsShaCache, manager);
-        }
-        case SummaryType.Handle: {
-            if (snapshot === undefined) {
-                throw Error("Parent summary does not exist to reference by handle.");
-            }
-            return getIdFromPath(object.handleType, object.handle, snapshot);
-        }
-        case SummaryType.Tree: {
-            return writeSummaryTree(manager, object, blobsShaCache, snapshot?.trees[key]);
-        }
-
-        default:
-            throw Error(`Unexpected summary object type: "${object.type}".`);
-    }
-}
-
-function getIdFromPath(
-    handleType: SummaryType,
-    handlePath: string,
-    fullSnapshot: ISnapshotTreeEx,
-): string {
-    const path = handlePath.split("/").map((part) => decodeURIComponent(part));
-    if (path[0] === "") {
-        // root of tree should be unnamed
-        path.shift();
-    }
-
-    return getIdFromPathCore(handleType, path, fullSnapshot);
-}
-
-function getIdFromPathCore(
-    handleType: SummaryType,
-    path: string[],
-    snapshot: ISnapshotTreeEx,
-): string {
-    const key = path[0];
-    if (path.length === 1) {
-        switch (handleType) {
-            case SummaryType.Blob: {
-                return snapshot.blobs[key];
-            }
-            case SummaryType.Tree: {
-                return snapshot.trees[key]?.id;
-            }
-            default:
-                throw Error(`Unexpected handle summary object type: "${handleType}".`);
-        }
-    }
-    return getIdFromPathCore(handleType, path.slice(1), snapshot);
-}
-
-async function writeSummaryBlob(
-    content: string | Uint8Array,
-    blobsShaCache: Set<string>,
-    manager: IGitManager,
-): Promise<string> {
-    const { parsedContent, encoding } = typeof content === "string"
-        ? { parsedContent: content, encoding: "utf-8" }
-        : { parsedContent: Uint8ArrayToString(content, "base64"), encoding: "base64" };
-
-    // The gitHashFile would return the same hash as returned by the server as blob.sha
-    const hash = await gitHashFile(IsoBuffer.from(parsedContent, encoding));
-    if (!blobsShaCache.has(hash)) {
-        const blob = await manager.createBlob(parsedContent, encoding);
-        blobsShaCache.add(blob.sha);
-    }
-    return hash;
 }


### PR DESCRIPTION
The `writeSummaryTree` logic is virtually identical in `services-shared` and `r11s-driver`. Differences between the 2 appear to indicate that services-shared implementation has fallen behind r11s-driver's implementation. So, the new `SummaryTreeUploadManager` in `services-client` is based on the implementation from r11s-driver.

This PR is a step toward consolidating the summary upload logic between the r11s service and driver. The next step will be to consume `SummaryTreeUploadManager` in the driver's DocumentStorageService in place of the writeSummaryTree codepath there.