### PR TITLE
Add api-extractor config for building reports

### DIFF
--- a/common/build/build-common/api-extractor-common-report.json
+++ b/common/build/build-common/api-extractor-common-report.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "./api-extractor-common.json",
+
+  /**
+   * Configures how the API report file (*.api.md) will be generated.
+   */
+  "apiReport": {
+    "enabled": true,
+    "reportFileName": "<unscopedPackageName>.api.md",
+    "reportFolder": "<projectFolder>/../../../api-report/",
+    "reportTempFolder": "<projectFolder>/_api-extractor-temp/"
+  },
+
+  /**
+   * Configures how the doc model file (*.api.json) will be generated.
+   */
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "<projectFolder>/../../../_api-extractor-temp/doc-models/<unscopedPackageName>.api.json"
+  },
+
+  /**
+   * Configures how the .d.ts rollup file will be generated.
+   */
+  "dtsRollup": {
+    "enabled": false,
+    "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",
+    "betaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-beta.d.ts",
+    "publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts"
+  }
+}


### PR DESCRIPTION
This config inherits from the existing one but enables [API reporting](https://api-extractor.com/pages/overview/demo_api_report/). In future commits, we can enable api reporting on a per-project basis as we lock down APIs more formally.