### PR TITLE
Move unprefixed PropertyDDS into fluid-internal

### DIFF
--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/README.md
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/README.md
@@ -1,4 +1,4 @@
-# platform-dependent
+# @fluid-internal/platform-dependent
 
 ## Overview
 This is an internal package that is only used during the build to load the correct code in dependence on the platform (browser/node)

--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "platform-dependent",
+  "name": "@fluid-internal/platform-dependent",
   "version": "1.0.0",
   "description": "Helper package that separates code for browser and server.",
   "homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fluid-internal/platform-dependent",
   "version": "1.0.0",
+  "private": true,
   "description": "Helper package that separates code for browser and server.",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",


### PR DESCRIPTION
The package name isn't prefixed and our pipeline tries to release it.  It's documentation says it's used only for building, so prefix it with @fluid-internal