### PR TITLE
Port https://github.com/microsoft/FluidFramework/pull/5773 to 0.38

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,6 +4,7 @@
 - [ODSP Driver url resolver for share link parameter consolidation](#ODSP-Driver-url-resolver-for-share-link-parameter-consolidation)
 - [AgentScheduler-related deprecations](#AgentScheduler-related-deprecations)
 - [Removed containerUrl from IContainerLoadOptions and IContainerConfig](#Removed-containerUrl-from-IContainerLoadOptions-and-IContainerConfig)
+- [LoaderHeader.pause](#LoaderHeader.pause)
 
 ### IPersistedCache changes
 IPersistedCache implementation no longer needs to implement updateUsage() method (removed form interface).
@@ -181,6 +182,16 @@ The option will be turned off by default in an upcoming release before being tur
 
 ### Removed containerUrl from IContainerLoadOptions and IContainerConfig
 Removed containerUrl from IContainerLoadOptions and IContainerConfig. This is no longer needed to route request.
+
+### LoaderHeader.pause
+LoaderHeader.pause has been removed. instead of
+```typescript
+[LoaderHeader.pause]: true
+```
+use
+```typescript
+[LoaderHeader.loadMode]: { deltaConnection: "none" }
+```
 
 ## 0.37 Breaking changes
 

--- a/packages/loader/container-definitions/src/deltas.ts
+++ b/packages/loader/container-definitions/src/deltas.ts
@@ -207,6 +207,8 @@ export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, ID
      * Returns all the items in the queue as an array. Does not remove them from the queue.
      */
     toArray(): T[];
+
+    waitTillProcessingDone(): Promise<void>;
 }
 
 export type ReadOnlyInfo = {

--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -272,7 +272,7 @@ export enum LoaderHeader {
     /**
      * Start the container in a paused, unconnected state. Defaults to false
      */
-    pause = "pause",
+    loadMode = "loadMode",
     reconnect = "fluid-reconnect",
     sequenceNumber = "fluid-sequence-number",
 
@@ -285,13 +285,55 @@ export enum LoaderHeader {
     version = "version",
 }
 
+export interface IContainerLoadMode {
+    opsBeforeReturn?:
+        /*
+         * No trailing ops are applied before container is returned.
+         * Default value.
+         */
+        | undefined
+        /*
+         * Only cached trailing ops are applied before returning container.
+         * Caching is optional and could be implemented by the driver.
+         * If driver does not implement any kind of local caching strategy, this is same as above.
+         * Driver may cache a lot of ops, so care needs to be exercised (see below).
+         */
+        | "cached"
+        /*
+         * All trailing ops in storage are fetched and applied before container is returned
+         * This mode might have significant impact on boot speed (depends on storage perf characteristics)
+         * Also there might be a lot of trailing ops and applying them might take time, so hosts are
+         * recommended to have some progress UX / cancellation built into loading flow when using this option.
+         */
+        | "all"
+    deltaConnection?:
+        /*
+         * Connection to delta stream is made only when Container.resume() call is made. Op processing
+         * is paused (when container is returned from Loader.resolve()) until Container.resume() call is made.
+         */
+        | "none"
+        /*
+         * Connection to delta stream is made only when Container.resume() call is made.
+         * Op fetching from storage is performed and ops are applied as they come in.
+         * This is useful option if connection to delta stream is expensive and thus it's beneficial to move it
+         * out from critical boot sequence, but it's beneficial to allow catch up to happen as fast as possible.
+         */
+        | "delayed"
+        /*
+         * Connection to delta stream is made right away.
+         * Ops processing is enabled and ops are flowing through the system.
+         * Default value.
+         */
+        | undefined
+}
+
 /**
  * Set of Request Headers that the Loader understands and may inspect or modify
  */
 export interface ILoaderHeader {
     [LoaderHeader.cache]: boolean;
     [LoaderHeader.clientDetails]: IClientDetails;
-    [LoaderHeader.pause]: boolean;
+    [LoaderHeader.loadMode]: IContainerLoadMode;
     [LoaderHeader.sequenceNumber]: number;
     [LoaderHeader.reconnect]: boolean;
     [LoaderHeader.version]: string | undefined | null;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -9,7 +9,7 @@ import { v4 as uuid } from "uuid";
 import {
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
-import { assert, performance } from "@fluidframework/common-utils";
+import { assert, performance, unreachableCase } from "@fluidframework/common-utils";
 import {
     IRequest,
     IResponse,
@@ -30,6 +30,7 @@ import {
     IPendingLocalState,
     ReadOnlyInfo,
     ILoaderOptions,
+    IContainerLoadMode,
 } from "@fluidframework/container-definitions";
 import {
     CreateContainerError,
@@ -122,7 +123,7 @@ export interface IContainerLoadOptions {
     /**
      * Loads the Container in paused state if true, unpaused otherwise.
      */
-    pause?: boolean;
+    loadMode?: IContainerLoadMode;
 }
 
 export interface IContainerConfig {
@@ -300,8 +301,13 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return PerformanceEvent.timedExecAsync(container.logger, { eventName: "Load" }, async (event) => {
             return new Promise<Container>((res, rej) => {
                 const version = loadOptions.version;
-                // always load unpaused with pending ops
-                const pause = pendingLocalState !== undefined ? false : loadOptions.pause;
+
+                // always load unpaused with pending ops!
+                // It is also default mode in general.
+                const defaultMode: IContainerLoadMode = { opsBeforeReturn: "cached" };
+                assert(pendingLocalState === undefined || loadOptions.loadMode === undefined,
+                    "pending state requires immidiate connection!");
+                const mode: IContainerLoadMode = loadOptions.loadMode ?? defaultMode;
 
                 const onClosed = (err?: ICriticalContainerError) => {
                     // Depending where error happens, we can be attempting to connect to web socket
@@ -313,7 +319,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 };
                 container.on("closed", onClosed);
 
-                container.load(version, pause === true, pendingLocalState)
+                container.load(version, mode, pendingLocalState)
                     .finally(() => {
                         container.removeListener("closed", onClosed);
                     })
@@ -881,7 +887,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     public resume() {
         if (!this.closed) {
-            this.resumeInternal({ reason: "DocumentOpenResume" });
+            // Note: no need to fetch ops as we do it preemptively as part of DeltaManager.attachOpHandler().
+            // If there is gap, we will learn about it once connected, but the gap should be small (if any),
+            // assuming that resume() is called quickly after initial container boot.
+            this.resumeInternal({ reason: "DocumentOpenResume", fetchOpsFromStorage: false });
         }
     }
 
@@ -892,7 +901,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         if (!this.resumedOpProcessingAfterLoad) {
             this.resumedOpProcessingAfterLoad = true;
             this._deltaManager.inbound.resume();
-            this._deltaManager.outbound.resume();
             this._deltaManager.inboundSignal.resume();
         }
 
@@ -1078,7 +1086,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      *   - otherwise, version sha to load snapshot
      * @param pause - start the container in a paused state
      */
-    private async load(specifiedVersion: string | null | undefined, pause: boolean, pendingLocalState?: unknown) {
+    private async load(
+        specifiedVersion: string | null | undefined,
+        loadMode: IContainerLoadMode,
+        pendingLocalState?: unknown)
+    {
         if (this._resolvedUrl === undefined) {
             throw new Error("Attempting to load without a resolved url");
         }
@@ -1095,11 +1107,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // connections to same file) in two ways:
         // A) creation flow breaks (as one of the clients "sees" file as existing, and hits #2 above)
         // B) Once file is created, transition from view-only connection to write does not work - some bugs to be fixed.
-        const connectionArgs: IConnectionArgs = { reason: "DocumentOpen", mode: "write" };
+        const connectionArgs: IConnectionArgs = { reason: "DocumentOpen", mode: "write", fetchOpsFromStorage: false };
 
         // Start websocket connection as soon as possible. Note that there is no op handler attached yet, but the
         // DeltaManager is resilient to this and will wait to start processing ops until after it is attached.
-        if (!pause) {
+        if (loadMode.deltaConnection === undefined) {
             startConnectionP = this.connectToDeltaStream(connectionArgs);
             startConnectionP.catch((error) => { });
         }
@@ -1120,26 +1132,49 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const protocolHandlerP =
             this.loadAndInitializeProtocolState(attributes, this.storageService, snapshot);
 
-        let loadDetailsP: Promise<void>;
+        let opsBeforeReturnP: Promise<void> | undefined;
 
         // Initialize document details - if loading a snapshot use that - otherwise we need to wait on
         // the initial details
         if (snapshot !== undefined) {
             this._existing = true;
-            loadDetailsP = Promise.resolve();
+            switch (loadMode.opsBeforeReturn) {
+                case undefined:
+                    if (loadMode.deltaConnection !== "none") {
+                        // Start prefetch, but not set opsBeforeReturnP - boot is not blocked by it!
+                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                        this._deltaManager.preFetchOps(false);
+                    }
+                    break;
+                case "cached":
+                    opsBeforeReturnP = this._deltaManager.preFetchOps(true);
+                    // Keep going with fetching ops from storage once we have all cached ops in.
+                    // Ops processing will start once cached ops are in and and will stop when queue is empty
+                    // (which in most cases will happen when we are done processing cached ops)
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    opsBeforeReturnP.then(async () => this._deltaManager.preFetchOps(false));
+                    break;
+                case "all":
+                    opsBeforeReturnP = this._deltaManager.preFetchOps(false);
+                    break;
+                default:
+                    unreachableCase(loadMode.opsBeforeReturn);
+            }
         } else {
+            //
+            // THIS IS LEGACY PATH
+            //
             if (startConnectionP === undefined) {
                 startConnectionP = this.connectToDeltaStream(connectionArgs);
             }
             // Intentionally don't .catch on this promise - we'll let any error throw below in the await.
-            loadDetailsP = startConnectionP.then((details) => {
-                this._existing = details.existing;
-            });
+            const details = await startConnectionP;
+            this._existing = details.existing;
         }
 
         // LoadContext directly requires protocolHandler to be ready, and eventually calls
-        // instantiateRuntime which will want to know existing state.  Wait for these promises to finish.
-        [this._protocolHandler] = await Promise.all([protocolHandlerP, loadDetailsP]);
+        // instantiateRuntime which will want to know existing state.
+        this._protocolHandler = await protocolHandlerP;
 
         const codeDetails = this.getCodeDetailsFromQuorum();
         await this.loadContext(codeDetails, attributes, snapshot, pendingLocalState);
@@ -1147,12 +1182,37 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // Propagate current connection state through the system.
         this.propagateConnectionState();
 
-        if (!pause) {
-            this.resume();
-        }
-
         // Internal context is fully loaded at this point
         this.loaded = true;
+
+        // We might have hit some failure that did not manifest itself in exception in this flow,
+        // do not start op processing in such case - static version of Container.load() will handle it correctly.
+        if (!this.closed) {
+            if (opsBeforeReturnP !== undefined) {
+                this._deltaManager.inbound.resume();
+
+                await opsBeforeReturnP;
+                await this._deltaManager.inbound.waitTillProcessingDone();
+
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                this._deltaManager.inbound.pause();
+            }
+
+            switch (loadMode.deltaConnection) {
+                case undefined:
+                    this.resume();
+                    break;
+                case "delayed":
+                    this.resumedOpProcessingAfterLoad = true;
+                    this._deltaManager.inbound.resume();
+                    this._deltaManager.inboundSignal.resume();
+                    break;
+                case "none":
+                    break;
+                default:
+                    unreachableCase(loadMode.deltaConnection);
+            }
+        }
 
         return {
             existing: this._existing,
@@ -1452,6 +1512,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             () => this.activeConnection(),
         );
 
+        // Disable inbound queues as Container is not ready to accept any ops until we are fully loaded!
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        deltaManager.inbound.pause();
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        deltaManager.inboundSignal.pause();
+
         deltaManager.on(connectEventName, (details: IConnectionDetails, opsBehind?: number) => {
             this.connectionStateHandler.receivedConnectEvent(
                 this._deltaManager.connectionMode,
@@ -1492,10 +1558,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.close(error);
         });
 
-        // If we're the outer frame, do we want to do this?
-        // Begin fetching any pending deltas once we know the base sequence #. Can this fail?
-        // It seems like something, like reconnection, that we would want to retry but otherwise allow
-        // the document to load
         this._deltaManager.attachOpHandler(
             attributes.minimumSequenceNumber,
             attributes.sequenceNumber,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -57,7 +57,6 @@ import {
     CreateProcessingError,
     DataCorruptionError,
 } from "@fluidframework/container-utils";
-import { debug } from "./debug";
 import { DeltaQueue } from "./deltaQueue";
 import { RetriableDocumentStorageService } from "./retriableDocumentStorageService";
 import { PrefetchDocumentStorageService } from "./prefetchDocumentStorageService";
@@ -212,7 +211,7 @@ export class DeltaManager
     private lastSubmittedClientId: string | undefined;
 
     private handler: IDeltaHandlerStrategy | undefined;
-    private deltaStorageP: Promise<IDocumentDeltaStorageService> | undefined;
+    private deltaStorage: IDocumentDeltaStorageService | undefined;
 
     private messageBuffer: IDocumentMessage[] = [];
 
@@ -491,13 +490,9 @@ export class DeltaManager
             this.close(CreateContainerError(error));
         });
 
-        // Require the user to start the processing
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this._inbound.pause();
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this._outbound.pause();
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this._inboundSignal.pause();
+        // Initially, all queues are created paused.
+        // - outbound is flipped back and forth in setupNewSuccessfulConnection / disconnectFromDeltaStream
+        // - inbound & inboundSignal are resumed in attachOpHandler() when we have handler setup
     }
 
     public dispose() {
@@ -513,8 +508,6 @@ export class DeltaManager
         term: number,
         handler: IDeltaHandlerStrategy,
     ) {
-        debug("Attached op handler", sequenceNumber);
-
         this.initSequenceNumber = sequenceNumber;
         this.lastProcessedSequenceNumber = sequenceNumber;
         this.baseTerm = term;
@@ -532,12 +525,19 @@ export class DeltaManager
         this._inboundSignal.resume();
 
         // We could have connected to delta stream before getting here
-        // If so, it's time to process any accumulated ops
+        // If so, it's time to process any accumulated ops, as there might be no other event that
+        // will force these pending ops to be processed.
         // Or request OPs from snapshot / or point zero (if we have no ops at all)
         if (this.pending.length > 0) {
             this.processPendingOps("DocumentOpen");
-        } else if (this.connection !== undefined || this.connectionP !== undefined) {
-            this.fetchMissingDeltas("DocumentOpen", this.lastQueuedSequenceNumber);
+        }
+    }
+
+    public async preFetchOps(cacheOnly: boolean) {
+        // Note that might already got connected to delta stream by now.
+        // If we did, then we proactively fetch ops at the end of setupNewSuccessfulConnection to ensure
+        if (this.connection === undefined) {
+            return this.fetchMissingDeltasCore("DocumentOpen", cacheOnly, this.lastQueuedSequenceNumber, undefined);
         }
     }
 
@@ -606,7 +606,7 @@ export class DeltaManager
         // But for view-only connection, we have no such signal, and with no traffic
         // on the wire, we might be always behind.
         // See comment at the end of setupNewSuccessfulConnection()
-        this.logger.debugAssert(this.handler !== undefined || fetchOpsFromStorage); // on boot, always fetch ops!
+        this.logger.debugAssert(this.handler !== undefined || !fetchOpsFromStorage); // can't fetch if no baseline
         if (fetchOpsFromStorage && this.handler !== undefined) {
             this.fetchMissingDeltas(args.reason, this.lastQueuedSequenceNumber);
         }
@@ -801,25 +801,25 @@ export class DeltaManager
     }
 
     private async getDeltas(
-        telemetryEventSuffix: string,
         from: number, // exclusive
         to: number | undefined, // exclusive
-        callback: (messages: ISequencedDocumentMessage[]) => void)
+        callback: (messages: ISequencedDocumentMessage[]) => void,
+        cacheOnly: boolean)
     {
         const docService = this.serviceProvider();
         if (docService === undefined) {
             throw new Error("Delta manager is not attached");
         }
 
-        if (this.deltaStorageP === undefined) {
-            this.deltaStorageP = docService.connectToDeltaStorage();
+        if (this.deltaStorage === undefined) {
+            this.deltaStorage = await docService.connectToDeltaStorage();
         }
 
-        const storage = await this.deltaStorageP;
-        const stream = storage.fetchMessages(
+        const stream = this.deltaStorage.fetchMessages(
             from, // inclusive
             to, // exclusive
-            this.closeAbortController.signal);
+            this.closeAbortController.signal,
+            cacheOnly);
 
         // eslint-disable-next-line no-constant-condition
         while (true) {
@@ -1334,7 +1334,20 @@ export class DeltaManager
     /**
      * Retrieves the missing deltas between the given sequence numbers
      */
-    private fetchMissingDeltas(telemetryEventSuffix: string, lastKnowOp: number, to?: number) {
+     private fetchMissingDeltas(telemetryEventSuffix: string, lastKnowOp: number, to?: number) {
+         // eslint-disable-next-line @typescript-eslint/no-floating-promises
+         this.fetchMissingDeltasCore(telemetryEventSuffix, false /* cacheOnly */, lastKnowOp, to);
+     }
+
+     /**
+     * Retrieves the missing deltas between the given sequence numbers
+     */
+    private async fetchMissingDeltasCore(
+        telemetryEventSuffix: string,
+        cacheOnly: boolean,
+        lastKnowOp: number,
+        to?: number)
+    {
         // Exit out early if we're already fetching deltas
         if (this.fetching) {
             return;
@@ -1345,33 +1358,39 @@ export class DeltaManager
             return;
         }
 
-        assert(lastKnowOp === this.lastQueuedSequenceNumber, 0x0f1 /* "from arg" */);
-        let from = lastKnowOp + 1;
+        try {
+            assert(lastKnowOp === this.lastQueuedSequenceNumber, 0x0f1 /* "from arg" */);
+            let from = lastKnowOp + 1;
 
-        const n = this.previouslyProcessedMessage?.sequenceNumber;
-        if (n !== undefined) {
-            // If we already processed at least one op, then we have this.previouslyProcessedMessage populated
-            // and can use it to validate that we are operating on same file, i.e. it was not overwritten.
-            // Knowing about this mechanism, we could ask for op we already observed to increase validation.
-            // This is especially useful when coming out of offline mode or loading from
-            // very old cached (by client / driver) snapshot.
-            assert(n === lastKnowOp, 0x0f2 /* "previouslyProcessedMessage" */);
-            assert(from > 1, 0x0f3 /* "not positive" */);
-            from--;
-        }
+            const n = this.previouslyProcessedMessage?.sequenceNumber;
+            if (n !== undefined) {
+                // If we already processed at least one op, then we have this.previouslyProcessedMessage populated
+                // and can use it to validate that we are operating on same file, i.e. it was not overwritten.
+                // Knowing about this mechanism, we could ask for op we already observed to increase validation.
+                // This is especially useful when coming out of offline mode or loading from
+                // very old cached (by client / driver) snapshot.
+                assert(n === lastKnowOp, 0x0f2 /* "previouslyProcessedMessage" */);
+                assert(from > 1, 0x0f3 /* "not positive" */);
+                from--;
+            }
 
-        this.fetching = true;
+            this.fetching = true;
 
-        this.getDeltas(telemetryEventSuffix, from, to, (messages) => {
-            this.refreshDelayInfo(this.deltaStorageDelayId);
-            this.enqueueMessages(messages, telemetryEventSuffix);
-        }).finally(() => {
-            this.refreshDelayInfo(this.deltaStorageDelayId);
-            this.fetching = false;
-        }).catch ((error) => {
+            await this.getDeltas(
+                from,
+                to,
+                (messages) => {
+                    this.refreshDelayInfo(this.deltaStorageDelayId);
+                    this.enqueueMessages(messages, telemetryEventSuffix);
+                },
+                cacheOnly);
+        } catch (error) {
             this.logger.sendErrorEvent({eventName: "GetDeltas_Exception"}, error);
             this.close(CreateContainerError(error));
-        });
+        } finally {
+            this.refreshDelayInfo(this.deltaStorageDelayId);
+            this.fetching = false;
+        }
     }
 
     private catchUp(messages: ISequencedDocumentMessage[], telemetryEventSuffix: string): void {

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -65,6 +65,10 @@ export class DeltaQueueProxy<T> extends EventForwarder<IDeltaQueueEvents<T>> imp
     public async resume(): Promise<void> {
         this.queue.resume();
     }
+
+    public async waitTillProcessingDone() {
+        return this.queue.waitTillProcessingDone();
+    }
 }
 
 /**

--- a/packages/loader/container-loader/src/deltaQueue.ts
+++ b/packages/loader/container-loader/src/deltaQueue.ts
@@ -44,6 +44,12 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
         return this.processingDeferred === undefined && this.q.length === 0;
     }
 
+    public async waitTillProcessingDone(): Promise<void> {
+        if (this.processingDeferred !== undefined) {
+            return this.processingDeferred.promise;
+        }
+    }
+
     /**
      * @param worker - A callback to process a delta.
      * @param logger - For logging telemetry.
@@ -81,9 +87,7 @@ export class DeltaQueue<T> extends TypedEventEmitter<IDeltaQueueEvents<T>> imple
         this.pauseCount++;
         // If called from within the processing loop, we are in the middle of processing an op. Return a promise
         // that will resolve when processing has actually stopped.
-        if (this.processingDeferred !== undefined) {
-            return this.processingDeferred.promise;
-        }
+        return this.waitTillProcessingDone();
     }
 
     public resume(): void {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -74,7 +74,7 @@ export class RelativeLoader extends EventEmitter implements ILoader {
                         clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
                         resolvedUrl: {...resolvedUrl},
                         version: request.headers?.[LoaderHeader.version],
-                        pause: request.headers?.[LoaderHeader.pause],
+                        loadMode: request.headers?.[LoaderHeader.loadMode],
                     },
                 );
                 return container;
@@ -438,7 +438,7 @@ export class Loader extends EventEmitter implements IHostLoader {
                 clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
                 resolvedUrl: resolved,
                 version: request.headers?.[LoaderHeader.version],
-                pause: request.headers?.[LoaderHeader.pause],
+                loadMode: request.headers?.[LoaderHeader.loadMode],
             },
             pendingLocalState,
         );

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -33,9 +33,6 @@ describe("Loader", () => {
 
             async function startDeltaManager() {
                 await deltaManager.connect({ reason: "test" });
-                deltaManager.inbound.resume();
-                deltaManager.outbound.resume();
-                deltaManager.inboundSignal.resume();
             }
 
             // function to yield control in the Javascript event loop.

--- a/packages/runtime/test-runtime-utils/src/mockDeltas.ts
+++ b/packages/runtime/test-runtime-utils/src/mockDeltas.ts
@@ -55,6 +55,8 @@ class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
 
     public dispose() { }
 
+    public async waitTillProcessingDone() { }
+
     constructor() {
         super();
     }

--- a/packages/test/functional-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/functional-tests/src/test/containerRuntime.spec.ts
@@ -32,9 +32,6 @@ describe("Container Runtime", () => {
 
         async function startDeltaManager() {
             await deltaManager.connect({ reason: "test" });
-            deltaManager.inbound.resume();
-            deltaManager.outbound.resume();
-            deltaManager.inboundSignal.resume();
         }
 
         // Function to yield control in the Javascript event loop.

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -10,7 +10,13 @@ import {
     ContainerErrorType,
     LoaderHeader,
 } from "@fluidframework/container-definitions";
-import { Container, ConnectionState, Loader, ILoaderProps } from "@fluidframework/container-loader";
+import {
+    Container,
+    ConnectionState,
+    Loader,
+    ILoaderProps,
+    waitContainerToCatchUp,
+} from "@fluidframework/container-loader";
 import {
     IDocumentServiceFactory,
 } from "@fluidframework/driver-definitions";
@@ -84,7 +90,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
                 clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
                 resolvedUrl: testResolved,
                 version: testRequest.headers?.[LoaderHeader.version],
-                pause: testRequest.headers?.[LoaderHeader.pause],
+                loadMode: testRequest.headers?.[LoaderHeader.loadMode],
             },
         );
     }
@@ -132,7 +138,8 @@ describeNoCompat("Container", (getTestObjectProvider) => {
                 service.connectToDeltaStorage = async () => Promise.reject(false);
                 return service;
             };
-            await loadContainer({ documentServiceFactory: mockFactory });
+            const container2 = await loadContainer({ documentServiceFactory: mockFactory });
+            await waitContainerToCatchUp(container2);
             assert.fail("Error expected");
         } catch (error) {
             assert.strictEqual(error.errorType, ContainerErrorType.genericError, "Error is not a general error");

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -64,7 +64,7 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
         mockFactory.createDocumentService = async (resolvedUrl) => {
             const service = await documentServiceFactory.createDocumentService(resolvedUrl);
             // eslint-disable-next-line prefer-promise-reject-errors
-            service.connectToDeltaStorage = async () => Promise.reject(false);
+            service.connectToDeltaStream = async () => Promise.reject(false);
             return service;
         };
 
@@ -86,7 +86,7 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                     clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
                     resolvedUrl: testResolved,
                     version: testRequest.headers?.[LoaderHeader.version],
-                    pause: testRequest.headers?.[LoaderHeader.pause],
+                    loadMode: testRequest.headers?.[LoaderHeader.loadMode],
                 },
             );
 

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "@fluidframework/aqueduct";
 import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
-import { IRequest, IResponse } from "@fluidframework/core-interfaces";
+import { IRequest, IResponse, IRequestHeader } from "@fluidframework/core-interfaces";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
@@ -152,9 +152,9 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
 
     it("loaded container is paused using loader pause flags", async () => {
         // load the container paused
-        const headers = {
+        const headers: IRequestHeader = {
             [LoaderHeader.cache]: false,
-            [LoaderHeader.pause]: true,
+            [LoaderHeader.loadMode]: { deltaConnection: "delayed" },
         };
         const url = await container.getAbsoluteUrl("");
         assert(url, "url is undefined");
@@ -190,8 +190,9 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
         const url = await container.getAbsoluteUrl("");
         assert(url, "url is undefined");
         // load the containers paused
-        const container1 = await loader.resolve({ url, headers: { [LoaderHeader.pause]: true } });
-        const container2 = await loader.resolve({ url, headers: { [LoaderHeader.pause]: true } });
+        const headers: IRequestHeader = { [LoaderHeader.loadMode]: { deltaConnection: "delayed" } };
+        const container1 = await loader.resolve({ url, headers });
+        const container2 = await loader.resolve({ url, headers });
 
         assert.strictEqual(container1, container2, "container not cached across multiple loader requests");
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -9,6 +9,9 @@ import { Container, Loader } from "@fluidframework/container-loader";
 import random from "random-js";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { IRequestHeader } from "@fluidframework/core-interfaces";
+import { LoaderHeader } from "@fluidframework/container-definitions";
+import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { ILoadTest, IRunConfig } from "./loadTestDataStore";
 import { createCodeLoader, createTestDriver, getProfile, loggerP, safeExit } from "./utils";
 import { FaultInjectionDocumentServiceFactory } from "./faultInjectionDriver";
@@ -79,6 +82,39 @@ async function main() {
     await safeExit(result, url, runId);
 }
 
+function *factoryPermutations<T extends IDocumentServiceFactory>(create: () => T) {
+    let counter = 0;
+    const factoryReused = create();
+
+    while (true) {
+        counter++;
+        // Switch between creating new factory vs. reusing factory.
+        // Certain behavior (like driver caches) are per factory instance, and by reusing it we hit those code paths
+        // At the same time we want to test newly created factory.
+        let documentServiceFactory: T = factoryReused;
+        let headers: IRequestHeader = {};
+        switch (counter % 5) {
+            default:
+            case 0:
+                documentServiceFactory = create();
+                break;
+            case 1:
+                headers = { [LoaderHeader.loadMode]: { opsBeforeReturn : "cached"} };
+                break;
+            case 2:
+                headers = { [LoaderHeader.loadMode]: { opsBeforeReturn : "all"} };
+                break;
+            case 3:
+                headers = { [LoaderHeader.loadMode]: { deltaConnection : "none"} };
+                break;
+            case 4:
+                headers = { [LoaderHeader.loadMode]: { deltaConnection : "delayed"} };
+                break;
+        }
+        yield { documentServiceFactory, headers };
+    }
+}
+
 /**
  * Implementation of the runner process. Returns the return code to exit the process with.
  */
@@ -95,17 +131,17 @@ async function runnerProcess(
         const testDriver = await createTestDriver(driver, seed, runConfig.runId);
         const logger = ChildLogger.create(
             await loggerP, undefined, {all: { runId: runConfig.runId, driverType: testDriver.type }});
-        const documentServiceFactoryReused =
-            new FaultInjectionDocumentServiceFactory(testDriver.createDocumentServiceFactory());
 
-        let done = false;
-        for(let iteration = 0; !done; iteration++) {
+        let iteration = 0;
+        const iterator = factoryPermutations(
+            () => new FaultInjectionDocumentServiceFactory(testDriver.createDocumentServiceFactory()));
+
+        for (const {documentServiceFactory, headers} of iterator) {
+            iteration++;
+
             // Switch between creating new factory vs. reusing factory.
             // Certain behavior (like driver caches) are per factory instance, and by reusing it we hit those code paths
             // At the same time we want to test newly created factory.
-            const documentServiceFactory = iteration % 2 === 0 ?
-                documentServiceFactoryReused :
-                new FaultInjectionDocumentServiceFactory(testDriver.createDocumentServiceFactory());
 
             // Construct the loader
             const loader = new Loader({
@@ -116,7 +152,8 @@ async function runnerProcess(
                 options: loaderOptions,
             });
 
-            const container = await loader.resolve({ url });
+            const container = await loader.resolve({ url, headers });
+            container.resume();
             const test = await requestFluidObject<ILoadTest>(container,"/");
 
             scheduleContainerClose(container, runConfig);
@@ -124,8 +161,11 @@ async function runnerProcess(
             try{
                 printProgress(runConfig);
                 printStatus(runConfig, `running`);
-                done = await test.run(runConfig, iteration === 0 /* reset */);
+                const done = await test.run(runConfig, iteration === 0 /* reset */);
                 printStatus(runConfig, done ?  `finished` : "closed");
+                if (done) {
+                    break;
+                }
             }catch(error) {
                 await loggerP.then(
                     async (l)=>l.sendErrorEvent({eventName: "RunnerFailed", runId: runConfig.runId}, error));

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -46,7 +46,7 @@ class WorkerLoader implements ILoader, IFluidRunnable {
             //     docId: decodeURI(this.id),
             //     resolvedUrl: this.resolved,
             //     version: request.headers?.[LoaderHeader.version],
-            //     pause: request.headers?.[LoaderHeader.pause],
+            //     loadMode: request.headers?.[LoaderHeader.loadMode],
             // },
         );
         this.container = container;


### PR DESCRIPTION
This change did not make it into 0.38 by one day.
After discussing it with Jade, we are running out of time to get it into hosts (including Teams) before GA on 5/7, so porting looks like responsible step, given that release likely did not make it yet to Bohemia.
Please let me know if you feel it's too risky given where we are.

Addresses #5477

It gives a lot of flexibility to developers to control loading process.
In particular, it allows Bohemia to apply cached ops before container is returned, and (optionally) allow ops from storage to continue to trickle in through initial boot / render cycle to speed up catch up process (this would need to be tested to ensure existing code behaves correctly in presence of changes).