### PR TITLE
Plumb unreferenced flag from ODSP driver to runtime

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3498,26 +3498,33 @@
             }
         },
         "@fluidframework/gitresources": {
-            "version": "0.1024.0-22696",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22696.tgz",
-            "integrity": "sha512-LwA+igVc+RQ7SxGysV17KC/nq9OI10cHOjZL6abSgP8VYC3prslP5ZisYy/jklwEKoiI4HSAm9zI/W9Vl+JNCw=="
+            "version": "0.1024.0-22909",
+            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
+            "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
         },
         "@fluidframework/protocol-base": {
-            "version": "0.1024.0-22696",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1024.0-22696.tgz",
-            "integrity": "sha512-PeyYrLAPDp0MeFEqYtMFiS+DygVKJ9IThMDZmJp6lo4sCjQEe38IzUtJbJ+HfNXnMSf5DvqpBFGXBL2KWnQamQ==",
+            "version": "0.1024.0-22909",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1024.0-22909.tgz",
+            "integrity": "sha512-czMBEGthIjYR9rqmjyDlOOsNuROJouaBkJAgIgD/PIzbDpetyX9GCjDbjIYJ0Bubt37mu2BTMrb+A3HOAVVmlg==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22696",
-                "@fluidframework/protocol-definitions": "0.1024.0-22696",
+                "@fluidframework/gitresources": "0.1024.0-22909",
+                "@fluidframework/protocol-definitions": "0.1024.0-22909",
                 "assert": "^2.0.0",
                 "lodash": "^4.17.21"
+            },
+            "dependencies": {
+                "@fluidframework/gitresources": {
+                    "version": "0.1024.0-22909",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
+                    "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
+                }
             }
         },
         "@fluidframework/protocol-definitions": {
-            "version": "0.1024.0-22696",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0-22696.tgz",
-            "integrity": "sha512-YQSqZ6lSD6TMD2J3BL7gZeHTz0zaycDQoOKfbNSSDPWEl3422zptF91rhsVGm/dpAi7s8Ik39depxmmYCCOhAw==",
+            "version": "0.1024.0-22909",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0-22909.tgz",
+            "integrity": "sha512-tq0EThwIMaKGlhluV+anewbys+DeONJlMamPHpWW8KILQe7iM46kl5vjvZf5urcs14pU9KmtIVCKaXQdysQ80A==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.0-0"
             }
@@ -3772,32 +3779,32 @@
             }
         },
         "@fluidframework/server-local-server": {
-            "version": "0.1024.0-22696",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1024.0-22696.tgz",
-            "integrity": "sha512-AgRdMR6zgvkio1+P4L31xHljlw9yIQH0PkAdcouCZrvrUuyHkc1rkUfPhw3qS0jx4fxc+3DCD6Nfjc1PsETq8w==",
+            "version": "0.1024.0-22909",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1024.0-22909.tgz",
+            "integrity": "sha512-qTU1/OqODF0hE1phhv21XzTl9ibExZJ7bDOsX4WlLKlFfCEoUscfuRiPHGFZw6LM9Z9os8HJtBoun3bSs0mSnw==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/protocol-definitions": "0.1024.0-22696",
-                "@fluidframework/server-lambdas": "0.1024.0-22696",
-                "@fluidframework/server-memory-orderer": "0.1024.0-22696",
-                "@fluidframework/server-services-client": "0.1024.0-22696",
-                "@fluidframework/server-services-core": "0.1024.0-22696",
-                "@fluidframework/server-test-utils": "0.1024.0-22696",
+                "@fluidframework/protocol-definitions": "0.1024.0-22909",
+                "@fluidframework/server-lambdas": "0.1024.0-22909",
+                "@fluidframework/server-memory-orderer": "0.1024.0-22909",
+                "@fluidframework/server-services-client": "0.1024.0-22909",
+                "@fluidframework/server-services-core": "0.1024.0-22909",
+                "@fluidframework/server-test-utils": "0.1024.0-22909",
                 "jsrsasign": "^10.0.2",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
                 "@fluidframework/server-lambdas": {
-                    "version": "0.1024.0-22696",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1024.0-22696.tgz",
-                    "integrity": "sha512-kvGYbopxpufjdGvuS4U9TnG6Jqu69i5d9el8gc/nIIGIukzAdB7TyGiAwlwbXgxrafHn99q7g7eZKR2VJbf2+g==",
+                    "version": "0.1024.0-22909",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1024.0-22909.tgz",
+                    "integrity": "sha512-gufc0oTNuF0R3k4ZpULR/1Jvt1gmxur+jl3UBOE0Fe747eAMn2Lwtt4I7pOYvG1itaMtw4t4LH5Zc5YKsFi5nw==",
                     "requires": {
                         "@fluidframework/common-utils": "^0.30.0-0",
-                        "@fluidframework/gitresources": "0.1024.0-22696",
-                        "@fluidframework/protocol-base": "0.1024.0-22696",
-                        "@fluidframework/protocol-definitions": "0.1024.0-22696",
-                        "@fluidframework/server-services-client": "0.1024.0-22696",
-                        "@fluidframework/server-services-core": "0.1024.0-22696",
+                        "@fluidframework/gitresources": "0.1024.0-22909",
+                        "@fluidframework/protocol-base": "0.1024.0-22909",
+                        "@fluidframework/protocol-definitions": "0.1024.0-22909",
+                        "@fluidframework/server-services-client": "0.1024.0-22909",
+                        "@fluidframework/server-services-core": "0.1024.0-22909",
                         "@types/semver": "^6.0.1",
                         "async": "^3.2.0",
                         "double-ended-queue": "^2.1.0-0",
@@ -3810,16 +3817,16 @@
                     }
                 },
                 "@fluidframework/server-memory-orderer": {
-                    "version": "0.1024.0-22696",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1024.0-22696.tgz",
-                    "integrity": "sha512-tXr1c6t50n3VFIDh3ZeTXEUSmw4XNvAFv/dajednK88kKoRdl1aFM+seFGSeqPr/AwkUHqAVYPjRZfrO4nNvxQ==",
+                    "version": "0.1024.0-22909",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1024.0-22909.tgz",
+                    "integrity": "sha512-OY5qSCUfCUMberaOxv+eOQm8J3ASI3SsYuNfNMyc8U4n8rXK/Gx1ZoA6gGFwD69wtkrRjOLB3gnCZhxWDV44Ig==",
                     "requires": {
                         "@fluidframework/common-utils": "^0.30.0-0",
-                        "@fluidframework/protocol-base": "0.1024.0-22696",
-                        "@fluidframework/protocol-definitions": "0.1024.0-22696",
-                        "@fluidframework/server-lambdas": "0.1024.0-22696",
-                        "@fluidframework/server-services-client": "0.1024.0-22696",
-                        "@fluidframework/server-services-core": "0.1024.0-22696",
+                        "@fluidframework/protocol-base": "0.1024.0-22909",
+                        "@fluidframework/protocol-definitions": "0.1024.0-22909",
+                        "@fluidframework/server-lambdas": "0.1024.0-22909",
+                        "@fluidframework/server-services-client": "0.1024.0-22909",
+                        "@fluidframework/server-services-core": "0.1024.0-22909",
                         "@types/debug": "^4.1.5",
                         "@types/double-ended-queue": "^2.1.0",
                         "@types/lodash": "^4.14.118",
@@ -4075,14 +4082,14 @@
             }
         },
         "@fluidframework/server-services-client": {
-            "version": "0.1024.0-22696",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1024.0-22696.tgz",
-            "integrity": "sha512-GzLieRHNKckqpTj6V3wkcOwmB194t5PNfnQKya3KechUa+uJikE4RfE0P67jz8wlJdI/QWudw14Hy1ru92ZG2Q==",
+            "version": "0.1024.0-22909",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1024.0-22909.tgz",
+            "integrity": "sha512-jz24E3VTkgIUkbvAfdxjAnN0M/FYaZkZg8lpFw94ncyEjAGW9lhj+1F2hmpt3S/GbhUjAVgOH2zNgcf2msL+0A==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22696",
-                "@fluidframework/protocol-base": "0.1024.0-22696",
-                "@fluidframework/protocol-definitions": "0.1024.0-22696",
+                "@fluidframework/gitresources": "0.1024.0-22909",
+                "@fluidframework/protocol-base": "0.1024.0-22909",
+                "@fluidframework/protocol-definitions": "0.1024.0-22909",
                 "@types/node": "^12.19.0",
                 "axios": "^0.21.1",
                 "debug": "^4.1.1",
@@ -4092,6 +4099,11 @@
                 "uuid": "^8.3.1"
             },
             "dependencies": {
+                "@fluidframework/gitresources": {
+                    "version": "0.1024.0-22909",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
+                    "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
+                },
                 "jwt-decode": {
                     "version": "3.1.2",
                     "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -4100,18 +4112,25 @@
             }
         },
         "@fluidframework/server-services-core": {
-            "version": "0.1024.0-22696",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1024.0-22696.tgz",
-            "integrity": "sha512-3zqgiIh57NZPIP9bJrRwJioxOrFcGphOA1/FGwjGihoXG+SYemsjy69JzKcgKEboqU2bJHRUQWA9lvCReIkVhw==",
+            "version": "0.1024.0-22909",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1024.0-22909.tgz",
+            "integrity": "sha512-3GwLFL/VVJUXwRha0zwh6IrHXpVt3Lxm9L1R2wRJnzul/xj2B5X+Bhi/kq0+YGiUreZMMbx/yiyjBcbEJjEbIA==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22696",
-                "@fluidframework/protocol-definitions": "0.1024.0-22696",
-                "@fluidframework/server-services-client": "0.1024.0-22696",
+                "@fluidframework/gitresources": "0.1024.0-22909",
+                "@fluidframework/protocol-definitions": "0.1024.0-22909",
+                "@fluidframework/server-services-client": "0.1024.0-22909",
                 "@types/nconf": "^0.10.0",
                 "@types/node": "^12.19.0",
                 "debug": "^4.1.1",
                 "nconf": "^0.11.0"
+            },
+            "dependencies": {
+                "@fluidframework/gitresources": {
+                    "version": "0.1024.0-22909",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
+                    "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
+                }
             }
         },
         "@fluidframework/server-services-shared": {
@@ -4575,16 +4594,16 @@
             }
         },
         "@fluidframework/server-test-utils": {
-            "version": "0.1024.0-22696",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1024.0-22696.tgz",
-            "integrity": "sha512-c/p+bNGolQiN5n5aENTHq9OJ8pMXgGtMHStJ8J8Fkt77yXH/RmvrOYV/G8Mxl1Ea2IlNhCdFBCmMooAKJ0eonw==",
+            "version": "0.1024.0-22909",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1024.0-22909.tgz",
+            "integrity": "sha512-znGfjc1GKc/fhKnnSLkzjRkXtzWpwbIYusyvauVBe5tOaFE/RHd+BP7qM7mSZzugfaV9gdoC0ikDX17iKXmKiw==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22696",
-                "@fluidframework/protocol-base": "0.1024.0-22696",
-                "@fluidframework/protocol-definitions": "0.1024.0-22696",
-                "@fluidframework/server-services-client": "0.1024.0-22696",
-                "@fluidframework/server-services-core": "0.1024.0-22696",
+                "@fluidframework/gitresources": "0.1024.0-22909",
+                "@fluidframework/protocol-base": "0.1024.0-22909",
+                "@fluidframework/protocol-definitions": "0.1024.0-22909",
+                "@fluidframework/server-services-client": "0.1024.0-22909",
+                "@fluidframework/server-services-core": "0.1024.0-22909",
                 "debug": "^4.1.1",
                 "lodash": "^4.17.21",
                 "string-hash": "^1.1.3",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3498,33 +3498,26 @@
             }
         },
         "@fluidframework/gitresources": {
-            "version": "0.1024.0-22909",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
-            "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
+            "version": "0.1024.0-23019",
+            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-23019.tgz",
+            "integrity": "sha512-rQZpieP2KD5S5hLJVBi+dovxuXtMg7CPgXW37wf3BV7HpiRo5nVEyD1ONEgjCZY2u9XGTw9LRi3MHNpaP1yL1w=="
         },
         "@fluidframework/protocol-base": {
-            "version": "0.1024.0-22909",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1024.0-22909.tgz",
-            "integrity": "sha512-czMBEGthIjYR9rqmjyDlOOsNuROJouaBkJAgIgD/PIzbDpetyX9GCjDbjIYJ0Bubt37mu2BTMrb+A3HOAVVmlg==",
+            "version": "0.1024.0-23019",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1024.0-23019.tgz",
+            "integrity": "sha512-rfUmBtKja8FC0OtsDz9BxX1ZCcsoqGXMr52r5WqgGMYxeuVCZ9GcR8o+WWOkV6G+mh0ybKyOLjofoMDa363xCA==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22909",
-                "@fluidframework/protocol-definitions": "0.1024.0-22909",
+                "@fluidframework/gitresources": "0.1024.0-23019",
+                "@fluidframework/protocol-definitions": "0.1024.0-23019",
                 "assert": "^2.0.0",
                 "lodash": "^4.17.21"
-            },
-            "dependencies": {
-                "@fluidframework/gitresources": {
-                    "version": "0.1024.0-22909",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
-                    "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
-                }
             }
         },
         "@fluidframework/protocol-definitions": {
-            "version": "0.1024.0-22909",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0-22909.tgz",
-            "integrity": "sha512-tq0EThwIMaKGlhluV+anewbys+DeONJlMamPHpWW8KILQe7iM46kl5vjvZf5urcs14pU9KmtIVCKaXQdysQ80A==",
+            "version": "0.1024.0-23019",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0-23019.tgz",
+            "integrity": "sha512-Wv5RvmwK/OZCQPJfCyrPR2rPzOACBfnUP6psnN9VOqJXPEgnc8+fn2b6Fx3ClWOab1Q9EgvWeqrJ5kmFJeE3xg==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.0-0"
             }
@@ -3779,32 +3772,32 @@
             }
         },
         "@fluidframework/server-local-server": {
-            "version": "0.1024.0-22909",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1024.0-22909.tgz",
-            "integrity": "sha512-qTU1/OqODF0hE1phhv21XzTl9ibExZJ7bDOsX4WlLKlFfCEoUscfuRiPHGFZw6LM9Z9os8HJtBoun3bSs0mSnw==",
+            "version": "0.1024.0-23019",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1024.0-23019.tgz",
+            "integrity": "sha512-WeU3vQf5RayA3Kib59LWf9lphbuMwe8RUicpg0lUk7roL5/C65WchMYFFdQobh9IRw9LXoZzJla9nRaiMT3CHQ==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/protocol-definitions": "0.1024.0-22909",
-                "@fluidframework/server-lambdas": "0.1024.0-22909",
-                "@fluidframework/server-memory-orderer": "0.1024.0-22909",
-                "@fluidframework/server-services-client": "0.1024.0-22909",
-                "@fluidframework/server-services-core": "0.1024.0-22909",
-                "@fluidframework/server-test-utils": "0.1024.0-22909",
+                "@fluidframework/protocol-definitions": "0.1024.0-23019",
+                "@fluidframework/server-lambdas": "0.1024.0-23019",
+                "@fluidframework/server-memory-orderer": "0.1024.0-23019",
+                "@fluidframework/server-services-client": "0.1024.0-23019",
+                "@fluidframework/server-services-core": "0.1024.0-23019",
+                "@fluidframework/server-test-utils": "0.1024.0-23019",
                 "jsrsasign": "^10.0.2",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
                 "@fluidframework/server-lambdas": {
-                    "version": "0.1024.0-22909",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1024.0-22909.tgz",
-                    "integrity": "sha512-gufc0oTNuF0R3k4ZpULR/1Jvt1gmxur+jl3UBOE0Fe747eAMn2Lwtt4I7pOYvG1itaMtw4t4LH5Zc5YKsFi5nw==",
+                    "version": "0.1024.0-23019",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1024.0-23019.tgz",
+                    "integrity": "sha512-vfQt2DVzHJqcaAkvZNgCZo3ZAq/2li9WptC6GjNvuOmUCYOT7uBfapU0utHS/7isnkbhXNasXIq4GXG1NHQM1g==",
                     "requires": {
                         "@fluidframework/common-utils": "^0.30.0-0",
-                        "@fluidframework/gitresources": "0.1024.0-22909",
-                        "@fluidframework/protocol-base": "0.1024.0-22909",
-                        "@fluidframework/protocol-definitions": "0.1024.0-22909",
-                        "@fluidframework/server-services-client": "0.1024.0-22909",
-                        "@fluidframework/server-services-core": "0.1024.0-22909",
+                        "@fluidframework/gitresources": "0.1024.0-23019",
+                        "@fluidframework/protocol-base": "0.1024.0-23019",
+                        "@fluidframework/protocol-definitions": "0.1024.0-23019",
+                        "@fluidframework/server-services-client": "0.1024.0-23019",
+                        "@fluidframework/server-services-core": "0.1024.0-23019",
                         "@types/semver": "^6.0.1",
                         "async": "^3.2.0",
                         "double-ended-queue": "^2.1.0-0",
@@ -3817,16 +3810,16 @@
                     }
                 },
                 "@fluidframework/server-memory-orderer": {
-                    "version": "0.1024.0-22909",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1024.0-22909.tgz",
-                    "integrity": "sha512-OY5qSCUfCUMberaOxv+eOQm8J3ASI3SsYuNfNMyc8U4n8rXK/Gx1ZoA6gGFwD69wtkrRjOLB3gnCZhxWDV44Ig==",
+                    "version": "0.1024.0-23019",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1024.0-23019.tgz",
+                    "integrity": "sha512-fsgaPXrHKY6IMqgjAYuPmrhnXGlqraTm7xs3xmIXUtBte7Wu1090YVZDCJjEJAugiwEaT+v+EMkamdMeIWA40w==",
                     "requires": {
                         "@fluidframework/common-utils": "^0.30.0-0",
-                        "@fluidframework/protocol-base": "0.1024.0-22909",
-                        "@fluidframework/protocol-definitions": "0.1024.0-22909",
-                        "@fluidframework/server-lambdas": "0.1024.0-22909",
-                        "@fluidframework/server-services-client": "0.1024.0-22909",
-                        "@fluidframework/server-services-core": "0.1024.0-22909",
+                        "@fluidframework/protocol-base": "0.1024.0-23019",
+                        "@fluidframework/protocol-definitions": "0.1024.0-23019",
+                        "@fluidframework/server-lambdas": "0.1024.0-23019",
+                        "@fluidframework/server-services-client": "0.1024.0-23019",
+                        "@fluidframework/server-services-core": "0.1024.0-23019",
                         "@types/debug": "^4.1.5",
                         "@types/double-ended-queue": "^2.1.0",
                         "@types/lodash": "^4.14.118",
@@ -4082,14 +4075,14 @@
             }
         },
         "@fluidframework/server-services-client": {
-            "version": "0.1024.0-22909",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1024.0-22909.tgz",
-            "integrity": "sha512-jz24E3VTkgIUkbvAfdxjAnN0M/FYaZkZg8lpFw94ncyEjAGW9lhj+1F2hmpt3S/GbhUjAVgOH2zNgcf2msL+0A==",
+            "version": "0.1024.0-23019",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1024.0-23019.tgz",
+            "integrity": "sha512-bHcL1u2613XA5a75QrY9wHYZTK5vFB3QbYDnnnrkr7txasLiMa77pc1H1ezm9FsyD2L17+W7jjmN9a7Wuavmfw==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22909",
-                "@fluidframework/protocol-base": "0.1024.0-22909",
-                "@fluidframework/protocol-definitions": "0.1024.0-22909",
+                "@fluidframework/gitresources": "0.1024.0-23019",
+                "@fluidframework/protocol-base": "0.1024.0-23019",
+                "@fluidframework/protocol-definitions": "0.1024.0-23019",
                 "@types/node": "^12.19.0",
                 "axios": "^0.21.1",
                 "debug": "^4.1.1",
@@ -4099,11 +4092,6 @@
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/gitresources": {
-                    "version": "0.1024.0-22909",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
-                    "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
-                },
                 "jwt-decode": {
                     "version": "3.1.2",
                     "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -4112,25 +4100,18 @@
             }
         },
         "@fluidframework/server-services-core": {
-            "version": "0.1024.0-22909",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1024.0-22909.tgz",
-            "integrity": "sha512-3GwLFL/VVJUXwRha0zwh6IrHXpVt3Lxm9L1R2wRJnzul/xj2B5X+Bhi/kq0+YGiUreZMMbx/yiyjBcbEJjEbIA==",
+            "version": "0.1024.0-23019",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1024.0-23019.tgz",
+            "integrity": "sha512-r9TIYnE7ftwxPCE8eBVzfyTC+Q6zzgewaJw89bYsUnNP93rYfC66GekIwE731gsyx8jDmQsWszbdRLz06HjVJw==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22909",
-                "@fluidframework/protocol-definitions": "0.1024.0-22909",
-                "@fluidframework/server-services-client": "0.1024.0-22909",
+                "@fluidframework/gitresources": "0.1024.0-23019",
+                "@fluidframework/protocol-definitions": "0.1024.0-23019",
+                "@fluidframework/server-services-client": "0.1024.0-23019",
                 "@types/nconf": "^0.10.0",
                 "@types/node": "^12.19.0",
                 "debug": "^4.1.1",
                 "nconf": "^0.11.0"
-            },
-            "dependencies": {
-                "@fluidframework/gitresources": {
-                    "version": "0.1024.0-22909",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1024.0-22909.tgz",
-                    "integrity": "sha512-zG02zk9oLX87b8lgXrblo5GBK11pz8/uwQ33C5X716YcvoMX6dpaL65aJTBF2cuPQ+2TQFBi1uAM+M19W7ucfg=="
-                }
             }
         },
         "@fluidframework/server-services-shared": {
@@ -4594,16 +4575,16 @@
             }
         },
         "@fluidframework/server-test-utils": {
-            "version": "0.1024.0-22909",
-            "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1024.0-22909.tgz",
-            "integrity": "sha512-znGfjc1GKc/fhKnnSLkzjRkXtzWpwbIYusyvauVBe5tOaFE/RHd+BP7qM7mSZzugfaV9gdoC0ikDX17iKXmKiw==",
+            "version": "0.1024.0-23019",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1024.0-23019.tgz",
+            "integrity": "sha512-+6/HkR1QR17jMLMI+Wk65eaS82TyJhaYySYEK/4HIYoTydbR88ROGs9G1liz0eFeZ/0BGAnjbAVLzPcAokKv7g==",
             "requires": {
                 "@fluidframework/common-utils": "^0.30.0-0",
-                "@fluidframework/gitresources": "0.1024.0-22909",
-                "@fluidframework/protocol-base": "0.1024.0-22909",
-                "@fluidframework/protocol-definitions": "0.1024.0-22909",
-                "@fluidframework/server-services-client": "0.1024.0-22909",
-                "@fluidframework/server-services-core": "0.1024.0-22909",
+                "@fluidframework/gitresources": "0.1024.0-23019",
+                "@fluidframework/protocol-base": "0.1024.0-23019",
+                "@fluidframework/protocol-definitions": "0.1024.0-23019",
+                "@fluidframework/server-services-client": "0.1024.0-23019",
+                "@fluidframework/server-services-core": "0.1024.0-23019",
                 "debug": "^4.1.1",
                 "lodash": "^4.17.21",
                 "string-hash": "^1.1.3",

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -140,6 +140,8 @@ export interface ITreeEntry {
     id: string;
     path: string;
     type: "commit" | "tree" | "blob";
+    // Indicates that this tree entry is unreferenced. If this is not present, the tree entry is considered referenced.
+    unreferenced?: true;
 }
 
 export interface ITree {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -79,7 +79,10 @@ function buildHierarchy(
 
         // Add in either the blob or tree
         if (entry.type === "tree") {
-            const newTree = { id: entry.id, blobs: {}, commits: {}, trees: {} };
+            const newTree: api.ISnapshotTree = { id: entry.id, blobs: {}, commits: {}, trees: {} };
+            if (entry.unreferenced) {
+                newTree.unreferenced = entry.unreferenced;
+            }
             node.trees[decodeURIComponent(entryPathBase)] = newTree;
             lookup[entry.path] = newTree;
         } else if (entry.type === "blob") {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -79,10 +79,13 @@ function buildHierarchy(
 
         // Add in either the blob or tree
         if (entry.type === "tree") {
-            const newTree: api.ISnapshotTree = { id: entry.id, blobs: {}, commits: {}, trees: {} };
-            if (entry.unreferenced) {
-                newTree.unreferenced = entry.unreferenced;
-            }
+            const newTree: api.ISnapshotTree = {
+                id: entry.id,
+                blobs: {},
+                commits: {},
+                trees: {},
+                unreferenced: entry.unreferenced,
+            };
             node.trees[decodeURIComponent(entryPathBase)] = newTree;
             lookup[entry.path] = newTree;
         } else if (entry.type === "blob") {

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -119,10 +119,8 @@ export class OdspSummaryUploadManager {
         const summaryTree: api.ISummaryTree = {
             type: api.SummaryType.Tree,
             tree: {},
+            unreferenced: snapshotTree.unreferenced,
         };
-        if (snapshotTree.unreferenced) {
-            summaryTree.unreferenced = snapshotTree.unreferenced;
-        }
         for (const [key, value] of Object.entries(snapshotTree.blobs)) {
             // fullBlobPath does not start with "/"
             const fullBlobPath = path === "" ? key : `${path}/${key}`;

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -120,6 +120,9 @@ export class OdspSummaryUploadManager {
             type: api.SummaryType.Tree,
             tree: {},
         };
+        if (snapshotTree.unreferenced) {
+            summaryTree.unreferenced = snapshotTree.unreferenced;
+        }
         for (const [key, value] of Object.entries(snapshotTree.blobs)) {
             // fullBlobPath does not start with "/"
             const fullBlobPath = path === "" ? key : `${path}/${key}`;


### PR DESCRIPTION
Fixes #5807.

Plumbed the `unreferenced` flag in ODSP driver when converting from `ITree` to `ISnapshotTree`. Also, when building blob dedup cache which converts `ISnapshotTree` to `ISummaryTree`. 