### PR TITLE
r11s-driver: Disable default loader caching in DocumentStorageService

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -16,6 +16,7 @@ import {
     IDocumentStorageService,
     ISummaryContext,
     IDocumentStorageServicePolicies,
+    LoaderCachingPolicy,
  } from "@fluidframework/driver-definitions";
 import * as resources from "@fluidframework/gitresources";
 import { buildHierarchy, getGitType, getGitMode } from "@fluidframework/protocol-base";
@@ -31,6 +32,11 @@ import {
 } from "@fluidframework/protocol-definitions";
 import type { GitManager } from "@fluidframework/server-services-client";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
+
+const defaultDocumentStorageServicePolicies = {
+    // Disable container-based caching/prefetch. Rely on built-in browser caching mechanisms.
+    caching: LoaderCachingPolicy.NoCaching,
+};
 
 /**
  * Document access to underlying storage for routerlicious driver.
@@ -53,7 +59,7 @@ export class DocumentStorageService implements IDocumentStorageService {
         public readonly id: string,
         public manager: GitManager,
         private readonly logger: ITelemetryLogger,
-        public readonly policies?: IDocumentStorageServicePolicies) {
+        public readonly policies: IDocumentStorageServicePolicies = defaultDocumentStorageServicePolicies) {
     }
 
     public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTreeEx | null> {


### PR DESCRIPTION
After enabling "Network Error" retries in #5800, we would enter a strange retry loop where RetriableDocumentStorageService would output an error on retry, but it wouldn't make any new network calls. Disabling PrefetchDocumentStorageService resolves the issue, and I don't think we need it in r11s anyways.

The policy is still over-writable so that LocalDriver is not impacted by this change.