### PR TITLE
Allow adding server metadata to the client leave message

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -103,7 +103,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
     /**
      * Sends the client leave op for this connection
      */
-    public async disconnect(): Promise<void> {
+    public async disconnect(clientLeaveMessageServerMetadata?: any): Promise<void> {
         const operation: IDocumentSystemMessage = {
             clientSequenceNumber: -1,
             contents: null,
@@ -111,6 +111,7 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
             referenceSequenceNumber: -1,
             traces: this.serviceConfiguration.enableTraces ? [] : undefined,
             type: MessageType.ClientLeave,
+            serverMetadata: clientLeaveMessageServerMetadata,
         };
         const message: core.IRawOperationMessage = {
             clientId: null,

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -60,7 +60,7 @@ export interface IOrdererConnection {
     /**
      * Sends the client leave op for this connection
      */
-    disconnect(): Promise<void>;
+    disconnect(clientLeaveMessageServerMetadata?: any): Promise<void>;
 }
 
 export interface IOrderer {


### PR DESCRIPTION
The ClientJoin message currently has this capability, but the leave message doesn't.