### PR TITLE
Disable noisy telemetry and use warnings instead

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -536,7 +536,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     public get IContainerRuntimeDirtyable() {
         // The IContainerRuntimeDirtyable interface and isMessageDirtyable() method are deprecated 0.38
-        this.logger.sendErrorEvent({ eventName: "UsedIContainerRuntimeDirtyable" });
+        console.warn("The IContainerRuntimeDirtyable interface and isMessageDirtyable() method are deprecated, "
+            + "see BREAKING.md for more details and migration instructions");
+        // Disabling noisy telemetry until customers have had some time to migrate
+        // this.logger.sendErrorEvent({ eventName: "UsedIContainerRuntimeDirtyable" });
         return this;
     }
     public get IFluidRouter() { return this; }
@@ -589,7 +592,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const combinedRuntimeOptions = { ...defaultRuntimeOptions, ...backCompatRuntimeOptions };
         if (combinedRuntimeOptions.addGlobalAgentSchedulerAndLeaderElection !== false) {
             // ContainerRuntime with AgentScheduler built-in is deprecated 0.38
-            logger.sendErrorEvent({ eventName: "UsedAddGlobalAgentSchedulerAndLeaderElection" });
+            console.warn("ContainerRuntime with AgentScheduler built-in is deprecated, "
+                + "see BREAKING.md for more details and migration instructions");
+            // Disabling noisy telemetry until customers have had some time to migrate
+            // logger.sendErrorEvent({ eventName: "UsedAddGlobalAgentSchedulerAndLeaderElection" });
         }
 
         const registry = combinedRuntimeOptions.addGlobalAgentSchedulerAndLeaderElection !== false
@@ -734,7 +740,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     public get leader(): boolean {
         // The ContainerRuntime.leader property and "leader"/"notleader" events are deprecated 0.38
-        this.logger.sendErrorEvent({ eventName: "UsedContainerRuntimeLeaderProperty" });
+        console.warn("The ContainerRuntime.leader property and \"leader\"/\"notleader\" events are deprecated, "
+            + "see BREAKING.md for more details and migration instructions");
+        // Disabling noisy telemetry until customers have had some time to migrate
+        // this.logger.sendErrorEvent({ eventName: "UsedContainerRuntimeLeaderProperty" });
         return this._leader;
     }
 
@@ -1513,7 +1522,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     public isMessageDirtyable(message: ISequencedDocumentMessage) {
         // The IContainerRuntimeDirtyable interface and isMessageDirtyable() method are deprecated 0.38
-        this.logger.sendErrorEvent({ eventName: "UsedIsMessageDirtyable" });
+        console.warn("The IContainerRuntimeDirtyable interface and isMessageDirtyable() method are deprecated, "
+            + "see BREAKING.md for more details and migration instructions");
+        // Disabling noisy telemetry until customers have had some time to migrate
+        // this.logger.sendErrorEvent({ eventName: "UsedIsMessageDirtyable" });
         assert(
             isRuntimeMessage(message) === true,
             0x12c /* "Message passed for dirtyable check should be a container runtime message" */,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -156,7 +156,10 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
      */
     public get leader(): boolean {
         // The FluidDataStoreContext.leader property and "leader"/"notleader" events are deprecated 0.38
-        this.logger.sendErrorEvent({ eventName: "UsedDataStoreContextLeaderProperty" });
+        console.warn("The FluidDataStoreContext.leader property and \"leader\"/\"notleader\" events are deprecated, "
+            + "see BREAKING.md for more details and migration instructions");
+        // Disabling noisy telemetry until customers have had some time to migrate
+        // this.logger.sendErrorEvent({ eventName: "UsedDataStoreContextLeaderProperty" });
         return this._containerRuntime.leader;
     }
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -126,7 +126,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
      */
     public get leader(): boolean {
         // The FluidDataStoreRuntime.leader property and "leader"/"notleader" events are deprecated 0.38
-        this.logger.sendErrorEvent({ eventName: "UsedDataStoreRuntimeLeaderProperty" });
+        console.warn("The FluidDataStoreRuntime.leader property and \"leader\"/\"notleader\" events are deprecated, "
+            + "see BREAKING.md for more details and migration instructions");
+        // Disabling noisy telemetry until customers have had some time to migrate
+        // this.logger.sendErrorEvent({ eventName: "UsedDataStoreRuntimeLeaderProperty" });
         return this.dataStoreContext.leader;
     }
 


### PR DESCRIPTION
Disabling the new `AgentScheduler` telemetry for now -- once customers have had some time to migrate we'll turn it back on.