### PR TITLE
[main > 0.38]: Fix Retry Seconds Milliseconds Confusion

### DIFF
--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -55,7 +55,7 @@ export async function getFileLink(
     const valueGenerator = async function() {
         let result: string | undefined;
         let success = false;
-        let retryAfter = 1;
+        let retryAfterSeconds = 1;
         do {
             try {
                 result = await getFileLinkCore(getToken, odspUrlParts, identityType, logger);
@@ -68,8 +68,8 @@ export async function getFileLink(
                 }
                 // If the error is throttling error, then wait for the specified time before retrying.
                 // If the waitTime is not specified, then we start with retrying immediately to max of 8s.
-                retryAfter = getRetryDelayFromError(err) ?? Math.min(retryAfter * 2, 8000);
-                await delay(retryAfter);
+                retryAfterSeconds = getRetryDelayFromError(err) ?? Math.min(retryAfterSeconds * 2, 8);
+                await delay(retryAfterSeconds * 1000);
             }
         } while (!success);
         return result;

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -117,7 +117,7 @@ export async function runWithRetry<T>(
 ): Promise<T> {
     let result: T | undefined;
     let success = false;
-    let retryAfter = 1; // has to be positive!
+    let retryAfterSeconds = 1; // has to be positive!
     let numRetries = 0;
     const startTime = performance.now();
     let lastError: any;
@@ -152,12 +152,12 @@ export async function runWithRetry<T>(
             lastError = err;
             // If the error is throttling error, then wait for the specified time before retrying.
             // If the waitTime is not specified, then we start with retrying immediately to max of 8s.
-            retryAfter = getRetryDelayFromError(err) ?? Math.min(retryAfter * 2, 8000);
+            retryAfterSeconds = getRetryDelayFromError(err) ?? Math.min(retryAfterSeconds * 2, 8);
             if (id === undefined) {
                 id = uuid();
             }
-            deltaManager.emitDelayInfo(id, retryAfter, CreateContainerError(err));
-            await delay(retryAfter);
+            deltaManager.emitDelayInfo(id, retryAfterSeconds, CreateContainerError(err));
+            await delay(retryAfterSeconds * 1000);
         }
     } while (!success);
     if (numRetries > 0) {

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -669,5 +669,5 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
             assert.strictEqual(container.id, provider.documentId, "Doc id is not matching!!");
         }
         assert.strictEqual(retryTimes, 0, "Should not succeed at first time");
-    });
+    }).timeout(5000);
 });


### PR DESCRIPTION
Fix bug in retry logic where we were not consistent with time units. specifically sometime we used seconds, and other time we use milliseconds, which lead to incorrect timeout delays