### PR TITLE
Add unreferenced property to ISnapshotTree in protocol definitions

### DIFF
--- a/server/routerlicious/packages/protocol-definitions/src/storage.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/storage.ts
@@ -101,6 +101,8 @@ export interface ISnapshotTree {
     // TODO: Commits should be removed from here to ISnapshotTreeEx once ODSP snapshots move away from commits
     commits: { [path: string]: string };
     trees: { [path: string]: ISnapshotTree };
+    // Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
+    unreferenced?: true;
 }
 
 export interface ISnapshotTreeEx extends ISnapshotTree {


### PR DESCRIPTION
Added "unreferenced" property to ISnapshotTree that is sent by the driver to the runtime. This is required for #5807