### PR TITLE
Code-Coverage: Workaround c8 Cobertura reporting bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
       "**/src/test/**/*.ts",
       "**/dist/test/**/*.js",
       "experimental/examples/**",
+      "experimental/PropertyDDS/examples/**",
       "**/*.bundle.js"
     ],
     "exclude-after-remap": false,


### PR DESCRIPTION
The filenames for webpack external modules can contain quotes, leading to a malformed Cobertura xml.

The work around for now is to exclude this one package from coverage:
```
<class name="external &quot;react&quot;" filename="../../@fluid-experimental/property-inspector-table/external "react"" line-rate="1" branch-rate="1">
```
(Bug reported [here](https://github.com/bcoe/c8/issues/302))