### PR TITLE
Added unreferenced property to ITree in protocol definitions

### DIFF
--- a/server/routerlicious/packages/protocol-definitions/src/storage.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/storage.ts
@@ -89,10 +89,11 @@ export enum TreeEntry {
 
 export interface ITree {
     entries: ITreeEntry[];
-
     // Unique ID representing all entries in the tree. Can be used to optimize snapshotting in the case
     // it is known that the ITree has already been created and stored
     id?: string;
+    // Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
+    unreferenced?: true;
 }
 
 export interface ISnapshotTree {


### PR DESCRIPTION
Missed adding the `unreferenced` property to `ITree` in protocol definitions which is different from the one in ODSP driver contract.
This is needed because we convert to and from `ITree` at multiple places in the runtime.