### PR TITLE
Improve deli nack control message

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -74,16 +74,7 @@ export class CheckpointContext {
         if (checkpoint.clear) {
             updateP = this.checkpointManager.deleteCheckpoint(checkpoint);
         } else {
-            const deliCheckpoint: IDeliState = {
-                branchMap: checkpoint.branchMap,
-                clients: checkpoint.clients,
-                durableSequenceNumber: checkpoint.durableSequenceNumber,
-                logOffset: checkpoint.logOffset,
-                sequenceNumber: checkpoint.sequenceNumber,
-                epoch: checkpoint.epoch,
-                term: checkpoint.term,
-                lastSentMSN: checkpoint.lastSentMSN,
-            };
+            const deliCheckpoint: IDeliState = { ...checkpoint };
 
             updateP = this.checkpointManager.writeCheckpoint(deliCheckpoint);
         }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -38,8 +38,8 @@ import {
     RawOperationType,
     SequencedOperationType,
     IQueuedMessage,
+    INackMessagesControlMessageContents,
     IUpdateDSNControlMessageContents,
-    INackFutureMessagesControlMessageContents,
 } from "@fluidframework/server-services-core";
 import { CheckpointContext } from "./checkpointContext";
 import { ClientSequenceNumberManager } from "./clientSeqManager";
@@ -104,8 +104,8 @@ export class DeliLambda implements IPartitionLambda {
     // @ts-ignore
     private canClose = false;
 
-    // when set, all messages will be nacked based on the provided info
-    private nackFutureMessages: INackFutureMessagesControlMessageContents | undefined;
+    // when set, messages will be nacked based on the provided info
+    private nackMessages: INackMessagesControlMessageContents | undefined;
 
     constructor(
         private readonly context: IContext,
@@ -138,11 +138,12 @@ export class DeliLambda implements IPartitionLambda {
         this.epoch = lastCheckpoint.epoch;
         this.durableSequenceNumber = lastCheckpoint.durableSequenceNumber;
         this.lastSentMSN = lastCheckpoint.lastSentMSN ?? 0;
+        this.logOffset = lastCheckpoint.logOffset;
+        this.nackMessages = lastCheckpoint.nackMessages;
 
         const msn = this.clientSeqManager.getMinimumSequenceNumber();
         this.minimumSequenceNumber = msn === -1 ? this.sequenceNumber : msn;
 
-        this.logOffset = lastCheckpoint.logOffset;
         this.checkpointContext = new CheckpointContext(this.tenantId, this.documentId, checkpointManager, context);
     }
 
@@ -245,14 +246,38 @@ export class DeliLambda implements IPartitionLambda {
         const message = rawMessage as IRawOperationMessage;
         const dataContent = this.extractDataContent(message);
 
-        // Check if we should nack all messages
-        if (this.nackFutureMessages) {
-            return this.createNackMessage(
-                message,
-                this.nackFutureMessages.code,
-                this.nackFutureMessages.type,
-                this.nackFutureMessages.message,
-                this.nackFutureMessages.retryAfter);
+        // Check if we should nack this message
+        const nackMessages = this.nackMessages;
+        if (nackMessages) {
+            let shouldNack = true;
+
+            if (nackMessages.allowSystemMessages && (isServiceMessageType(message.type) || !message.clientId)) {
+                // this is a system message. don't nack it
+                shouldNack = false;
+            } else if (nackMessages.allowedScopes) {
+                const clientId = message.clientId;
+                if (clientId) {
+                    const client = this.clientSeqManager.get(clientId);
+                    if (client) {
+                        for (const scope of nackMessages.allowedScopes) {
+                            if (client.scopes.includes(scope)) {
+                                // this client has an allowed scope. don't nack it
+                                shouldNack = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (shouldNack) {
+                return this.createNackMessage(
+                    message,
+                    nackMessages.content.code,
+                    nackMessages.content.type,
+                    nackMessages.content.message,
+                    nackMessages.content.retryAfter);
+            }
         }
 
         // Check incoming message order. Nack if there is any gap so that the client can resend.
@@ -447,8 +472,8 @@ export class DeliLambda implements IPartitionLambda {
                     break;
                 }
 
-                case ControlMessageType.NackFutureMessages: {
-                    this.nackFutureMessages = controlMessage.contents as INackFutureMessagesControlMessageContents;
+                case ControlMessageType.NackMessages: {
+                    this.nackMessages = controlMessage.contents;
                     break;
                 }
 
@@ -719,6 +744,7 @@ export class DeliLambda implements IPartitionLambda {
             sequenceNumber: this.sequenceNumber,
             term: this.term,
             lastSentMSN: this.lastSentMSN,
+            nackMessages: this.nackMessages ? { ...this.nackMessages } : undefined,
         };
     }
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -41,6 +41,7 @@ const getDefaultCheckpooint = (epoch: number): IDeliState => {
         sequenceNumber: 0,
         term: 1,
         lastSentMSN: 0,
+        nackMessages: undefined,
     };
 };
 

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -26,6 +26,7 @@ describe("Routerlicious", () => {
                     sequenceNumber,
                     term: 1,
                     lastSentMSN: 0,
+                    nackMessages: undefined,
                     queuedMessage: {
                         offset: logOffset,
                         partition: 1,

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -63,6 +63,7 @@ const DefaultDeli: IDeliState = {
     sequenceNumber: 0,
     term: 1,
     lastSentMSN: 0,
+    nackMessages: undefined,
 };
 
 class LocalSocketPublisher implements IPublisher {

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -7,6 +7,7 @@ import { IRangeTrackerSnapshot } from "@fluidframework/common-utils";
 import { ICommit, ICommitDetails } from "@fluidframework/gitresources";
 import { IProtocolState, ISummaryTree, ICommittedProposal } from "@fluidframework/protocol-definitions";
 import { IGitCache } from "@fluidframework/server-services-client";
+import { INackMessagesControlMessageContents } from "./messages";
 
 export interface IDocumentDetails {
     existing: boolean;
@@ -70,6 +71,9 @@ export interface IDeliState {
 
     // Last sent minimum sequence number
     lastSentMSN: number | undefined;
+
+    // Nack messages state
+    nackMessages: INackMessagesControlMessageContents | undefined;
 }
 
 // TODO: We should probably rename this to IScribeState

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -8,6 +8,7 @@ import {
     INack,
     INackContent,
     ISequencedDocumentMessage,
+    ScopeType,
 } from "@fluidframework/protocol-definitions";
 
 // String identifying the raw operation message
@@ -151,8 +152,8 @@ export enum ControlMessageType {
     // Instruction sent to update Durable sequence number
     UpdateDSN = "updateDSN",
 
-    // Instruction sent to have deli nack all future messages
-    NackFutureMessages = "nackFutureMessages",
+    // Instruction sent to control if deli nacks messages
+    NackMessages = "nackMessages",
 }
 
 export interface IUpdateDSNControlMessageContents {
@@ -160,4 +161,20 @@ export interface IUpdateDSNControlMessageContents {
     clearCache: boolean;
 }
 
-export type INackFutureMessagesControlMessageContents = INackContent;
+export interface INackMessagesControlMessageContents {
+    /**
+     * The INackContent to send when nacking the message
+     */
+    content: INackContent;
+
+    /**
+     * If a client has a scope in this list, there message will be allowed
+     * If undefined, scope will not affect message nacking
+     */
+    allowedScopes?: ScopeType[];
+
+    /**
+     * Controls if system messages should be nacked
+     */
+    allowSystemMessages?: boolean;
+}

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -112,6 +112,7 @@ export class DocumentStorage implements IDocumentStorage {
             epoch: undefined,
             term: 1,
             lastSentMSN: 0,
+            nackMessages: undefined,
         };
 
         const scribe: IScribe = {
@@ -278,11 +279,11 @@ export class DocumentStorage implements IDocumentStorage {
             // TODO: Make the rest endpoint handle this case.
             const opsContent = await gitManager.getContent(existingRef.object.sha, ".logTail/logTail");
             const ops = JSON.parse(
-                            Buffer.from(
-                                opsContent.content,
-                                Buffer.isEncoding(opsContent.encoding) ? opsContent.encoding : undefined,
-                            ).toString(),
-                        ) as ISequencedDocumentMessage[];
+                Buffer.from(
+                    opsContent.content,
+                    Buffer.isEncoding(opsContent.encoding) ? opsContent.encoding : undefined,
+                ).toString(),
+            ) as ISequencedDocumentMessage[];
             const dbOps = ops.map((op: ISequencedDocumentMessage) => {
                 return {
                     documentId,

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -106,6 +106,7 @@ export class TestDocumentStorage implements IDocumentStorage {
             epoch: undefined,
             term: 1,
             lastSentMSN: 0,
+            nackMessages: undefined,
         };
 
         const scribe: IScribe = {


### PR DESCRIPTION
Follow-up on #5201

The idea is that we should be able to nack regular ops for non-summarizer clients in the event that clients are not summarizing properly.

- Rename `nackFutureMessages` control type to `nackMessages` - since the signature is changing and it's more generic now
- Add the ability to not nack messages submitted by clients that have specific scopes
- Add the ability to not nack system messages
- Save nack messages state in the deli checkpoint

An example flow:
- Some backend service detects that it has been X number of ops since the last summary. That service will submit a `nackMessages` control message to deli with `allowSystemMessages: true` and `allowedScopes: [ScopeType.SummaryWrite]`.
- Once a summary arrives, the backend service will submit a `nackMessages` control message set to `undefined`, which clears this state from deli.