### PR TITLE
Enable sending unreferenced flag to ODSP in the driver.

### DIFF
--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -43,9 +43,7 @@ function gatesMarkUnreferencedNodes() {
         }
     } catch (e) {}
 
-    // We are starting disabled. This will be enabled once Apps (Bohemia) have finished GC work.
-    // See - https://github.com/microsoft/FluidFramework/issues/5127
-    return false;
+    return true;
 }
 
 export interface IDedupCaches {


### PR DESCRIPTION
The runtime will send it to the driver only for documents that can be GC'd. Basically, only containers that are created with the `gcAllowed` GC runtime options will run GC and send this flag to the driver.