### PR TITLE
Delete all cached into about the file if we can't cache all the ops because we hit the limit

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -477,11 +477,13 @@ export class OdspDocumentService implements IDocumentService {
         this._opsCache = new OpsCache(
             seqNumber,
             this.logger,
+            // ICache
             {
                 write: async (key: string, opsData: string) => {
                     return this.cache.persistedCache.put({...opsKey, key}, opsData);
                 },
                 read: async (batch: string) => undefined,
+                remove: () => { this.cache.persistedCache.removeEntries().catch(() => {}); },
             },
             this.hostPolicy.opsCaching?.batchSize ?? 100,
             this.hostPolicy.opsCaching?.timerGranularity ?? 5000,

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -25,6 +25,7 @@ export interface IBatch {
 export interface ICache {
   write(batchNumber: string, data: string): Promise<void>;
   read(batchNumber: string): Promise<string | undefined>;
+  remove(): void;
 }
 
 export class OpsCache {
@@ -49,6 +50,14 @@ export class OpsCache {
                 batchData : this.initializeNewBatchDataArray(),
                 dirty: false,
             });
+        }
+    }
+
+    public dispose() {
+        this.batches.clear();
+        if (this.timer !== undefined) {
+            clearTimeout(this.timer);
+            this.timer = undefined;
         }
     }
 
@@ -101,8 +110,8 @@ export class OpsCache {
             this.totalOpsToCache--;
             if (this.totalOpsToCache === 0) {
                 this.logger.sendPerformanceEvent({ eventName: "CacheOpsLimitHit"});
-                this.flushOps();
-                this.batches.clear();
+                this.cache.remove();
+                this.dispose();
                 break;
             }
         }


### PR DESCRIPTION
This will cause to load from storage next time we are loading file, istead of current - rehydrate from old snapshot, apply a ton of local ops and then go to storage.