### PR TITLE
Fixed races in GC data store tests by waiting for specific summaries

### DIFF
--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -6,7 +6,7 @@
 import { IContainer, IHostLoader, ILoaderOptions } from "@fluidframework/container-definitions";
 import { Container, Loader, waitContainerToCatchUp } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
+import { IFluidCodeDetails, IRequestHeader } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 import { ITestDriver } from "@fluidframework/test-driver-definitions";
 import { v4 as uuid } from "uuid";
@@ -31,7 +31,11 @@ export interface IOpProcessingController {
 export interface ITestObjectProvider {
     createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, options?: ILoaderOptions): IHostLoader;
     createContainer(entryPoint: fluidEntryPoint, options?: ILoaderOptions): Promise<IContainer>;
-    loadContainer(entryPoint: fluidEntryPoint, options?: ILoaderOptions): Promise<IContainer>;
+    loadContainer(
+        entryPoint: fluidEntryPoint,
+        options?: ILoaderOptions,
+        requestHeader?: IRequestHeader,
+    ): Promise<IContainer>;
 
     /**
      * Used to create a test Container. The Loader/ContainerRuntime/DataRuntime might be different versioned.
@@ -51,7 +55,6 @@ export interface ITestObjectProvider {
 
     documentId: string,
     driver: ITestDriver;
-
 }
 
 export enum DataObjectFactoryType {
@@ -164,10 +167,11 @@ export class TestObjectProvider {
         return container;
     }
 
-    public async loadContainer(entryPoint: fluidEntryPoint, options?: ILoaderOptions) {
+    public async loadContainer(entryPoint: fluidEntryPoint, options?: ILoaderOptions, requestHeader?: IRequestHeader) {
         const loader = this.createLoader([[defaultCodeDetails, entryPoint]], options);
-        return loader.resolve({ url: await this.driver.createContainerUrl(this.documentId) });
+        return loader.resolve({ url: await this.driver.createContainerUrl(this.documentId), headers: requestHeader });
     }
+
     /**
      * Make a test loader.  Container created/loaded thru this loader will not be automatically added
      * to the OpProcessingController, and will need to be added manually if needed.


### PR DESCRIPTION
Fixes #5717.

There are couple of requirements for this test that resulted in races with the existing implementation:
- It needs a particular to be processed by the Summarizer before it summarizes. However, since op processing and summary are both async, summary was getting initiated while waiting for the op to be processed resulting in a race.
- It needs to load a new container with a specific (latest) summary. Due to caching in the odsp driver and other details in the server, its possible that asking for latest summary might result in getting back an older summary.

The fix here is to get the sequenceNumber of the required op and waiting for a summary that contains this op. Next, instead of loading from latest summary, load a container with the "version" of the specific summary that is needed. This will result in  deterministic tests.