### PR TITLE
Improving logging for lambda/document corrupt errors

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { inspect } from "util";
 import {
     IContextErrorData,
     IPartitionLambda,
@@ -133,6 +134,14 @@ export class DocumentPartition {
      */
     private markAsCorrupt(message: IQueuedMessage, error: any) {
         this.corrupt = true;
+        this.context.log?.error(
+            `Marking document as corrupted due to error: ${inspect(error)}`,
+            {
+                messageMetaData: {
+                    documentId: this.documentId,
+                    tenantId: this.tenantId,
+                },
+            });
         this.context.error(error, { restart: false, tenantId: this.tenantId, documentId: this.documentId });
         this.context.checkpoint(message);
     }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -47,12 +47,19 @@ export class KafkaRunner implements IRunner {
 
         this.partitionManager = new PartitionManager(this.factory, this.consumer, this.config, logger);
         this.partitionManager.on("error", (error, errorData: IContextErrorData) => {
+            const metadata = {
+                messageMetaData: {
+                    documentId: errorData?.documentId,
+                    tenantId: errorData?.tenantId,
+                },
+            };
+
             if (errorData && !errorData.restart) {
-                logger?.error("KakfaRunner encountered an error that is not configured to trigger restart.");
-                logger?.error(inspect(error));
+                logger?.error("KakfaRunner encountered an error that is not configured to trigger restart.", metadata);
+                logger?.error(inspect(error), metadata);
             } else {
-                logger?.error("KakfaRunner encountered an error that will trigger a restart.");
-                logger?.error(inspect(error));
+                logger?.error("KakfaRunner encountered an error that will trigger a restart.", metadata);
+                logger?.error(inspect(error), metadata);
                 deferred.reject(error);
             }
         });


### PR DESCRIPTION
1. Adds explicit logging when we mark a DocumentPartition as corrupted
2. Improves Kafka Runner error logging by adding the `documentId` and `tenantId` metadata fields if present in `IContextErrorData `