### PR TITLE
logging test types/host names - e2e and stress tests

### DIFF
--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -14,7 +14,7 @@ class TestLogger implements ITelemetryBufferedLogger {
         if (this.testName !== undefined) {
             event.testName = this.testName;
         }
-        event.hostName = `${pkgName}`;
+        event.hostName = pkgName;
         this.parentLogger.send(event);
     }
     async flush() {

--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -13,6 +13,7 @@ class TestLogger implements ITelemetryBufferedLogger {
         if (this.testName !== undefined) {
             event.testName = this.testName;
         }
+        event.hostName = "Mocha";
         this.parentLogger.send(event);
     }
     async flush() {

--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -6,6 +6,7 @@
 import { ITelemetryBufferedLogger } from "@fluidframework/test-driver-definitions";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { Context } from "mocha";
+import { pkgName } from "./packageVersion";
 
 const _global: any = global;
 class TestLogger implements ITelemetryBufferedLogger {
@@ -13,7 +14,7 @@ class TestLogger implements ITelemetryBufferedLogger {
         if (this.testName !== undefined) {
             event.testName = this.testName;
         }
-        event.hostName = "Mocha";
+        event.hostName = `${pkgName}`;
         this.parentLogger.send(event);
     }
     async flush() {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -58,7 +58,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
         this.baseLogger?.send(event);
 
         event.Event_Time = Date.now();
-        event.hostName = `${pkgName}`;
+        event.hostName = pkgName;
         // keep track of the frequency of every log event, as we'll sort by most common on write
         Object.keys(event).forEach((k)=>this.schema.set(k, (this.schema.get(k) ?? 0) + 1));
         if(event.category === "error") {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -58,7 +58,6 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
         this.baseLogger?.send({...event, hostName: pkgName});
 
         event.Event_Time = Date.now();
-        event.hostName = pkgName;
         // keep track of the frequency of every log event, as we'll sort by most common on write
         Object.keys(event).forEach((k)=>this.schema.set(k, (this.schema.get(k) ?? 0) + 1));
         if(event.category === "error") {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -96,7 +96,8 @@ export async function initialize(testDriver: ITestDriver, seed: number) {
         urlResolver: testDriver.createUrlResolver(),
         documentServiceFactory: testDriver.createDocumentServiceFactory(),
         codeLoader: createCodeLoader(random.pick(randEng, generateRuntimeOptions(seed))),
-        logger: ChildLogger.create(await loggerP, undefined, {all: { driverType: testDriver.type }}),
+        logger: ChildLogger.create(await loggerP, undefined, {all: { driverType: testDriver.type,
+                hostName: "Stress Tests" }}),
         options,
     });
 

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -58,6 +58,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
         this.baseLogger?.send(event);
 
         event.Event_Time = Date.now();
+        event.hostName = `${pkgName}`;
         // keep track of the frequency of every log event, as we'll sort by most common on write
         Object.keys(event).forEach((k)=>this.schema.set(k, (this.schema.get(k) ?? 0) + 1));
         if(event.category === "error") {
@@ -96,8 +97,7 @@ export async function initialize(testDriver: ITestDriver, seed: number) {
         urlResolver: testDriver.createUrlResolver(),
         documentServiceFactory: testDriver.createDocumentServiceFactory(),
         codeLoader: createCodeLoader(random.pick(randEng, generateRuntimeOptions(seed))),
-        logger: ChildLogger.create(await loggerP, undefined, {all: { driverType: testDriver.type,
-                hostName: "Stress Tests" }}),
+        logger: ChildLogger.create(await loggerP, undefined, {all: { driverType: testDriver.type }}),
         options,
     });
 

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -55,7 +55,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
         return baseFlushP;
     }
     send(event: ITelemetryBaseEvent): void {
-        this.baseLogger?.send(event);
+        this.baseLogger?.send({...event, hostName: pkgName});
 
         event.Event_Time = Date.now();
         event.hostName = pkgName;


### PR DESCRIPTION
Fixes #5576 
Added a property "hostName" to both e2e and stress test logging