### PR TITLE
Runtime-Utils: Revive handle serialization benchmark

### DIFF
--- a/packages/runtime/runtime-utils/bench/src/index.ts
+++ b/packages/runtime/runtime-utils/bench/src/index.ts
@@ -3,28 +3,66 @@
  * Licensed under the MIT License.
  */
 
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { Suite } from "benchmark";
-import { ComponentSerializer } from "../../src";
-import { handle, makeJson, mockHandleContext as context } from "../../src/test/utils";
+import { FluidSerializer } from "../..";
+import { makeJson, MockHandleContext } from "../../src/test/utils";
 import { consume, runSuites } from "./util";
 
-const serializer = new ComponentSerializer(context);
-const deepNoHandles = makeJson(/* breadth: */ 8, /* depth: */ 8, () => ({}));
+const serializer = new FluidSerializer(new MockHandleContext());
+
+// Mock fluid handle
+const handle: IFluidHandle = {
+    get IFluidHandle() { return handle; },
+    absolutePath: "/",
+    isAttached: false,
+
+    attachGraph(): void { },
+    get: async () => Promise.resolve(undefined as any),
+    bind() {},
+};
+
+const shallowNoHandles = makeJson(/* breadth: */ 2, /* depth: */ 2, () => ({}));
 const deepWithHandles = makeJson(/* breadth: */ 8, /* depth: */ 8, () => handle);
 
-function measure(name: string, value: any) {
-    return new Suite(name)
-        .add("replaceHandles", () => {
-            consume(serializer.replaceHandles(value, handle));
-        })
-        .add("stringify", () => {
-            consume(serializer.stringify(value, handle));
-        });
-}
+const shallowNoHandlesString = serializer.stringify(shallowNoHandles, handle);
+const deepWithHandlesString =  serializer.stringify(deepWithHandles, handle);
+
+const measureReplaceHandles = (name: string, value: any) => new Suite(`replaceHandles Handles: ${name}`)
+    .add("replaceHandles(...)", () => {
+        consume(serializer.replaceHandles(value, handle));
+    })
+    .add("parse(stringify(...))", () => {
+        consume(serializer.parse(serializer.stringify(value, handle)));
+    });
+
+const measureStringify = (name: string, value: any) => new Suite(`Stringify: ${name}`)
+    .add("JSON.stringify(replaceHandles(...))", () => {
+        consume(JSON.stringify(serializer.replaceHandles(value, handle)));
+    })
+    .add("stringify(...)", () => {
+        consume(serializer.stringify(value, handle));
+    });
+
+const measureParse = (name: string, value: any) => new Suite(`Parse: ${name}`)
+    .add("parse(...)", () => {
+        consume(serializer.parse(value));
+    });
 
 runSuites([
-    measure("primitive", 0),
-    measure("handle", handle),
-    measure("deep (no handles)", deepNoHandles),
-    measure("deep (with handles)", deepWithHandles),
+    measureReplaceHandles("primitive", 0),
+    measureReplaceHandles("shallow (no handles)", shallowNoHandles),
+    measureReplaceHandles("deep (with handles)", deepWithHandles),
+]);
+
+runSuites([
+    measureStringify("primitive", 0),
+    measureStringify("shallow (no handles)", shallowNoHandles),
+    measureStringify("deep (with handles)", deepWithHandles),
+]);
+
+runSuites([
+    measureParse("primitive", "0"),
+    measureParse("shallow (no handles)", shallowNoHandlesString),
+    measureParse("deep (with handles)", deepWithHandlesString),
 ]);

--- a/packages/runtime/runtime-utils/bench/src/index.ts
+++ b/packages/runtime/runtime-utils/bench/src/index.ts
@@ -11,7 +11,7 @@ import { consume, runSuites } from "./util";
 
 const serializer = new FluidSerializer(new MockHandleContext());
 
-// Mock fluid handle
+// Mock Fluid handle
 const handle: IFluidHandle = {
     get IFluidHandle() { return handle; },
     absolutePath: "/",

--- a/packages/runtime/runtime-utils/bench/src/util.ts
+++ b/packages/runtime/runtime-utils/bench/src/util.ts
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable no-bitwise */
+
 // This file contains some helpers creating/executing benchmark suites using 'Benchmark.js'.
 
-import { Suite } from "benchmark";
 import process = require("process");
+import { Suite } from "benchmark";
 
 let count = 0;
 let cached: any;


### PR DESCRIPTION
Reviving benchmark that measures various methods of serializing IFluidHandles.