### PR TITLE
Unblock PR: Add missing '@types/marked' dependency

### DIFF
--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -46,15 +46,16 @@
     "@fluidframework/runtime-definitions": "^0.38.0",
     "@fluidframework/sequence": "^0.38.0",
     "@fluidframework/view-interfaces": "^0.38.0",
-    "@types/simplemde": "^1.11.7",
-    "marked": "^0.8.0",
+    "marked": "^2.0.3",
     "simplemde": "^1.11.2"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.21.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/webpack-fluid-loader": "^0.38.0",
+    "@types/marked": "^2.0.2",
     "@types/node": "^12.19.0",
+    "@types/simplemde": "^1.11.7",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/smde/src/marked.ts
+++ b/examples/data-objects/smde/src/marked.ts
@@ -4,7 +4,7 @@
  */
 
 import { SharedString } from "@fluidframework/sequence";
-import * as marked from "marked";
+import marked from "marked";
 
 export class Viewer {
     constructor(private readonly elm: HTMLElement, private readonly text: SharedString) {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -9875,6 +9875,11 @@
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
             "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
+        "@types/marked": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.2.tgz",
+            "integrity": "sha512-P4zanhCQKs4tiWPPBGpB7lHflgFCP9DFGNI5YtpW9MALKoy2qs9rHNWJ+z55cegD9uCfnmsKuaosq9FNvbxrOw=="
+        },
         "@types/mime": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -26144,9 +26149,9 @@
             }
         },
         "marked": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-            "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+            "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA=="
         },
         "marky": {
             "version": "1.2.1",


### PR DESCRIPTION
This is one of several related changes to address technical debt required to unblock PR #5767.

This adds the missing '@types/marked' dependency that previously was omitted.

(PR #5796 has an explanation of why this is blocking an unrelated PR.)