### PR TITLE
Consolidating all parameters needed for share link fetching in single parameter

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -75,7 +75,7 @@ new OdspDriverUrlResolverForShareLink(
 
 // After:
 new OdspDriverUrlResolverForShareLink(
-    shareLinkFetcherProps: { tokenFetcher, identityType },
+    { tokenFetcher, identityType },
     logger,
     appName,
 );

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,6 +1,7 @@
 ## 0.38 Breaking changes
 - [IPersistedCache changes](#IPersistedCache-changes)
 - [ODSP Driver Type Unification](#ODSP-Driver-Type-Unification)
+- [ODSP Driver url resolver for share link parameter consolidation](#ODSP-Driver-url-resolver-for-share-link-parameter-consolidation)
 
 ### IPersistedCache changes
 IPersistedCache implementation no longer needs to implement updateUsage() method (removed form interface).
@@ -11,7 +12,7 @@ Please note that format of data stored by driver changed. It will ignore cache e
 ## ODSP Driver Type Unification
 This change reuses existing contracts to reduce redundancy improve consistency.
 
-The breaking protion of  this change does rename some parameters to some helper functions, but the change are purely mechanical. In most cases you will likely find you are pulling properties off an object individually to pass them as params, whereas now you can just pass the object itself.
+The breaking portion of this change does rename some parameters to some helper functions, but the change are purely mechanical. In most cases you will likely find you are pulling properties off an object individually to pass them as params, whereas now you can just pass the object itself.
 
 ``` typescript
 // before:
@@ -57,6 +58,28 @@ getFileLink(
 )
 ```
 
+## ODSP Driver url resolver for share link parameter consolidation
+OdspDriverUrlResolverForShareLink constructor signature has been changed to simplify instance
+creation in case resolver is not supposed to generate share link. Instead of separately specifying
+constructor parameters that are used to fetch share link there will be single parameter in shape of
+object that consolidates all properties that are necessary to get share link.
+
+``` typescript
+// before:
+new OdspDriverUrlResolverForShareLink(
+    tokenFetcher,
+    identityType,
+    logger,
+    appName,
+);
+
+// After:
+new OdspDriverUrlResolverForShareLink(
+    shareLinkFetcherProps: { tokenFetcher, identityType },
+    logger,
+    appName,
+);
+```
 
 ## 0.37 Breaking changes
 

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -24,6 +24,20 @@ import {
 import { getFileLink } from "./getFileLink";
 
 /**
+ * Properties passed to the code responsible for fetching share link for a file.
+ */
+export type ShareLinkFetcherProps = {
+    /**
+     * Callback method that is used to fetch access token necessary to call API that produces share link
+     */
+    tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>,
+    /**
+     * Identity type determining the shape of share link as it differs for Enterprise and Consumer users.
+     */
+    identityType: IdentityType
+};
+
+/**
  * Resolver to resolve urls like the ones created by createOdspUrl which is driver inner
  * url format and the ones which have things like driveId, siteId, itemId etc encoded in nav param.
  * This resolver also handles share links and try to generate one for the use by the app.
@@ -31,28 +45,29 @@ import { getFileLink } from "./getFileLink";
 export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     private readonly logger: ITelemetryLogger;
     private readonly sharingLinkCache = new PromiseCache<string, string>();
-    private readonly instrumentedTokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions> | undefined;
+    private readonly shareLinkFetcherProps: ShareLinkFetcherProps | undefined;
+
     /**
      * Creates url resolver instance
-     * @param tokenFetcher - Function that returns access token used to fetch share link.
+     * @param shareLinkFetcherProps - properties used when fetching share link.
      * Can be set as 'undefined' for cases where share link is not needed. Currently, only
      * getAbsoluteUrl() method requires share link.
-     * @param identityType - identity type for signed in user. This value determines the shape
-     * of share link as it differs for Enterprise and Consumer users
      * @param logger - logger object that is used as telemetry sink
      * @param appName - application name hint that is encoded with url produced by getAbsoluteUrl() method.
      * This hint is used by link handling logic which determines which app to redirect to when user
      * navigates directly to the link.
      */
     public constructor(
-        tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions> | undefined = undefined,
-        private readonly identityType: IdentityType = "Enterprise",
+        shareLinkFetcherProps?: ShareLinkFetcherProps | undefined,
         logger?: ITelemetryBaseLogger,
         private readonly appName?: string,
     ) {
         this.logger = ChildLogger.create(logger, "OdspDriver");
-        if (tokenFetcher) {
-            this.instrumentedTokenFetcher = this.toInstrumentedTokenFetcher(this.logger, tokenFetcher);
+        if (shareLinkFetcherProps) {
+            this.shareLinkFetcherProps = {
+                ...shareLinkFetcherProps,
+                tokenFetcher: this.toInstrumentedTokenFetcher(this.logger, shareLinkFetcherProps.tokenFetcher),
+            };
         }
     }
 
@@ -150,8 +165,8 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     }
 
     private async getShareLinkPromise(resolvedUrl: IOdspResolvedUrl): Promise<string> {
-        if (this.instrumentedTokenFetcher === undefined) {
-            throw new Error("Failed to get share link because token fetcher is missing");
+        if (this.shareLinkFetcherProps === undefined) {
+            throw new Error("Failed to get share link because share link fetcher props are missing");
         }
 
         if (!(resolvedUrl.siteUrl && resolvedUrl.driveId && resolvedUrl.itemId)) {
@@ -165,9 +180,9 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
             return cachedLinkPromise;
         }
         const newLinkPromise = getFileLink(
-            this.instrumentedTokenFetcher,
+            this.shareLinkFetcherProps.tokenFetcher,
             resolvedUrl,
-            this.identityType,
+            this.shareLinkFetcherProps.identityType,
             this.logger,
         ).then((fileLink) => {
             if (!fileLink) {
@@ -184,7 +199,8 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     }
 
     /**
-     * Requests a driver + data store storage URL
+     * Requests a driver + data store storage URL. Note that this method requires share link to be fetched
+     * and it will throw in case share link fetcher props were not specified when instance was created.
      * @param resolvedUrl - The driver resolved URL
      * @param request - The relative data store path URL. For requesting a driver URL, this value should always be '/'
      */

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -26,16 +26,16 @@ import { getFileLink } from "./getFileLink";
 /**
  * Properties passed to the code responsible for fetching share link for a file.
  */
-export type ShareLinkFetcherProps = {
+export interface ShareLinkFetcherProps {
     /**
      * Callback method that is used to fetch access token necessary to call API that produces share link
      */
-    tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>,
+    tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>;
     /**
      * Identity type determining the shape of share link as it differs for Enterprise and Consumer users.
      */
-    identityType: IdentityType
-};
+    identityType: IdentityType;
+}
 
 /**
  * Resolver to resolve urls like the ones created by createOdspUrl which is driver inner

--- a/packages/drivers/odsp-driver/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver/src/tokenFetch.ts
@@ -84,4 +84,9 @@ export function isTokenFromCache(tokenResponse: string | TokenResponse | null): 
         : tokenResponse.fromCache;
 }
 
-export type IdentityType = "Consumer" | "Enterprise";
+/**
+ * Identity types supported by ODSP driver.
+ *  Consumer represents user authenticated with Microsoft Account (MSA)
+ *  Enterprise represents user authenticated with M365 tenant account
+ */
+ export type IdentityType = "Consumer" | "Enterprise";


### PR DESCRIPTION
This simplifies usage of this class when share link fetching should be optional.