### PR TITLE
Unblock PR by bumping @types/node to ^12.19.0

### DIFF
--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -53,7 +53,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/apps/cra-demo/package.json
+++ b/examples/apps/cra-demo/package.json
@@ -40,7 +40,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "22.2.3",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "react-scripts": "4.0.2",

--- a/examples/apps/likes-and-comments/package.json
+++ b/examples/apps/likes-and-comments/package.json
@@ -52,7 +52,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -65,7 +65,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/prop-types": "^15",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -49,7 +49,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -51,7 +51,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -50,7 +50,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -50,7 +50,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -52,7 +52,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -51,7 +51,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -51,7 +51,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -55,7 +55,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -79,7 +79,7 @@
     "@types/debug": "^4.1.5",
     "@types/jsdom": "^12.0.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -52,7 +52,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "assert": "^2.0.0",

--- a/examples/data-objects/image-collection/package.json
+++ b/examples/data-objects/image-collection/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/map": "^0.38.0",
     "@fluidframework/runtime-definitions": "^0.38.0",
     "@fluidframework/view-interfaces": "^0.38.0",
-    "@types/node": "^10.17.24"
+    "@types/node": "^12.19.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@types/react-image-gallery": "^0.8.4",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/math/package.json
+++ b/examples/data-objects/math/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/runtime-definitions": "^0.38.0",
     "@fluidframework/sequence": "^0.38.0",
     "@fluidframework/view-interfaces": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "monaco-editor": "^0.15.6"
   },
   "devDependencies": {

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -51,7 +51,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -49,7 +49,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -60,7 +60,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -49,7 +49,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/expect-puppeteer": "2.2.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -48,7 +48,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -48,7 +48,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -48,7 +48,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
     "@types/babel__core": "^7",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -58,7 +58,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/progress-bars/package.json
+++ b/examples/data-objects/progress-bars/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/map": "^0.38.0",
     "@fluidframework/runtime-definitions": "^0.38.0",
     "@fluidframework/view-interfaces": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "bootstrap": "^3.3.7"
   },
   "devDependencies": {

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/orderedmap": "^1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/react-inputs/package.json
+++ b/examples/data-objects/react-inputs/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/runtime-definitions": "^0.38.0",
     "@fluidframework/sequence": "^0.38.0",
     "@fluidframework/view-interfaces": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "async": "^2.6.1",
     "axios": "^0.21.1",
     "bootstrap": "^3.3.7",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@fluidframework/core-interfaces": "^0.38.0",
     "@fluidframework/merge-tree": "^0.38.0",
-    "@types/node": "^10.17.24"
+    "@types/node": "^12.19.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/runtime-utils": "^0.38.0",
     "@fluidframework/sequence": "^0.38.0",
     "@fluidframework/view-interfaces": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "axios": "^0.21.1",
     "bootstrap": "^3.3.7",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/test-version-utils": "^0.38.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -60,7 +60,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/video-players/package.json
+++ b/examples/data-objects/video-players/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/map": "^0.38.0",
     "@fluidframework/runtime-definitions": "^0.38.0",
     "@fluidframework/view-interfaces": "^0.38.0",
-    "@types/node": "^10.17.24"
+    "@types/node": "^12.19.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@types/uuid": "^8.3.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -91,7 +91,7 @@
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -51,7 +51,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -55,7 +55,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -46,7 +46,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/bundle-size-tools": "^0.0.8505",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@mixer/webpack-bundle-compare": "^0.1.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -72,7 +72,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "best-random": "^1.0.0",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -75,7 +75,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "best-random": "^1.0.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -56,7 +56,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -58,7 +58,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -57,7 +57,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/experimental/framework/experimental-fluidframework/package.json
+++ b/experimental/framework/experimental-fluidframework/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/experimental/framework/fluid-static/package.json
+++ b/experimental/framework/fluid-static/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -9910,9 +9910,9 @@
             }
         },
         "@types/node": {
-            "version": "10.17.24",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-            "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+            "version": "12.20.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+            "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         },
         "@types/node-fetch": {
             "version": "2.5.10",

--- a/packages/agents/intelligence-runner-agent/package.json
+++ b/packages/agents/intelligence-runner-agent/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/request": "^2.47.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -73,7 +73,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -70,7 +70,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -76,7 +76,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -70,7 +70,7 @@
     "@types/assert": "^1.5.2",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/random-js": "^1.0.31",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -71,7 +71,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -73,7 +73,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -83,7 +83,7 @@
     "@types/debug": "^4.1.5",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/random-js": "^1.0.31",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -48,7 +48,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -71,7 +71,7 @@
     "@types/assert": "^1.5.2",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "assert": "^2.0.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -76,7 +76,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -40,7 +40,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -42,7 +42,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/socket.io-client": "^1.4.32",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -42,7 +42,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -45,7 +45,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/socket.io-client": "^1.4.32",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -76,7 +76,7 @@
     "@types/assert": "^1.5.2",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/drivers/local-driver/src/localResolver.ts
+++ b/packages/drivers/local-driver/src/localResolver.ts
@@ -68,11 +68,12 @@ export class LocalResolver implements IUrlResolver {
         const fluidResolvedUrl = resolvedUrl as IFluidResolvedUrl;
 
         const parsedUrl = parse(fluidResolvedUrl.url);
-        if (parsedUrl.pathname === undefined) {
+        // eslint-disable-next-line no-null/no-null
+        if (parsedUrl.pathname === null) {
             throw new Error("Url should contain tenant and docId!!");
         }
         const [, , documentId] = parsedUrl.pathname.split("/");
-        assert(!!documentId, 0x09a /* "The resolvedUrl must have a documentId" */);
+        assert(!!documentId, 0x09a /* "'documentId' must be a defined, non-zero length string." */);
 
         return `http://localhost:3000/${documentId}/${url}`;
     }

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -45,7 +45,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "assert": "^2.0.0",

--- a/packages/drivers/routerlicious-host/src/urlResolver.ts
+++ b/packages/drivers/routerlicious-host/src/urlResolver.ts
@@ -58,10 +58,11 @@ export class ContainerUrlResolver implements IUrlResolver {
         const fluidResolvedUrl = resolvedUrl as IFluidResolvedUrl;
 
         const parsedUrl = parse(fluidResolvedUrl.url);
-        assert(parsedUrl.pathname !== undefined, 0x0b7 /* "Pathname should be defined" */);
+        // eslint-disable-next-line no-null/no-null
+        assert(parsedUrl.pathname !== null, 0x0b7 /* "Pathname should be defined" */);
         const [, tenantId, documentId] = parsedUrl.pathname.split("/");
-        assert(documentId !== undefined && tenantId !== undefined,
-            0x0b8 /* "Document and tenant IDs should both be defined" */);
+        assert(!!tenantId && !!documentId,
+            0x0b8 /* "'tenantId' and 'documentId' must be defined, non-zero length strings." */);
 
         let url = relativeUrl;
         if (url.startsWith("/")) {

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -45,7 +45,7 @@
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
     "@types/nconf": "^0.10.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "assert": "^2.0.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -82,7 +82,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -71,7 +71,7 @@
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -71,7 +71,7 @@
     "@types/assert": "^1.5.2",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/random-js": "^1.0.31",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/framework/last-edited-experimental/package.json
+++ b/packages/framework/last-edited-experimental/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -68,7 +68,7 @@
     "@types/assert": "^1.5.2",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/random-js": "^1.0.31",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -78,7 +78,7 @@
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -83,7 +83,7 @@
     "@types/double-ended-queue": "^2.1.0",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -68,7 +68,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/loader/core-interfaces/package.json
+++ b/packages/loader/core-interfaces/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -73,7 +73,7 @@
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -65,7 +65,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/runtime-utils": "^0.38.0",
     "@fluidframework/sequence": "^0.38.0",
     "@fluidframework/shared-object-base": "^0.38.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "debug": "^4.1.1",
     "jwt-decode": "^2.2.0"
   },

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/driver-definitions": "^0.38.0",
     "@fluidframework/protocol-definitions": "^0.1022.0-0",
     "@fluidframework/runtime-definitions": "^0.38.0",
-    "@types/node": "^10.17.24"
+    "@types/node": "^12.19.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -86,7 +86,7 @@
     "@types/debug": "^4.1.5",
     "@types/double-ended-queue": "^2.1.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/sinon": "^7.0.13",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/core-interfaces": "^0.38.0",
     "@fluidframework/protocol-definitions": "^0.1022.0-0",
     "@fluidframework/runtime-definitions": "^0.38.0",
-    "@types/node": "^10.17.24"
+    "@types/node": "^12.19.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -83,7 +83,7 @@
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/core-interfaces": "^0.38.0",
     "@fluidframework/driver-definitions": "^0.38.0",
     "@fluidframework/protocol-definitions": "^0.1022.0-0",
-    "@types/node": "^10.17.24"
+    "@types/node": "^12.19.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -73,7 +73,7 @@
     "@types/assert": "^1.5.2",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "benchmark": "^2.1.4",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -74,7 +74,7 @@
     "@types/assert": "^1.5.2",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/runtime/test-runtime-utils/src/test/insecureUrlResolverTest.spec.ts
+++ b/packages/runtime/test-runtime-utils/src/test/insecureUrlResolverTest.spec.ts
@@ -22,6 +22,14 @@ describe("Insecure Url Resolver Test", () => {
     beforeEach(() => {
         resolver = new InsecureUrlResolver(hostUrl, ordererUrl, storageUrl, tenantId, bearer);
         request = resolver.createCreateNewRequest(fileName);
+
+        // Mocking window since the resolver depends on window.location.host
+        if (typeof window === "undefined" && typeof global === "object") {
+            // eslint-disable-next-line @typescript-eslint/dot-notation
+            global["window"] = {
+                location: { host:"localhost" } as unknown as Location,
+            } as unknown as (Window & typeof globalThis);
+        }
     });
 
     it("Create New Request", async () => {
@@ -57,11 +65,6 @@ describe("Insecure Url Resolver Test", () => {
             url: `https://localhost/${fileName}`,
             headers: {},
         };
-        // Mocking window since the resolver depends on window.location.host
-        if (typeof window === "undefined" && typeof global === "object") {
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            global["window"] = { location: { host:"localhost" } };
-        }
         const resolvedUrl = await resolver.resolve(testRequest);
         ensureFluidResolvedUrl(resolvedUrl);
 
@@ -74,12 +77,6 @@ describe("Insecure Url Resolver Test", () => {
             url: `https://localhost/${fileName}/dataStore1/dataStore2`,
             headers: {},
         };
-        // Mocking window since the resolver depends on window.location.host
-        if (typeof window === "undefined" && typeof global === "object") {
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            global["window"] = { location: { host:"localhost" } };
-        }
-
         const resolvedUrl = await resolver.resolve(testRequest);
         ensureFluidResolvedUrl(resolvedUrl);
 
@@ -98,11 +95,6 @@ describe("Insecure Url Resolver Test", () => {
             url: `https://localhost/${fileName}/`,
             headers: {},
         };
-        // Mocking window since the resolver depends on window.location.host
-        if (typeof window === "undefined" && typeof global === "object") {
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            global["window"] = { location: { host:"localhost" } };
-        }
         const resolvedUrl = await resolver.resolve(testRequest);
         ensureFluidResolvedUrl(resolvedUrl);
 
@@ -115,11 +107,6 @@ describe("Insecure Url Resolver Test", () => {
             url: `https://localhost/${fileName}//`,
             headers: {},
         };
-        // Mocking window since the resolver depends on window.location.host
-        if (typeof window === "undefined" && typeof global === "object") {
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            global["window"] = { location: { host:"localhost" } };
-        }
         const resolvedUrl = await resolver.resolve(testRequest);
         ensureFluidResolvedUrl(resolvedUrl);
 
@@ -132,11 +119,6 @@ describe("Insecure Url Resolver Test", () => {
             url: `https://localhost/${fileName}/!@$123/dataStore!@$`,
             headers: {},
         };
-        // Mocking window since the resolver depends on window.location.host
-        if (typeof window === "undefined" && typeof global === "object") {
-            // eslint-disable-next-line @typescript-eslint/dot-notation
-            global["window"] = { location: { host:"localhost" } };
-        }
         const resolvedUrl = await resolver.resolve(testRequest);
         ensureFluidResolvedUrl(resolvedUrl);
 

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -93,7 +93,7 @@
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -108,7 +108,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.38.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -78,7 +78,7 @@
     "@types/assert": "^1.5.2",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/random-js": "^1.0.31",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -93,7 +93,7 @@
     "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/assert": "^1.5.2",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/assert": "^1.5.2",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -92,7 +92,7 @@
     "@types/assert": "^1.5.2",
     "@types/express": "^4.11.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -71,7 +71,7 @@
     "@types/debug": "^4.1.5",
     "@types/events": "^3.0.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -71,7 +71,7 @@
     "@types/debug": "^4.1.5",
     "@types/jwt-decode": "^2.2.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/tools/generator-fluid/app/templates/package.json
+++ b/tools/generator-fluid/app/templates/package.json
@@ -27,7 +27,7 @@
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",
-    "@types/node": "^10.17.24",
+    "@types/node": "^12.19.0",
     "@types/puppeteer": "1.3.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.0.11",


### PR DESCRIPTION
Note: we're already on '^12.19.0' for server.  Just client is stale.

This is one of several related changes to address technical debt required to unblock PR #5767.

The general issue/pattern is this:
* We had trouble getting '@types/blahblah' to work, so we omitted the dependency.
* Orthogonal PR #5767 has a transitive dependency that installs '@types/blahblah'.
* Lerna hoists '@types/blahblah' to the root '/node_modules/' folder.
* TypeScript now discovers '@types/blahblah' and emits compilation errors for otherwise unchanged packages.

In this instance, the missing dependency is '@types/fs-extras'.  The reason TypeScript explodes is that the *.d.ts for 'fs-extras' exposes the 'Dir' type, which was introduced in node v12.