### PR TITLE
Fix tutorial code for containerCode

### DIFF
--- a/docs/content/start/tutorial.md
+++ b/docs/content/start/tutorial.md
@@ -154,7 +154,7 @@ needs (in this case, just the single model type).  This list is called the **con
 
 ```ts
 export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRollerInstantiationFactory.type,
+    DiceRollerInstantiationFactory,
     new Map([
         DiceRollerInstantiationFactory.registryEntry,
     ]),


### PR DESCRIPTION
`ContainerRuntimeFactoryWithDefaultDataStore` expects an `IFluidDataStoreFactory` as first arg, not a `string`. This is also how it's called in https://github.com/microsoft/FluidHelloWorld/blob/main/src/containerCode.ts#L20-L24