### PR TITLE
Ops caching: Back compat

### DIFF
--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -112,7 +112,7 @@ export class OpsCache {
         let batchNumber = this.getBatchNumber(from + 1);
         // eslint-disable-next-line no-constant-condition
         while (true) {
-            const res = await this.cache.read(batchNumber.toString());
+            const res = await this.cache.read(`${this.batchSize}_${batchNumber}`);
             if (res === undefined) {
                 break;
             }
@@ -152,7 +152,7 @@ export class OpsCache {
     protected write(batchNumber: number, payload: IBatch) {
         // Errors are caught and logged by PersistedCacheWithErrorHandling that sits
         // in the adapter chain of cache adapters
-        this.cache.write(batchNumber.toString(), JSON.stringify(payload.batchData)).catch(() => {
+        this.cache.write(`${this.batchSize}_${batchNumber}`, JSON.stringify(payload.batchData)).catch(() => {
             this.totalOpsToCache = 0;
         });
     }

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -159,7 +159,7 @@ export async function runTest(
     batchSize: number,
     initialSeq: number,
     mockData: MyDataInput[],
-    expected: { [key: number]: (MyDataInput | undefined)[] },
+    expected: { [key: string]: (MyDataInput | undefined)[] },
     initialWritesExpected: number,
     totalWritesExpected: number)
 {
@@ -200,12 +200,12 @@ describe("OpsCache write", () => {
                 { sequenceNumber: 105, data: "105" },
             ],
             {
-                20: [
-                undefined,
-                { sequenceNumber: 101, data: "101" },
-                { sequenceNumber: 102, data: "102" },
-                { sequenceNumber: 103, data: "103" },
-                { sequenceNumber: 104, data: "104" },
+                "5_20": [
+                    undefined,
+                    { sequenceNumber: 101, data: "101" },
+                    { sequenceNumber: 102, data: "102" },
+                    { sequenceNumber: 103, data: "103" },
+                    { sequenceNumber: 104, data: "104" },
                 ],
             },
             1,
@@ -223,10 +223,10 @@ describe("OpsCache write", () => {
             101,
             mockData3,
             {
-            51: [
-                { sequenceNumber: 102, data: "102" },
-                { sequenceNumber: 103, data: "103" },
-            ],
+                "2_51": [
+                    { sequenceNumber: 102, data: "102" },
+                    { sequenceNumber: 103, data: "103" },
+                ],
             },
             1,
             1);
@@ -238,8 +238,8 @@ describe("OpsCache write", () => {
             101,
             mockData3,
             {
-            102: [{ sequenceNumber: 102, data: "102" }],
-            103: [{ sequenceNumber: 103, data: "103" }],
+                "1_102": [{ sequenceNumber: 102, data: "102" }],
+                "1_103": [{ sequenceNumber: 103, data: "103" }],
             },
             2,
             2);


### PR DESCRIPTION
Host may change (over time) batching strategy. This may result in failures in algorithm as we would read wrong batches.
To avoid potential problems, add batch size into the key calculation, to separate address space per batch size.