### PR TITLE
Remove Riddler dependency on Handlebarsjs

### DIFF
--- a/server/routerlicious/README.md
+++ b/server/routerlicious/README.md
@@ -85,7 +85,6 @@ Then use another command window to deliver the changes:
 * `npm run build` - build
 * `docker-compose restart {modified service}` - allow the container to pick up the changes stored on the local machine
 or
-* `npm run browserify` - rebuild the view code (.hjs, view controllers) and reload the browser
 
 ### Standalone
 

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -10116,14 +10116,6 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
 		},
-		"hjs": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/hjs/-/hjs-0.0.6.tgz",
-			"integrity": "sha1-v6xGfeQM0MfFSHTmrEiXqCF9cp0=",
-			"requires": {
-				"hogan.js": ">=2.0.0"
-			}
-		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -10132,30 +10124,6 @@
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"hogan.js": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
-			"integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
-			"requires": {
-				"mkdirp": "0.3.0",
-				"nopt": "1.0.10"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-					"integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
-				},
-				"nopt": {
-					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-					"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-					"requires": {
-						"abbrev": "1"
-					}
-				}
 			}
 		},
 		"homedir-polyfill": {

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -16,13 +16,12 @@ import compression from "compression";
 import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
-import safeStringify from "json-stringify-safe";
 import morgan from "morgan";
 import { Provider } from "nconf";
 import * as winston from "winston";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { bindCorrelationId } from "@fluidframework/server-services-utils";
-import { getTenantIdFromRequest } from "../utils";
+import { catch404, getTenantIdFromRequest, handleError } from "../utils";
 import * as alfredRoutes from "./routes";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -95,18 +94,11 @@ export function create(
     app.use(routes.api);
 
     // Catch 404 and forward to error handler
-    app.use((req, res, next) => {
-        const err = new Error("Not Found");
-        (err as any).status = 404;
-        next(err);
-    });
+    app.use(catch404());
 
     // Error handlers
 
-    app.use((err, req, res, next) => {
-        res.status(err.status || 500);
-        res.json({ error: safeStringify(err), message: err.message });
-    });
+    app.use(handleError());
 
     return app;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -77,7 +77,7 @@ export function create(
 
     // Error handlers
 
-    app.use(handleError());
+    app.use(handleError(app.get("env") === "development"));
 
     return app;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -9,7 +9,7 @@ import express from "express";
 import morgan from "morgan";
 import * as winston from "winston";
 import { bindCorrelationId } from "@fluidframework/server-services-utils";
-import { getTenantIdFromRequest } from "../utils";
+import { catch404, getTenantIdFromRequest, handleError } from "../utils";
 import * as api from "./api";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -39,8 +39,6 @@ export function create(
     // Running behind iisnode
     app.set("trust proxy", 1);
 
-    // View engine setup.
-    app.set("view engine", "hjs");
     if (loggerFormat === "json") {
         app.use(morgan((tokens, req, res) => {
             const messageMetaData = {
@@ -75,35 +73,11 @@ export function create(
             secretManager));
 
     // Catch 404 and forward to error handler
-    app.use((req, res, next) => {
-        const err = new Error("Not Found");
-        (err as any).status = 404;
-        next(err);
-    });
+    app.use(catch404());
 
     // Error handlers
 
-    // development error handler
-    // will print stacktrace
-    if (app.get("env") === "development") {
-        app.use((err, req, res, next) => {
-            res.status(err.status || 500);
-            res.render("error", {
-                error: err,
-                message: err.message,
-            });
-        });
-    }
-
-    // Production error handler
-    // no stacktraces leaked to user
-    app.use((err, req, res, next) => {
-        res.status(err.status || 500);
-        res.render("error", {
-            error: {},
-            message: err.message,
-        });
-    });
+    app.use(handleError());
 
     return app;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
@@ -4,5 +4,6 @@
  */
 
 export * from "./constants";
+export * from "./middleware";
 export * from "./params";
 export * from "./runner";

--- a/server/routerlicious/packages/routerlicious-base/src/utils/middleware.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/middleware.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { ErrorRequestHandler, RequestHandler } from "express";
+import safeStringify from "json-stringify-safe";
+
+export const catch404: () => RequestHandler = () => (req, res, next) => {
+    const err = new Error("Not Found");
+    (err as any).status = 404;
+    next(err);
+};
+
+export const handleError: () => ErrorRequestHandler = () => (err, req, res, next) => {
+    res.status(err?.status || 500);
+    res.json({ error: safeStringify(err), message: err?.message });
+};

--- a/server/routerlicious/packages/routerlicious-base/src/utils/middleware.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/middleware.ts
@@ -12,7 +12,8 @@ export const catch404: () => RequestHandler = () => (req, res, next) => {
     next(err);
 };
 
-export const handleError: () => ErrorRequestHandler = () => (err, req, res, next) => {
-    res.status(err?.status || 500);
-    res.json({ error: safeStringify(err), message: err?.message });
-};
+export const handleError: (showStackTrace?: boolean) => ErrorRequestHandler =
+    (showStackTrace = true) => (err, req, res, next) => {
+        res.status(err?.status || 500);
+        res.json({ error: showStackTrace ? safeStringify(err) : "", message: err?.message });
+    };

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -59,7 +59,6 @@
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",
     "express": "^4.16.3",
-    "hjs": "^0.0.6",
     "ioredis": "^4.24.2",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.4.0",


### PR DESCRIPTION
When Riddler encounters an error, it tries to render a handlebars view that doesn't exist. I'm not sure when the views were there or when the were removed, but seems OK to have Alfred and Riddler handle errors in the same way with a simple JSON output.

There are no other mentions of `hjs` or `handlebars` in the Routerlicious code, so I removed that dependency as well.