### PR TITLE
Create New Resolved Url Instance on Load

### DIFF
--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -72,7 +72,7 @@ export class RelativeLoader extends EventEmitter implements ILoader {
                     {
                         canReconnect: request.headers?.[LoaderHeader.reconnect],
                         clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
-                        resolvedUrl,
+                        resolvedUrl: {...resolvedUrl},
                         version: request.headers?.[LoaderHeader.version],
                         pause: request.headers?.[LoaderHeader.pause],
                     },


### PR DESCRIPTION
reusing the instance creates problems for stress tests, and it seems safer to create a new instance anyway