### PR TITLE
Lift Summary Collection to Container Runtime

### DIFF
--- a/packages/runtime/container-runtime/src/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summaryCollection.ts
@@ -5,7 +5,9 @@
 
 import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { Deferred, assert } from "@fluidframework/common-utils";
+import { IDeltaManager } from "@fluidframework/container-definitions";
 import {
+    IDocumentMessage,
     ISequencedDocumentMessage,
     ISummaryAck,
     ISummaryContent,
@@ -205,14 +207,18 @@ export class SummaryCollection {
     private lastSummaryTimestamp: number | undefined;
     private maxAckWaitTime: number | undefined;
     private pendingAckTimerTimeoutCallback: (() => void) | undefined;
-    private lastAck?: IAckedSummary;
+    private lastAck: IAckedSummary | undefined;
 
     public get latestAck() { return this.lastAck; }
 
     public constructor(
-        public readonly initialSequenceNumber: number,
+        private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         private readonly logger: ITelemetryLogger,
-    ) { }
+    ) {
+        this.deltaManager.on(
+            "op",
+            (op) => this.handleOp(op));
+    }
 
     /**
      * Creates and returns a summary watcher for a specific client.
@@ -264,7 +270,7 @@ export class SummaryCollection {
      * Handler for ops; only handles ops relating to summaries.
      * @param op - op message to handle
      */
-    public handleOp(op: ISequencedDocumentMessage) {
+    private handleOp(op: ISequencedDocumentMessage) {
         switch (op.type) {
             case MessageType.Summarize: {
                 this.handleSummaryOp(op as ISummaryOpMessage);
@@ -328,7 +334,7 @@ export class SummaryCollection {
             // from. i.e. initialSequenceNumber > summarySequenceNumber.
             // We really don't care about it for now, since it is older than
             // the one we loaded from.
-            if (seq >= this.initialSequenceNumber) {
+            if (seq >= this.deltaManager.initialSequenceNumber) {
                 // Potential causes for it to be later than our initialSequenceNumber
                 // are that the summaryOp was nacked then acked, double-acked, or
                 // the summarySequenceNumber is incorrect.
@@ -336,7 +342,7 @@ export class SummaryCollection {
                     eventName: "SummaryAckWithoutOp",
                     sequenceNumber: op.sequenceNumber, // summary ack seq #
                     summarySequenceNumber: seq, // missing summary seq #
-                    initialSequenceNumber: this.initialSequenceNumber,
+                    initialSequenceNumber: this.deltaManager.initialSequenceNumber,
                 });
             }
             return;

--- a/packages/runtime/container-runtime/src/test/summarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizer.spec.ts
@@ -13,7 +13,7 @@ import {
     ISummaryProposal,
     MessageType,
 } from "@fluidframework/protocol-definitions";
-import { MockLogger } from "@fluidframework/test-runtime-utils";
+import { MockDeltaManager, MockLogger } from "@fluidframework/test-runtime-utils";
 import { RunningSummarizer } from "../summarizer";
 import { SummaryCollection } from "../summaryCollection";
 
@@ -24,6 +24,7 @@ describe("Runtime", () => {
                 let runCount: number;
                 let clock: sinon.SinonFakeTimers;
                 let mockLogger: MockLogger;
+                let mockDeltaManager: MockDeltaManager;
                 let summaryCollection: SummaryCollection;
                 let summarizer: RunningSummarizer;
                 const summarizerClientId = "test";
@@ -49,13 +50,12 @@ describe("Runtime", () => {
                         timestamp,
                     };
                     summarizer.handleOp(undefined, op as ISequencedDocumentMessage);
-                    summaryCollection.handleOp(op as ISequencedDocumentMessage);
+                    mockDeltaManager.emit("op", op);
                     await flushPromises();
                 }
 
                 function emitBroadcast() {
-                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-                    summaryCollection.handleOp({
+                    mockDeltaManager.emit("op",{
                         type: MessageType.Summarize,
                         clientId: summarizerClientId,
                         referenceSequenceNumber: lastRefSeq,
@@ -65,7 +65,7 @@ describe("Runtime", () => {
                             handle: "test-broadcast-handle",
                         },
                         timestamp: Date.now(),
-                    } as ISequencedDocumentMessage);
+                    });
                 }
 
                 async function emitAck(type: MessageType = MessageType.SummaryAck) {
@@ -76,8 +76,7 @@ describe("Runtime", () => {
                         handle: "test-ack-handle",
                         summaryProposal,
                     };
-                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-                    summaryCollection.handleOp({ contents, type } as ISequencedDocumentMessage);
+                    mockDeltaManager.emit("op", { contents, type });
 
                     await flushPromises(); // let summarize run
                 }
@@ -97,7 +96,10 @@ describe("Runtime", () => {
                     runCount = 0;
                     lastRefSeq = 0;
                     mockLogger = new MockLogger();
-                    summaryCollection = new SummaryCollection(0, mockLogger);
+                    mockDeltaManager = new MockDeltaManager();
+                    summaryCollection = new SummaryCollection(
+                        mockDeltaManager,
+                        mockLogger);
                     summarizer = await RunningSummarizer.start(
                         summarizerClientId,
                         onBehalfOfClientId,


### PR DESCRIPTION
This change lifts the summary collection from the summarizer to the container runtime. This will make all container runtimes track summaries. This will enable #5376 and #5222 which require that the container runtime be aware of the last summary produced