### PR TITLE
Remove driver serialized format as it is redundant

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -151,29 +151,18 @@ export enum ConnectionState {
     Connected,
 }
 
-// It specifies the summary taken by the serialize api on detached container.
-export interface IDetachedContainerSnapshot {
-    summary: ISummaryTree,
-    formatVersion: string,
-}
-
 // This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
 // a detached container can be rehydrated.
-export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot: IDetachedContainerSnapshot) => {
+export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot: ISummaryTree) => {
     let snapshotTree: ISnapshotTree;
-    if (detachedContainerSnapshot.formatVersion === "0.1") {
-        const summaryTree = detachedContainerSnapshot.summary as ISummaryTree;
-        const protocolSummaryTree = summaryTree.tree[".protocol"] as ISummaryTree;
-        const appSummaryTree = summaryTree.tree[".app"] as ISummaryTree;
-        assert(protocolSummaryTree !== undefined && appSummaryTree !== undefined,
-            "Protocol and App summary trees should be present");
-        snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(
-            protocolSummaryTree,
-            appSummaryTree,
-        );
-    } else {
-        assert(false, "No other version supported yet!");
-    }
+    const protocolSummaryTree = detachedContainerSnapshot.tree[".protocol"] as ISummaryTree;
+    const appSummaryTree = detachedContainerSnapshot.tree[".app"] as ISummaryTree;
+    assert(protocolSummaryTree !== undefined && appSummaryTree !== undefined,
+        "Protocol and App summary trees should be present");
+    snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(
+        protocolSummaryTree,
+        appSummaryTree,
+    );
     return snapshotTree;
 };
 
@@ -775,11 +764,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         const appSummary: ISummaryTree = this.context.createSummary();
         const protocolSummary = this.captureProtocolSummary();
-        const combinedTree = combineAppAndProtocolSummary(appSummary, protocolSummary);
-        const serializedSnapshot: IDetachedContainerSnapshot = {
-            summary: combinedTree,
-            formatVersion: "0.1",
-        };
+        const serializedSnapshot = combineAppAndProtocolSummary(appSummary, protocolSummary);
         return JSON.stringify(serializedSnapshot);
     }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -154,12 +154,11 @@ export enum ConnectionState {
 // This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
 // a detached container can be rehydrated.
 export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot: ISummaryTree) => {
-    let snapshotTree: ISnapshotTree;
     const protocolSummaryTree = detachedContainerSnapshot.tree[".protocol"] as ISummaryTree;
     const appSummaryTree = detachedContainerSnapshot.tree[".app"] as ISummaryTree;
     assert(protocolSummaryTree !== undefined && appSummaryTree !== undefined,
         "Protocol and App summary trees should be present");
-    snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(
+    const snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(
         protocolSummaryTree,
         appSummaryTree,
     );

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -764,8 +764,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         const appSummary: ISummaryTree = this.context.createSummary();
         const protocolSummary = this.captureProtocolSummary();
-        const serializedSnapshot = combineAppAndProtocolSummary(appSummary, protocolSummary);
-        return JSON.stringify(serializedSnapshot);
+        const combinedSummary = combineAppAndProtocolSummary(appSummary, protocolSummary);
+        return JSON.stringify(combinedSummary);
     }
 
     public async attach(request: IRequest): Promise<void> {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -374,7 +374,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const container = new Container(
             loader,
             {});
-        const deserializedSummary = JSON.parse(snapshot);
+        const deserializedSummary = JSON.parse(snapshot) as ISummaryTree;
         await container.rehydrateDetachedFromSnapshot(deserializedSummary);
         return container;
     }
@@ -1272,7 +1272,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.loaded = true;
     }
 
-    private async rehydrateDetachedFromSnapshot(detachedContainerSnapshot: IDetachedContainerSnapshot) {
+    private async rehydrateDetachedFromSnapshot(detachedContainerSnapshot: ISummaryTree) {
         const snapshotTree: ISnapshotTree = getSnapshotTreeFromSerializedContainer(detachedContainerSnapshot);
         const attributes = await this.getDocumentAttributes(undefined, snapshotTree);
         assert(attributes.sequenceNumber === 0, 0x0db /* "Seq number in detached container should be 0!!" */);

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -279,9 +279,7 @@ export class Loader extends EventEmitter implements IHostLoader {
     public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<Container> {
         debug(`Container creating in detached state: ${performance.now()} `);
 
-        return Container.rehydrateDetachedFromSnapshot(
-            this,
-            JSON.parse(snapshot));
+        return Container.rehydrateDetachedFromSnapshot(this, snapshot);
     }
 
     public async resolve(request: IRequest, pendingLocalState?: string): Promise<Container> {

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -4,12 +4,12 @@
  */
 
 import {
+    assert,
+    fromBase64ToUtf8,
     IsoBuffer,
     Uint8ArrayToString,
     unreachableCase,
     stringToBuffer,
-    fromBase64ToUtf8,
-    assert,
 } from "@fluidframework/common-utils";
 import { AttachmentTreeEntry, BlobTreeEntry, TreeTreeEntry } from "@fluidframework/protocol-base";
 import {
@@ -238,7 +238,7 @@ export function convertToSummaryTree(
  * was taken by serialize api in detached container.
  * @param snapshot - snapshot in ISnapshotTree format
  */
- export function convertSnapshotTreeToSummaryTree(
+export function convertSnapshotTreeToSummaryTree(
     snapshot: ISnapshotTree,
 ): ISummaryTreeWithStats {
     assert(Object.keys(snapshot.commits).length === 0,

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -5,7 +5,10 @@
 
 import { strict as assert } from "assert";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
-import { Loader } from "@fluidframework/container-loader";
+import {
+    convertDetachedContainerSnapshot,
+    Loader,
+} from "@fluidframework/container-loader";
 import {
     LocalCodeLoader,
     TestFluidObjectFactory,
@@ -153,7 +156,7 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
         it("Dehydrated container snapshot", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();
-            const snapshotTree: ISnapshotTree = JSON.parse(container.serialize());
+            const snapshotTree: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
 
             // Check for scheduler
             assertSchedulerTree(snapshotTree);
@@ -178,12 +181,12 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
         it("Dehydrated container snapshot 2 times with changes in between", async () => {
             const { container, defaultDataStore } =
                 await createDetachedContainerAndGetRootDataStore();
-            const snapshotTree1: ISnapshotTree = JSON.parse(container.serialize());
+            const snapshotTree1: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
             // Create a channel
             const channel = defaultDataStore.runtime.createChannel("test1",
                 "https://graph.microsoft.com/types/map") as SharedMap;
             channel.bindToContext();
-            const snapshotTree2: ISnapshotTree = JSON.parse(container.serialize());
+            const snapshotTree2: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
 
             assert.strictEqual(JSON.stringify(Object.keys(snapshotTree1.trees)),
                 JSON.stringify(Object.keys(snapshotTree2.trees)),
@@ -216,7 +219,7 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
             rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
-            const snapshotTree: ISnapshotTree = JSON.parse(container.serialize());
+            const snapshotTree: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
 
             assertProtocolTree(snapshotTree);
             const { channelsTree } = assertSchedulerTree(snapshotTree);
@@ -580,7 +583,7 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             // Create another not bounded dataStore
             await createPeerDataStore(defaultDataStore.context.containerRuntime);
 
-            const snapshotTree = JSON.parse(container.serialize());
+            const snapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
 
             assertProtocolTree(snapshotTree);
             const { channelsTree } = assertSchedulerTree(snapshotTree);

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import {
-    convertDetachedContainerSnapshot,
+    getSnapshotTreeFromSerializedContainer,
     Loader,
 } from "@fluidframework/container-loader";
 import {
@@ -156,7 +156,8 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
         it("Dehydrated container snapshot", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();
-            const snapshotTree: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
+            const snapshotTree: ISnapshotTree =
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
 
             // Check for scheduler
             assertSchedulerTree(snapshotTree);
@@ -181,12 +182,14 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
         it("Dehydrated container snapshot 2 times with changes in between", async () => {
             const { container, defaultDataStore } =
                 await createDetachedContainerAndGetRootDataStore();
-            const snapshotTree1: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
+            const snapshotTree1: ISnapshotTree =
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
             // Create a channel
             const channel = defaultDataStore.runtime.createChannel("test1",
                 "https://graph.microsoft.com/types/map") as SharedMap;
             channel.bindToContext();
-            const snapshotTree2: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
+            const snapshotTree2: ISnapshotTree =
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
 
             assert.strictEqual(JSON.stringify(Object.keys(snapshotTree1.trees)),
                 JSON.stringify(Object.keys(snapshotTree2.trees)),
@@ -219,7 +222,8 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
             rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
-            const snapshotTree: ISnapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
+            const snapshotTree: ISnapshotTree =
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
 
             assertProtocolTree(snapshotTree);
             const { channelsTree } = assertSchedulerTree(snapshotTree);
@@ -583,7 +587,7 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             // Create another not bounded dataStore
             await createPeerDataStore(defaultDataStore.context.containerRuntime);
 
-            const snapshotTree = convertDetachedContainerSnapshot(JSON.parse(container.serialize()));
+            const snapshotTree = getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
 
             assertProtocolTree(snapshotTree);
             const { channelsTree } = assertSchedulerTree(snapshotTree);

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
-import { ConnectionState, IDetachedContainerSnapshot, Loader } from "@fluidframework/container-loader";
+import { ConnectionState, Loader } from "@fluidframework/container-loader";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import {
     ITestContainerConfig,
@@ -658,11 +658,11 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
         const subDataStore1 = await createFluidObject(dataStore.context, "default");
         dataStore.root.set("attachKey", subDataStore1.handle);
 
-        const summaryForAttach: IDetachedContainerSnapshot = JSON.parse(container.serialize());
+        const summaryForAttach: ISummaryTree = JSON.parse(container.serialize());
         const resolvedUrl = await provider.urlResolver.resolve(request);
         assert(resolvedUrl);
         const service = await provider.documentServiceFactory.createContainer(
-            summaryForAttach.summary as ISummaryTree,
+            summaryForAttach,
             resolvedUrl,
         );
         const absoluteUrl = await provider.urlResolver.getAbsoluteUrl(service.resolvedUrl, "/");

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
-import { ConnectionState, Loader } from "@fluidframework/container-loader";
+import { ConnectionState, IDetachedContainerSnapshot, Loader } from "@fluidframework/container-loader";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import {
     ITestContainerConfig,
@@ -63,19 +63,19 @@ const testContainerConfig: ITestContainerConfig = {
     registry,
 };
 
+const createFluidObject = (async (
+    dataStoreContext: IFluidDataStoreContext,
+    type: string,
+) => {
+    return requestFluidObject<ITestFluidObject>(
+        await dataStoreContext.containerRuntime.createDataStore(type),
+        "");
+});
+
 describeFullCompat("Detached Container", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     let request: IRequest;
     let loader: Loader;
-
-    const createFluidObject = (async (
-        dataStoreContext: IFluidDataStoreContext,
-        type: string,
-    ) => {
-        return requestFluidObject<ITestFluidObject>(
-            await dataStoreContext.containerRuntime.createDataStore(type),
-            "");
-    });
 
     beforeEach(() => {
         provider = getTestObjectProvider();
@@ -237,30 +237,6 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         assert(dataStore2, "Data store created in failed attach mode should exist");
         assert.strictEqual(dataStore1.runtime.attachState, AttachState.Attached, "Data store 1 should be attached");
         assert.strictEqual(dataStore2.runtime.attachState, AttachState.Attached, "Data store 2 should be attached");
-    });
-
-    it("Directly attach container through service factory, should resolve to same container", async () => {
-        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
-        // Get the root dataStore from the detached container.
-        const response = await container.request({ url: "/" });
-        const dataStore = response.value as ITestFluidObject;
-
-        // Create a sub dataStore of type TestFluidObject.
-        const subDataStore1 = await createFluidObject(dataStore.context, "default");
-        dataStore.root.set("attachKey", subDataStore1.handle);
-
-        const summaryForAttach: ISummaryTree = JSON.parse(container.serialize());
-        const resolvedUrl = await provider.urlResolver.resolve(request);
-        assert(resolvedUrl);
-        const service = await provider.documentServiceFactory.createContainer(summaryForAttach, resolvedUrl);
-        const absoluteUrl = await provider.urlResolver.getAbsoluteUrl(service.resolvedUrl, "/");
-
-        const container2 = await loader.resolve({ url: absoluteUrl });
-        // Get the root dataStore from the detached container.
-        const response2 = await container2.request({ url: "/" });
-        const dataStore2 = response2.value as ITestFluidObject;
-        assert.strictEqual(dataStore2.root.get("attachKey").absolutePath, subDataStore1.handle.absolutePath,
-            "Stored handle should match!!");
     });
 
     it("Fire ops during container attach for shared string", async () => {
@@ -623,10 +599,12 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
 describeNoCompat("Detached Container", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     let request: IRequest;
+    let loader: Loader;
 
     beforeEach(() => {
         provider = getTestObjectProvider();
         request = provider.driver.createCreateNewRequest(provider.documentId);
+        loader = provider.makeTestLoader(testContainerConfig) as Loader;
     });
 
     it("Retry attaching detached container", async () => {
@@ -650,14 +628,14 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
         const codeLoader = new LocalCodeLoader([
             [provider.defaultCodeDetails, fluidExport],
         ]);
-        const loader = new Loader({
+        const mockLoader = new Loader({
             urlResolver: provider.urlResolver,
             documentServiceFactory,
             codeLoader,
             logger: new TelemetryNullLogger(),
         });
 
-        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        const container = await mockLoader.createDetachedContainer(provider.defaultCodeDetails);
         await container.attach(request);
         assert.strictEqual(container.attachState, AttachState.Attached, "Container should be attached");
         assert.strictEqual(container.closed, false, "Container should be open");
@@ -668,5 +646,32 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
             assert.strictEqual(container.id, provider.documentId, "Doc id is not matching!!");
         }
         assert.strictEqual(retryTimes, 0, "Should not succeed at first time");
+    });
+
+    it("Directly attach container through service factory, should resolve to same container", async () => {
+        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        // Get the root dataStore from the detached container.
+        const response = await container.request({ url: "/" });
+        const dataStore = response.value as ITestFluidObject;
+
+        // Create a sub dataStore of type TestFluidObject.
+        const subDataStore1 = await createFluidObject(dataStore.context, "default");
+        dataStore.root.set("attachKey", subDataStore1.handle);
+
+        const summaryForAttach: IDetachedContainerSnapshot = JSON.parse(container.serialize());
+        const resolvedUrl = await provider.urlResolver.resolve(request);
+        assert(resolvedUrl);
+        const service = await provider.documentServiceFactory.createContainer(
+            summaryForAttach.summary as ISummaryTree,
+            resolvedUrl,
+        );
+        const absoluteUrl = await provider.urlResolver.getAbsoluteUrl(service.resolvedUrl, "/");
+
+        const container2 = await loader.resolve({ url: absoluteUrl });
+        // Get the root dataStore from the detached container.
+        const response2 = await container2.request({ url: "/" });
+        const dataStore2 = response2.value as ITestFluidObject;
+        assert.strictEqual(dataStore2.root.get("attachKey").absolutePath, subDataStore1.handle.absolutePath,
+            "Stored handle should match!!");
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -27,10 +27,10 @@ import { ConsensusRegisterCollection } from "@fluidframework/register-collection
 import { SharedCell } from "@fluidframework/cell";
 import { ConsensusQueue } from "@fluidframework/ordered-collection";
 import { MergeTreeDeltaType } from "@fluidframework/merge-tree";
-import { MessageType, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { MessageType, ISequencedDocumentMessage, ISummaryTree } from "@fluidframework/protocol-definitions";
 import { DataStoreMessageType } from "@fluidframework/datastore";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
-import { convertContainerToDriverSerializedFormat, requestFluidObject } from "@fluidframework/runtime-utils";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeFullCompat, describeNoCompat } from "@fluidframework/test-version-utils";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 
@@ -249,11 +249,10 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         const subDataStore1 = await createFluidObject(dataStore.context, "default");
         dataStore.root.set("attachKey", subDataStore1.handle);
 
-        const snapshotTree = container.serialize();
-        const summaryForAttach = convertContainerToDriverSerializedFormat(snapshotTree);
+        const summaryForAttach: ISummaryTree = JSON.parse(container.serialize());
         const resolvedUrl = await provider.urlResolver.resolve(request);
         assert(resolvedUrl);
-        const service = await provider.documentServiceFactory.createContainer(summaryForAttach as any, resolvedUrl);
+        const service = await provider.documentServiceFactory.createContainer(summaryForAttach, resolvedUrl);
         const absoluteUrl = await provider.urlResolver.getAbsoluteUrl(service.resolvedUrl, "/");
 
         const container2 = await loader.resolve({ url: absoluteUrl });


### PR DESCRIPTION
This change removes the function `convertContainerToDriverSerializedFormat`.
This was used to convert the snapshot taken in detached container to a format which was understandable by driver for cases where app directly used the document service factory to create the container with the snapshot.
Now the snapshot returned by `container.serialize()` api is already in that format. So it reduces work done by apps.