### PR TITLE
VS Code: Add launch config for debugging Jest tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -296,6 +296,22 @@
             "outFiles": [
                 "${fileDirname}/../../dist/**/*.js"
             ],
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Current Jest Test (JS)",
+            "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+            "cwd": "${fileDirname}/..",
+            "args": [
+                "--verbose",
+                "-i",
+                "--no-cache",
+                "${file}"
+            ],
+            "runtimeArgs": ["--unhandled-rejections=strict"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
         }
     ]
 }


### PR DESCRIPTION
Same as "Debug Current Mocha Test (JS)" config, but for Jest.

(I recently looked up the recipe in order to debug a failing Puppeteer test.  Should we keep it?)
