### PR TITLE
Fix tutorial docs error

### DIFF
--- a/docs/content/start/tutorial.md
+++ b/docs/content/start/tutorial.md
@@ -154,7 +154,7 @@ needs (in this case, just the single model type).  This list is called the **con
 
 ```ts
 export const DiceRollerContainerRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
-    DiceRollerInstantiationFactory.type,
+    DiceRollerInstantiationFactory,
     new Map([
         DiceRollerInstantiationFactory.registryEntry,
     ]),


### PR DESCRIPTION
Updates the tutorial doc's reference to creating a ContainerRuntimeFactoryWithDefaultDataStore to reflect the working code in the hello fluid sample.