### PR TITLE
Tinylicious: Roll back to last released 'build-common'

### DIFF
--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -169,9 +169,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.21.0-16694",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.21.0-16694.tgz",
-      "integrity": "sha512-qNBAutQ/gcudnvyTaCREgTgibEn67TUtvkFVfynHKy+5vBymbHMHj6SspQQnMu0i5k4I15hmCQAgj/u0yqFO7g==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.20.0.tgz",
+      "integrity": "sha512-m6Jcq7Qzj/xV97o0kV7ctC462bgqhcU0D/vjJi4Ah2gXOJ5+poVDxpXexQCnFWYKJRG3YqhH9OFMcpAX96TbgA==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -63,7 +63,7 @@
     "winston": "^3.1.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.21.0-0",
+    "@fluidframework/build-common": "^0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.13.1",


### PR DESCRIPTION
Rationale:
1.  We need to publish a new version of Tinylicious in order to finish the port change to 7070.
2.  Our pipeline forbids publishing a release version that depends on pre-release packages.
3.  Our pipeline does not support publishing pre-release versions of Tinylicious (see @curtisman 's comment [here](https://github.com/microsoft/FluidFramework/pull/5745#issuecomment-815245644)).

...so I think the only option is to roll back for now (or wait).