### PR TITLE
Add deprecated flag for absolutePath in IFluidHandle

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,6 +4,7 @@
 - [ODSP driver definitions](#ODSP-driver-definitions)
 - [ITelemetryLogger Remove redundant methods](#ITelemetryLogger-Remove-redundant-methods)
 - [fileOverwrittenInStorage](#fileOverwrittenInStorage)
+- [absolutePath use in IFluidHandle is deprecated](#absolutepath-use-in-ifluidhandle-is-deprecated)
 
 ### connect event removed from Container
 The `"connect"` event would previously fire on the `Container` after `connect_document_success` was received from the server (which likely happens before the client's own join message is processed).  This event does not represent a safe-to-use state, and has been removed.  To detect when the `Container` is fully connected, the `"connected"` event should be used instead.
@@ -28,6 +29,9 @@ Remove deprecated `shipAssert` `debugAssert` `logException` `logGenericError` in
 
 ### fileOverwrittenInStorage
 Please use `DriverErrorType.fileOverwrittenInStorage` instead of `OdspErrorType.epochVersionMismatch`
+
+### absolutePath use in IFluidHandle is deprecated
+Please use `get` in IFluidHandle for routing instead of storing absolute paths.
 
 ## 0.38 Breaking changes
 - [IPersistedCache changes](#IPersistedCache-changes)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -31,7 +31,7 @@ Remove deprecated `shipAssert` `debugAssert` `logException` `logGenericError` in
 Please use `DriverErrorType.fileOverwrittenInStorage` instead of `OdspErrorType.epochVersionMismatch`
 
 ### absolutePath use in IFluidHandle is deprecated
-Rather than retrieving the absolute path, ostensibly to be stored, one should instead store the handle itself. To load, first retrieve the handle and then call `get` on it to get the actual object.
+Rather than retrieving the absolute path, ostensibly to be stored, one should instead store the handle itself. To load, first retrieve the handle and then call `get` on it to get the actual object. Note that it is assumed that the container is responsible both for mapping an external URI to an internal object and for requesting resolved objects with any remaining tail of the external URI. For example, if a container has some map that maps `/a --> <some handle>`, then a request like `request(/a/b/c)` should flow like `request(/a/b/c) --> <some handle> --> <object> -->  request(/b/c)`.
 
 ## 0.38 Breaking changes
 - [IPersistedCache changes](#IPersistedCache-changes)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -31,7 +31,7 @@ Remove deprecated `shipAssert` `debugAssert` `logException` `logGenericError` in
 Please use `DriverErrorType.fileOverwrittenInStorage` instead of `OdspErrorType.epochVersionMismatch`
 
 ### absolutePath use in IFluidHandle is deprecated
-Please use `get` in IFluidHandle for routing instead of storing absolute paths.
+Rather than retrieving the absolute path, ostensibly to be stored, one should instead store the handle itself. To load, first retrieve the handle and then call `get` on it to get the actual object.
 
 ## 0.38 Breaking changes
 - [IPersistedCache changes](#IPersistedCache-changes)

--- a/packages/loader/core-interfaces/src/handles.ts
+++ b/packages/loader/core-interfaces/src/handles.ts
@@ -56,6 +56,8 @@ export interface IFluidHandle<
     > extends IProvideFluidHandle {
 
     /**
+     * @deprecated - Use handles instead of absolute paths
+     *
      * The absolute path to the handle context from the root.
      */
     absolutePath: string;

--- a/packages/loader/core-interfaces/src/handles.ts
+++ b/packages/loader/core-interfaces/src/handles.ts
@@ -56,7 +56,7 @@ export interface IFluidHandle<
     > extends IProvideFluidHandle {
 
     /**
-     * @deprecated - Use handles instead of absolute paths
+     * @deprecated - Do not use handle's path for routing. Use `get` to get the underlying object.
      *
      * The absolute path to the handle context from the root.
      */

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -15,6 +15,9 @@ export class FluidObjectHandle<T extends IFluidObject = IFluidObject> implements
     // This is used to break the recursion while attaching the graph. Also tells the attach state of the graph.
     private graphAttachState: AttachState = AttachState.Detached;
     private bound: Set<IFluidHandle> | undefined;
+    /**
+     * @deprecated - use handles instead of absolute paths
+     */
     public readonly absolutePath: string;
 
     public get IFluidHandle(): IFluidHandle { return this; }

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -15,9 +15,6 @@ export class FluidObjectHandle<T extends IFluidObject = IFluidObject> implements
     // This is used to break the recursion while attaching the graph. Also tells the attach state of the graph.
     private graphAttachState: AttachState = AttachState.Detached;
     private bound: Set<IFluidHandle> | undefined;
-    /**
-     * @deprecated - use handles instead of absolute paths
-     */
     public readonly absolutePath: string;
 
     public get IFluidHandle(): IFluidHandle { return this; }


### PR DESCRIPTION
Absolute path use should be deprecated for GC.