### PR TITLE
Add handling for 410 (error code raised by ODSP when we try to fetch ops that were deleted)

### DIFF
--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -47,7 +47,7 @@ export enum OdspErrorType {
     // This condition will happen when user was offline for too long, resulting in old ops / blobs being deleted
     // by storage, and thus removing an ability for client to catch up.
     // This ondition will result in any local changes being lost (i.e. only way to save state is by user
-    // copying it over mannually)
+    // copying it over manually)
     cannotCatchUp = "cannotCatchUp",
 }
 

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -46,7 +46,7 @@ export enum OdspErrorType {
     // This error will be raised when client is too behind with no way to catch up.
     // This condition will happen when user was offline for too long, resulting in old ops / blobs being deleted
     // by storage, and thus removing an ability for client to catch up.
-    // This ondition will result in any local changes being lost (i.e. only way to save state is by user
+    // This condition will result in any local changes being lost (i.e. only way to save state is by user
     // copying it over manually)
     cannotCatchUp = "cannotCatchUp",
 }

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -42,6 +42,13 @@ export enum OdspErrorType {
     epochVersionMismatch = "epochVersionMismatch",
 
     fetchTokenError = "fetchTokenError",
+
+    // This error will be raised when client is too behind with no way to catch up.
+    // This condition will happen when user was offline for too long, resulting in old ops / blobs being deleted
+    // by storage, and thus removing an ability for client to catch up.
+    // This ondition will result in any local changes being lost (i.e. only way to save state is by user
+    // copying it over mannually)
+    cannotCatchUp = "cannotCatchUp",
 }
 
 /**

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -5,7 +5,7 @@
 
 import { DriverError } from "@fluidframework/driver-definitions";
 import {
-    NetworkErrorBasic,
+    NonRetryableError,
     GenericNetworkError,
     createGenericNetworkError,
     AuthorizationError,
@@ -61,8 +61,8 @@ export function createR11sNetworkError(
         case 403:
             return new AuthorizationError(errorMessage, undefined, undefined, statusCode);
         case 404:
-            return new NetworkErrorBasic(
-                errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, false, statusCode);
+            return new NonRetryableError(
+                errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, statusCode);
         case 429:
             return createGenericNetworkError(
                 errorMessage, true, retryAfterSeconds, statusCode);

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -57,7 +57,7 @@ export class AuthorizationError extends LoggingError implements IAuthorizationEr
     }
 }
 
-class NetworkErrorBasic<T> extends LoggingError {
+export class NetworkErrorBasic<T> extends LoggingError {
     constructor(
         errorMessage: string,
         readonly errorType: T,

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -57,7 +57,7 @@ export class AuthorizationError extends LoggingError implements IAuthorizationEr
     }
 }
 
-export class NetworkErrorBasic<T> extends LoggingError {
+class NetworkErrorBasic<T> extends LoggingError {
     constructor(
         errorMessage: string,
         readonly errorType: T,
@@ -75,6 +75,16 @@ export class NonRetryableError<T> extends NetworkErrorBasic<T> {
         statusCode: number | undefined,
     ) {
         super(errorMessage, errorType, false, statusCode);
+    }
+}
+
+export class RetryableError<T> extends NetworkErrorBasic<T> {
+    constructor(
+        errorMessage: string,
+        readonly errorType: T,
+        statusCode: number | undefined,
+    ) {
+        super(errorMessage, errorType, true, statusCode);
     }
 }
 

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -21,7 +21,7 @@ import {
     IDocumentStorageService,
     LoaderCachingPolicy,
 } from "@fluidframework/driver-definitions";
-import { NetworkErrorBasic, readAndParse } from "@fluidframework/driver-utils";
+import { NonRetryableError, readAndParse } from "@fluidframework/driver-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ReferenceType, TextSegment } from "@fluidframework/merge-tree";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
@@ -99,10 +99,9 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
                             const blobObj = await readAndParse<any>(realStorage, id);
                             // throw when trying to load the header blob
                             if (blobObj.headerMetadata !== undefined) {
-                                throw new NetworkErrorBasic(
+                                throw new NonRetryableError(
                                     "Not Found",
                                     undefined,
-                                    false,
                                     404);
                             }
                             return blob;


### PR DESCRIPTION
Also remove usage of NetworkErrorBasic in favor of more descriptive NonRetryableError & RetryableError classes.