### PR TITLE
Forcing restart process on critical error

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -51,6 +51,8 @@ export class KafkaRunner implements IRunner {
                 logger?.error("KakfaRunner encountered an error that is not configured to trigger restart.");
                 logger?.error(inspect(error));
             } else {
+                logger?.error("KakfaRunner encountered an error that will trigger a restart.");
+                logger?.error(inspect(error));
                 deferred.reject(error);
             }
         });

--- a/server/routerlicious/packages/routerlicious/src/runner/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/runner/index.ts
@@ -72,6 +72,7 @@ export async function run<T extends IResources>(
                     .stop()
                     .catch((innerError) => {
                         logger?.error(`Could not stop runner due to error: ${innerError}`);
+                        error.forceKill = true;
                     });
             return Promise.reject(error);
         });
@@ -113,6 +114,10 @@ export function runService<T extends IResources>(
         (error) => {
             logger?.error(`${group} service exiting due to error`);
             logger?.error(inspect(error));
-            process.exit(1);
+            if (error.forceKill) {
+                process.kill(process.pid, "SIGKILL");
+            } else {
+                process.exit(1);
+            }
         });
 }


### PR DESCRIPTION
Follow-up to #5517. We have observed that we still do not restart pods on certain occasions. Usually that happens upon receiving an error which is configured to restart, and then not being able to complete `runner.stop()` successfully. As a result, we leave handles and connections open, and we don't restart the service, which hangs on a crashed state. The logs below show an example of such situation.

To fix that, this PR introduces a new `forceKill` property that is set when the runner could not be stopped successfully. That ensures that the service is terminated and restarted automatically, avoiding the necessity for manual intervention. To verify the fix works, I initially reproduced the issue of services crashing and hanging by using the [Shared Tree Bubble Benchmarking tool](https://github.com/microsoft/FluidFramework/tree/main/experimental/examples/bubblebench/sharedtree). After adding the fix, the microservices restart automatically as expected.

```
{"message":"LibrdKafkaError: Broker: Request timed out\n    at Function.createLibrdkafkaError [as create] (/usr/src/server/node_modules/node-rdkafka/lib/error.js:423:10)\n    at KafkaConsumer.conf.offset_commit_cb (/usr/src/server/node_modules/node-rdkafka/lib/kafka-consumer.js:97:31) {\n  code: 7,\n  errno: 7,\n  origin: 'local'\n}","level":"error","label":"winston"}
{"message":"Stop requested","level":"info","label":"winston"}
{"message":"No pending work for partition 16. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 17. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 18. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 19. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 20. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 21. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 22. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 23. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 24. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 25. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 26. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 27. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 28. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 29. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 30. Exiting early","level":"info","label":"winston"}
{"message":"No pending work for partition 31. Exiting early","level":"info","label":"winston"}
{"message":"Could not stop runner due to error: Error: Broker: Request timed out","level":"error","label":"winston"}
{"message":"deli service exiting due to error","level":"error","label":"winston"}
{"message":"LibrdKafkaError: Broker: Request timed out\n    at Function.createLibrdkafkaError [as create] (/usr/src/server/node_modules/node-rdkafka/lib/error.js:423:10)\n    at KafkaConsumer.conf.offset_commit_cb (/usr/src/server/node_modules/node-rdkafka/lib/kafka-consumer.js:97:31) {\n  code: 7,\n  errno: 7,\n  origin: 'local',\n  forceKill: true\n}","level":"error","label":"winston"}
// does not restart
```

Note: it is also important to go after and solve each error/bug that surfaces. For example, the error above is associated with committing the offset in Kafka and it should be fixes. We are investigating that separately. In this PR, the scope is just to make sure that microservices are capable of automatically restarting and recovering in case of unforeseen/unexpected issues we have not fixed yet.