### PR TITLE
Add Clicker's registryEntry to registryEntries-parameter of DataObjectFactory-constructor

### DIFF
--- a/examples/data-objects/simple-fluidobject-embed/src/index.tsx
+++ b/examples/data-objects/simple-fluidobject-embed/src/index.tsx
@@ -58,6 +58,7 @@ export const SimpleFluidObjectEmbedInstantiationFactory =
         SimpleFluidObjectEmbed,
         [],
         {},
+        [ClickerInstantiationFactory.registryEntry]
     );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/examples/data-objects/simple-fluidobject-embed/src/index.tsx
+++ b/examples/data-objects/simple-fluidobject-embed/src/index.tsx
@@ -66,6 +66,6 @@ export const SimpleFluidObjectEmbedInstantiationFactory =
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
     SimpleFluidObjectEmbedInstantiationFactory,
     new Map([
-        SimpleFluidObjectEmbedInstantiationFactory.registryEntry,        
+        SimpleFluidObjectEmbedInstantiationFactory.registryEntry,
     ]),
 );

--- a/examples/data-objects/simple-fluidobject-embed/src/index.tsx
+++ b/examples/data-objects/simple-fluidobject-embed/src/index.tsx
@@ -66,7 +66,6 @@ export const SimpleFluidObjectEmbedInstantiationFactory =
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
     SimpleFluidObjectEmbedInstantiationFactory,
     new Map([
-        SimpleFluidObjectEmbedInstantiationFactory.registryEntry,
-        ClickerInstantiationFactory.registryEntry,
+        SimpleFluidObjectEmbedInstantiationFactory.registryEntry,        
     ]),
 );

--- a/examples/data-objects/simple-fluidobject-embed/src/index.tsx
+++ b/examples/data-objects/simple-fluidobject-embed/src/index.tsx
@@ -58,7 +58,9 @@ export const SimpleFluidObjectEmbedInstantiationFactory =
         SimpleFluidObjectEmbed,
         [],
         {},
-        [ClickerInstantiationFactory.registryEntry]
+        new Map([
+            ClickerInstantiationFactory.registryEntry,
+        ]),
     );
 
 export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(


### PR DESCRIPTION
Hi folks!

While trying out the example "simple-fluidobject-embed" the following error occurred and interrupted the clicker's startup:

<img width="1271" alt="simple-fluidobject-embed-errormessage" src="https://user-images.githubusercontent.com/7999242/116269304-65c41800-a77e-11eb-8cf2-e09e9b0b1f87.png">

As the error message describes, the registry for the `"Clicker"`-package is missing. I could solve this by passing the parameter `registryEntries` to the `DataObjectFactory`-constructor, which I set to an array with `ClickerInstantiationFactory.registryEntry` as the single item.

Is this a legitimate fix, or did I miss some other intended behaviour here?