### PR TITLE
Fix error in ProseMirror example

### DIFF
--- a/examples/data-objects/prosemirror/src/footnoteView.ts
+++ b/examples/data-objects/prosemirror/src/footnoteView.ts
@@ -88,7 +88,7 @@ export class FootnoteView {
 
             for (const transaction of transactions) {
                 for (const step of transaction.steps) {
-                    outerTr.step(step).map(offsetMap);
+                    outerTr.step(step.map(offsetMap));
                 }
             }
 


### PR DESCRIPTION
Fix an error `outerTr.step(step).map() is not a function` while running ProseMirror example
