### PR TITLE
Safely retain properties in throttling warning in deltaManager.emitDelayInfo

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -905,7 +905,7 @@ export class DeltaManager
             };
             const reconfiguredError: IThrottlingWarning = {
                 ...CreateContainerError(error),
-                ...throttlingWarning
+                ...throttlingWarning,
             };
             this.emit("throttled", reconfiguredError);
         }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -896,12 +896,18 @@ export class DeltaManager
         this.throttlingIdSet.add(id);
         if (delaySeconds > 0 && (timeNow + delaySeconds > this.timeTillThrottling)) {
             this.timeTillThrottling = timeNow + delaySeconds;
-            const throttlingError: IThrottlingWarning = {
+
+            // Add 'throttling' properties to an error with safely extracted properties:
+            const throttlingWarning: IThrottlingWarning = {
                 errorType: ContainerErrorType.throttlingError,
                 message: `Service busy/throttled: ${error.message}`,
                 retryAfterSeconds: delaySeconds,
             };
-            this.emit("throttled", throttlingError);
+            const reconfiguredError: IThrottlingWarning = {
+                ...CreateContainerError(error),
+                ...throttlingWarning
+            };
+            this.emit("throttled", reconfiguredError);
         }
     }
 


### PR DESCRIPTION
In `deltaManager.emitDelayInfo()`, there is a bug with our manually crafted error message missing properties (such as the stack). This uses the safer `CreateContainerError()` to retain them.