### PR TITLE
make this change to make sure relativePath won't become undefined

### DIFF
--- a/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
@@ -90,8 +90,9 @@ export class InsecureUrlResolver implements IUrlResolver {
         const encodedTenantId = encodeURIComponent(this.tenantId);
         const encodedDocId = encodeURIComponent(documentId);
         const host = new URL(this.ordererUrl).host;
-        const relativePath = !documentRelativePath || documentRelativePath.startsWith("/")
-            ? "" : `/${documentRelativePath}`;
+        const tmpRelativePath = !documentRelativePath || documentRelativePath.startsWith("/")
+        ? documentRelativePath : `/${documentRelativePath}`;
+        const relativePath = tmpRelativePath == undefined? '': tmpRelativePath;
         const documentUrl = `fluid://${host}/${encodedTenantId}/${encodedDocId}${relativePath}${queryParams}`;
 
         const deltaStorageUrl = `${this.ordererUrl}/deltas/${encodedTenantId}/${encodedDocId}`;

--- a/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
@@ -91,7 +91,7 @@ export class InsecureUrlResolver implements IUrlResolver {
         const encodedDocId = encodeURIComponent(documentId);
         const host = new URL(this.ordererUrl).host;
         const relativePath = !documentRelativePath || documentRelativePath.startsWith("/")
-            ? documentRelativePath : `/${documentRelativePath}`;
+            ? "" : `/${documentRelativePath}`;
         const documentUrl = `fluid://${host}/${encodedTenantId}/${encodedDocId}${relativePath}${queryParams}`;
 
         const deltaStorageUrl = `${this.ordererUrl}/deltas/${encodedTenantId}/${encodedDocId}`;

--- a/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
@@ -55,7 +55,8 @@ export class InsecureUrlResolver implements IUrlResolver {
         // If hosts match then we use the local tenant information. Otherwise we make a REST call out to the hosting
         // service using our bearer token.
         if (this.isForNodeTest) {
-            const [, documentId, relativePath] = parsedUrl.pathname.substr(1).split("/");
+            const [, documentId, tmpRelativePath] = parsedUrl.pathname.substr(1).split("/");
+            const relativePath = tmpRelativePath === undefined ? "" : tmpRelativePath;
             return this.resolveHelper(documentId, relativePath, parsedUrl.search);
         } else if (parsedUrl.host === window.location.host) {
             const fullPath = parsedUrl.pathname.substr(1);
@@ -90,9 +91,8 @@ export class InsecureUrlResolver implements IUrlResolver {
         const encodedTenantId = encodeURIComponent(this.tenantId);
         const encodedDocId = encodeURIComponent(documentId);
         const host = new URL(this.ordererUrl).host;
-        const tmpRelativePath = !documentRelativePath || documentRelativePath.startsWith("/")
-        ? documentRelativePath : `/${documentRelativePath}`;
-        const relativePath = tmpRelativePath === undefined ? "" : tmpRelativePath;
+        const relativePath = !documentRelativePath || documentRelativePath.startsWith("/")
+            ? documentRelativePath : `/${documentRelativePath}`;
         const documentUrl = `fluid://${host}/${encodedTenantId}/${encodedDocId}${relativePath}${queryParams}`;
 
         const deltaStorageUrl = `${this.ordererUrl}/deltas/${encodedTenantId}/${encodedDocId}`;

--- a/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureUrlResolver.ts
@@ -92,7 +92,7 @@ export class InsecureUrlResolver implements IUrlResolver {
         const host = new URL(this.ordererUrl).host;
         const tmpRelativePath = !documentRelativePath || documentRelativePath.startsWith("/")
         ? documentRelativePath : `/${documentRelativePath}`;
-        const relativePath = tmpRelativePath == undefined? '': tmpRelativePath;
+        const relativePath = tmpRelativePath === undefined ? "" : tmpRelativePath;
         const documentUrl = `fluid://${host}/${encodedTenantId}/${encodedDocId}${relativePath}${queryParams}`;
 
         const deltaStorageUrl = `${this.ordererUrl}/deltas/${encodedTenantId}/${encodedDocId}`;


### PR DESCRIPTION
This pull request is to pass E2E test for routerlicious
The pr break E2E test for routerlicious: https://github.com/microsoft/FluidFramework/commit/3455abf46cba386c8c4ca629768fe44e5fff60f1#diff-709854e39c4ae051761dcc30a70c61d4628b2737d2ac307f277d58ffe259bf0e

It seems that odsp and routerlicious have different format in url.
This pr is to make sure relativePath passing the resolverHelper won't be undefined 