### PR TITLE
r11s-driver: Use services-client SummaryTreeUploadManager

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -5,20 +5,15 @@
 
 import type { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
-    assert,
-    gitHashFile,
-    IsoBuffer,
     stringToBuffer,
     Uint8ArrayToString,
-    unreachableCase,
 } from "@fluidframework/common-utils";
 import {
     IDocumentStorageService,
     ISummaryContext,
     IDocumentStorageServicePolicies,
  } from "@fluidframework/driver-definitions";
-import * as resources from "@fluidframework/gitresources";
-import { buildHierarchy, getGitType, getGitMode } from "@fluidframework/protocol-base";
+import { buildHierarchy } from "@fluidframework/protocol-base";
 import {
     ICreateBlobResponse,
     ISnapshotTreeEx,
@@ -26,10 +21,8 @@ import {
     ISummaryTree,
     ITree,
     IVersion,
-    SummaryObject,
-    SummaryType,
 } from "@fluidframework/protocol-definitions";
-import type { GitManager } from "@fluidframework/server-services-client";
+import { GitManager, ISummaryUploadManager, SummaryTreeUploadManager } from "@fluidframework/server-services-client";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 
 /**
@@ -39,6 +32,7 @@ export class DocumentStorageService implements IDocumentStorageService {
     // The values of this cache is useless. We only need the keys. So we are always putting
     // empty strings as values.
     private readonly blobsShaCache = new Map<string, string>();
+    private readonly summaryUploadManager: ISummaryUploadManager;
     private _logTailSha: string | undefined = undefined;
 
     public get repositoryUrl(): string {
@@ -54,6 +48,11 @@ export class DocumentStorageService implements IDocumentStorageService {
         public manager: GitManager,
         private readonly logger: ITelemetryLogger,
         public readonly policies?: IDocumentStorageServicePolicies) {
+        this.summaryUploadManager = new SummaryTreeUploadManager(
+            this.manager,
+            this.blobsShaCache,
+            this.getPreviousFullSnapshot.bind(this),
+        );
     }
 
     public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTreeEx | null> {
@@ -119,21 +118,14 @@ export class DocumentStorageService implements IDocumentStorageService {
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
-        const snapshot = context.ackHandle
-            ? await this.getVersions(context.ackHandle, 1)
-                .then(async (versions) => {
-                    // Clear the cache as the getSnapshotTree call will fill the cache.
-                    this.blobsShaCache.clear();
-                    return this.getSnapshotTree(versions[0]);
-                })
-            : undefined;
-        return PerformanceEvent.timedExecAsync(
+        const summaryHandle = await PerformanceEvent.timedExecAsync(
             this.logger,
             {
                 eventName: "uploadSummaryWithContext",
             },
-            async () => this.writeSummaryTree(summary, snapshot ?? undefined),
+            async () => this.summaryUploadManager.writeSummaryTree(summary, context.ackHandle ?? ""),
         );
+        return summaryHandle;
     }
 
     public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
@@ -180,111 +172,14 @@ export class DocumentStorageService implements IDocumentStorageService {
         return stringToBuffer(value.content, value.encoding);
     }
 
-    private async writeSummaryTree(
-        summaryTree: ISummaryTree,
-        /** Entire previous snapshot, not subtree */
-        previousFullSnapshot: ISnapshotTreeEx | undefined,
-    ): Promise<string> {
-        const entries = await Promise.all(Object.keys(summaryTree.tree).map(async (key) => {
-            const entry = summaryTree.tree[key];
-            const pathHandle = await this.writeSummaryTreeObject(key, entry, previousFullSnapshot);
-            const treeEntry: resources.ICreateTreeEntry = {
-                mode: getGitMode(entry),
-                path: encodeURIComponent(key),
-                sha: pathHandle,
-                type: getGitType(entry),
-            };
-            return treeEntry;
-        }));
-
-        const treeHandle = await this.manager.createGitTree({ tree: entries });
-        return treeHandle.sha;
-    }
-
-    private async writeSummaryTreeObject(
-        key: string,
-        object: SummaryObject,
-        previousFullSnapshot: ISnapshotTreeEx | undefined,
-        currentPath = "",
-    ): Promise<string> {
-        switch (object.type) {
-            case SummaryType.Blob: {
-                return this.writeSummaryBlob(object.content);
-            }
-            case SummaryType.Handle: {
-                if (previousFullSnapshot === undefined) {
-                    throw Error("Parent summary does not exist to reference by handle.");
-                }
-                return this.getIdFromPath(object.handleType, object.handle, previousFullSnapshot);
-            }
-            case SummaryType.Tree: {
-                return this.writeSummaryTree(object, previousFullSnapshot);
-            }
-            case SummaryType.Attachment: {
-                return object.id;
-            }
-
-            default:
-                unreachableCase(object, `Unknown type: ${(object as any).type}`);
-        }
-    }
-
-    private getIdFromPath(
-        handleType: SummaryType,
-        handlePath: string,
-        previousFullSnapshot: ISnapshotTreeEx,
-    ): string {
-        const path = handlePath.split("/").map((part) => decodeURIComponent(part));
-        if (path[0] === "") {
-            // root of tree should be unnamed
-            path.shift();
-        }
-        if (path.length === 0) {
-            return previousFullSnapshot.id;
-        }
-
-        return this.getIdFromPathCore(handleType, path, previousFullSnapshot);
-    }
-
-    private getIdFromPathCore(
-        handleType: SummaryType,
-        path: string[],
-        /** Previous snapshot, subtree relative to this path part */
-        previousSnapshot: ISnapshotTreeEx,
-    ): string {
-        assert(path.length > 0, 0x0b3 /* "Expected at least 1 path part" */);
-        const key = path[0];
-        if (path.length === 1) {
-            switch (handleType) {
-                case SummaryType.Blob: {
-                    const tryId = previousSnapshot.blobs[key];
-                    assert(!!tryId, 0x0b4 /* "Parent summary does not have blob handle for specified path." */);
-                    return tryId;
-                }
-                case SummaryType.Tree: {
-                    const tryId = previousSnapshot.trees[key]?.id;
-                    assert(!!tryId, 0x0b5 /* "Parent summary does not have tree handle for specified path." */);
-                    return tryId;
-                }
-                default:
-                    throw Error(`Unexpected handle summary object type: "${handleType}".`);
-            }
-        }
-        return this.getIdFromPathCore(handleType, path.slice(1), previousSnapshot.trees[key]);
-    }
-
-    private async writeSummaryBlob(content: string | Uint8Array): Promise<string> {
-        const { parsedContent, encoding } = typeof content === "string"
-            ? { parsedContent: content, encoding: "utf-8" }
-            : { parsedContent: Uint8ArrayToString(content, "base64"), encoding: "base64" };
-
-        // The gitHashFile would return the same hash as returned by the server as blob.sha
-        const hash = await gitHashFile(IsoBuffer.from(parsedContent, encoding));
-        if (!this.blobsShaCache.has(hash)) {
-            this.blobsShaCache.set(hash, "");
-            const blob = await this.manager.createBlob(parsedContent, encoding);
-            assert(hash === blob.sha, 0x0b6 /* "Blob.sha and hash do not match!!" */);
-        }
-        return hash;
+    private async getPreviousFullSnapshot(parentHandle: string): Promise<ISnapshotTreeEx | null | undefined> {
+        return parentHandle
+            ? this.getVersions(parentHandle, 1)
+                .then(async (versions) => {
+                    // Clear the cache as the getSnapshotTree call will fill the cache.
+                    this.blobsShaCache.clear();
+                    return this.getSnapshotTree(versions[0]);
+                })
+            : undefined;
     }
 }


### PR DESCRIPTION
Follow-up to #5724 where I moved summary tree upload logic into a class in services-client for use in both the service and driver.