### PR TITLE
Add a new flag to summary op and block client uploading protocol specific details

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/scribeHelper.ts
+++ b/server/routerlicious/packages/protocol-base/src/scribeHelper.ts
@@ -62,8 +62,12 @@ export function getQuorumTreeEntries(
     return entries;
 }
 
-export function mergeAppAndProtocolTree(appSummaryTree: ITree, protocolTree: ITree): ICreateTreeEntry[] {
-    const newTreeEntries = appSummaryTree.tree.map((value) => {
+export function mergeAppAndProtocolTree(
+    appSummaryTree: ITree,
+    protocolTree: ITree): ICreateTreeEntry[] {
+    const newTreeEntries = appSummaryTree.tree
+    .filter((value) => !isInvalidPath(value.path))
+    .map((value) => {
         const createTreeEntry: ICreateTreeEntry = {
             mode: value.mode,
             path: value.path,
@@ -107,3 +111,8 @@ export function generateServiceProtocolEntries(deli: string, scribe: string): IT
     );
     return serviceProtocolEntries;
 }
+
+const isInvalidPath = (path: string) => (
+    path === ".protocol" ||
+    path === ".logTail" ||
+    path === ".serviceProtocol");

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -181,7 +181,6 @@ export interface ISignalMessage {
 }
 
 export interface IUploadedSummaryDetails {
-
     // Indicates whether the uploaded summary contains ".protocol" tree
     includesProtocolTree?: boolean;
 }

--- a/server/routerlicious/packages/protocol-definitions/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/protocol.ts
@@ -180,6 +180,12 @@ export interface ISignalMessage {
     content: any;
 }
 
+export interface IUploadedSummaryDetails {
+
+    // Indicates whether the uploaded summary contains ".protocol" tree
+    includesProtocolTree?: boolean;
+}
+
 export interface ISummaryContent {
     // Handle reference to the summary data
     handle: string;
@@ -192,6 +198,9 @@ export interface ISummaryContent {
 
     // Handle to the current latest summary stored by the service
     head: string;
+
+    // Details of the uploaded summary
+    details?: IUploadedSummaryDetails;
 
     // TODO - need an epoch/reload bit to indicate to clients that the summary has changed and requires a reload
     // This could be encoded in the summary itself as well but then would require the client to download it to check


### PR DESCRIPTION
The PR addresses #5900 and #5901.

1. Added a field to ISummaryContent with a flag. Client can use the field to start uploading summaries with .protocol inside them.
2. I realized that scribe was accepting any path uploaded by the client. We should not allow clients to upload to restricted path. For now, I am blocking all three restricted paths (.protocol, .serviceProtocol, and .logTail). Once client starts uploading .protocol, we can check the flag and allow them to upload .protocol  part of the tree (if validation passes).  