### PR TITLE
Matrix: Remove unused 'annotations' array

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -86,7 +86,6 @@ export class SharedMatrix<T extends Serializable = Serializable>
     private readonly cols: PermutationVector;   // Map logical col to storage handle (if any)
 
     private cells = new SparseArray2D<T>();         // Stores cell values.
-    private annotations = new SparseArray2D<T>();   // Tracks cell annotations.
     private pending = new SparseArray2D<number>();  // Tracks pending writes.
 
     constructor(runtime: IFluidDataStoreRuntime, public id: string, attributes: IChannelAttributes) {
@@ -230,7 +229,6 @@ export class SharedMatrix<T extends Serializable = Serializable>
         }
 
         this.cells.setCell(rowHandle, colHandle, value);
-        this.annotations.setCell(rowHandle, colHandle, undefined);
 
         this.sendSetCellOp(row, col, value, rowHandle, colHandle);
     }
@@ -541,7 +539,6 @@ export class SharedMatrix<T extends Serializable = Serializable>
             const [cellData, pendingCliSeqData] = await deserializeBlob(storage, SnapshotPath.cells, this.serializer);
 
             this.cells = SparseArray2D.load(cellData);
-            this.annotations = new SparseArray2D();
             this.pending = SparseArray2D.load(pendingCliSeqData);
         } catch (error) {
             this.logger.sendErrorEvent({ eventName: "MatrixLoadFailed" }, error);
@@ -596,7 +593,6 @@ export class SharedMatrix<T extends Serializable = Serializable>
                             if (this.pending.getCell(rowHandle, colHandle) === undefined) {
                                 const { value } = contents;
                                 this.cells.setCell(rowHandle, colHandle, value);
-                                this.annotations.setCell(rowHandle, colHandle, undefined);
 
                                 for (const consumer of this.consumers.values()) {
                                     consumer.cellsChanged(adjustedRow, adjustedCol, 1, 1, this);
@@ -631,7 +627,6 @@ export class SharedMatrix<T extends Serializable = Serializable>
     private readonly onRowHandlesRecycled = (rowHandles: Handle[]) => {
         for (const rowHandle of rowHandles) {
             this.cells.clearRows(/* rowStart: */ rowHandle, /* rowCount: */ 1);
-            this.annotations.clearRows(/* rowStart: */ rowHandle, /* rowCount: */ 1);
             this.pending.clearRows(/* rowStart: */ rowHandle, /* rowCount: */ 1);
         }
     };
@@ -639,7 +634,6 @@ export class SharedMatrix<T extends Serializable = Serializable>
     private readonly onColHandlesRecycled = (colHandles: Handle[]) => {
         for (const colHandle of colHandles) {
             this.cells.clearCols(/* colStart: */ colHandle, /* colCount: */ 1);
-            this.annotations.clearCols(/* colStart: */ colHandle, /* colCount: */ 1);
             this.pending.clearCols(/* colStart: */ colHandle, /* colCount: */ 1);
         }
     };


### PR DESCRIPTION
The public API was removed quite a while ago, but this private (and now unused) 2D array somehow survived.