### PR TITLE
Allowing RdKafka to retry on commitCheckpoint errors (plus other minor changes)

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -35,11 +35,15 @@ data:
         },
         "kafka": {
             "lib": {
-                "name": "kafka-node",
+                "name": "{{ .Values.kafka.libname }}",
                 "endpoint": "{{ .Values.kafka.url }}",
                 "producerPollIntervalMs": 10,
                 "numberOfPartitions": 32,
-                "replicationFactor": 3
+                "replicationFactor": 3,
+                "rdkafkaOptimizedRebalance": true,
+                "rdkafkaAutomaticConsume": true,
+                "rdkafkaConsumeTimeout": 5,
+                "rdkafkaMaxConsumerCommitRetries": 10
             }
         },
         "zookeeper": {

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -93,6 +93,7 @@ kafka:
     rawdeltas: rawdeltas
     deltas: deltas
   url: kafka_url:port
+  libname: rdkafka
 
 ingress:
   class: nginx-prod

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -655,7 +655,7 @@
 			"version": "0.20.0-22799",
 			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0-22799.tgz",
 			"integrity": "sha512-nrAGZ4akY473LTEPU2L3AsPeVy0HRhgPlOlhYQxEmQW2KaMILf1wfpAdE17l91zR71hRF9nvka3bLJ6FVEhunA=="
-		  },
+		},
 		"@fluidframework/common-utils": {
 			"version": "0.30.0-22678",
 			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.30.0-22678.tgz",

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/resourcesFactory.ts
@@ -46,6 +46,8 @@ export class KafkaResourcesFactory implements IResourcesFactory<KafkaResources> 
         // Inbound Kafka configuration
         const kafkaEndpoint = config.get("kafka:lib:endpoint");
         const zookeeperEndpoint = config.get("zookeeper:endpoint");
+        const numberOfPartitions = config.get("kafka:lib:numberOfPartitions");
+        const replicationFactor = config.get("kafka:lib:replicationFactor");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -61,6 +63,8 @@ export class KafkaResourcesFactory implements IResourcesFactory<KafkaResources> 
             groupId,
             receiveTopic,
             zookeeperEndpoint,
+            numberOfPartitions,
+            replicationFactor,
         );
 
         return new KafkaResources(

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -303,20 +303,20 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			} catch (ex) {
 				const hasPartition = this.assignedPartitions.has(partitionId);
 				const willRetry = this.consumer?.isConnected()
-									&& retries < this.consumerOptions.maxConsumerCommitRetries
-									&& hasPartition;
+														&& retries < this.consumerOptions.maxConsumerCommitRetries
+														&& hasPartition;
 
 				const latency = Date.now() - startTime;
 				this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
 				console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
 
 				if (willRetry) {
-					console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
-					return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
+						console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
+						return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
 				}
 
 				throw ex;
-			}
+		}
 	}
 
 	public async pause() {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -299,7 +299,6 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
                 const result = await deferredCommit.promise;
 				const latency = Date.now() - startTime;
 				this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
-				console.log("[RDKAFKA COMMIT LOG] Commit checkpoint success in RdKafkaConsumer! Retry: ", retries);
                 return result;
 			} catch (ex) {
 				const hasPartition = this.assignedPartitions.has(partitionId);

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -299,6 +299,9 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 				const result = await deferredCommit.promise;
 				const latency = Date.now() - startTime;
 				this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
+                if (retries > 0) {
+                    console.log("[RDKAFKA COMMIT LOG] Commit checkpoint succeeded after retries: ", retries);
+                }
 				return result;
 			} catch (ex) {
 				const hasPartition = this.assignedPartitions.has(partitionId);

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -277,11 +277,11 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		const startTime = Date.now();
 			try {
 				if (!this.consumer) {
-						throw new Error("Invalid consumer");
+					throw new Error("Invalid consumer");
 				}
 
 				if (this.pendingCommits.has(partitionId)) {
-						throw new Error(`There is already a pending commit for partition ${partitionId}`);
+					throw new Error(`There is already a pending commit for partition ${partitionId}`);
 				}
 
 				// this will be resolved in the "offset.commit" event
@@ -301,21 +301,21 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 				console.log("[RDKAFKA COMMIT LOG] Commit checkpoint success in RdKafkaConsumer!");
 				return deferredCommit.promise;
 			} catch (ex) {
-					const hasPartition = this.assignedPartitions.has(partitionId);
-					const willRetry = this.consumer?.isConnected()
-                                      && retries < this.consumerOptions.maxConsumerCommitRetries
-                                      && hasPartition;
+				const hasPartition = this.assignedPartitions.has(partitionId);
+				const willRetry = this.consumer?.isConnected()
+									&& retries < this.consumerOptions.maxConsumerCommitRetries
+									&& hasPartition;
 
-					const latency = Date.now() - startTime;
-					this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
-					console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
+				const latency = Date.now() - startTime;
+				this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
+				console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
 
-					if (willRetry) {
-						console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
-						return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
-					}
+				if (willRetry) {
+					console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
+					return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
+				}
 
-					throw ex;
+				throw ex;
 			}
 	}
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -19,7 +19,7 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
 	optimizedRebalance: boolean;
 	commitRetryDelay: number;
 	automaticConsume: boolean;
-    maxConsumerCommitRetries: number;
+	maxConsumerCommitRetries: number;
 	additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
 }
 
@@ -52,7 +52,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			optimizedRebalance: options?.optimizedRebalance ?? false,
 			commitRetryDelay: options?.commitRetryDelay ?? 1000,
 			automaticConsume: options?.automaticConsume ?? true,
-            maxConsumerCommitRetries: options?.maxConsumerCommitRetries ?? 10,
+			maxConsumerCommitRetries: options?.maxConsumerCommitRetries ?? 10,
 		};
 	}
 
@@ -270,54 +270,54 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		}
 	}
 
-    public async commitCheckpoint(
-        partitionId: number,
-        queuedMessage: IQueuedMessage,
-        retries: number = 0): Promise<void> {
-        const startTime = Date.now();
-        try {
-            if (!this.consumer) {
-                throw new Error("Invalid consumer");
-            }
+	public async commitCheckpoint(
+		partitionId: number,
+		queuedMessage: IQueuedMessage,
+		retries: number = 0): Promise<void> {
+		const startTime = Date.now();
+			try {
+				if (!this.consumer) {
+						throw new Error("Invalid consumer");
+				}
 
-            if (this.pendingCommits.has(partitionId)) {
-                throw new Error(`There is already a pending commit for partition ${partitionId}`);
-            }
+				if (this.pendingCommits.has(partitionId)) {
+						throw new Error(`There is already a pending commit for partition ${partitionId}`);
+				}
 
-            // this will be resolved in the "offset.commit" event
-            const deferredCommit = new Deferred<void>();
-            this.pendingCommits.set(partitionId, deferredCommit);
+				// this will be resolved in the "offset.commit" event
+				const deferredCommit = new Deferred<void>();
+				this.pendingCommits.set(partitionId, deferredCommit);
 
-            // logs are replayed from the last checkpointed offset.
-            // to avoid reprocessing the last message twice, we checkpoint at offset + 1
-            this.consumer.commit({
-                topic: this.topic,
-                partition: partitionId,
-                offset: queuedMessage.offset + 1,
-            });
+				// logs are replayed from the last checkpointed offset.
+				// to avoid reprocessing the last message twice, we checkpoint at offset + 1
+				this.consumer.commit({
+					topic: this.topic,
+					partition: partitionId,
+					offset: queuedMessage.offset + 1,
+				});
 
-            const latency = Date.now() - startTime;
-            this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
-            console.log("[RDKAFKA COMMIT LOG] Commit checkpoint success in RdKafkaConsumer!");
-            return deferredCommit.promise;
-        } catch (ex) {
-            const hasPartition = this.assignedPartitions.has(partitionId);
-            const willRetry = this.consumer?.isConnected()
-                              && retries < this.consumerOptions.maxConsumerCommitRetries
-                              && hasPartition;
+				const latency = Date.now() - startTime;
+				this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
+				console.log("[RDKAFKA COMMIT LOG] Commit checkpoint success in RdKafkaConsumer!");
+				return deferredCommit.promise;
+			} catch (ex) {
+					const hasPartition = this.assignedPartitions.has(partitionId);
+					const willRetry = this.consumer?.isConnected()
+                                      && retries < this.consumerOptions.maxConsumerCommitRetries
+                                      && hasPartition;
 
-            const latency = Date.now() - startTime;
-            this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
-            console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
+					const latency = Date.now() - startTime;
+					this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
+					console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
 
-            if (willRetry) {
-                console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
-                return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
-            }
+					if (willRetry) {
+						console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
+						return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
+					}
 
-            throw ex;
-        }
-    }
+					throw ex;
+			}
+	}
 
 	public async pause() {
 		this.consumer?.unsubscribe();

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -303,16 +303,16 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			} catch (ex) {
 				const hasPartition = this.assignedPartitions.has(partitionId);
 				const willRetry = this.consumer?.isConnected()
-														&& retries < this.consumerOptions.maxConsumerCommitRetries
-														&& hasPartition;
+									&& retries < this.consumerOptions.maxConsumerCommitRetries
+									&& hasPartition;
 
 				const latency = Date.now() - startTime;
 				this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
 				console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
 
 				if (willRetry) {
-						console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
-						return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
+					console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
+					return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
 				}
 
 				throw ex;

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -19,6 +19,7 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
 	optimizedRebalance: boolean;
 	commitRetryDelay: number;
 	automaticConsume: boolean;
+    maxConsumerCommitRetries: number;
 	additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
 }
 
@@ -51,6 +52,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			optimizedRebalance: options?.optimizedRebalance ?? false,
 			commitRetryDelay: options?.commitRetryDelay ?? 1000,
 			automaticConsume: options?.automaticConsume ?? true,
+            maxConsumerCommitRetries: options?.maxConsumerCommitRetries ?? 10,
 		};
 	}
 
@@ -268,29 +270,51 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		}
 	}
 
-	public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
-		if (!this.consumer) {
-			throw new Error("Invalid consumer");
-		}
+    public async commitCheckpoint(
+        partitionId: number,
+        queuedMessage: IQueuedMessage,
+        retries: number = 0): Promise<void> {
+        const startTime = Date.now();
+        try {
+            if (!this.consumer) {
+                throw new Error("Invalid consumer");
+            }
 
-		if (this.pendingCommits.has(partitionId)) {
-			throw new Error(`There is already a pending commit for partition ${partitionId}`);
-		}
+            if (this.pendingCommits.has(partitionId)) {
+                throw new Error(`There is already a pending commit for partition ${partitionId}`);
+            }
 
-		// this will be resolved in the "offset.commit" event
-		const deferredCommit = new Deferred<void>();
-		this.pendingCommits.set(partitionId, deferredCommit);
+            // this will be resolved in the "offset.commit" event
+            const deferredCommit = new Deferred<void>();
+            this.pendingCommits.set(partitionId, deferredCommit);
 
-		// logs are replayed from the last checkpointed offset.
-		// to avoid reprocessing the last message twice, we checkpoint at offset + 1
-		this.consumer.commit({
-			topic: this.topic,
-			partition: partitionId,
-			offset: queuedMessage.offset + 1,
-		});
+            // logs are replayed from the last checkpointed offset.
+            // to avoid reprocessing the last message twice, we checkpoint at offset + 1
+            this.consumer.commit({
+                topic: this.topic,
+                partition: partitionId,
+                offset: queuedMessage.offset + 1,
+            });
 
-		return deferredCommit.promise;
-	}
+            const latency = Date.now() - startTime;
+            this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
+            return deferredCommit.promise;
+        } catch (ex) {
+            const hasPartition = this.assignedPartitions.has(partitionId);
+            const willRetry = this.consumer?.isConnected()
+                              && retries < this.consumerOptions.maxConsumerCommitRetries
+                              && hasPartition;
+
+            const latency = Date.now() - startTime;
+            this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
+
+            if (willRetry) {
+                return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
+            }
+
+            throw ex;
+        }
+    }
 
 	public async pause() {
 		this.consumer?.unsubscribe();

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -296,10 +296,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 					offset: queuedMessage.offset + 1,
 				});
 
-                const result = await deferredCommit.promise;
+				const result = await deferredCommit.promise;
 				const latency = Date.now() - startTime;
 				this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
-                return result;
+				return result;
 			} catch (ex) {
 				const hasPartition = this.assignedPartitions.has(partitionId);
 				const willRetry = this.consumer?.isConnected()

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -299,9 +299,6 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 				const result = await deferredCommit.promise;
 				const latency = Date.now() - startTime;
 				this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
-                if (retries > 0) {
-                    console.log("[RDKAFKA COMMIT LOG] Commit checkpoint succeeded after retries: ", retries);
-                }
 				return result;
 			} catch (ex) {
 				const hasPartition = this.assignedPartitions.has(partitionId);
@@ -311,10 +308,8 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 
 				const latency = Date.now() - startTime;
 				this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
-				console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
 
 				if (willRetry) {
-					console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Current retry count: ", retries);
 					return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
 				}
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -298,6 +298,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 
             const latency = Date.now() - startTime;
             this.emit("checkpoint_success", partitionId, queuedMessage, retries, latency);
+            console.log("[RDKAFKA COMMIT LOG] Commit checkpoint success in RdKafkaConsumer!");
             return deferredCommit.promise;
         } catch (ex) {
             const hasPartition = this.assignedPartitions.has(partitionId);
@@ -307,8 +308,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 
             const latency = Date.now() - startTime;
             this.emit("checkpoint_error", partitionId, queuedMessage, retries, latency, willRetry);
+            console.log("[RDKAFKA COMMIT LOG] Commit checkpoint error in RdKafkaConsumer. Error", ex);
 
             if (willRetry) {
+                console.log("[RDKAFKA COMMIT LOG] Will retry after failure. Next retry count: ", retries + 1);
                 return this.commitCheckpoint(partitionId, queuedMessage, retries + 1);
             }
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -67,7 +67,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
             clientId,
             receiveTopic,
             groupId,
-            { numberOfPartitions, replicationFactor },
+            { numberOfPartitions, replicationFactor, optimizedRebalance: true },
         );
 
         return new RdkafkaResources(

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -48,6 +48,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const zookeeperEndpoint: string = config.get("zookeeper:endpoint");
         const numberOfPartitions = config.get("kafka:lib:numberOfPartitions");
         const replicationFactor = config.get("kafka:lib:replicationFactor");
+        const shouldCallbackOffsetCommit = config.get("kafka:lib:shouldCallbackOffsetCommit");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -67,7 +68,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
             clientId,
             receiveTopic,
             groupId,
-            { numberOfPartitions, replicationFactor, optimizedRebalance: true },
+            { numberOfPartitions, replicationFactor, optimizedRebalance: true, shouldCallbackOffsetCommit },
         );
 
         return new RdkafkaResources(

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -48,7 +48,6 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const zookeeperEndpoint: string = config.get("zookeeper:endpoint");
         const numberOfPartitions = config.get("kafka:lib:numberOfPartitions");
         const replicationFactor = config.get("kafka:lib:replicationFactor");
-        const shouldCallbackOffsetCommit = config.get("kafka:lib:shouldCallbackOffsetCommit");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -68,7 +67,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
             clientId,
             receiveTopic,
             groupId,
-            { numberOfPartitions, replicationFactor, optimizedRebalance: true, shouldCallbackOffsetCommit },
+            { numberOfPartitions, replicationFactor },
         );
 
         return new RdkafkaResources(

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -48,6 +48,10 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const zookeeperEndpoint: string = config.get("zookeeper:endpoint");
         const numberOfPartitions = config.get("kafka:lib:numberOfPartitions");
         const replicationFactor = config.get("kafka:lib:replicationFactor");
+        const optimizedRebalance = config.get("kafka:lib:rdkafkaOptimizedRebalance");
+        const automaticConsume = config.get("kafka:lib:rdkafkaAutomaticConsume");
+        const consumeTimeout = config.get("kafka:lib:rdkafkaConsumeTimeout");
+        const maxConsumerCommitRetries = config.get("kafka:lib:rdkafkaMaxConsumerCommitRetries");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -67,7 +71,14 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
             clientId,
             receiveTopic,
             groupId,
-            { numberOfPartitions, replicationFactor },
+            {
+                numberOfPartitions,
+                replicationFactor,
+                optimizedRebalance,
+                automaticConsume,
+                consumeTimeout,
+                maxConsumerCommitRetries,
+            },
         );
 
         return new RdkafkaResources(

--- a/server/routerlicious/packages/services/src/kafkaFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaFactory.ts
@@ -23,7 +23,14 @@ export function createConsumer(
         return new RdkafkaConsumer(endpoints, clientId, topic, groupId, { numberOfPartitions, replicationFactor });
     }
 
-    return new KafkaNodeConsumer({ kafkaHost: kafkaEndPoint }, clientId, groupId, topic, zookeeperEndPoint);
+    return new KafkaNodeConsumer(
+        { kafkaHost: kafkaEndPoint },
+        clientId,
+        groupId,
+        topic,
+        zookeeperEndPoint,
+        numberOfPartitions,
+        replicationFactor);
 }
 
 export function createProducer(
@@ -53,7 +60,12 @@ export function createProducer(
             }
         });
     } else {
-        producer =  new KafkaNodeProducer({ kafkaHost: kafkaEndPoint }, clientId, topic);
+        producer =  new KafkaNodeProducer(
+            { kafkaHost: kafkaEndPoint },
+            clientId,
+            topic,
+            numberOfPartitions,
+            replicationFactor);
         producer.on("error", (error) => {
             winston.error(error);
         });


### PR DESCRIPTION
We have observed that sometimes (especially under load) RdKafka consumers might fail to `commitCheckpoint` due to the following error:
```
{"message":"LibrdKafkaError: Broker: Request timed out\n
at Function.createLibrdkafkaError [as create] (/usr/src/server/node_modules/node-rdkafka/lib/error.js:423:10)\n
at KafkaConsumer.conf.offset_commit_cb (/usr/src/server/node_modules/node-rdkafka/lib/kafka-consumer.js:97:31)
{\n  code: 7,\n  errno: 7,\n  origin: 'local'\n}","level":"error","label":"winston"}
```
Even though RdKafka client errors are not configured to restart/crash the process, [the client error would surface as a checkpoint error](https://github.com/microsoft/FluidFramework/blob/cd3c8a8f3419f0dd3f68fba4f73024dfad4a12e8/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts#L77) in `CheckpointManager`. And that would bubble up to the `Context`, [which would emit an error configured to restart the process](https://github.com/microsoft/FluidFramework/blob/cd3c8a8f3419f0dd3f68fba4f73024dfad4a12e8/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts#L33).

The client error above (`Broker: Request timed out`) and other similar checkpoint errors should be retried before we crash the process - which can be a disruptive action. This PR adds support to retrying the RdKafka `commitCheckpoint` method.

Other minor improvements:
- updating Kubernets/Helm files to use RdKafka library - our code around RdKafka is more robust and tested than Kafka-Node. Kafka-Node is still here because it can help in agile development. RdKafka is based on native code, and might produce errors when volume mounting in Docker if the host OS is not the same as the Docker OS.
- Allowing Kafka-Node code consumers and producers to overwrite the default number of partitions and replication factor. In local development, our Docker setup takes care of creating Kafka topics, but in some occasions, probably due to race conditions, the r11s microservices would start before topics would be automatically created. Then, Kafka-Node code would try to create topics with a replication factor of 3 - causing an error since in Docker we only have one Kafka broker. The errors eventually go away and things stabilize, but this change should prevent them from happening and also gives support to those using Kafka-Node to have a more flexible, config-based setup. 