### PR TITLE
adding a section about URL in the test-service-load README

### DIFF
--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -43,7 +43,7 @@ There are several npm scripts in [package.json](./package.json) to make it quick
 ### URL
 
 When running the stress tests, there will be a url printed in console, after the line "Connecting to new Container targeting with url:".
-This URL can be passed as-is to Fluid debugger as well as fetch-tool
+This URL can be passed as-is to Fluid Debugger as well as fetch-tool
 
 ### Options
 

--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -40,6 +40,11 @@ There are several npm scripts in [package.json](./package.json) to make it quick
 `npm run start` - Launches in Orchestrator Mode with default options
 `npm run debug` - Debugs in Orchestrator Mode with `--debug` provided to allow for attaching to child test runners.
 
+### URL
+
+When running the stress tests, there will be a url printed in console, after the line "Connecting to new Container targeting with url:".
+This URL can be passed as-is to fluid debugger as well as fetch-tool
+
 ### Options
 
 #### --driver, -d

--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -42,7 +42,7 @@ There are several npm scripts in [package.json](./package.json) to make it quick
 
 ### URL
 
-When running the stress tests, there will be a url printed in console, after the line "Connecting to new Container targeting with url:".
+When running the stress tests, there will be a URL printed in console, after the line "Connecting to new Container targeting with url:".
 This URL can be passed as-is to Fluid Debugger as well as fetch-tool.
 
 ### Options

--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -43,7 +43,7 @@ There are several npm scripts in [package.json](./package.json) to make it quick
 ### URL
 
 When running the stress tests, there will be a url printed in console, after the line "Connecting to new Container targeting with url:".
-This URL can be passed as-is to fluid debugger as well as fetch-tool
+This URL can be passed as-is to Fluid debugger as well as fetch-tool
 
 ### Options
 

--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -43,7 +43,7 @@ There are several npm scripts in [package.json](./package.json) to make it quick
 ### URL
 
 When running the stress tests, there will be a url printed in console, after the line "Connecting to new Container targeting with url:".
-This URL can be passed as-is to Fluid Debugger as well as fetch-tool
+This URL can be passed as-is to Fluid Debugger as well as fetch-tool.
 
 ### Options
 


### PR DESCRIPTION
Fixes #5563 
When running the stress tests, the URL printed in console can be passed in as-is to fluid debugger and fetch-tool