### PR TITLE
Make relative request in relative loader to be routed to original container

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1732,7 +1732,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // The relative loader will proxy requests to '/' to the loader itself assuming no non-cache flags
         // are set. Global requests will still go directly to the loader
-        const loader = new RelativeLoader(this.loader);
+        const loader = new RelativeLoader(this.loader, this);
         this._context = await ContainerContext.createOrLoad(
             this,
             this.scope,
@@ -1755,7 +1755,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             pendingLocalState,
         );
 
-        loader.resolveContainer(this);
         this.emit("contextChanged", codeDetails);
     }
 

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -82,7 +82,6 @@ describeNoCompat("Container", (getTestObjectProvider) => {
             {
                 canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                 clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
-                containerUrl: testRequest.url,
                 docId: "documentId",
                 resolvedUrl: testResolved,
                 version: testRequest.headers?.[LoaderHeader.version],

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -84,7 +84,6 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                 {
                     canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                     clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
-                    containerUrl: testRequest.url,
                     docId: "documentId",
                     resolvedUrl: testResolved,
                     version: testRequest.headers?.[LoaderHeader.version],


### PR DESCRIPTION
I don't think checking for no cache serves any purpose here. We always have original container which created the relative loader. So we can always use that. This will also improve the performance. 