### PR TITLE
Remove dotenv-webpack dependency

### DIFF
--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -69,7 +69,6 @@
     "clean-webpack-plugin": "^3.0.0",
     "concurrently": "^5.2.0",
     "css-loader": "^1.0.0",
-    "dotenv-webpack": "^4.0.0",
     "eslint": "~7.18.0",
     "eslint-plugin-eslint-comments": "~3.2.0",
     "eslint-plugin-import": "~2.22.1",

--- a/experimental/PropertyDDS/examples/partial-checkout/webpack.config.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/webpack.config.js
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const Dotenv = require('dotenv-webpack');
 
 module.exports = env => {
     const htmlTemplate = "./src/index.html";
@@ -29,8 +28,7 @@ module.exports = env => {
         plugins: [
             new HtmlWebpackPlugin({
                 template: htmlTemplate
-            }),
-            new Dotenv()
+            })
         ],
         resolve: {
             extensions: [".ts", ".tsx", ".js"],

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -73,7 +73,6 @@
     "clean-webpack-plugin": "^3.0.0",
     "concurrently": "^5.2.0",
     "css-loader": "^1.0.0",
-    "dotenv-webpack": "^4.0.0",
     "eslint": "~7.18.0",
     "eslint-plugin-eslint-comments": "~3.2.0",
     "eslint-plugin-import": "~2.22.1",

--- a/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
+++ b/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const Dotenv = require('dotenv-webpack');
 const path = require('path');
 
 module.exports = env => {
@@ -36,8 +35,7 @@ module.exports = env => {
         plugins: [
             new HtmlWebpackPlugin({
                 template: htmlTemplate
-            }),
-            new Dotenv()
+            })
         ],
         resolve: {
             extensions: [".ts", ".tsx", ".js"]

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -20856,24 +20856,6 @@
             "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
         },
-        "dotenv-webpack": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-4.0.0.tgz",
-            "integrity": "sha512-nmfhB0fV1AJVLGrU0E+F+/mfcP8dYAqiuFPgepQmX8D0uZoynxC1AYdlBn3fiA3Cfr9h0efFftprDfSS/C3kkg==",
-            "requires": {
-                "dotenv-defaults": "^2.0.1"
-            },
-            "dependencies": {
-                "dotenv-defaults": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz",
-                    "integrity": "sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==",
-                    "requires": {
-                        "dotenv": "^8.2.0"
-                    }
-                }
-            }
-        },
         "double-ended-queue": {
             "version": "2.1.0-0",
             "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",


### PR DESCRIPTION
A webpack warning in the partial-checkout and property-inspector packages causes fluid-build to try rebuilding the package every time even though the build succeeds.  It doesn't appear that the dotenv-webpack dependency is needed, so removing it to resolve the warning.