### PR TITLE
Remove options calls while fetching ops

### DIFF
--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -32,9 +32,9 @@ describe("DeltaStorageService", () => {
             async (_refresh) => "?access_token=123",
             createUtEpochTracker(fileEntry, logger),
             logger);
-        const actualDeltaUrl = await deltaStorageService.buildUrl(3, 8);
+        const actualDeltaUrl = deltaStorageService.buildUrl(3, 8);
         // eslint-disable-next-line max-len
-        const expectedDeltaUrl = `${deltaStorageBasePath}/drives/testdrive/items/testitem/opStream?filter=sequenceNumber%20ge%203%20and%20sequenceNumber%20le%207`;
+        const expectedDeltaUrl = `${deltaStorageBasePath}/drives/testdrive/items/testitem/opStream?ump=1&filter=sequenceNumber%20ge%203%20and%20sequenceNumber%20le%207`;
         assert.equal(actualDeltaUrl, expectedDeltaUrl, "The constructed delta url is invalid");
     });
 


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/4811
Convert get ops call to a post call and add header to that so as to remove the options call and improve the perf.