### PR TITLE
[bump] package version for common-utils (patch)

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Collection of utility functions for Fluid",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.30.0";
+export const pkgVersion = "0.30.1";

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -52,7 +52,7 @@
     "@fluid-example/fluid-object-interfaces": "^0.39.0",
     "@fluid-example/search-menu": "^0.39.0",
     "@fluid-internal/client-api": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/agent-scheduler": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
     "@fluidframework/cell": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/merge-tree": "^0.39.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@fluid-example/flow-util-lib": "^0.39.0",
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/data-object-base": "^0.39.0",
     "@fluidframework/map": "^0.39.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/property-proxy": "^0.39.0",
     "@fluid-experimental/schemas": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/property-proxy": "^0.39.0",
     "@fluid-experimental/schemas": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluid-experimental/property-changeset": "^0.39.0",
     "@fluid-experimental/property-properties": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluid-experimental/ot": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/experimental/dds/tree-graphql/package.json
+++ b/experimental/dds/tree-graphql/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluid-experimental/tree": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@graphql-codegen/plugin-helpers": "^1.18.2",
     "@graphql-codegen/visitor-plugin-common": "^1.18.2",
     "graphql": "^15.4.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/merge-tree": "^0.39.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/protocol-base": "^0.1024.0-0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/map": "^0.39.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore": "^0.39.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/odsp-driver": "^0.39.0",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-base": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-base": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-base": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/map": "^0.39.0",
     "@fluidframework/merge-tree": "^0.39.0",
     "@fluidframework/runtime-definitions": "^0.39.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/runtime-definitions": "^0.39.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-utils": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",
     "@fluidframework/telemetry-utils": "^0.39.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/gitresources": "^0.1024.0-0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0"

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore": "^0.39.0",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
     "@fluidframework/cell": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/agent-scheduler": "^0.39.0",
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.39.0",
     "@fluidframework/container-utils": "^0.39.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-utils": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/runtime-definitions": "^0.39.0"
   },
   "devDependencies": {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",
     "@fluidframework/garbage-collector": "^0.39.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.39.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/base-host": "^0.39.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/cell": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluid-internal/replay-tool": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",
     "@fluidframework/file-driver": "^0.39.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@fluid-internal/test-pairwise-generator": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/local-driver": "^0.39.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/assert": "^1.5.2",
     "@types/debug": "^4.1.5",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "random-js": "^1.0.8"
   },
   "devDependencies": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -55,7 +55,7 @@
     "@fluid-internal/test-pairwise-generator": "^0.39.0",
     "@fluidframework/aqueduct": "^0.39.0",
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
     "@fluidframework/cell": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/container-runtime": "^0.39.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluid-internal/fluidapp-odsp-urlresolver": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/datastore": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-runtime": "^0.39.0",
     "@fluidframework/file-driver": "^0.39.0",
     "@fluidframework/merge-tree": "^0.39.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluid-internal/client-api": "^0.39.0",
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.39.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.39.0",
     "@fluidframework/odsp-driver-definitions": "^0.39.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "debug": "^4.1.1",
     "events": "^3.1.0"
   },

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/odsp-doclib-utils": "^0.39.0",
     "@fluidframework/protocol-base": "^0.1024.0-0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -657,11 +657,11 @@
 			"integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.30.0-22678",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.30.0-22678.tgz",
-			"integrity": "sha512-goAqOEEzENdXp59U7j6m5gpIkHBrYAB5d4Ykp9xFVhayJ2Gan+flOb5Yeu5e4KpRykj8wbkm3VSECjYtts6y8w==",
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.30.0.tgz",
+			"integrity": "sha512-AXmmHQuaD6bL6U/AzBgNwgbt/lUB89chJ/LyAth1qy5HmKM8veXTeVb84aRllZz58zSFQYn3fRbscoX4NgJTLg==",
 			"requires": {
-				"@fluidframework/common-definitions": "^0.20.0-0",
+				"@fluidframework/common-definitions": "^0.20.0",
 				"@types/events": "^3.0.0",
 				"assert": "^2.0.0",
 				"base64-js": "^1.3.1",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/server-services-client": "^0.1024.0",
     "@fluidframework/server-services-core": "^0.1024.0",
     "async": "^3.2.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-base": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1024.0",
     "@fluidframework/server-memory-orderer": "^0.1024.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/protocol-base": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1024.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "assert": "^2.0.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-kafka-orderer": "^0.1024.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -39,7 +39,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-kafka-orderer": "^0.1024.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-base": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1024.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/server-services-core": "^0.1024.0",
     "@fluidframework/server-services-ordering-zookeeper": "^0.1024.0",
     "moniker": "^0.1.2",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-base": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1024.0",
     "@fluidframework/server-services-core": "^0.1024.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.30.0-0",
+    "@fluidframework/common-utils": "^0.30.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/protocol-base": "^0.1024.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",


### PR DESCRIPTION
```
            @fluidframework/build-common:     0.22.1 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.0 (unchanged)
      @fluidframework/common-definitions:     0.20.1 (unchanged)
            @fluidframework/common-utils:     0.30.0 -> 0.30.1
                                  Server:   0.1024.0 (unchanged)
                                  Client:     0.39.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for common-utils
            @fluidframework/common-utils -> ^0.30.0
```