### PR TITLE
SharedMatrix: fix #5805 and #5809

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -505,7 +505,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
                     const col = this.cols.handleToPosition(colHandle, localSeq);
 
                     if (row >= 0 && col >= 0) {
-                        this.setCellCore(
+                        this.sendSetCellOp(
                             row,
                             col,
                             setOp.value,

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -774,7 +774,7 @@ describe("Matrix", () => {
             // Reconnect the second client.
             containerRuntime1.connected = true;
 
-            // Note: We cannot 'deepEquals' bound fluid handles, and therefore cannot use our
+            // Note: We cannot 'deepEquals' bound Fluid handles, and therefore cannot use our
             //       'expect()' helper here.  Instead, we 'processAllMessages()' and then compare
             //       the relevant fields of IFluidHandle.
 

--- a/packages/runtime/test-runtime-utils/src/index.ts
+++ b/packages/runtime/test-runtime-utils/src/index.ts
@@ -7,6 +7,7 @@ export * from "./insecureTokenProvider";
 export * from "./insecureUrlResolver";
 export * from "./mocksDataStoreContext";
 export * from "./mockDeltas";
+export * from "./mockHandle";
 export * from "./mockLogger";
 export * from "./mocks";
 export * from "./mocksForReconnection";

--- a/packages/runtime/test-runtime-utils/src/mockHandle.ts
+++ b/packages/runtime/test-runtime-utils/src/mockHandle.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { AttachState } from "@fluidframework/container-definitions";
+
+/**
+ * Mock implementation of IFluidHandle.
+ */
+export class MockHandle<T> implements IFluidHandle {
+    private graphAttachState: AttachState = AttachState.Detached;
+
+    public get IFluidHandle(): IFluidHandle { return this; }
+    public get isAttached(): boolean { return this.graphAttachState === AttachState.Attached; }
+
+    constructor(
+        protected readonly value: T,
+        public readonly path = `mock-handle-${Math.random().toString(36).slice(2)}`,
+        public readonly absolutePath: string = `/${path}`,
+    ) { }
+
+    public async get(): Promise<any> { return this.value; }
+    public attachGraph(): void { this.graphAttachState = AttachState.Attached; }
+    public bind() { throw Error("MockHandle.bind() unimplemented."); }
+}


### PR DESCRIPTION
Fixes two bugs caused by the same code-reuse issue.

In both cases, the issue is calling `setCellCore()` instead of `sendSetCellOp()` when resubmitting ops during reconnection.

The problems with calling `setCellCore()` are that:

1. It (re-)emits events for the undo manager which were already emitted when the cell was set. (#5805).
2. It writes the value to the storage, which would be benign, except that 'op.value' has had handles encoded for serialization (#5809).