### PR TITLE
Always wait for removeMemver event in case the client was in quorum and had unacked ops

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -15,7 +15,6 @@ export interface IConnectionStateHandler {
     protocolHandler: () => ProtocolOpHandler | undefined,
     logConnectionStateChangeTelemetry:
         (value: ConnectionState, oldState: ConnectionState, reason?: string | undefined) => void,
-    shouldClientJoinWrite: () => boolean,
     maxClientLeaveWaitTime: number | undefined,
 }
 
@@ -35,12 +34,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
     private _pendingClientId: string | undefined;
     private _clientId: string | undefined;
     private readonly prevClientLeftTimer: Timer;
-    // True if we received the leave. False if timed out. Undefined when
-    // starting the timer.
-    private leaveReceivedResult: boolean | undefined;
     private waitEvent: PerformanceEvent | undefined;
-    private _clientSentOps: boolean = false;
-    private clientConnectionMode: ConnectionMode | undefined;
 
     public get connectionState(): ConnectionState {
         return this._connectionState;
@@ -67,18 +61,9 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
             // Default is 90 sec for which we are going to wait for its own "leave" message.
             this.handler.maxClientLeaveWaitTime ?? 90000,
             () => {
-                this.leaveReceivedResult = false;
                 this.applyForConnectedState("timeout");
             },
         );
-    }
-
-    // This is true when this client submitted any ops.
-    public clientSentOps(connectionMode: ConnectionMode) {
-        assert(this._connectionState === ConnectionState.Connected,
-            0x1d7 /* "Ops could only be sent when connected" */);
-        this._clientSentOps = true;
-        this.clientConnectionMode = connectionMode;
     }
 
     public receivedAddMemberEvent(clientId: string) {
@@ -89,7 +74,6 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
                 this.waitEvent = PerformanceEvent.start(this.logger, {
                     eventName: "WaitBeforeClientLeave",
                     waitOnClientId: this._clientId,
-                    hadOutstandingOps: this.handler.shouldClientJoinWrite(),
                 });
             }
             this.applyForConnectedState("addMemberEvent");
@@ -106,7 +90,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
             && protocolHandler !== undefined && protocolHandler.quorum.getMember(this.pendingClientId) !== undefined
             && !this.prevClientLeftTimer.hasTimer
         ) {
-            this.waitEvent?.end({ leaveReceived: this.leaveReceivedResult, source });
+            this.waitEvent?.end({ source });
             this.setConnectionState(ConnectionState.Connected);
         } else {
             // Adding this event temporarily so that we can get help debugging if something goes wrong.
@@ -126,7 +110,6 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         // If the client which has left was us, then finish the timer.
         if (this.clientId === clientId) {
             this.prevClientLeftTimer.clear();
-            this.leaveReceivedResult = true;
             this.applyForConnectedState("removeMemberEvent");
         }
     }
@@ -150,7 +133,6 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         // join message. after we see the join message for out new connection with our new client id,
         // we know there can no longer be outstanding ops that we sent with the previous client id.
         this._pendingClientId = details.clientId;
-
         // Report telemetry after we set client id!
         this.handler.logConnectionStateChangeTelemetry(ConnectionState.Connecting, oldState);
 
@@ -178,47 +160,33 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
 
         const oldState = this._connectionState;
         this._connectionState = value;
+        let client: ILocalSequencedClient | undefined;
+        if (this._clientId !== undefined) {
+            client = this.handler.protocolHandler()?.quorum.getMember(this._clientId);
+        }
         if (value === ConnectionState.Connected) {
             assert(oldState === ConnectionState.Connecting,
                 0x1d8 /* "Should only transition from Connecting state" */);
             // Mark our old client should have left in the quorum if it's still there
-            if (this._clientId !== undefined) {
-                const client: ILocalSequencedClient | undefined =
-                    this.handler.protocolHandler()?.quorum.getMember(this._clientId);
-                if (client !== undefined) {
-                    client.shouldHaveLeft = true;
-                }
+            if (client !== undefined) {
+                client.shouldHaveLeft = true;
             }
             this._clientId = this.pendingClientId;
-            // Set _clientSentOps to false as this is a fresh connection.
-            this._clientSentOps = false;
         } else if (value === ConnectionState.Disconnected) {
             // Important as we process our own joinSession message through delta request
             this._pendingClientId = undefined;
-            // Only wait for "leave" message if we have some outstanding ops and the client was write client as
-            // server would not accept ops from read client. Also check if the timer is not already running as we
-            // could receive "Disconnected" event multiple times without getting connected and in that case we
+            // Only wait for "leave" message if the connected client exists in the quorum because only the write
+            // client will exist in the quorum and only for those clients we will receive "removeMember" event.
+            // Also server would not accept ops from read client. Also check if the timer is not already running as
+            // we could receive "Disconnected" event multiple times without getting connected and in that case we
             // don't want to reset the timer as we still want to wait on original client which started this timer.
-            // We also check the dirty state of this connection as we only want to wait for the client leave of the
-            // client which created the ops. This helps with situation where a client disconnects immediately after
-            // getting connected without sending any ops(from previous client). In this case, we would join as write
-            // because there would be a diff between client seq number and clientSeqNumberObserved but then we don't
-            // want to wait for newly disconnected client to leave as it has not sent any ops yet.
-            if (this.handler.shouldClientJoinWrite()
-                && this.clientConnectionMode === "write"
-                && this.prevClientLeftTimer.hasTimer === false
-                && this._clientSentOps
-            ) {
-                this.leaveReceivedResult = undefined;
+            if (client !== undefined && this.prevClientLeftTimer.hasTimer === false) {
                 this.prevClientLeftTimer.restart();
             } else {
                 // Adding this event temporarily so that we can get help debugging if something goes wrong.
                 this.logger.sendTelemetryEvent({
                     eventName: "noWaitOnDisconnected",
-                    clientConnectionMode: this.clientConnectionMode,
                     hasTimer: this.prevClientLeftTimer.hasTimer,
-                    clientSentOps: this._clientSentOps,
-                    shouldClientJoinWrite: this.handler.shouldClientJoinWrite(),
                 });
             }
         }

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -186,6 +186,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
                 // Adding this event temporarily so that we can get help debugging if something goes wrong.
                 this.logger.sendTelemetryEvent({
                     eventName: "noWaitOnDisconnected",
+                    inQuorum: client !== undefined,
                     hasTimer: this.prevClientLeftTimer.hasTimer,
                 });
             }

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -164,10 +164,9 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         const oldState = this._connectionState;
         this._connectionState = value;
         const quorum = this.handler.protocolHandler()?.quorum;
-        assert(quorum !== undefined, "Quorum should be defined here!");
         let client: ILocalSequencedClient | undefined;
         if (this._clientId !== undefined) {
-            client = quorum.getMember(this._clientId);
+            client = quorum?.getMember(this._clientId);
         }
         if (value === ConnectionState.Connected) {
             assert(oldState === ConnectionState.Connecting,

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -163,9 +163,11 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
 
         const oldState = this._connectionState;
         this._connectionState = value;
+        const quorum = this.handler.protocolHandler()?.quorum;
+        assert(quorum !== undefined, "Quorum should be defined here!");
         let client: ILocalSequencedClient | undefined;
         if (this._clientId !== undefined) {
-            client = this.handler.protocolHandler()?.quorum.getMember(this._clientId);
+            client = quorum.getMember(this._clientId);
         }
         if (value === ConnectionState.Connected) {
             assert(oldState === ConnectionState.Connecting,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1549,6 +1549,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         deltaManager.on("disconnect", (reason: string) => {
             this.manualReconnectInProgress = false;
+            // Register submitOp event again as we only want to listen for first op from this client.
+            this.registerSubmitOpEvent();
             this.connectionStateHandler.receivedDisconnectEvent(reason);
         });
 
@@ -1561,6 +1563,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         });
 
         return deltaManager;
+    }
+
+    private registerSubmitOpEvent() {
+        this._deltaManager.once("submitOp", (message: IDocumentMessage) => {
+            this.connectionStateHandler.clientSentOps(this._deltaManager.connectionMode);
+        });
     }
 
     private attachDeltaManagerOpHandler(attributes: IDocumentAttributes): void {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -626,6 +626,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 protocolHandler: () => this._protocolHandler,
                 logConnectionStateChangeTelemetry: (value, oldState, reason) =>
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
+                shouldClientJoinWrite: () => this._deltaManager.shouldJoinWrite(),
                 maxClientLeaveWaitTime: this.loader.services.options.maxClientLeaveWaitTime,
             },
             this.logger,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -626,7 +626,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 protocolHandler: () => this._protocolHandler,
                 logConnectionStateChangeTelemetry: (value, oldState, reason) =>
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
-                shouldClientJoinWrite: () => this._deltaManager.shouldJoinWrite(),
                 maxClientLeaveWaitTime: this.loader.services.options.maxClientLeaveWaitTime,
             },
             this.logger,
@@ -1543,14 +1542,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             }
         });
 
-        deltaManager.once("submitOp", (message: IDocumentMessage) => {
-            this.connectionStateHandler.clientSentOps(this._deltaManager.connectionMode);
-        });
-
         deltaManager.on("disconnect", (reason: string) => {
             this.manualReconnectInProgress = false;
-            // Register submitOp event again as we only want to listen for first op from this client.
-            this.registerSubmitOpEvent();
             this.connectionStateHandler.receivedDisconnectEvent(reason);
         });
 
@@ -1563,12 +1556,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         });
 
         return deltaManager;
-    }
-
-    private registerSubmitOpEvent() {
-        this._deltaManager.once("submitOp", (message: IDocumentMessage) => {
-            this.connectionStateHandler.clientSentOps(this._deltaManager.connectionMode);
-        });
     }
 
     private attachDeltaManagerOpHandler(attributes: IDocumentAttributes): void {

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -16,6 +16,7 @@ describe("ConnectionStateHandler Tests", () => {
     let clock: SinonFakeTimers;
     let connectionStateHandler: ConnectionStateHandler;
     let protocolHandler: ProtocolOpHandler;
+    let shouldClientJoinWrite: boolean;
     let connectionDetails: IConnectionDetails;
     let client: IClient;
     const expectedTimeout = 90000;
@@ -73,6 +74,7 @@ describe("ConnectionStateHandler Tests", () => {
                 logConnectionStateChangeTelemetry: () => undefined,
                 maxClientLeaveWaitTime: expectedTimeout,
                 protocolHandler: () => protocolHandler,
+                shouldClientJoinWrite: () => shouldClientJoinWrite,
             },
             new TelemetryNullLogger(),
         );
@@ -111,6 +113,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client should be in connected state");
 
+        shouldClientJoinWrite = true;
         client.mode = "write";
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -139,6 +142,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client should be in connected state");
 
+        shouldClientJoinWrite = true;
         client.mode = "write";
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -173,6 +177,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
+        shouldClientJoinWrite = true;
         client.mode = "write";
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -218,6 +223,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
+        shouldClientJoinWrite = true;
         client.mode = "write";
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -269,6 +275,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
+        shouldClientJoinWrite = true;
         client.mode = "write";
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -318,6 +325,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
+        shouldClientJoinWrite = true;
         client.mode = "write";
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
@@ -372,6 +380,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
+        shouldClientJoinWrite = true;
         client.mode = "write";
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -16,7 +16,6 @@ describe("ConnectionStateHandler Tests", () => {
     let clock: SinonFakeTimers;
     let connectionStateHandler: ConnectionStateHandler;
     let protocolHandler: ProtocolOpHandler;
-    let shouldClientJoinWrite: boolean;
     let connectionDetails: IConnectionDetails;
     let client: IClient;
     const expectedTimeout = 90000;
@@ -74,7 +73,6 @@ describe("ConnectionStateHandler Tests", () => {
                 logConnectionStateChangeTelemetry: () => undefined,
                 maxClientLeaveWaitTime: expectedTimeout,
                 protocolHandler: () => protocolHandler,
-                shouldClientJoinWrite: () => shouldClientJoinWrite,
             },
             new TelemetryNullLogger(),
         );
@@ -113,10 +111,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client should be in connected state");
 
-        // Mock as though the client sent some ops.
-        shouldClientJoinWrite = true;
         client.mode = "write";
-        connectionStateHandler.clientSentOps(client.mode);
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -144,10 +139,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client should be in connected state");
 
-        // Mock as though the client sent some ops.
-        shouldClientJoinWrite = true;
         client.mode = "write";
-        connectionStateHandler.clientSentOps(client.mode);
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -181,10 +173,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
-        // Mock as though the client sent some ops.
-        shouldClientJoinWrite = true;
         client.mode = "write";
-        connectionStateHandler.clientSentOps(client.mode);
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -229,10 +218,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
-        // Mock as though the client sent some ops.
-        shouldClientJoinWrite = true;
         client.mode = "write";
-        connectionStateHandler.clientSentOps(client.mode);
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -283,10 +269,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
-        // Mock as though the client sent some ops.
-        shouldClientJoinWrite = true;
         client.mode = "write";
-        connectionStateHandler.clientSentOps(client.mode);
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -335,10 +318,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
-        // Mock as though the client sent some ops.
-        shouldClientJoinWrite = true;
         client.mode = "write";
-        connectionStateHandler.clientSentOps(client.mode);
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -382,7 +362,7 @@ describe("ConnectionStateHandler Tests", () => {
             "Client 3 should move to connected state");
     });
 
-    it("Client 3 should not wait for client 2(which got disconnected without sending any ops) to leave " +
+    it("Client 3 should wait for client 2(which got disconnected without sending any ops) to leave " +
         "when client 2 already waited on client 1", async () =>
     {
         client.mode = "write";
@@ -392,10 +372,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 1 should be in connected state");
 
-        // Mock as though the client sent some ops.
-        shouldClientJoinWrite = true;
         client.mode = "write";
-        connectionStateHandler.clientSentOps(client.mode);
         // Disconnect the client
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
@@ -414,7 +391,7 @@ describe("ConnectionStateHandler Tests", () => {
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 2 should move to connected state");
 
-        // Client 2 leaves without sending any ops. So dirty state should be false
+        // Client 2 leaves without sending any ops.
         connectionStateHandler.receivedDisconnectEvent("Test");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
             "Client 2 should be in disconnected state");
@@ -426,6 +403,11 @@ describe("ConnectionStateHandler Tests", () => {
             "Client 3 should still be in connecting state");
         protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
         connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+            "Client 3 should still be in connecting state");
+
+        // Client 2 leaves.
+        connectionStateHandler.receivedRemoveMemberEvent("pendingClientId2");
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 3 should move to connected state");
         // Timeout should not raise any error as timer should be cleared


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/5866
We were listening to the submitOp event only once and rather we had to listen to it once for a new client. Because of this mostly we were not waiting on the client leave op. This tells us that the new client has suibmitted ops for itself and hence connectionhandler might need to wait for leave op.

But we have removed this logic all together to make it simpler. Now we always wait for removeMember event in case the client was in quorum and had unacked ops