### PR TITLE
r11s-driver: Make Network Error retriable

### DIFF
--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -52,6 +52,11 @@ export function createR11sNetworkError(
     retryAfterSeconds?: number,
 ): R11sError {
     switch (statusCode) {
+        case undefined:
+            // If a service is temporarily down or a browser resource limit is reached, Axios will throw
+            // a network error with no status code (e.g. err:ERR_CONN_REFUSED or err:ERR_FAILED) and
+            // error message, "Network Error".
+            return new GenericNetworkError(errorMessage, errorMessage === "Network Error", statusCode);
         case 401:
         case 403:
             return new AuthorizationError(errorMessage, undefined, undefined, statusCode);

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -51,9 +51,15 @@ describe("ErrorUtils", () => {
             assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
             assert.strictEqual(error.canRetry, true);
         });
+        it("creates retriable error on Network Error", () => {
+            const message = "Network Error";
+            const error = createR11sNetworkError(message);
+            assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
+            assert.strictEqual(error.canRetry, true);
+        });
         it("creates retriable error on anything else with retryAfter", () => {
             const message = "test error";
-            const error = createR11sNetworkError(message, undefined, 100);
+            const error = createR11sNetworkError(message, 400, 100);
             assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
             assert.strictEqual(error.canRetry, true);
             assert.strictEqual((error as any).retryAfterSeconds, 100);
@@ -63,6 +69,9 @@ describe("ErrorUtils", () => {
             const error = createR11sNetworkError(message);
             assert.strictEqual(error.errorType, DriverErrorType.genericNetworkError);
             assert.strictEqual(error.canRetry, false);
+            const error2 = createR11sNetworkError(message, 400);
+            assert.strictEqual(error2.errorType, DriverErrorType.genericNetworkError);
+            assert.strictEqual(error2.canRetry, false);
         });
     });
     describe("throwR11sNetworkError()", () => {
@@ -121,10 +130,19 @@ describe("ErrorUtils", () => {
                 canRetry: true,
             });
         });
+        it("throws retriable error on Network Error", () => {
+            const message = "Network Error";
+            assert.throws(() => {
+                throwR11sNetworkError(message);
+            }, {
+                errorType: DriverErrorType.genericNetworkError,
+                canRetry: true,
+            });
+        });
         it("throws retriable error on anything else with retryAfter", () => {
             const message = "test error";
             assert.throws(() => {
-                throwR11sNetworkError(message, undefined, 200);
+                throwR11sNetworkError(message, 400, 200);
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
@@ -135,6 +153,12 @@ describe("ErrorUtils", () => {
             const message = "test error";
             assert.throws(() => {
                 throwR11sNetworkError(message);
+            }, {
+                errorType: DriverErrorType.genericNetworkError,
+                canRetry: false,
+            });
+            assert.throws(() => {
+                throwR11sNetworkError(message, 400);
             }, {
                 errorType: DriverErrorType.genericNetworkError,
                 canRetry: false,


### PR DESCRIPTION
Axios gives a consistent error message, "Network Error", for all generic network errors such as "err:ERR_FAILED" or "err:ERR_CONNECTION_REFUSED". We can/should retry these to recover from temporary network failures or service connectivity failures.