### PR TITLE
Odsp: Add missing '@types/node-fetch'

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -9922,6 +9922,27 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
             "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
         },
+        "@types/node-fetch": {
+            "version": "2.5.10",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+            "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
+            "requires": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                }
+            }
+        },
         "@types/normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -18294,6 +18315,11 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
             "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
         },
+        "fast-diff": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+        },
         "fast-glob": {
             "version": "2.2.7",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
@@ -25579,8 +25605,7 @@
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-            "dev": true
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
         },
         "lodash.debounce": {
             "version": "4.0.8",
@@ -31961,6 +31986,16 @@
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
             "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
             "dev": true
+        },
+        "quill-delta": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-4.2.2.tgz",
+            "integrity": "sha512-qjbn82b/yJzOjstBgkhtBjN2TNK+ZHP/BgUQO+j6bRhWQQdmj2lH6hXG7+nwwLF41Xgn//7/83lxs9n2BkTtTg==",
+            "requires": {
+                "fast-diff": "1.2.0",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.isequal": "^4.5.0"
+            }
         },
         "raf": {
             "version": "3.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -82,6 +82,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
+    "@types/node-fetch": "^2.5.10",
     "@types/sha.js": "^2.4.0",
     "@types/socket.io-client": "^1.4.32",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/drivers/odsp-driver/src/fetch.ts
+++ b/packages/drivers/odsp-driver/src/fetch.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    default as nodeFetch,
+    RequestInfo as FetchRequestInfo,
+    RequestInit as FetchRequestInit,
+} from "node-fetch";
+
+// The only purpose of this helper is to work around the slight misalignments between the
+// Browser's fetch API and the 'node-fetch' package.
+//
+// Originally, our code simply omitted the '@types/node-fetch' dependency and let TypeScript
+// use the 'fetch' declarations in 'DOM.lib.ts'.  This works until some other package introduces
+// a dependency on '@types/node-fetch' and Lerna hoists '@types/node-fetch' to the root /node_modules/.
+export const fetch = async (request: RequestInfo, config?: RequestInit): Promise<Response> =>
+    nodeFetch(request as FetchRequestInfo, config as FetchRequestInit) as unknown as Response;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -16,14 +16,9 @@ import {
     throwOdspNetworkError,
     getSPOAndGraphRequestIdsFromResponse,
 } from "@fluidframework/odsp-doclib-utils";
-import {
-    default as fetch,
-    RequestInfo as FetchRequestInfo,
-    RequestInit as FetchRequestInit,
-    Headers,
-} from "node-fetch";
 import sha from "sha.js";
 import { debug } from "./debug";
+import { fetch } from "./fetch";
 import { TokenFetchOptions } from "./tokenFetch";
 import { RateLimiter } from "./rateLimiter";
 import { IOdspResolvedUrl } from "./contracts";
@@ -85,9 +80,7 @@ export async function fetchHelper(
     const start = performance.now();
 
     // Node-fetch and dom have conflicting typing, force them to work by casting for now
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return fetch(requestInfo as FetchRequestInfo, requestInit as FetchRequestInit).then(async (fetchResponse) => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    return fetch(requestInfo, requestInit).then(async (fetchResponse) => {
         const response = fetchResponse as any as Response;
         // Let's assume we can retry.
         if (!response) {

--- a/packages/drivers/odsp-driver/src/test/mockFetch.ts
+++ b/packages/drivers/odsp-driver/src/test/mockFetch.ts
@@ -36,7 +36,7 @@ export async function mockFetchMultiple<T>(
         }
         const cb = responses.shift();
         assert(cb !== undefined, "the end");
-        return cb();
+        return cb() as Promise<fetchModule.Response>;
     });
     try {
         return await callback();

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -66,6 +66,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@types/mocha": "^5.2.5",
+    "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/utils/odsp-doclib-utils/src/fetch.ts
+++ b/packages/utils/odsp-doclib-utils/src/fetch.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    default as nodeFetch,
+    RequestInfo as FetchRequestInfo,
+    RequestInit as FetchRequestInit,
+} from "node-fetch";
+
+// The only purpose of this helper is to work around the slight misalignments between the
+// Browser's fetch API and the 'node-fetch' package.
+//
+// Originally, our code simply omitted the '@types/node-fetch' dependency and let TypeScript
+// use the 'fetch' declarations in 'DOM.lib.ts'.  This works until some other package introduces
+// a dependency on '@types/node-fetch' and Lerna hoists '@types/node-fetch' to the root /node_modules/.
+export const fetch = async (request: RequestInfo, config?: RequestInit): Promise<Response> =>
+    nodeFetch(request as FetchRequestInfo, config as FetchRequestInit) as unknown as Response;

--- a/packages/utils/odsp-doclib-utils/src/odspRequest.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import fetch from "node-fetch";
+import { fetch } from "./fetch";
 import {
     IOdspAuthRequestInfo,
     authRequestWithRetry,
@@ -13,7 +13,6 @@ export async function getAsync(
     url: string,
     authRequestInfo: IOdspAuthRequestInfo,
 ): Promise<Response> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return authRequest(authRequestInfo, async (config: RequestInit) => fetch(url, config));
 }
 
@@ -26,7 +25,6 @@ export async function putAsync(
             ...config,
             method: "PUT",
         };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return fetch(url, putConfig);
     });
 }
@@ -42,14 +40,12 @@ export async function postAsync(
             body,
             method: "POST",
         };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return fetch(url, postConfig);
     });
 }
 
 export async function unauthPostAsync(url: string, body: any): Promise<Response> {
     return safeRequestCore(async () => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return fetch(url, { body, method: "POST" });
     });
 }


### PR DESCRIPTION
There are slight API misalignments between the DOM 'fetch' API and the 'node-fetch' package.

Previously, a couple of ODSP packages ignored these discrepancies by omitting the '@types/node-fetch' dependency.  

However, an orthogonal contribution (PR #5767) introduces a '@types/node-fetch' dependency elsewhere.  Because Lerna hoists this new dependency to the root /node_modules/, TypeScript now discovers the correct type info for "node-fetch" and breaks.

Hence this PR, which functions the same as the original, but using explicit casts instead of implicit typing omissions.