### PR TITLE
Matrix: Fix incorrect row/col adjustment w/multiple reconnections

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -230,32 +230,36 @@ export class SharedMatrix<T extends Serializable = Serializable>
 
         this.cells.setCell(rowHandle, colHandle, value);
 
-        this.sendSetCellOp(row, col, value, rowHandle, colHandle);
+        if (this.isAttached()) {
+            this.sendSetCellOp(row, col, value, rowHandle, colHandle);
+        }
     }
 
-    private sendSetCellOp(row: number, col: number, value: T, rowHandle: Handle, colHandle: Handle) {
-        // If the SharedMatrix is local, it will by synchronized via a Snapshot when initially connected.
-        // Do not queue a message or track the pending op, as there will never be an ACK, etc.
-        if (this.isAttached()) {
-            const localSeq = this.nextLocalSeq();
+    private sendSetCellOp(
+        row: number,
+        col: number,
+        value: T,
+        rowHandle: Handle,
+        colHandle: Handle,
+        localSeq = this.nextLocalSeq(),
+    ) {
+        assert(this.isAttached(), 0x1e2 /* "Caller must ensure 'isAttached()' before calling 'sendSetCellOp'." */);
 
-            const op: ISetOp<T> = {
-                type: MatrixOp.set,
-                row,
-                col,
-                value,
-            };
+        const op: ISetOp<T> = {
+            type: MatrixOp.set,
+            row,
+            col,
+            value,
+        };
 
-            const metadata: ISetOpMetadata = {
-                rowHandle,
-                colHandle,
-                localSeq,
-            };
+        const metadata: ISetOpMetadata = {
+            rowHandle,
+            colHandle,
+            localSeq,
+        };
 
-            this.submitLocalMessage(op, metadata);
-
-            this.pending.setCell(rowHandle, colHandle, localSeq);
-        }
+        this.submitLocalMessage(op, metadata);
+        this.pending.setCell(rowHandle, colHandle, localSeq);
     }
 
     private submitVectorMessage(
@@ -342,7 +346,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
                 const colHandle = this.colHandles.getHandle(col);
                 const value = this.cells.getCell(rowHandle, colHandle);
                 // eslint-disable-next-line no-null/no-null
-                if (value !== undefined && value !== null) {
+                if (this.isAttached() && value !== undefined && value !== null) {
                     this.sendSetCellOp(
                         row,
                         col,
@@ -385,7 +389,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
                 const rowHandle = this.rowHandles.getHandle(row);
                 const value = this.cells.getCell(rowHandle, colHandle);
                 // eslint-disable-next-line no-null/no-null
-                if (value !== undefined && value !== null) {
+                if (this.isAttached() && value !== undefined && value !== null) {
                     this.sendSetCellOp(
                         row,
                         col,
@@ -511,6 +515,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
                             setOp.value,
                             rowHandle,
                             colHandle,
+                            localSeq,
                         );
                     }
                 }

--- a/packages/dds/matrix/src/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.stress.spec.ts
@@ -234,7 +234,14 @@ describe("Matrix", () => {
                         }
                     }
 
-                    if (runtimes[matrixIndex].connected && float64() < disconnectProbability) {
+                    if (float64() < disconnectProbability) {
+                        // If the client is already disconnected, first reconnect it to cover the case where
+                        // multiple reconnections are required.
+                        if (!runtimes[matrixIndex].connected) {
+                            trace?.push(`containerRuntime${matrixIndex + 1}.connected = true;`);
+                            runtimes[matrixIndex].connected = true;
+                        }
+
                         trace?.push(`containerRuntime${matrixIndex + 1}.connected = false;`);
 
                         runtimes[matrixIndex].connected = false;
@@ -269,7 +276,7 @@ describe("Matrix", () => {
             { numClients: 2, numOps: 200, syncProbability: 0.3, disconnectProbability: 0, seed: 0x84d43a0a },
             { numClients: 3, numOps: 200, syncProbability: 0.1, disconnectProbability: 0, seed: 0x655c763b },
             { numClients: 5, numOps: 200, syncProbability: 0.0, disconnectProbability: 0, seed: 0x2f98736d },
-            { numClients: 2, numOps: 200, syncProbability: 0.3, disconnectProbability: 1, seed: 0x84d43a0a },
+            { numClients: 2, numOps: 200, syncProbability: 0.2, disconnectProbability: 0.4, seed: 0x84d43a0a },
         ]) {
             // eslint-disable-next-line max-len
             it(`Stress (numClients=${numClients} numOps=${numOps} syncProbability=${syncProbability} disconnectProbability=${disconnectProbability} seed=0x${seed.toString(16).padStart(8, "0")})`,
@@ -301,9 +308,13 @@ describe("Matrix", () => {
                         /* seed: */ (Math.random() * 0x100000000) >>> 0,
                     );
 
-                    // console.log(matrices[0].toString());
-                    // eslint-disable-next-line max-len
-                    console.log(`Stress loop: ${++iterations} iterations completed - Total Elapsed: ${((Date.now() - start) / 1000).toFixed(2)}s`);
+                    // Note: Mocha reporter intercepts 'console.log()' so use 'process.stdout.write' instead.
+                    process.stdout.write(matrices[0].toString());
+
+                    process.stdout.write(
+                        `Stress loop: ${++iterations} iterations completed - Total Elapsed: ${
+                            ((Date.now() - start) / 1000).toFixed(2)
+                        }s\n`);
                 }
             },
         );


### PR DESCRIPTION
This fixes a data loss issue during reconnection that reproduces when the initial submission fails and the 1st reconnection attempt also fails.  (Fixes #5808).

The cause of the issue is that SharedMatrix previously advanced 'localSeq' when resubmitting ops the 1st time.  During the 2nd reconnection attempt, the runtime replays the ops that were resubmitted during the 1st attempt (as opposed to the originally submitted ops), which now have higher 'localSeq' than those stored in the MergeTree segments.

This results in incorrect adjustment of row/col when resubmitting 'setCell()' ops, as the higher 'localSeqs' cause adjustment to behave as if all 'setCell()' calls occurred after all row/col insertions and removals (i.e., no adjustment takes place.)