### PR TITLE
Undo change to DeltaManager event name

### DIFF
--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -81,10 +81,10 @@ export interface IDeltaManagerEvents extends IEvent {
     (event: "allSentOpsAckd", listener: () => void);
     (event: "pong" | "processTime", listener: (latency: number) => void);
     /**
-     * The connect_document_success event fires once we've received the connect_document_success message from the
+     * The connect event fires once we've received the connect_document_success message from the
      * server.  This happens prior to the client's join message (if there is a join message).
      */
-    (event: "connect_document_success", listener: (details: IConnectionDetails, opsBehind?: number) => void);
+    (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void);
     (event: "disconnect", listener: (reason: string) => void);
     (event: "readonly", listener: (readonly: boolean) => void);
 }

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -135,7 +135,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         this.setConnectionState(ConnectionState.Disconnected, reason);
     }
 
-    public receivedConnectDocumentSuccessEvent(
+    public receivedConnectEvent(
         connectionMode: ConnectionMode,
         details: IConnectionDetails,
         opsBehind?: number,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1446,8 +1446,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             () => this.activeConnection(),
         );
 
-        deltaManager.on("connect_document_success", (details: IConnectionDetails, opsBehind?: number) => {
-            this.connectionStateHandler.receivedConnectDocumentSuccessEvent(
+        deltaManager.on("connect", (details: IConnectionDetails, opsBehind?: number) => {
+            this.connectionStateHandler.receivedConnectEvent(
                 this._deltaManager.connectionMode,
                 details,
                 opsBehind,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1034,7 +1034,7 @@ export class DeltaManager
         // WARNING: This has to happen before processInitialMessages() call below.
         // If not, we may not update Container.pendingClientId in time before seeing our own join session op.
         this.emit(
-            "connect_document_success",
+            "connect",
             DeltaManager.detailsFromConnection(connection),
             this._hasCheckpointSequenceNumber ? this.lastKnownSeqNumber - this.lastSequenceNumber : undefined);
 

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -83,7 +83,7 @@ describe("ConnectionStateHandler Tests", () => {
     it("Should move to connected state on normal flow for read client", async () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
             "Client should be in disconnected state");
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Read Client should be in connected state");
     });
@@ -92,7 +92,7 @@ describe("ConnectionStateHandler Tests", () => {
         client.mode = "write";
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
             "Client should be in disconnected state");
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
             "Client should be in connecting state");
         protocolHandler.quorum.addMember("anotherClientId", { client, sequenceNumber: 0 });
@@ -107,7 +107,7 @@ describe("ConnectionStateHandler Tests", () => {
 
     it("Should wait for previous client to leave before moving to conencted state", async () => {
         client.mode = "write";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(pendingClientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
@@ -124,7 +124,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client join so that it waits for previous client to leave
         connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
@@ -138,7 +138,7 @@ describe("ConnectionStateHandler Tests", () => {
 
     it("Should wait for timeout before moving to conencted state if no leave received", async () => {
         client.mode = "write";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(pendingClientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
@@ -155,7 +155,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client join so that it waits for previous client to leave
         connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
@@ -175,7 +175,7 @@ describe("ConnectionStateHandler Tests", () => {
         "got disconnected from connecting state", async () =>
     {
         client.mode = "write";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(pendingClientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
@@ -192,7 +192,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client join but disconnect it from connecting state
         connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
             "Client 2 should be in connecting state");
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -201,7 +201,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client 3 join so that it waits for client 1 to leave
         connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
 
@@ -223,7 +223,7 @@ describe("ConnectionStateHandler Tests", () => {
         "got disconnected from connecting state", async () =>
     {
         client.mode = "write";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(pendingClientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
@@ -240,7 +240,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client join but disconnect it from connecting state
         connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
             "Client 2 should be in connecting state");
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -249,7 +249,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client 3 join so that it waits for client 1 to leave
         connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
 
@@ -277,7 +277,7 @@ describe("ConnectionStateHandler Tests", () => {
         "got disconnected from connected state", async () =>
     {
         client.mode = "write";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(pendingClientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
@@ -294,7 +294,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client join but disconnect it from connected state
         connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent("pendingClientId2");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
@@ -305,7 +305,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client 3 join so that it waits for client 1 to leave
         connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
@@ -329,7 +329,7 @@ describe("ConnectionStateHandler Tests", () => {
         "got disconnected from connected state", async () =>
     {
         client.mode = "write";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(pendingClientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
@@ -346,7 +346,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client join but disconnect it from connecting state
         connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent("pendingClientId2");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
@@ -357,7 +357,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client 3 join so that it waits for client 1 to leave
         connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
 
@@ -386,7 +386,7 @@ describe("ConnectionStateHandler Tests", () => {
         "when client 2 already waited on client 1", async () =>
     {
         client.mode = "write";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(pendingClientId);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
@@ -403,7 +403,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client join but disconnect it from connected state
         connectionDetails.clientId = "pendingClientId2";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent("pendingClientId2");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
@@ -421,7 +421,7 @@ describe("ConnectionStateHandler Tests", () => {
 
         // Make new client 3 join. Now it should not wait for previous client as client 2 already waited.
         connectionDetails.clientId = "pendingClientId3";
-        connectionStateHandler.receivedConnectDocumentSuccessEvent(client.mode, connectionDetails, 0);
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails, 0);
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
             "Client 3 should still be in connecting state");
         protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -42,7 +42,7 @@ class OpPerfTelemetry {
 
         this.deltaManager.on("op", (message) => this.afterProcessingOp(message));
 
-        this.deltaManager.on("connect_document_success", (details, opsBehind) => {
+        this.deltaManager.on("connect", (details, opsBehind) => {
             this.clientId = details.clientId;
             if (opsBehind !== undefined) {
                 this.connectionOpSeqNumber = this.deltaManager.lastKnownSeqNumber;

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -502,7 +502,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
                     + `${msg.type} ${getContentsString(msg.type, msg.contents)}`);
             });
 
-            container.deltaManager.on("connect_document_success", (details) => {
+            container.deltaManager.on("connect", (details) => {
                 debugOp(`${index}: CON: clientId: ${details.clientId}`);
             });
             container.deltaManager.on("disconnect", (reason) => {

--- a/packages/test/test-utils/src/opProcessingController.ts
+++ b/packages/test/test-utils/src/opProcessingController.ts
@@ -134,7 +134,7 @@ class DeltaManagerMonitor extends DeltaManagerToggle {
             this.connect(id);
         }
 
-        deltaManager.on("connect_document_success", (details) => this.connect(details.clientId));
+        deltaManager.on("connect", (details) => this.connect(details.clientId));
         deltaManager.on("disconnect", (reason) => {
             assert(this.clientId !== undefined);
             this.trace("DIS");
@@ -296,7 +296,7 @@ export class OpProcessingController {
                         monitor2.onClientDisconnect(clientId);
                     });
                 }
-                monitor1.deltaManager.on("connect_document_success", (details) => {
+                monitor1.deltaManager.on("connect", (details) => {
                     if (monitor1.deltaManager.active) {
                         monitor1.deltaManager.once("disconnect", () => {
                             monitor2.onClientDisconnect(details.clientId);


### PR DESCRIPTION
@anthony-murphy pointed out that this change would break `OpPerfTelemetry` for mismatched loader/runtime version -- reverting.