### PR TITLE
Move 'configureLogging' to service-utils

### DIFF
--- a/server/routerlicious/packages/routerlicious/src/alfred/www.ts
+++ b/server/routerlicious/packages/routerlicious/src/alfred/www.ts
@@ -5,8 +5,7 @@
 
 import * as path from "path";
 import * as winston from "winston";
-import { configureLogging } from "@fluidframework/server-services";
-import { runService } from "@fluidframework/server-services-utils";
+import { configureLogging, runService } from "@fluidframework/server-services-utils";
 import { AlfredResourcesFactory, AlfredRunnerFactory } from "@fluidframework/server-routerlicious-base";
 
 const configPath = path.join(__dirname, "../../config/config.json");

--- a/server/routerlicious/packages/routerlicious/src/event-hub-service/command.ts
+++ b/server/routerlicious/packages/routerlicious/src/event-hub-service/command.ts
@@ -4,14 +4,13 @@
  */
 
 import { IKafkaResources, KafkaRunnerFactory } from "@fluidframework/server-lambdas-driver";
-import * as utils from "@fluidframework/server-services-utils";
-import { configureLogging } from "@fluidframework/server-services";
+import { configureLogging, runService, IResourcesFactory } from "@fluidframework/server-services-utils";
 import commander from "commander";
 import nconf from "nconf";
 import * as winston from "winston";
 
 export function execute(
-    factoryFn: (name: string, lambda: string) => utils.IResourcesFactory<IKafkaResources>,
+    factoryFn: (name: string, lambda: string) => IResourcesFactory<IKafkaResources>,
     configOrPath: nconf.Provider | string) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const packageDetails = require("../../package.json");
@@ -24,7 +23,7 @@ export function execute(
             configureLogging(configOrPath);
 
             action = true;
-            utils.runService(
+            runService(
                 factoryFn(name, lambda),
                 new KafkaRunnerFactory(),
                 winston,

--- a/server/routerlicious/packages/routerlicious/src/kafka-service/command.ts
+++ b/server/routerlicious/packages/routerlicious/src/kafka-service/command.ts
@@ -4,14 +4,13 @@
  */
 
 import { IKafkaResources, KafkaRunnerFactory } from "@fluidframework/server-lambdas-driver";
-import * as utils from "@fluidframework/server-services-utils";
-import { configureLogging } from "@fluidframework/server-services";
+import { configureLogging, runService, IResourcesFactory } from "@fluidframework/server-services-utils";
 import commander from "commander";
 import nconf from "nconf";
 import * as winston from "winston";
 
 export function execute(
-    factoryFn: (name: string, lambda: string) => utils.IResourcesFactory<IKafkaResources>,
+    factoryFn: (name: string, lambda: string) => IResourcesFactory<IKafkaResources>,
     configOrPath: nconf.Provider | string) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const packageDetails = require("../../package.json");
@@ -24,7 +23,7 @@ export function execute(
             configureLogging(configOrPath);
 
             action = true;
-            utils.runService(
+            runService(
                 factoryFn(name, lambda),
                 new KafkaRunnerFactory(),
                 winston,

--- a/server/routerlicious/packages/routerlicious/src/riddler/www.ts
+++ b/server/routerlicious/packages/routerlicious/src/riddler/www.ts
@@ -5,15 +5,14 @@
 
 import * as path from "path";
 import * as winston from "winston";
-import * as utils from "@fluidframework/server-services-utils";
-import { configureLogging } from "@fluidframework/server-services";
+import { configureLogging, runService } from "@fluidframework/server-services-utils";
 import { RiddlerResourcesFactory, RiddlerRunnerFactory } from "@fluidframework/server-routerlicious-base";
 
 const configPath = path.join(__dirname, "../../config/config.json");
 
 configureLogging(configPath);
 
-utils.runService(
+runService(
     new RiddlerResourcesFactory(),
     new RiddlerRunnerFactory(),
     winston,

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -57,6 +57,7 @@
     "jsonwebtoken": "^8.4.0",
     "nconf": "^0.11.0",
     "sillyname": "0.1.0",
+    "winston": "^3.1.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -57,8 +57,8 @@
     "jsonwebtoken": "^8.4.0",
     "nconf": "^0.11.0",
     "sillyname": "0.1.0",
-    "winston": "^3.1.0",
-    "uuid": "^8.3.1"
+    "uuid": "^8.3.1",
+    "winston": "^3.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -9,6 +9,7 @@ export * from "./conversion";
 export * from "./dns";
 export * from "./errorTrackingService";
 export * from "./generateNames";
+export * from "./logger";
 export * from "./port";
 export * from "./runner";
 export * from "./throttlerMiddleware";

--- a/server/routerlicious/packages/services-utils/src/logger.ts
+++ b/server/routerlicious/packages/services-utils/src/logger.ts
@@ -22,8 +22,9 @@ export interface IWinstonConfig {
  * Configures the default behavior of the Winston logger based on the provided config
  */
 export function configureLogging(configOrPath: nconf.Provider | string) {
-    // eslint-disable-next-line max-len
-    const config = typeof configOrPath === "string" ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory") : configOrPath;
+    const config = typeof configOrPath === "string"
+        ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory")
+        : configOrPath;
 
     const winstonConfig = config.get("logger");
 

--- a/server/routerlicious/packages/services-utils/src/runner.ts
+++ b/server/routerlicious/packages/services-utils/src/runner.ts
@@ -97,9 +97,11 @@ export function runService<T extends IResources>(
     runnerFactory: IRunnerFactory<T>,
     logger: ILogger | undefined,
     group: string,
-    configOrPath: nconf.Provider | string) {
-    // eslint-disable-next-line max-len
-    const config = typeof configOrPath === "string" ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory") : configOrPath;
+    configOrPath: nconf.Provider | string,
+) {
+    const config = typeof configOrPath === "string"
+        ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory")
+        : configOrPath;
 
     const runningP = run(config, resourceFactory, runnerFactory, logger);
 

--- a/server/routerlicious/packages/services/src/index.ts
+++ b/server/routerlicious/packages/services/src/index.ts
@@ -4,7 +4,6 @@
  */
 
 export * from "./kafkaFactory";
-export * from "./logger";
 export * from "./messageReceiver";
 export * from "./messageSender";
 export * from "./metricClient";


### PR DESCRIPTION
This relocates 'configureLogging()' to the same package as 'runServices'.

Rationale: now that the logger is passed as a parameter to 'runService()', nearly all callers must also call 'configureLogging()'.
