### PR TITLE
Property-Inspector: Address intermittent test failures

### DIFF
--- a/experimental/PropertyDDS/examples/property-inspector/tests/property_inspector.test.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/tests/property_inspector.test.ts
@@ -5,8 +5,7 @@
 
 import { globals } from "../jest.config";
 
-// Tests disabled -- requires Tinylicious to be running, which our test environment doesn't do.
-describe("diceRoller", () => {
+describe("Property Inspector", () => {
     beforeAll(async () => {
         // Wait for the page to load first before running any tests
         // so this time isn't attributed to the first test
@@ -19,10 +18,10 @@ describe("diceRoller", () => {
     });
 
     it("Inspector at root1 is rendered", async () => {
-        expect(await page.$eval('#root1', el => el.children.length)).toEqual(1);
+        await page.waitForSelector("#root1 > :first-child");
     });
 
     it("Inspector at root2 is rendered", async () => {
-        expect(await page.$eval('#root2', el => el.children.length)).toEqual(1);
+        await page.waitForSelector("#root2 > :first-child");
     });
 });


### PR DESCRIPTION
@karlbom @evaliyev @ruiterr - We were seeing occasional failures of the 'Property-Inspector' tests in CI.

I believe the cause is that `#root` is attach before its first child, creating a window during which $eval() can observe zero children under `#root` (especially in a parallel CI environment.)

I've modified the test to wait for the first child instead of expecting it to already be present.  (Let me know if you'd like this done differently.)