### PR TITLE
Pipeline: Add 'prerelease' option to tinylicious-build

### DIFF
--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -12,6 +12,7 @@ parameters:
   default: none
   values:
     - none
+    - prerelease
     - release
 - name: publishOverride
   displayName: Publish Override (default = based on branch)


### PR DESCRIPTION
Changing Tinylicious port number, day 3: 

Need the ability to publish a prerelease Tinylicious to pick up a prerelease 'service-utils' to avoid node-gyp attempting to run 'make' on the VM that lacks the 'build-essential' apt pkg.