### PR TITLE
Adding Redis key TTL, using multi and making TTL configurable

### DIFF
--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -527,18 +527,18 @@
 			}
 		},
 		"@fluidframework/build-common": {
-			"version": "0.21.0-21167",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.21.0-21167.tgz",
-			"integrity": "sha512-8CoJ0WBzMj1h2qVOFzjZfcEqAo993xFI4W9jTTI4/BBOgtyVnh29O/mCTgOROdtNPtSfD3sUfZGhWjUmIe3+/w=="
+			"version": "0.22.0-22551",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.22.0-22551.tgz",
+			"integrity": "sha512-26desAhAr80kjFxGRlKwAM6zfmWUmUINe6G8VyNN9i9Aku2+M9T0yMYldM+Od7RIHMDV0z1nQeuVzMl2tgaZnQ=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.22098",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.22098.tgz",
-			"integrity": "sha512-KAw8xWH5mshq4pYJUMNpc/bhocBVTQO0NFrOfACk4RTHNlyShLgnELBtt/3ytoSavFibAgRhvjujgGNhN6VJJw==",
+			"version": "0.2.22453",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.22453.tgz",
+			"integrity": "sha512-TFCz0WznhF6ejmrsOy6sXOskzHCnBPIPYMlLWWmO5ZOI4+WaI2ovnDxEgnIbLbTHL0xS4ZSFRNGCHRj95w5QWQ==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
-				"async": "^2.6.2",
+				"async": "^3.2.0",
 				"chalk": "^2.4.2",
 				"commander": "^2.20.0",
 				"danger": "^10.4.1",
@@ -910,7 +910,6 @@
 				"@fluidframework/server-services-client": "0.1023.0-22054",
 				"@fluidframework/server-services-core": "0.1023.0-22054",
 				"@types/semver": "^6.0.1",
-				"async": "^2.6.1",
 				"double-ended-queue": "^2.1.0-0",
 				"json-stringify-safe": "^5.0.1",
 				"jsonwebtoken": "^8.4.0",
@@ -3788,9 +3787,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4965,13 +4964,13 @@
 		"acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
 			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+			"integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=",
 			"dev": true
 		},
 		"adal-node": {
@@ -5631,12 +5630,9 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
-			"requires": {
-				"lodash": "^4.17.14"
-			}
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 		},
 		"async-limiter": {
 			"version": "1.0.1",
@@ -6283,7 +6279,7 @@
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
 			"dev": true
 		},
 		"camelcase": {
@@ -8367,7 +8363,7 @@
 		"eslint-ast-utils": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz",
-			"integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
+			"integrity": "sha1-PVi6VXgBz7HJQdaBMe6fjDS9FYY=",
 			"dev": true,
 			"requires": {
 				"lodash.get": "^4.4.2",
@@ -8377,7 +8373,7 @@
 		"eslint-import-resolver-node": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-			"integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+			"integrity": "sha1-hf+oGULCUBLYIxCW3fZ5wDBCxxc=",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
@@ -8387,7 +8383,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -8404,7 +8400,7 @@
 		"eslint-module-utils": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"integrity": "sha1-V569CU9Wr3eX0ZyYZsnJSGYpv6Y=",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
@@ -8414,7 +8410,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -8971,7 +8967,7 @@
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
 			"dev": true
 		},
 		"etag": {
@@ -12014,7 +12010,6 @@
 			"resolved": "https://registry.npmjs.org/kafka-node/-/kafka-node-5.0.0.tgz",
 			"integrity": "sha512-dD2ga5gLcQhsq1yNoQdy1MU4x4z7YnXM5bcG9SdQuiNr5KKuAmXixH1Mggwdah5o7EfholFbcNDPSVA6BIfaug==",
 			"requires": {
-				"async": "^2.6.2",
 				"binary": "~0.3.0",
 				"bl": "^2.2.0",
 				"buffer-crc32": "~0.2.5",
@@ -12393,7 +12388,7 @@
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
 			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -13062,7 +13057,7 @@
 		"multimap": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
-			"integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+			"integrity": "sha1-UmP+vAhaF5HDO1m7OvxqdqKhDKg=",
 			"dev": true
 		},
 		"multimatch": {
@@ -14622,7 +14617,7 @@
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
@@ -14943,7 +14938,7 @@
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
 			"dev": true
 		},
 		"promise-inflight": {
@@ -14987,7 +14982,7 @@
 		"prop-types": {
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
@@ -15156,7 +15151,7 @@
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
 			"dev": true
 		},
 		"read": {
@@ -15448,9 +15443,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -17004,7 +16999,7 @@
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
 			"dev": true
 		},
 		"strong-log-transformer": {
@@ -18086,7 +18081,7 @@
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
 			"dev": true
 		},
 		"wordwrap": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -433,13 +433,13 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.22098",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.22098.tgz",
-      "integrity": "sha512-KAw8xWH5mshq4pYJUMNpc/bhocBVTQO0NFrOfACk4RTHNlyShLgnELBtt/3ytoSavFibAgRhvjujgGNhN6VJJw==",
+      "version": "0.2.22453",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.22453.tgz",
+      "integrity": "sha512-TFCz0WznhF6ejmrsOy6sXOskzHCnBPIPYMlLWWmO5ZOI4+WaI2ovnDxEgnIbLbTHL0xS4ZSFRNGCHRj95w5QWQ==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
-        "async": "^2.6.2",
+        "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^2.20.0",
         "danger": "^10.4.1",
@@ -2682,9 +2682,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -3693,13 +3693,13 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
       "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=",
       "dev": true
     },
     "agent-base": {
@@ -4255,13 +4255,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "async-retry": {
       "version": "1.2.3",
@@ -4643,7 +4640,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
     },
     "camelcase": {
@@ -6467,7 +6464,7 @@
     "eslint-ast-utils": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz",
-      "integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
+      "integrity": "sha1-PVi6VXgBz7HJQdaBMe6fjDS9FYY=",
       "dev": true,
       "requires": {
         "lodash.get": "^4.4.2",
@@ -6477,7 +6474,7 @@
     "eslint-import-resolver-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "integrity": "sha1-hf+oGULCUBLYIxCW3fZ5wDBCxxc=",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
@@ -6487,7 +6484,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -6504,7 +6501,7 @@
     "eslint-module-utils": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "integrity": "sha1-V569CU9Wr3eX0ZyYZsnJSGYpv6Y=",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
@@ -6514,7 +6511,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -7071,7 +7068,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "event-lite": {
@@ -10248,7 +10245,7 @@
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10783,7 +10780,7 @@
     "multimap": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
-      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+      "integrity": "sha1-UmP+vAhaF5HDO1m7OvxqdqKhDKg=",
       "dev": true
     },
     "multimatch": {
@@ -12099,7 +12096,7 @@
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
@@ -12361,7 +12358,7 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true
     },
     "promise-inflight": {
@@ -12405,7 +12402,7 @@
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
       "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
@@ -12527,7 +12524,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
       "dev": true
     },
     "read": {
@@ -12806,9 +12803,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -13889,7 +13886,7 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true
     },
     "strong-log-transformer": {
@@ -14872,7 +14869,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
     },
     "wordwrap": {

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -44,9 +44,13 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
             };
         }
 
+        const redisParams = {
+            expireAfterSeconds: redisConfig.keyExpireAfterSeconds as number | undefined,
+        };
+
         const redisClient = new Redis(redisOptions);
-        const gitCache = new historianServices.RedisCache(redisClient);
-        const tenantCache = new historianServices.RedisTenantCache(redisClient);
+        const gitCache = new historianServices.RedisCache(redisClient, redisParams);
+        const tenantCache = new historianServices.RedisTenantCache(redisClient, redisParams);
         // Create services
         const riddlerEndpoint = config.get("riddler");
         const asyncLocalStorage = config.get("asyncLocalStorageInstance")?.[0];

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -82,3 +82,8 @@ export interface IOauthAccessInfo {
     refreshToken: string;
     expiresAt: string;
 }
+
+export interface IRedisParameters {
+    prefix?: string;
+    expireAfterSeconds?: number;
+}

--- a/server/historian/packages/historian-base/src/services/redisCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisCache.ts
@@ -19,12 +19,10 @@ export class RedisCache implements ICache {
         parameters?: IRedisParameters) {
         if (parameters?.expireAfterSeconds) {
             this.expireAfterSeconds = parameters.expireAfterSeconds;
-            console.log("Overriding git expiry");
         }
 
         if (parameters?.prefix) {
             this.prefix = parameters.prefix;
-            console.log("Overriding git prefix");
         }
 
         client.on("error", (error) => {

--- a/server/historian/packages/historian-base/src/services/redisTenantCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisTenantCache.ts
@@ -18,12 +18,10 @@ export class RedisTenantCache {
         parameters?: IRedisParameters) {
         if (parameters?.expireAfterSeconds) {
             this.expireAfterSeconds = parameters.expireAfterSeconds;
-            console.log("Overriding tenant expiry");
         }
 
         if (parameters?.prefix) {
             this.prefix = parameters.prefix;
-            console.log("Overriding tenant prefix");
         }
 
         client.on("error", (error) => {

--- a/server/historian/packages/historian-base/src/services/redisTenantCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisTenantCache.ts
@@ -5,15 +5,27 @@
 
 import { Redis } from "ioredis";
 import * as winston from "winston";
-
+import { IRedisParameters } from "./definitions";
 /**
  * Redis based cache client for caching and expiring tenants and tokens.
  */
 export class RedisTenantCache {
+    private readonly expireAfterSeconds: number = 60 * 60 * 24;
+    private readonly prefix: string = "tenant";
+
     constructor(
         private readonly client: Redis,
-        private readonly expireInSeconds = 60 * 60 * 24,
-        private readonly prefix = "tenant") {
+        parameters?: IRedisParameters) {
+        if (parameters?.expireAfterSeconds) {
+            this.expireAfterSeconds = parameters.expireAfterSeconds;
+            console.log("Overriding tenant expiry");
+        }
+
+        if (parameters?.prefix) {
+            this.prefix = parameters.prefix;
+            console.log("Overriding tenant prefix");
+        }
+
         client.on("error", (error) => {
             winston.error("Redis Tenant Cache Error:", error);
         });
@@ -27,14 +39,12 @@ export class RedisTenantCache {
     public async set(
         key: string,
         value: string = "",
-        expiresInSeconds: number = this.expireInSeconds): Promise<void> {
-        const result = await this.client.set(this.getKey(key), value);
+        expireAfterSeconds: number = this.expireAfterSeconds): Promise<void> {
+        const result = await this.client.set(this.getKey(key), value, "EX", expireAfterSeconds);
         if (result !== "OK")
         {
             return Promise.reject(result);
         }
-
-        await this.client.expire(this.getKey(key), expiresInSeconds);
     }
 
     public async get(key: string): Promise<string> {

--- a/server/routerlicious/api-report/protocol-definitions.api.md
+++ b/server/routerlicious/api-report/protocol-definitions.api.md
@@ -387,8 +387,6 @@ export interface ISnapshotTree {
     trees: {
         [path: string]: ISnapshotTree;
     };
-    // (undocumented)
-    unreferenced?: true;
 }
 
 // @public (undocumented)
@@ -457,8 +455,6 @@ export interface ISummaryConfiguration {
 
 // @public (undocumented)
 export interface ISummaryContent {
-    // (undocumented)
-    details?: IUploadedSummaryDetails;
     // (undocumented)
     handle: string;
     // (undocumented)
@@ -576,12 +572,6 @@ export type ITreeEntry = {
     type: TreeEntry.Attachment;
     value: IAttachment;
 });
-
-// @public (undocumented)
-export interface IUploadedSummaryDetails {
-    // (undocumented)
-    includesProtocolTree?: boolean;
-}
 
 // @public
 export interface IUser {

--- a/server/routerlicious/api-report/protocol-definitions.api.md
+++ b/server/routerlicious/api-report/protocol-definitions.api.md
@@ -387,6 +387,8 @@ export interface ISnapshotTree {
     trees: {
         [path: string]: ISnapshotTree;
     };
+    // (undocumented)
+    unreferenced?: true;
 }
 
 // @public (undocumented)
@@ -455,6 +457,8 @@ export interface ISummaryConfiguration {
 
 // @public (undocumented)
 export interface ISummaryContent {
+    // (undocumented)
+    details?: IUploadedSummaryDetails;
     // (undocumented)
     handle: string;
     // (undocumented)
@@ -572,6 +576,12 @@ export type ITreeEntry = {
     type: TreeEntry.Attachment;
     value: IAttachment;
 });
+
+// @public (undocumented)
+export interface IUploadedSummaryDetails {
+    // (undocumented)
+    includesProtocolTree?: boolean;
+}
 
 // @public
 export interface IUser {

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -655,7 +655,7 @@
 			"version": "0.20.0-22799",
 			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0-22799.tgz",
 			"integrity": "sha512-nrAGZ4akY473LTEPU2L3AsPeVy0HRhgPlOlhYQxEmQW2KaMILf1wfpAdE17l91zR71hRF9nvka3bLJ6FVEhunA=="
-		  },
+		},
 		"@fluidframework/common-utils": {
 			"version": "0.30.0-22678",
 			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.30.0-22678.tgz",

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -138,8 +138,11 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
                 servername: redisConfig2.host,
             };
         }
+
+        const redisParams2 = { expireAfterSeconds: redisConfig2.keyExpireAfterSeconds };
+
         const redisClient = new Redis(redisOptions2);
-        const clientManager = new services.ClientManager(redisClient);
+        const clientManager = new services.ClientManager(redisClient, redisParams2);
 
         // Database connection
         const mongoUrl = config.get("mongo:endpoint") as string;
@@ -187,6 +190,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
                 servername: redisConfigForThrottling.host,
             };
         }
+        const redisParamsForThrottling = { expireAfterSeconds: redisConfigForThrottling.keyExpireAfterSeconds };
         const redisClientForThrottling = new Redis(redisOptionsForThrottling);
 
         // Rest API Throttler
@@ -198,7 +202,8 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
             config.get("alfred:throttling:restCalls:minCooldownIntervalInMs") as number | undefined;
         const throttleMinRequestThrottleIntervalInMs =
             config.get("alfred:throttling:restCalls:minThrottleIntervalInMs") as number | undefined;
-        const throttleStorageManager = new services.RedisThrottleStorageManager(redisClientForThrottling);
+        const throttleStorageManager =
+            new services.RedisThrottleStorageManager(redisClientForThrottling, redisParamsForThrottling);
         const restThrottlerHelper = new services.ThrottlerHelper(
             throttleStorageManager,
             throttleMaxRequestsPerMs,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -139,7 +139,9 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
             };
         }
 
-        const redisParams2 = { expireAfterSeconds: redisConfig2.keyExpireAfterSeconds };
+        const redisParams2 = {
+            expireAfterSeconds: redisConfig2.keyExpireAfterSeconds as number | undefined,
+        };
 
         const redisClient = new Redis(redisOptions2);
         const clientManager = new services.ClientManager(redisClient, redisParams2);
@@ -190,7 +192,10 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
                 servername: redisConfigForThrottling.host,
             };
         }
-        const redisParamsForThrottling = { expireAfterSeconds: redisConfigForThrottling.keyExpireAfterSeconds };
+        const redisParamsForThrottling = {
+            expireAfterSeconds: redisConfigForThrottling.keyExpireAfterSeconds as number | undefined,
+        };
+
         const redisClientForThrottling = new Redis(redisOptionsForThrottling);
 
         // Rest API Throttler

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,12 +47,14 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluidframework/common-utils": "^0.29.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1024.0",
     "@fluidframework/server-services-core": "^0.1024.0",
     "@sentry/node": "^5.6.2",
     "debug": "^4.1.1",
     "express": "^4.16.3",
+    "ioredis": "^4.24.2",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.4.0",
     "nconf": "^0.11.0",
@@ -65,6 +67,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1024.0",
     "@types/debug": "^4.1.5",
+    "@types/ioredis": "^4.22.0",
     "@types/json-stringify-safe": "^5.0.0",
     "@types/jsonwebtoken": "^8.3.0",
     "@types/mocha": "^5.2.5",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.29.0",
+    "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1024.0",
     "@fluidframework/server-services-core": "^0.1024.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,7 +47,6 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1024.0",
     "@fluidframework/server-services-core": "^0.1024.0",

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -11,4 +11,5 @@ export * from "./errorTrackingService";
 export * from "./generateNames";
 export * from "./logger";
 export * from "./port";
+export * from "./redisUtils";
 export * from "./throttlerMiddleware";

--- a/server/routerlicious/packages/services-utils/src/redisUtils.ts
+++ b/server/routerlicious/packages/services-utils/src/redisUtils.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Deferred } from "@fluidframework/common-utils";
+import { Redis } from "ioredis";
+
+export async function executeRedisMultiWithHmsetExpire(
+    client: Redis,
+    key: string,
+    data: { [key: string]: any },
+    expireAfterSeconds: number) {
+    const deferred = new Deferred<void>();
+    await client.multi()
+                .hmset(key, data)
+                .expire(key, expireAfterSeconds)
+                .exec((err, results) => {
+                    // `err` refers to possible errors in the exec command (compile-time)
+                    // and `results` is an array of responses corresponding to the sequence of queued commands.
+                    // Each response follows the format `[err, result]`. `err` refers to runtime errors.
+
+                    // Check if exec had an error
+                    if (err) {
+                        deferred.reject(err);
+                        return;
+                    }
+
+                    // Check if any queued command had an error
+                    for (const result of results) {
+                        if (result[0] && result[0] instanceof Error) {
+                            deferred.reject(err);
+                            return;
+                        }
+                    }
+
+                    // HMSET should return the string OK indicating success. Otherwise, we had an error.
+                    if (results[0][1] !== "OK") {
+                        deferred.reject(new Error(`Redis HMSET returned unexpected response: ${results[0][1]}`));
+                        return;
+                    }
+
+                    // EXPIRE should return the number 1 indicating success. Otherwise, we had an error.
+                    if (results[1][1] !== 1) {
+                        deferred.reject(new Error(`Redis EXPIRE returned unexpected response: ${results[0][1]}`));
+                        return;
+                    }
+
+                    deferred.resolve();
+                });
+
+    return deferred.promise;
+}

--- a/server/routerlicious/packages/services-utils/src/redisUtils.ts
+++ b/server/routerlicious/packages/services-utils/src/redisUtils.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Deferred } from "@fluidframework/common-utils";
 import { Redis } from "ioredis";
 
 export interface IRedisParameters {
@@ -11,48 +10,41 @@ export interface IRedisParameters {
     expireAfterSeconds?: number;
 }
 
-export async function executeRedisMultiWithHmsetExpire(
+export const executeRedisMultiWithHmsetExpire = async (
     client: Redis,
     key: string,
     data: { [key: string]: any },
-    expireAfterSeconds: number) {
-    const deferred = new Deferred<void>();
-    await client.multi()
-                .hmset(key, data)
-                .expire(key, expireAfterSeconds)
-                .exec((err, results) => {
-                    // `err` refers to possible errors in the exec command (compile-time)
-                    // and `results` is an array of responses corresponding to the sequence of queued commands.
-                    // Each response follows the format `[err, result]`. `err` refers to runtime errors.
+    expireAfterSeconds: number): Promise<void> => new Promise<void>((resolve, reject) => {
+        client.multi()
+        .hmset(key, data)
+        .expire(key, expireAfterSeconds)
+        .exec()
+        .then((results) => {
+            // results` is an array of responses corresponding to the sequence of queued commands.
+            // In other words, it is [Error | null, any][].
+            // Each response follows the format `[err, result]`. `err` refers to runtime errors.
 
-                    // Check if exec had an error
-                    if (err) {
-                        deferred.reject(err);
-                        return;
-                    }
+            // Check if any queued command had an error
+            for (const result of results) {
+                if (result[0] && result[0] instanceof Error) {
+                    reject(result[0]);
+                    return;
+                }
+            }
 
-                    // Check if any queued command had an error
-                    for (const result of results) {
-                        if (result[0] && result[0] instanceof Error) {
-                            deferred.reject(err);
-                            return;
-                        }
-                    }
+            // HMSET should return the string OK indicating success. Otherwise, we had an error.
+            if (results[0][1] !== "OK") {
+                reject(new Error(`Redis HMSET returned unexpected response: ${results[0][1]}`));
+                return;
+            }
 
-                    // HMSET should return the string OK indicating success. Otherwise, we had an error.
-                    if (results[0][1] !== "OK") {
-                        deferred.reject(new Error(`Redis HMSET returned unexpected response: ${results[0][1]}`));
-                        return;
-                    }
+            // EXPIRE should return the number 1 indicating success. Otherwise, we had an error.
+            if (results[1][1] !== 1) {
+                reject(new Error(`Redis EXPIRE returned unexpected response: ${results[0][1]}`));
+                return;
+            }
 
-                    // EXPIRE should return the number 1 indicating success. Otherwise, we had an error.
-                    if (results[1][1] !== 1) {
-                        deferred.reject(new Error(`Redis EXPIRE returned unexpected response: ${results[0][1]}`));
-                        return;
-                    }
-
-                    deferred.resolve();
-                });
-
-    return deferred.promise;
-}
+            resolve();
+        })
+        .catch((error) => { reject(error); });
+});

--- a/server/routerlicious/packages/services-utils/src/redisUtils.ts
+++ b/server/routerlicious/packages/services-utils/src/redisUtils.ts
@@ -6,6 +6,11 @@
 import { Deferred } from "@fluidframework/common-utils";
 import { Redis } from "ioredis";
 
+export interface IRedisParameters {
+    prefix?: string;
+    expireAfterSeconds?: number;
+}
+
 export async function executeRedisMultiWithHmsetExpire(
     client: Redis,
     key: string,

--- a/server/routerlicious/packages/services/src/redis.ts
+++ b/server/routerlicious/packages/services/src/redis.ts
@@ -10,19 +10,21 @@ import * as winston from "winston";
  * Redis based cache client
  */
 export class RedisCache implements ICache {
-    constructor(private readonly client: Redis, private readonly prefix = "page") {
+    constructor(
+        private readonly client: Redis,
+        private readonly expireAfterSeconds = 60 * 60 * 24,
+        private readonly prefix = "page") {
         client.on("error", (err) => {
             winston.error("Error with Redis:", err);
         });
     }
 
     public async get(key: string): Promise<string> {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this.client.get(this.getKey(key));
     }
 
     public async set(key: string, value: string): Promise<void> {
-        const result = await this.client.set(this.getKey(key), value);
+        const result = await this.client.set(this.getKey(key), value, "EX", this.expireAfterSeconds);
         if (result !== "OK") {
             return Promise.reject(result);
         }

--- a/server/routerlicious/packages/services/src/redis.ts
+++ b/server/routerlicious/packages/services/src/redis.ts
@@ -4,16 +4,26 @@
  */
 
 import { ICache } from "@fluidframework/server-services-core";
+import { IRedisParameters } from "@fluidframework/server-services-utils";
 import { Redis } from "ioredis";
 import * as winston from "winston";
 /**
  * Redis based cache client
  */
 export class RedisCache implements ICache {
+    private readonly expireAfterSeconds: number = 60 * 60 * 24;
+    private readonly prefix: string = "page";
     constructor(
         private readonly client: Redis,
-        private readonly expireAfterSeconds = 60 * 60 * 24,
-        private readonly prefix = "page") {
+        parameters?: IRedisParameters) {
+        if (parameters?.expireAfterSeconds) {
+            this.expireAfterSeconds = parameters.expireAfterSeconds;
+        }
+
+        if (parameters?.prefix) {
+            this.prefix = parameters.prefix;
+        }
+
         client.on("error", (err) => {
             winston.error("Error with Redis:", err);
         });

--- a/server/routerlicious/packages/services/src/redisClientManager.ts
+++ b/server/routerlicious/packages/services/src/redisClientManager.ts
@@ -19,12 +19,10 @@ export class ClientManager implements IClientManager {
         parameters?: IRedisParameters) {
         if (parameters?.expireAfterSeconds) {
             this.expireAfterSeconds = parameters.expireAfterSeconds;
-            console.log("Overriding client expiry");
         }
 
         if (parameters?.prefix) {
             this.prefix = parameters.prefix;
-            console.log("Overriding client prefix");
         }
 
         client.on("error", (error) => {

--- a/server/routerlicious/packages/services/src/redisThrottleStorageManager.ts
+++ b/server/routerlicious/packages/services/src/redisThrottleStorageManager.ts
@@ -23,12 +23,10 @@ export class RedisThrottleStorageManager implements IThrottleStorageManager {
         parameters?: IRedisParameters) {
         if (parameters?.expireAfterSeconds) {
             this.expireAfterSeconds = parameters.expireAfterSeconds;
-            console.log("Overriding throttle expiry");
         }
 
         if (parameters?.prefix) {
             this.prefix = parameters.prefix;
-            console.log("Overriding throttle prefix");
         }
 
         client.on("error", (error) => {

--- a/server/routerlicious/packages/services/src/test/redisThrottleStorageManager.spec.ts
+++ b/server/routerlicious/packages/services/src/test/redisThrottleStorageManager.spec.ts
@@ -78,7 +78,7 @@ describe("RedisThrottleStorageManager", () => {
 
     it("Expires outdated values", async () => {
         const ttlInSeconds = 10;
-        const throttleManager = new RedisThrottleStorageManager(mockRedisClient, ttlInSeconds);
+        const throttleManager = new RedisThrottleStorageManager(mockRedisClient, { expireAfterSeconds: ttlInSeconds });
 
         const id = "test-id";
         const originalThrottlingMetric: IThrottlingMetrics = {
@@ -103,7 +103,7 @@ describe("RedisThrottleStorageManager", () => {
 
     it("Updates expiration on overwrite, then expires outdated values", async () => {
         const ttlInSeconds = 10;
-        const throttleManager = new RedisThrottleStorageManager(mockRedisClient, ttlInSeconds);
+        const throttleManager = new RedisThrottleStorageManager(mockRedisClient, { expireAfterSeconds: ttlInSeconds });
 
         const id = "test-id";
         const originalThrottlingMetric: IThrottlingMetrics = {


### PR DESCRIPTION
Most of the data cached in Redis has an associated TTL/expiry. But that was not the case for Redis data related to Git/Summaries. The result is that we would slowly fill up all Redis memory since the cached summary data would never expiry. And depending on the Redis eviction policy, we run the risk of not having any available memory after a certain point.

This PR:

- introduces TTL/expiry rules for Summary/Git data cached in Redis
- makes the TTL/expiry configurable when creating the Redis client, reading the `keyExpireAfterSeconds` from the config and passing it to the Redis client. Now, we just need to edit config.json or Kubernetes files to introduce the `keyExpireAfterSeconds` config.
- introduces the Redis command MULTI when setting hash values in the cache followed by setting the expiry. For SET commands, we can provide the expiry as a parameter. But that is not the case for HMSET, which requires a follow-up EXPIRE command. By using MULTI, we leverage the concept of transactions and reduce chances of successfully running HMSET, but failing EXPIRE after.

Note 1: since this change touches 2 lerna projects at the same time (historian and routerlicious) there is some follow-up work required to remove code duplication. Eventually, historian should use the `IRedisParameters` definition from routerlicious, for example. But since that would require a new r11s package to be released and we want to expedite the historian fix, that work will happen later. #5915 will track that.

Note 2: as [Redis docs](https://redis.io/topics/transactions) explain, it is possible that individual Redis commands within a transaction might fail - since Redis does not implement rollback. As pointed out in the docs: `[...] a command may fail after EXEC is called, for instance since we performed an operation against a key with the wrong value (like calling a list operation against a string value).` That should be fine, though - as mentioned in the docs: `Redis commands can fail only if called with a wrong syntax (and the problem is not detectable during the command queueing), or against keys holding the wrong data type: this means that in practical terms a failing command is the result of a programming errors, and a kind of error that is very likely to be detected during development, and not in production.` Also, EXEC makes transactions be processed atomically (`[...] either all of the commands or none are processed, so a Redis transaction is also atomic.`) and that is what we are mainly interested in, since it prevents that network errors in between different commands cause one of them to fail, and the other to succeed.