### PR TITLE
fix: correct url path for SimpleUrlResolver

### DIFF
--- a/experimental/framework/get-container/src/routerliciousService.ts
+++ b/experimental/framework/get-container/src/routerliciousService.ts
@@ -39,10 +39,10 @@ class SimpleUrlResolver implements IUrlResolver {
                 scopes: ["doc:read", "doc:write", "summary:write"],
             },
             this.config.key);
-        const documentUrl = `${this.config.orderer}/${this.config.tenantId}/${request.url}`;
+        const documentUrl = `${this.config.orderer}/${this.config.tenantId}/${containerId}`;
         return Promise.resolve({
             endpoints: {
-                deltaStorageUrl: `${this.config.orderer}/deltas/${this.config.tenantId}/${request.url}`,
+                deltaStorageUrl: `${this.config.orderer}/deltas/${this.config.tenantId}/${containerId}`,
                 ordererUrl: `${this.config.orderer}`,
                 storageUrl: `${this.config.storage}/repos/${this.config.tenantId}`,
             },


### PR DESCRIPTION
Currently, the fluid url created by SimpleUrlResolver in `@fluid-experimental/get-container` has the potential to include an absolute URL where docId should be. Now that containerId is explicitly parsed, we can simply use that to fix a bug where r11s-driver receives `https:` as a docId parsed from the resolved url.

Eventually, we will use the new `id` property of `IFluidResolvedURL` in the r11s-driver, but this is a more immediate fix without any breaking changes to existing hosts.