### PR TITLE
Experiment with stronger typing for map

### DIFF
--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidSerializer } from "@fluidframework/core-interfaces";
+import { IFluidSerializer, IFluidHandle } from "@fluidframework/core-interfaces";
 import { addBlobToTree } from "@fluidframework/protocol-base";
 import {
     ISequencedDocumentMessage,
@@ -103,6 +103,8 @@ export class MapFactory implements IChannelFactory {
  * However, the keys of a SharedMap must be strings.
  */
 export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
+    declare public readonly handle: IFluidHandle<SharedMap>;
+
     /**
      * Create a new shared map.
      * @param runtime - The data store runtime that the new shared map belongs to.

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -306,8 +306,7 @@ export class MapKernel implements IValueTypeCreator {
         return new Promise<T>((resolve) => {
             const callback = (changed: IValueChanged) => {
                 if (key === changed.key) {
-                    // eslint-disable-next-line max-len
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     resolve(this.get<T>(changed.key)!);
                     this.eventEmitter.removeListener("valueChanged", callback);
                 }


### PR DESCRIPTION
Is this interesting direction to explore?

It can take many forms, like
- stronger (whiteout undefined) typing if there is controlled creation path that populates initial values.
- users could mark some fields as readonly (likely useful only with above or having two alternative interfaces for same data).
- types baked into DDS (as an optional layer on top of it):
```typescript
class SharedMapTyped<T> extends SharedMap {
    readonly values: WithUndefined<T>;
}
```
- potentially alternative handle representation (if we find something interesting / useful here to reduce mental overload).
