### PR TITLE
Removed container url and use resolved url from container in relative loader

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -3,6 +3,7 @@
 - [ODSP Driver Type Unification](#ODSP-Driver-Type-Unification)
 - [ODSP Driver url resolver for share link parameter consolidation](#ODSP-Driver-url-resolver-for-share-link-parameter-consolidation)
 - [AgentScheduler-related deprecations](#AgentScheduler-related-deprecations)
+- [Removed containerUrl from IContainerLoadOptions and IContainerConfig](#Removed-containerUrl-from-IContainerLoadOptions-and-IContainerConfig)
 
 ### IPersistedCache changes
 IPersistedCache implementation no longer needs to implement updateUsage() method (removed form interface).
@@ -177,6 +178,9 @@ if (!context.existing) {
 ```
 
 The option will be turned off by default in an upcoming release before being turned off permanently, so it is recommended to make these updates proactively.
+
+### Removed containerUrl from IContainerLoadOptions and IContainerConfig
+Removed containerUrl from IContainerLoadOptions and IContainerConfig. This is no longer needed to route request.
 
 ## 0.37 Breaking changes
 

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -196,7 +196,7 @@ export interface ILoader extends IFluidRouter {
      * An analogy for this is resolve is a DNS resolve of a Fluid container. Request then executes
      * a request against the server found from the resolve step.
      */
-    resolve(request: IRequest, pendingLocalState?: string, resolvedUrl?: IResolvedUrl): Promise<IContainer>;
+    resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
 }
 
 /**

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -196,7 +196,7 @@ export interface ILoader extends IFluidRouter {
      * An analogy for this is resolve is a DNS resolve of a Fluid container. Request then executes
      * a request against the server found from the resolve step.
      */
-    resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
+    resolve(request: IRequest, pendingLocalState?: string, resolvedUrl?: IResolvedUrl): Promise<IContainer>;
 }
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -82,7 +82,6 @@ describeNoCompat("Container", (getTestObjectProvider) => {
             {
                 canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                 clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
-                containerUrl: testRequest.url,
                 resolvedUrl: testResolved,
                 version: testRequest.headers?.[LoaderHeader.version],
                 pause: testRequest.headers?.[LoaderHeader.pause],

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -84,7 +84,6 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                 {
                     canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                     clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
-                    containerUrl: testRequest.url,
                     resolvedUrl: testResolved,
                     version: testRequest.headers?.[LoaderHeader.version],
                     pause: testRequest.headers?.[LoaderHeader.pause],


### PR DESCRIPTION
1.) Remove container url from container as we don't need it anymore to route request to base container.
