### PR TITLE
Dev Container: Refresh 'docker-from-docker' and Chromium

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# Fluid Development Container based on "docker-from-docker" template:
+# https://github.com/microsoft/vscode-dev-containers/blob/master/containers/docker-from-docker/.devcontainer/Dockerfile
+
 ARG NODE_VERSION=12
 
 # 'node:${VARIANT}' base image includes the following:
@@ -9,41 +12,34 @@ ARG NODE_VERSION=12
 #
 # Debian base image includes the following:
 #
-#    curl, g++, git, make, procps, python, wget
+#    ca-certificates, curl, g++, git, gnupg, libxss1, make, procps, python, wget
 #
 # (See https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node/.devcontainer)
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
 
+# Install Chromium to get .so libraries required for Puppeteer tests.
+# (Note that Puppeteer bundles its own version of Chromium, we just need OS dependencies.)
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends chromium libxss1
+
 # Install Docker CLI / Docker-Compose and create '/usr/local/share/docker-init.sh' to proxy the
 # docker socket.  (We retrieve the script from the 'docker-from-docker' dev container template)
-RUN mkdir /tmp/library-scripts \
-    && curl -o /tmp/library-scripts/docker-debian.sh -sS https://raw.githubusercontent.com/microsoft/vscode-dev-containers/c3214ad7fcf5086e898e3941a36e0171959a48ca/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh \
-    && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "${SOURCE_SOCKET}" "${TARGET_SOCKET}" "node" \
-    && rm -rf /tmp/library-scripts/
 
-# Update package information before installing
-RUN apt-get update
+# [Option] Enable non-root Docker access in container
+ARG ENABLE_NONROOT_DOCKER="true"
+# [Option] Use the OSS Moby CLI instead of the licensed Docker CLI
+ARG USE_MOBY="true"
 
-# Install .so libraries required for Puppeteer tests
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
-        libpangocairo-1.0-0 \
-        libxi6 \
-        libatk-bridge2.0-0 \
-        libgtk-3-0 \
-        libasound2 \
-        libatk1.0-0 \
-        libcups2 \
-        libnss3 \
-        libx11-6 \
-        libx11-xcb1 \
-        libxcomposite1 \
-        libxcursor1 \
-        libxdamage1 \
-        libxext6 \
-        libxrandr2 \
-        libxss1 \
-        libxtst6
+# A user of "automatic" attempts to reuse an user ID if one already exists.
+ARG USERNAME=automatic
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN mkdir /tmp/library-scripts
+RUN wget -O /tmp/library-scripts/docker-debian.sh https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
+RUN /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}" "${USE_MOBY}"
+RUN rm -rf /tmp/library-scripts/
 
 # Install additional desired packages here
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -63,3 +59,7 @@ RUN git clone https://github.com/zsh-users/zsh-syntax-highlighting ${ZSH_CUSTOM:
 
 # Copy our custom .zshrc to user's home directory
 COPY .zshrc /home/node/.zshrc
+
+# Set '/usr/local/share/docker-init.sh' as entrypoint to proxy Docker socket on start.
+ENTRYPOINT ["/usr/local/share/docker-init.sh"]
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,38 @@
+// Fluid Development Container based on "docker-from-docker" template:
+// https://github.com/microsoft/vscode-dev-containers/blob/master/containers/docker-from-docker/.devcontainer/devcontainer.json
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json
 {
-	"name": "Fluid",
-	"build": {
-		"dockerfile": "Dockerfile",
+    "name": "Fluid",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Update 'NODE_VERSION' to pick a Node version: 10, 12, 14
+        "args": {
+            "NODE_VERSION": "12"
+        }
+    },
+    "runArgs": [ "--init" ],
+    "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
+    "overrideCommand": false,
 
-		// Update 'NODE_VERSION' to pick a Node version: 10, 12, 14
-		"args": { "NODE_VERSION": "12" }
-	},
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.shell.linux": "/usr/bin/zsh"
+    },
 
-    // Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
-    // at the root of the ${workspaceFolder}.
-    "postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install",
-
-    // Expose 'docker.sock' to the dev container and proxy access for the 'node' user.
-	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
-	"postStartCommand": "/usr/local/share/docker-init.sh",
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": { "terminal.integrated.shell.linux": "/usr/bin/zsh" },
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
         "dbaeumer.vscode-eslint",
         "ms-azuretools.vscode-docker",
         "editorconfig.editorconfig"
-	],
+    ],
 
     // Forward port for Tinylicious
-    "forwardPorts": [ 3000 ]
+    "forwardPorts": [ 7070 ],
+
+    // Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
+    // located at the root of the ${workspaceFolder}.
+    "postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install",
+
+    // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "node"
 }


### PR DESCRIPTION
Not much "real" change, just a different way of doing the same things:

* Leverages newer 'docker-from-docker' template to proxy docker socket into dev container.
* Installs 'Chromium' in order to get Puppeteer dependencies instead of installing them manually.
* Fixed Tinylicious port to new 7070.

(I was having some trouble debugging Puppeteer tests in a dev container.  Turned out to be unrelated, but though I'd keep the changes.)