### PR TITLE
Odsp ops caching: More UTs, logging

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -4,9 +4,13 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import * as api from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { TokenFetchOptions } from "@fluidframework/odsp-driver-definitions";
+import { IDeltasFetchResult, IDocumentDeltaStorageService } from "@fluidframework/driver-definitions";
+import {
+    requestOps,
+    streamObserver,
+} from "@fluidframework/driver-utils";
 import { IDeltaStorageGetResponse, ISequencedDeltaOpMessage } from "./contracts";
 import { EpochTracker } from "./epochTracker";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
@@ -27,7 +31,7 @@ export class OdspDeltaStorageService {
     public async get(
         from: number,
         to: number,
-    ): Promise<api.IDeltasFetchResult> {
+    ): Promise<IDeltasFetchResult> {
         return getWithRetryForTokenRefresh(async (options) => {
             // Note - this call ends up in getSocketStorageDiscovery() and can refresh token
             // Thus it needs to be done before we call getStorageToken() to reduce extra calls
@@ -66,5 +70,80 @@ export class OdspDeltaStorageService {
         const filter = encodeURIComponent(`sequenceNumber ge ${from} and sequenceNumber le ${to - 1}`);
         const queryString = `?filter=${filter}`;
         return `${this.deltaFeedUrl}${queryString}`;
+    }
+}
+
+export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
+    public constructor(
+        private snapshotOps: ISequencedDeltaOpMessage[] | undefined,
+        private readonly service: OdspDeltaStorageService,
+        private readonly logger: ITelemetryLogger,
+        private readonly batchSize: number,
+        private readonly concurrency: number,
+        private readonly get: (from: number, to: number) => Promise<ISequencedDocumentMessage[]>,
+        private readonly opsReceived: (ops: ISequencedDocumentMessage[]) => void,
+    ) {
+    }
+
+    public fetchMessages(
+        fromTotal: number,
+        toTotal: number | undefined,
+        abortSignal?: AbortSignal,
+        cachedOnly?: boolean)
+    {
+        let missed = false;
+        const stream = requestOps(
+            async (from: number, to: number) => {
+                if (this.snapshotOps !== undefined && this.snapshotOps.length !== 0) {
+                    const messages = this.snapshotOps.filter((op) =>
+                        op.sequenceNumber >= from).map((op) => op.op);
+                    if (messages.length > 0 && messages[0].sequenceNumber === from) {
+                        // Consider not caching these ops as they will be cached as part of
+                        // snapshot cache entry
+                        this.opsReceived(messages);
+                        this.snapshotOps = undefined;
+                        return { messages, partialResult: true };
+                    } else {
+                        this.logger.sendErrorEvent({
+                            eventName: "SnapshotOpsNotUsed",
+                            length: this.snapshotOps.length,
+                            first: this.snapshotOps[0].sequenceNumber,
+                            from,
+                            to,
+                        });
+                        this.snapshotOps = undefined;
+                    }
+                }
+                // We always write ops sequentially. Once there is a miss, stop consulting cache.
+                // This saves a bit of processing time
+                if (!missed) {
+                    const messagesFromCache = await this.get(from, to);
+                    if (messagesFromCache !== undefined && messagesFromCache.length !== 0) {
+                        return {
+                            messages: messagesFromCache,
+                            partialResult: true,
+                        };
+                    }
+                    missed = true;
+                }
+
+                // Proper implementaiton Coming in future
+                if (cachedOnly) {
+                    return { messages: [], partialResult: false };
+                }
+
+                return this.service.get(from, to);
+            },
+            // Staging: starting with no concurrency, listening for feedback first.
+            // In future releases we will switch to actual concurrency
+            this.concurrency,
+            fromTotal, // inclusive
+            toTotal, // exclusive
+            this.batchSize,
+            this.logger,
+            abortSignal,
+        );
+
+        return streamObserver(stream, (ops) => this.opsReceived(ops));
     }
 }

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -220,7 +220,7 @@ export class OdspDocumentService implements IDocumentService {
      * @returns returns the document delta storage service for sharepoint driver.
      */
     public async connectToDeltaStorage(): Promise<IDocumentDeltaStorageService> {
-        const snapshotOps = this.storageManager?.ops;
+        const snapshotOps = this.storageManager?.ops ?? [];
         const service = new OdspDeltaStorageService(
             this.odspResolvedUrl.endpoints.deltaStorageUrl,
             this.getStorageToken,
@@ -233,11 +233,11 @@ export class OdspDocumentService implements IDocumentService {
         const concurrency = this.hostPolicy.concurrentOpsBatches ?? 1;
 
         return new OdspDeltaStorageWithCache(
-            snapshotOps,
-            service,
+            snapshotOps.map((op) => op.op),
             this.logger,
             batchSize,
             concurrency,
+            async (from, to) => service.get(from, to),
             async (from, to) => {
                 const res = await this.opsCache?.get(from, to);
                 return res as ISequencedDocumentMessage[] ?? [];

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -19,8 +19,6 @@ import {
 } from "@fluidframework/driver-definitions";
 import {
     canRetryOnError,
-    requestOps,
-    streamObserver,
 } from "@fluidframework/driver-utils";
 import { fetchTokenErrorCode, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import {
@@ -39,7 +37,7 @@ import {
     ISocketStorageDiscovery,
 } from "./contracts";
 import { IOdspCache } from "./odspCache";
-import { OdspDeltaStorageService } from "./odspDeltaStorageService";
+import { OdspDeltaStorageService, OdspDeltaStorageWithCache } from "./odspDeltaStorageService";
 import { OdspDocumentDeltaConnection } from "./odspDocumentDeltaConnection";
 import { OdspDocumentStorageService } from "./odspDocumentStorageManager";
 import { getWithRetryForTokenRefresh, isLocalStorageAvailable, getOdspResolvedUrl } from "./odspUtils";
@@ -222,7 +220,7 @@ export class OdspDocumentService implements IDocumentService {
      * @returns returns the document delta storage service for sharepoint driver.
      */
     public async connectToDeltaStorage(): Promise<IDocumentDeltaStorageService> {
-        let snapshotOps = this.storageManager?.ops;
+        const snapshotOps = this.storageManager?.ops;
         const service = new OdspDeltaStorageService(
             this.odspResolvedUrl.endpoints.deltaStorageUrl,
             this.getStorageToken,
@@ -234,68 +232,18 @@ export class OdspDocumentService implements IDocumentService {
         const batchSize = this.hostPolicy.opsBatchSize ?? 5000;
         const concurrency = this.hostPolicy.concurrentOpsBatches ?? 1;
 
-        return {
-            fetchMessages: (
-                fromTotal: number,
-                toTotal: number | undefined,
-                abortSignal?: AbortSignal,
-                cachedOnly?: boolean) => {
-                    let missed = false;
-                    const stream = requestOps(
-                        async (from: number, to: number) => {
-                            if (snapshotOps !== undefined && snapshotOps.length !== 0) {
-                                const messages = snapshotOps.filter((op) =>
-                                    op.sequenceNumber >= from).map((op) => op.op);
-                                if (messages.length > 0 && messages[0].sequenceNumber === from) {
-                                    // Consider not caching these ops as they will be cached as part of
-                                    // snapshot cache entry
-                                    this.opsReceived(messages);
-                                    snapshotOps = undefined;
-                                    return { messages, partialResult: true };
-                                } else {
-                                    this.logger.sendErrorEvent({
-                                        eventName: "SnapshotOpsNotUsed",
-                                        length: snapshotOps.length,
-                                        first: snapshotOps[0].sequenceNumber,
-                                        from,
-                                        to,
-                                    });
-                                    snapshotOps = undefined;
-                                }
-                            }
-                                    // We always write ops sequentially. Once there is a miss, stop consulting cache.
-                            // This saves a bit of processing time
-                            if (!missed) {
-                                const messagesFromCache = await this.opsCache?.get(from, to);
-                                if (messagesFromCache !== undefined && messagesFromCache.length !== 0) {
-                                    return {
-                                        messages: messagesFromCache as ISequencedDocumentMessage[],
-                                        partialResult: true,
-                                    };
-                                }
-                                missed = true;
-                            }
-
-                            // Proper implementaiton Coming in future
-                            if (cachedOnly) {
-                                return { messages: [], partialResult: false };
-                            }
-
-                            return service.get(from, to);
-                        },
-                        // Staging: starting with no concurrency, listening for feedback first.
-                        // In future releases we will switch to actual concurrency
-                        concurrency,
-                        fromTotal, // inclusive
-                        toTotal, // exclusive
-                        batchSize,
-                        this.logger,
-                        abortSignal,
-                    );
-
-                    return streamObserver(stream, (ops) => this.opsReceived(ops));
-                },
-        };
+        return new OdspDeltaStorageWithCache(
+            snapshotOps,
+            service,
+            this.logger,
+            batchSize,
+            concurrency,
+            async (from, to) => {
+                const res = await this.opsCache?.get(from, to);
+                return res as ISequencedDocumentMessage[] ?? [];
+            },
+            (ops: ISequencedDocumentMessage[]) => this.opsReceived(ops),
+        );
     }
 
     /**

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -4,6 +4,7 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { performance } from "@fluidframework/common-utils";
 
 // ISequencedDocumentMessage
 export interface IMessage {
@@ -110,6 +111,7 @@ export class OpsCache {
     public async get(from: number, to?: number): Promise<IMessage[]> {
         const messages: IMessage[] = [];
         let batchNumber = this.getBatchNumber(from + 1);
+        const start = performance.now();
         // eslint-disable-next-line no-constant-condition
         while (true) {
             const res = await this.cache.read(`${this.batchSize}_${batchNumber}`);
@@ -144,6 +146,7 @@ export class OpsCache {
                 from,
                 to,
                 length: messages.length,
+                duration: performance.now() - start,
             });
         }
         return messages;

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -4,6 +4,9 @@
  */
 import { strict as assert } from "assert";
 import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { IStream } from "@fluidframework/driver-definitions";
+import { OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { OpsCache, ICache, IMessage, CacheEntry } from "../opsCaching";
 
 export type MyDataInput = IMessage & { data: string; };
@@ -167,7 +170,7 @@ export async function runTest(
     await runTestWithTimer(batchSize, initialSeq, mockData, expected, initialWritesExpected, totalWritesExpected);
 }
 
-describe("OpsCache write", () => {
+describe("OpsCache", () => {
     const mockData1: MyDataInput[] = [
         { sequenceNumber: 105, data: "105" },
         { sequenceNumber: 110, data: "110" },
@@ -243,5 +246,139 @@ describe("OpsCache write", () => {
             },
             2,
             2);
+    });
+});
+
+describe("OdspDeltaStorageWithCache", () => {
+    async function readAll(stream: IStream<ISequencedDocumentMessage[]>) {
+        const ops: ISequencedDocumentMessage[] = [];
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const result = await stream.read();
+            if (result.done) { break; }
+            ops.push(...result.value);
+        }
+        return ops;
+    }
+
+    const batchSize = 100;
+    const concurrency = 1;
+
+    function createOps(fromArg: number, length: number) {
+        const ops: ISequencedDocumentMessage[] = [];
+        let from = fromArg;
+        const to = from + length;
+        while (from < to) {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            ops.push({ sequenceNumber: from } as ISequencedDocumentMessage);
+            from++;
+        }
+        return ops;
+    }
+
+    function filterOps(ops: ISequencedDocumentMessage[], from: number, to: number) {
+        return ops.filter((op) => op.sequenceNumber >= from && op.sequenceNumber < to);
+    }
+
+    function validateOps(ops: ISequencedDocumentMessage[], from: number, to: number) {
+        if (to < from) {
+            assert(ops.length === 0);
+        } else {
+            assert(ops.length === to - from);
+            assert(ops.length === 0 || ops[0].sequenceNumber === from);
+            assert(ops.length === 0 || ops[ops.length - 1].sequenceNumber === to - 1);
+        }
+    }
+
+    async function testStorage(
+        fromTotal: number,
+        toTotal: number | undefined,
+        cacheOnly: boolean,
+        opsFromSnapshot: number,
+        opsFromCache: number,
+        opsFromStorage: number,
+    ) {
+        const snapshotOps = createOps(fromTotal, opsFromSnapshot);
+        const cachedOps = createOps(fromTotal + opsFromSnapshot, opsFromCache);
+        const storageOps = createOps(fromTotal + opsFromSnapshot + opsFromCache, opsFromStorage);
+
+        let totalOps = opsFromSnapshot + opsFromCache + (cacheOnly ? 0 : opsFromStorage);
+        const actualTo = toTotal === undefined ? fromTotal + totalOps : toTotal;
+        assert(actualTo <= fromTotal + totalOps); // code will deadlock if that's not the case
+        const askingOps = actualTo - fromTotal;
+        totalOps = Math.min(totalOps, askingOps);
+
+        const opsToCache: ISequencedDocumentMessage[] = [];
+
+        const storage = new OdspDeltaStorageWithCache(
+            snapshotOps,
+            new TelemetryUTLogger(),
+            batchSize,
+            concurrency,
+            // getFromStorage
+            async (from: number, to: number) => {
+                return {messages: filterOps(storageOps, from, to), partialResult: false};
+            },
+            // getCached
+            async (from: number, to: number) => filterOps(cachedOps, from, to),
+            // opsReceived
+            (ops: ISequencedDocumentMessage[]) => opsToCache.push(...ops),
+        );
+
+        const stream = storage.fetchMessages(
+            fromTotal,
+            toTotal,
+            undefined, // abortSignal
+            cacheOnly,
+        );
+
+        const opsAll = await readAll(stream);
+
+        validateOps(opsAll, fromTotal, fromTotal + totalOps);
+        if (cacheOnly) {
+            assert(opsToCache.length === 0);
+        } else {
+            validateOps(opsToCache, fromTotal + opsFromSnapshot + opsFromCache, fromTotal + totalOps);
+        }
+    }
+
+    it("test all", async () => {
+        await testStorage(105, undefined, false, 0, 0, 0);
+        await testStorage(105, undefined, false, 110, 0, 0);
+        await testStorage(105, undefined, false, 110, 245, 0);
+        await testStorage(105, undefined, false, 110, 245, 1000);
+        await testStorage(105, undefined, false, 110, 9001, 8002);
+
+        await testStorage(105, undefined, false, 0, 245, 0);
+        await testStorage(105, undefined, false, 0, 9000, 0);
+        await testStorage(105, undefined, false, 0, 245, 150);
+
+        await testStorage(105, undefined, false, 110, 0, 150);
+        await testStorage(105, undefined, false, 0, 0, 150);
+    });
+
+    it("test cached", async () => {
+        await testStorage(105, undefined, true, 0, 0, 0);
+        await testStorage(105, undefined, true, 110, 0, 0);
+        await testStorage(105, undefined, true, 110, 245, 0);
+        await testStorage(105, undefined, true, 1001, 8001, 0);
+        await testStorage(105, undefined, true, 110, 245, 1000);
+
+        await testStorage(105, undefined, true, 0, 245, 0);
+        await testStorage(105, undefined, true, 0, 245, 150);
+
+        await testStorage(105, undefined, true, 110, 0, 150);
+        await testStorage(105, undefined, true, 0, 0, 150);
+    });
+
+    it("test fixed to", async () => {
+        await testStorage(105, 105 + 110, false, 110, 0, 0);
+        await testStorage(105, 105 + 110 + 245, false, 110, 245, 0);
+        await testStorage(105, 105 + 110 + 245 + 500, false, 110, 245, 1000);
+
+        await testStorage(105, 105 + 245 + 150, false, 0, 245, 150);
+
+        await testStorage(105, 105 + 110 + 150, false, 110, 0, 150);
+        await testStorage(105, 105 + 140, false, 0, 0, 150);
     });
 });

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -534,13 +534,11 @@ export function streamFromMessages(messagesArg: Promise<ISequencedDocumentMessag
 }
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function streamObserver<T>(stream: IStream<T>, handler: (value: T) => void): IStream<T> {
+export function streamObserver<T>(stream: IStream<T>, handler: (value: IStreamResult<T>) => void): IStream<T> {
     return {
         read: async () => {
             const value = await stream.read();
-            if (value.done === false) {
-                handler(value.value);
-            }
+            handler(value);
             return value;
         },
     };


### PR DESCRIPTION
Move ODSP fetchMessages logic into its own class, cover it with UTs, add more logging and address issues that are hit in UT (they are not impacting current production flows, but good to address to make platform more robust for future scenarios)