### PR TITLE
[bump] package version for common-definitions (patch)

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-definitions",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-definitions",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Fluid common definitions",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -407,9 +407,9 @@
       "dev": true
     },
     "@fluidframework/common-definitions": {
-      "version": "0.20.0-22799",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0-22799.tgz",
-      "integrity": "sha512-nrAGZ4akY473LTEPU2L3AsPeVy0HRhgPlOlhYQxEmQW2KaMILf1wfpAdE17l91zR71hRF9nvka3bLJ6FVEhunA=="
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0.tgz",
+      "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
     },
     "@fluidframework/eslint-config-fluid": {
       "version": "0.23.0",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -68,7 +68,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@types/events": "^3.0.0",
     "assert": "^2.0.0",
     "base64-js": "^1.3.1",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/react-inputs": "^0.39.0",
     "@fluidframework/sequence": "^0.39.0",

--- a/examples/apps/likes-and-comments/package.json
+++ b/examples/apps/likes-and-comments/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/counter": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/map": "^0.39.0",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -43,7 +43,7 @@
     "@fluid-example/prosemirror": "^0.39.0",
     "@fluid-experimental/get-container": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/runtime-definitions": "^0.39.0",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "css-loader": "^1.0.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
     "@fluidframework/cell": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/map": "^0.39.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/ink": "^0.39.0",
     "@fluidframework/view-interfaces": "^0.39.0"

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/react": "^0.39.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/react": "^0.39.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/counter": "^0.39.0",
     "@fluidframework/react": "^0.39.0",
     "react": "^16.10.2",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/counter": "^0.39.0",
     "@fluidframework/react": "^0.39.0",
     "react": "^16.10.2",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/counter": "^0.39.0",
     "@fluidframework/react": "^0.39.0",
     "react": "^16.10.2",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-experimental/task-manager": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/counter": "^0.39.0",
     "@fluidframework/runtime-definitions": "^0.39.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/map": "^0.39.0",
     "@fluidframework/view-interfaces": "^0.39.0",
     "react": "^16.10.2",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/map": "^0.39.0",
     "@fluidframework/view-interfaces": "^0.39.0",
     "react": "^16.10.2",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -39,7 +39,7 @@
     "@fluid-example/multiview-coordinate-interface": "^0.39.0",
     "@fluid-example/multiview-coordinate-model": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/map": "^0.39.0"
   },

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@fluid-example/multiview-coordinate-interface": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/map": "^0.39.0"
   },
   "devDependencies": {

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/map": "^0.39.0",
     "@fluidframework/view-interfaces": "^0.39.0",
     "rc-slider": "^8.6.9",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/counter": "^0.39.0",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/map": "^0.39.0",
     "@fluidframework/view-interfaces": "^0.39.0",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluid-example/clicker": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/view-interfaces": "^0.39.0"
   },
   "devDependencies": {

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/flow-util-lib": "^0.39.0",
     "@fluid-example/table-document": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/runtime-utils": "^0.39.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/clicker": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
     "@fluidframework/cell": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/map": "^0.39.0",
     "@fluidframework/react-inputs": "^0.39.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -41,7 +41,7 @@
     "@fluid-example/prosemirror": "^0.39.0",
     "@fluid-example/spaces": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@fluid-example/flow-util-lib": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/data-object-base": "^0.39.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "css-loader": "^1.0.0",
     "style-loader": "^1.0.0"
   },

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -30,7 +30,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-experimental/bubblebench-common": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/bubblebench-common": "^0.39.0",
     "@fluid-experimental/sharejs-json1": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/bubblebench-common": "^0.39.0",
     "@fluid-experimental/tree": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/map": "^0.39.0"
   },
   "devDependencies": {

--- a/experimental/framework/fluid-static/package.json
+++ b/experimental/framework/fluid-static/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -53,7 +53,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -53,7 +53,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-base": "^0.39.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-base": "^0.39.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/driver-base": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -57,7 +57,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -53,7 +53,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/packages/framework/last-edited-experimental/package.json
+++ b/packages/framework/last-edited-experimental/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/counter": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",

--- a/packages/loader/container-definitions/package.json
+++ b/packages/loader/container-definitions/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0"

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-utils": "^0.39.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -53,7 +53,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0"
   },

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/agent-scheduler": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-utils": "^0.39.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -58,7 +58,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/runtime-definitions": "^0.39.0"
   },

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/test-driver-definitions": "^0.39.0",
     "mocha": "^8.1.1"
   },

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -49,7 +49,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -54,7 +54,7 @@
     "@fluid-experimental/task-manager": "^0.39.0",
     "@fluid-internal/test-pairwise-generator": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluid-internal/client-api": "^0.39.0",
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -58,7 +58,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/common-utils": "^0.30.0-0",
     "debug": "^4.1.1",
     "events": "^3.1.0"

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -652,9 +652,9 @@
 			}
 		},
 		"@fluidframework/common-definitions": {
-			"version": "0.20.0-22799",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0-22799.tgz",
-			"integrity": "sha512-nrAGZ4akY473LTEPU2L3AsPeVy0HRhgPlOlhYQxEmQW2KaMILf1wfpAdE17l91zR71hRF9nvka3bLJ6FVEhunA=="
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0.tgz",
+			"integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
 		},
 		"@fluidframework/common-utils": {
 			"version": "0.30.0-22678",

--- a/server/routerlicious/packages/protocol-definitions/package.json
+++ b/server/routerlicious/packages/protocol-definitions/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0-0"
+    "@fluidframework/common-definitions": "^0.20.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",


### PR DESCRIPTION
```
            @fluidframework/build-common:     0.22.1 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.0 (unchanged)
      @fluidframework/common-definitions:     0.20.0 -> 0.20.1
            @fluidframework/common-utils:     0.30.0 (unchanged)
                                  Server:   0.1024.0 (unchanged)
                                  Client:     0.39.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for common-definitions
      @fluidframework/common-definitions -> ^0.20.0
```