### PR TITLE
Refactor how OdspDocumentService handles websocket token fetching + extend HostStoragePolicy to allow for options that are used to pass user display name

### DIFF
--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -50,6 +50,14 @@ export interface IOpsCachingPolicy {
     totalOpsToCache?: number;
 }
 
+export interface ICollabSessionOptions {
+    /**
+     * Value indicating the display name for session that admits unauthenticated user.
+     * This name will be used in attribution associated with edits made by such user.
+     */
+     unauthenticatedUserDisplayName?: string;
+}
+
 export interface HostStoragePolicy {
     snapshotOptions?: ISnapshotOptions;
 
@@ -74,4 +82,9 @@ export interface HostStoragePolicy {
      * Policy controlling ops caching (leveraging IPersistedCache passed to driver factory)
      */
     opsCaching?: IOpsCachingPolicy;
+
+    /**
+     * Policy controlling how collaboration session is established
+     */
+    sessionOptions?: ICollabSessionOptions;
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -31,10 +31,7 @@ import {
     IEntry,
     HostStoragePolicy,
 } from "@fluidframework/odsp-driver-definitions";
-import {
-    HostStoragePolicyInternal,
-    ISocketStorageDiscovery,
-} from "./contracts";
+import { HostStoragePolicyInternal, ISocketStorageDiscovery } from "./contracts";
 import { IOdspCache } from "./odspCache";
 import { OdspDeltaStorageService, OdspDeltaStorageWithCache } from "./odspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./odspDocumentDeltaConnection";
@@ -58,7 +55,7 @@ function isAfdCacheValid(): boolean {
         const lastAfdConnection = localStorage.getItem(lastAfdConnectionTimeMsKey);
         if (lastAfdConnection !== null) {
             const lastAfdTimeMs = Number(lastAfdConnection);
-            // If we have used the AFD URL within a certain amount of time in the past,
+            // If we have used the AFD URL within a certain amount of time in the past
             // then we should use it again.
             if (!isNaN(lastAfdTimeMs) && lastAfdTimeMs > 0
                 && Date.now() - lastAfdTimeMs <= afdUrlConnectExpirationMs) {
@@ -105,18 +102,22 @@ export class OdspDocumentService implements IDocumentService {
     readonly policies: IDocumentServicePolicies;
 
     /**
+     * @param resolvedUrl - resolved url identifying document that will be managed by returned service instance.
      * @param getStorageToken - function that can provide the storage token. This is is also referred to as
-     * the "VROOM" token in SPO.
-     * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
-     * referred to as the "Push" token in SPO.
+     * the "Vroom" token in SPO.
+     * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also referred
+     * to as the "Push" token in SPO. If undefined then websocket token is expected to be returned with joinSession
+     * response payload.
      * @param logger - a logger that can capture performance and diagnostic information
      * @param socketIoClientFactory - A factory that returns a promise to the socket io library required by the driver
      * @param cache - This caches response for joinSession.
+     * @param hostPolicy - This host constructed policy which customizes service behavior.
+     * @param epochTracker - This helper class which adds epoch to backend calls made by returned service instance.
      */
     public static async create(
         resolvedUrl: IResolvedUrl,
         getStorageToken: (options: TokenFetchOptions, name: string) => Promise<string | null>,
-        getWebsocketToken: (options: TokenFetchOptions) => Promise<string | null>,
+        getWebsocketToken: ((options: TokenFetchOptions) => Promise<string | null>) | undefined,
         logger: ITelemetryLogger,
         socketIoClientFactory: () => Promise<SocketIOClientStatic>,
         cache: IOdspCache,
@@ -141,25 +142,27 @@ export class OdspDocumentService implements IDocumentService {
 
     private readonly joinSessionKey: string;
 
-    private readonly isOdc: boolean;
-
     private readonly hostPolicy: HostStoragePolicyInternal;
 
     private _opsCache?: OpsCache;
 
     /**
+     * @param odspResolvedUrl - resolved url identifying document that will be managed by this service instance.
      * @param getStorageToken - function that can provide the storage token. This is is also referred to as
-     * the "VROOM" token in SPO.
+     * the "Vroom" token in SPO.
      * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also referred
-     * to as the "Push" token in SPO.
+     * to as the "Push" token in SPO. If undefined then websocket token is expected to be returned with joinSession
+     * response payload.
      * @param logger - a logger that can capture performance and diagnostic information
      * @param socketIoClientFactory - A factory that returns a promise to the socket io library required by the driver
      * @param cache - This caches response for joinSession.
+     * @param hostPolicy - This host constructed policy which customizes service behavior.
+     * @param epochTracker - This helper class which adds epoch to backend calls made by this service instance.
      */
     constructor(
         public readonly odspResolvedUrl: IOdspResolvedUrl,
         private readonly getStorageToken: (options: TokenFetchOptions, name: string) => Promise<string | null>,
-        private readonly getWebsocketToken: (options: TokenFetchOptions) => Promise<string | null>,
+        private readonly getWebsocketToken: ((options: TokenFetchOptions) => Promise<string | null>) | undefined,
         logger: ITelemetryLogger,
         private readonly socketIoClientFactory: () => Promise<SocketIOClientStatic>,
         private readonly cache: IOdspCache,
@@ -172,12 +175,11 @@ export class OdspDocumentService implements IDocumentService {
         };
 
         this.joinSessionKey = `${this.odspResolvedUrl.hashedDocumentId}/joinsession`;
-        this.isOdc = isOdcOrigin(new URL(this.odspResolvedUrl.endpoints.snapshotStorageUrl).origin);
         this.logger = ChildLogger.create(logger,
             undefined,
             {
                 all: {
-                    odc: this.isOdc,
+                    odc: isOdcOrigin(new URL(this.odspResolvedUrl.endpoints.snapshotStorageUrl).origin),
                 },
             });
 
@@ -253,35 +255,28 @@ export class OdspDocumentService implements IDocumentService {
     public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
         // Attempt to connect twice, in case we used expired token.
         return getWithRetryForTokenRefresh<IDocumentDeltaConnection>(async (options) => {
-            // For ODC, we do not rely on getWebsocketToken callback and just use the token from joinsession
-            const socketTokenPromise = this.isOdc ? Promise.resolve(null) : this.getWebsocketToken(options);
-            const [websocketEndpoint, webSocketToken, io] =
-                await Promise.all([this.joinSession(), socketTokenPromise, this.socketIoClientFactory()]);
+            // Presence of getWebsocketToken callback dictates whether callback is used for fetching
+            // websocket token or whether it is returned with joinSession response payload
+            const requestWebsocketTokenFromJoinSession = this.getWebsocketToken === undefined;
+            const websocketTokenPromise = requestWebsocketTokenFromJoinSession
+                ? Promise.resolve(null)
+                : this.getWebsocketToken!(options);
+            const [websocketEndpoint, websocketToken, io] =
+                await Promise.all([
+                    this.joinSession(requestWebsocketTokenFromJoinSession),
+                    websocketTokenPromise,
+                    this.socketIoClientFactory(),
+                ]);
 
-            // This check exists because of a typescript bug.
-            // Issue: https://github.com/microsoft/TypeScript/issues/33752
-            // The TS team has plans to fix this in the 3.8 release
-            if (!websocketEndpoint) {
-                throw new Error("websocket endpoint should be defined");
-            }
-
-            // This check exists because of a typescript bug.
-            // Issue: https://github.com/microsoft/TypeScript/issues/33752
-            // The TS team has plans to fix this in the 3.8 release
-            if (!io) {
-                throw new Error("websocket endpoint should be defined");
-            }
-
-            const finalSocketToken = webSocketToken ?? (websocketEndpoint.socketToken || null);
-            if (finalSocketToken === null) {
+            const finalWebsocketToken = websocketToken ?? (websocketEndpoint.socketToken || null);
+            if (finalWebsocketToken === null) {
                 throwOdspNetworkError("Push Token is null", fetchTokenErrorCode);
             }
             try {
                 const connection = await this.connectToDeltaStreamWithRetry(
                     websocketEndpoint.tenantId,
                     websocketEndpoint.id,
-                    // Accounts for ODC where websocket token is returned as part of joinsession response payload
-                    finalSocketToken,
+                    finalWebsocketToken,
                     io,
                     client,
                     websocketEndpoint.deltaStreamSocketUrl,
@@ -300,7 +295,7 @@ export class OdspDocumentService implements IDocumentService {
         });
     }
 
-    private async joinSession(): Promise<ISocketStorageDiscovery> {
+    private async joinSession(requestSocketToken: boolean): Promise<ISocketStorageDiscovery> {
         const executeFetch = async () =>
             fetchJoinSession(
                 this.odspResolvedUrl,
@@ -309,6 +304,8 @@ export class OdspDocumentService implements IDocumentService {
                 this.logger,
                 this.getStorageToken,
                 this.epochTracker,
+                requestSocketToken,
+                this.hostPolicy.sessionOptions?.unauthenticatedUserDisplayName,
             );
 
         // Note: The sessionCache is configured with a sliding expiry of 1 hour,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -22,7 +22,7 @@ export class OdspDocumentServiceFactory
     implements IDocumentServiceFactory {
     constructor(
         getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,
-        getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions>,
+        getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -157,7 +157,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             : async (options: TokenFetchOptions) => this.toInstrumentedOdspTokenFetcher(
                 odspLogger,
                 odspResolvedUrl,
-                this.getWebsocketToken,
+                this.getWebsocketToken!,
                 false /* throwOnNullToken */,
             )(options, "GetWebsocketToken");
 

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -108,17 +108,18 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
     }
 
     /**
-   * @param getStorageToken - function that can provide the storage token for a given site. This is
-   * is also referred to as the "VROOM" token in SPO.
-   * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
-   * referred to as the "Push" token in SPO.
-   * @param storageFetchWrapper - if not provided FetchWrapper will be used
-   * @param deltasFetchWrapper - if not provided FetchWrapper will be used
-   * @param persistedCache - PersistedCache provided by host for use in this session.
-   */
+     * @param getStorageToken - function that can provide the storage token for a given site. This is
+     * is also referred to as the "Vroom" token in SPO.
+     * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also
+     * to as the "Push" token in SPO. If undefined then websocket token is expected to be returned with joinSession
+     * response payload.
+     * @param storageFetchWrapper - if not provided FetchWrapper will be used
+     * @param deltasFetchWrapper - if not provided FetchWrapper will be used
+     * @param persistedCache - PersistedCache provided by host for use in this session.
+     */
     constructor(
         private readonly getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,
-        private readonly getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions>,
+        private readonly getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined,
         private readonly getSocketIOClient: () => Promise<SocketIOClientStatic>,
         protected persistedCache: IPersistedCache = new LocalPersistentCache(),
         private readonly hostPolicy: HostStoragePolicy = {},
@@ -151,17 +152,19 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             true /* throwOnNullToken */,
         );
 
-        const webSocketTokenFetcher = this.toInstrumentedOdspTokenFetcher(
-            odspLogger,
-            odspResolvedUrl,
-            this.getWebsocketToken,
-            false /* throwOnNullToken */,
-        );
+        const webSocketTokenFetcher = this.getWebsocketToken === undefined
+            ? undefined
+            : async (options: TokenFetchOptions) => this.toInstrumentedOdspTokenFetcher(
+                odspLogger,
+                odspResolvedUrl,
+                this.getWebsocketToken,
+                false /* throwOnNullToken */,
+            )(options, "GetWebsocketToken");
 
         return OdspDocumentService.create(
             resolvedUrl,
             storageTokenFetcher,
-            async (options: TokenFetchOptions) => webSocketTokenFetcher(options, "GetWebsocketToken"),
+            webSocketTokenFetcher,
             odspLogger,
             this.getSocketIOClient,
             cacheAndTracker.cache,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryWithCodeSplit.ts
@@ -17,7 +17,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit
     implements IDocumentServiceFactory {
     constructor(
         getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,
-        getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions>,
+        getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined,
         persistedCache?: IPersistedCache,
         hostPolicy?: HostStoragePolicy,
     ) {

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -63,12 +63,12 @@ export async function fetchJoinSession(
                     headers = { Authorization: `Bearer ${token}` };
                 }
                 let body: IJoinSessionBody | undefined;
-                if (requestSocketToken || !!guestDisplayName) {
+                if (requestSocketToken || guestDisplayName) {
                     body = {};
                     if (requestSocketToken) {
                         body.requestSocketToken = true;
                     }
-                    if (!!guestDisplayName) {
+                    if (guestDisplayName) {
                         body.guestDisplayName = guestDisplayName;
                     }
                 }
@@ -77,7 +77,7 @@ export async function fetchJoinSession(
                     `${getApiRoot(siteOrigin)}/drives/${
                         urlParts.driveId
                     }/items/${urlParts.itemId}/${path}?${queryParams}`,
-                    { method, headers, body: JSON.stringify(body) },
+                    { method, headers, body: body ? JSON.stringify(body) : undefined },
                     "joinSession",
                 );
 

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -39,7 +39,7 @@ export async function fetchJoinSession(
     getStorageToken: (options: TokenFetchOptions, name: string) => Promise<string | null>,
     epochTracker: EpochTracker,
     requestSocketToken: boolean,
-    guestDisplayName?: string
+    guestDisplayName?: string,
 ): Promise<ISocketStorageDiscovery> {
     return getWithRetryForTokenRefresh(async (options) => {
         const token = await getStorageToken(options, "JoinSession");

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -11,6 +11,11 @@ import { getWithRetryForTokenRefresh, getOrigin } from "./odspUtils";
 import { getApiRoot } from "./odspUrlHelper";
 import { EpochTracker } from "./epochTracker";
 
+interface IJoinSessionBody {
+    requestSocketToken?: boolean;
+    guestDisplayName?: string;
+}
+
 /**
  * Makes join session call on SPO to get information about the web socket for a document
  * @param driveId - The SPO drive id that this request should be made against
@@ -20,7 +25,11 @@ import { EpochTracker } from "./epochTracker";
  * @param method - The type of request, such as GET or POST
  * @param logger - A logger to use for this request
  * @param getStorageToken - A function that is able to provide the access token for this request
- * @param epochTracker - fetch wrapper which incorporates epoch logic around joisSession call.
+ * @param epochTracker - fetch wrapper which incorporates epoch logic around joinSession call
+ * @param requestSocketToken - flag indicating whether joinSession is expected to return access token
+ * which is used when establishing websocket connection with collab session backend service.
+ * @param guestDisplayName - display name used to identify guest user joining a session.
+ * This is optional and used only when collab session is being joined via invite.
  */
 export async function fetchJoinSession(
     urlParts: IOdspUrlParts,
@@ -29,6 +38,8 @@ export async function fetchJoinSession(
     logger: ITelemetryLogger,
     getStorageToken: (options: TokenFetchOptions, name: string) => Promise<string | null>,
     epochTracker: EpochTracker,
+    requestSocketToken: boolean,
+    guestDisplayName?: string
 ): Promise<ISocketStorageDiscovery> {
     return getWithRetryForTokenRefresh(async (options) => {
         const token = await getStorageToken(options, "JoinSession");
@@ -51,11 +62,22 @@ export async function fetchJoinSession(
                     queryParams = "";
                     headers = { Authorization: `Bearer ${token}` };
                 }
+                let body: IJoinSessionBody | undefined;
+                if (requestSocketToken || !!guestDisplayName) {
+                    body = {};
+                    if (requestSocketToken) {
+                        body.requestSocketToken = true;
+                    }
+                    if (!!guestDisplayName) {
+                        body.guestDisplayName = guestDisplayName;
+                    }
+                }
 
                 const response = await epochTracker.fetchAndParseAsJSON<ISocketStorageDiscovery>(
-                    // eslint-disable-next-line max-len
-                    `${getApiRoot(siteOrigin)}/drives/${urlParts.driveId}/items/${urlParts.itemId}/${path}?${queryParams}`,
-                    { method, headers },
+                    `${getApiRoot(siteOrigin)}/drives/${
+                        urlParts.driveId
+                    }/items/${urlParts.itemId}/${path}?${queryParams}`,
+                    { method, headers, body: JSON.stringify(body) },
                     "joinSession",
                 );
 

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -13,6 +13,7 @@ import {
     HostStoragePolicy,
     ISnapshotOptions,
     IOpsCachingPolicy,
+    ICollabSessionOptions,
 } from "@fluidframework/odsp-driver-definitions";
 import {
     booleanCases,
@@ -27,7 +28,7 @@ export const OdspDriverApi = {
     OdspDocumentServiceFactory,
     OdspDriverUrlResolver,
     createOdspCreateContainerRequest,
-    createOdspUrl,                          // REVIEW: does this need to be back compat?
+    createOdspUrl, // REVIEW: does this need to be back compat?
 };
 
 export type OdspDriverApiType = typeof OdspDriverApi;
@@ -46,6 +47,10 @@ const odspOpsCaching: OptionsMatrix<IOpsCachingPolicy> = {
     totalOpsToCache: numberCases,
 };
 
+const odspSessionOptions: OptionsMatrix<ICollabSessionOptions> = {
+    unauthenticatedUserDisplayName: [undefined],
+};
+
 export const generateOdspHostStoragePolicy = (seed: number)=> {
     const odspHostPolicyMatrix: OptionsMatrix<HostStoragePolicy> = {
         blobDeduping: booleanCases,
@@ -54,6 +59,7 @@ export const generateOdspHostStoragePolicy = (seed: number)=> {
         concurrentOpsBatches: numberCases,
         snapshotOptions:[undefined, ...generatePairwiseOptions(odspSnapshotOptions, seed)],
         opsCaching: [undefined, ...generatePairwiseOptions(odspOpsCaching, seed)],
+        sessionOptions: [undefined, ...generatePairwiseOptions(odspSessionOptions, seed)],
     };
     return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };


### PR DESCRIPTION
Change #1: allow getWebsocketToken callback to be specified as undefined as a way to indicate that odsp-driver should expect to get token that is passed to Push as part of joinSession response payload. This is something that is already supported for Consumer case but will be needed in future to support unauthenticated access on behalf of another authorized user. There is still one active TODO related to this change: we need to figure out how this intent is passed to joinSession API. 

Change#2: extend HostStoragePolicy to allow host to pass display name that will be used to attribute changes when unauthenticated user is making changes using authorization that was given to another user. This mode is facilitated by acquiring proof token to specific document and then securely passing it to another client. In addition to using proof token, client will pass display name inside hostConfig.hostStoragePolicy.sessionOptions. That value will be included inside IConnect.client.user object when client sends connect-document message to Push