### PR TITLE
Check for trees before evaluating

### DIFF
--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -55,7 +55,7 @@ export async function getFileLink(
     const valueGenerator = async function() {
         let result: string | undefined;
         let success = false;
-        let retryAfter = 0;
+        let retryAfter = 1;
         do {
             try {
                 result = await getFileLinkCore(getToken, odspUrlParts, identityType, logger);

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -805,12 +805,14 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         let numBlobs = 0;
         let encodedBlobsSize = 0;
         let decodedBlobsSize = 0;
-        for (const tree of snapshot.trees) {
-            for(const treeEntry of tree.entries) {
-                if (treeEntry.type === "blob") {
-                    numBlobs++;
-                } else if (treeEntry.type === "tree") {
-                    numTrees++;
+        if (snapshot.trees !== undefined) {
+            for (const tree of snapshot.trees) {
+                for(const treeEntry of tree.entries) {
+                    if (treeEntry.type === "blob") {
+                        numBlobs++;
+                    } else if (treeEntry.type === "tree") {
+                        numTrees++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
1.) In ff test telemetry we are seeing that trees are not iterable.
office_fluid_ffautomation_error
| where Data_error startswith "snapshot.trees is not iterable"
Trees can be empty for empty files but for detached container we should always have tree atleast for scheduler or deafult component. So here just checking if the trees are undefined. This would also let us know the "sprequestguid" which is recorded after this so that we can know why the trees were not there in the snapshot.

2.) Set default retry after as 1 instead of 0 as otherwise it will always remain 0.