### PR TITLE
Added GC related testing to stress tests

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -64,6 +64,7 @@
     "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/map": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1024.0-0",
+    "@fluidframework/runtime-definitions": "^0.40.0",
     "@fluidframework/runtime-utils": "^0.40.0",
     "@fluidframework/telemetry-utils": "^0.40.0",
     "@fluidframework/test-driver-definitions": "^0.40.0",


### PR DESCRIPTION
Added the following to the stress test:
- Create a new data store for each client pair. The url to the data store is stored in a key common to the pair.
- When a client becomes the writer by acquiring the lock, it adds a reference to the data store by storing its handle.
- When a client becomes the reader by releasing the lock, it removes the reference to the data store by removing the handle.

The idea is that at any point in time, there is a data store for each client pair and that data store can have either 0, 1 or 2 references. This should give us some coverage for GC where there are a lot of clients and each is adding / deleting data stores. 