### PR TITLE
ODSP: Renames and get rid of IDs for trees

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -97,7 +97,7 @@ export interface IWriteSummaryResponse {
     id: string;
 }
 
-export type OdspSummaryTreeEntry = IOdspSummaryTreeValueEntry | ISummaryTreeHandleEntry;
+export type OdspSummaryTreeEntry = IOdspSummaryTreeValueEntry | IOdspSummaryTreeHandleEntry;
 
 export interface IOdspSummaryTreeBaseEntry {
     path: string;
@@ -110,7 +110,7 @@ export interface IOdspSummaryTreeValueEntry extends IOdspSummaryTreeBaseEntry {
     unreferenced?: true;
 }
 
-export interface ISummaryTreeHandleEntry extends IOdspSummaryTreeBaseEntry {
+export interface IOdspSummaryTreeHandleEntry extends IOdspSummaryTreeBaseEntry {
     id: string;
 }
 

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -80,67 +80,85 @@ export interface IDocumentStorageVersion {
     id: string;
 }
 
-export enum SnapshotType {
-    Container = "container",
-    Channel = "channel",
-}
+/**
+ *
+ * Data structures that form ODSP Summary
+ *
+ */
 
 export interface IOdspSummaryPayload {
-    type: SnapshotType;
+    type: "container" | "channel";
     message: string;
     sequenceNumber: number;
-    entries: SnapshotTreeEntry[];
+    entries: OdspSummaryTreeEntry[];
 }
 
-export interface ISnapshotResponse {
+export interface IWriteSummaryResponse {
     id: string;
 }
 
-export type SnapshotTreeEntry = ISnapshotTreeValueEntry | ISnapshotTreeHandleEntry;
+export type OdspSummaryTreeEntry = IOdspSummaryTreeValueEntry | ISummaryTreeHandleEntry;
 
-export interface ISnapshotTreeBaseEntry {
+export interface IOdspSummaryTreeBaseEntry {
     path: string;
     type: "blob" | "tree" | "commit";
 }
 
-export interface ISnapshotTreeValueEntry extends ISnapshotTreeBaseEntry {
-    value: SnapshotTreeValue;
+export interface IOdspSummaryTreeValueEntry extends IOdspSummaryTreeBaseEntry {
+    value: OdspSummaryTreeValue;
     // Indicates that this tree entry is unreferenced. If this is not present, the tree entry is considered referenced.
     unreferenced?: true;
 }
 
-export interface ISnapshotTreeHandleEntry extends ISnapshotTreeBaseEntry {
+export interface ISummaryTreeHandleEntry extends IOdspSummaryTreeBaseEntry {
     id: string;
 }
 
-export type SnapshotTreeValue = ISnapshotTree | ISnapshotBlob | ISnapshotCommit;
+export type OdspSummaryTreeValue = IOdspSummaryTree | IOdspSummaryBlob;
 
-export interface ISnapshotTree {
+export interface IOdspSummaryTree {
     type: "tree";
-    entries?: SnapshotTreeEntry[];
+    entries?: OdspSummaryTreeEntry[];
 }
 
-export interface ISnapshotBlob {
+export interface IOdspSummaryBlob {
     type: "blob";
     content: string;
     encoding: "base64" | "utf-8";
 }
 
-export interface ISnapshotCommit {
-    type: "commit";
-    content: string;
-}
+/**
+ *
+ * Data structures that form ODSP Snapshot
+ *
+ */
 
-export interface ITreeEntry {
-    id: string;
+export interface IOdspSnapshotTreeEntryTree {
     path: string;
-    type: "commit" | "tree" | "blob";
+    type: "tree";
     // Indicates that this tree entry is unreferenced. If this is not present, the tree entry is considered referenced.
     unreferenced?: true;
 }
 
-export interface ITree {
-    entries: ITreeEntry[];
+export interface IOdspSnapshotTreeEntryCommit {
+    id: string;
+    path: string;
+    type: "commit";
+}
+
+export interface IOdspSnapshotTreeEntryBlob {
+    id: string;
+    path: string;
+    type: "blob";
+}
+
+export type IOdspSnapshotTreeEntry =
+    | IOdspSnapshotTreeEntryTree
+    | IOdspSnapshotTreeEntryCommit
+    | IOdspSnapshotTreeEntryBlob;
+
+export interface IOdspSnapshotTree {
+    entries: IOdspSnapshotTreeEntry[];
     id: string;
     sequenceNumber: number;
 }
@@ -148,7 +166,7 @@ export interface ITree {
 /**
  * Blob content, represents blobs in downloaded snapshot.
  */
-export interface IBlob {
+export interface IOdspSnapshotBlob {
     content: string;
     // SPO only uses "base64" today for download.
     // We are adding undefined too, as temp way to roundtrip strings unchanged.
@@ -159,8 +177,8 @@ export interface IBlob {
 
 export interface IOdspSnapshot {
     id: string;
-    trees: ITree[];
-    blobs?: IBlob[];
+    trees: IOdspSnapshotTree[];
+    blobs?: IOdspSnapshotBlob[];
     ops?: ISequencedDeltaOpMessage[];
 }
 

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -157,7 +157,7 @@ export type IOdspSnapshotTreeEntry =
     | IOdspSnapshotTreeEntryCommit
     | IOdspSnapshotTreeEntryBlob;
 
-export interface IOdspSnapshotTree {
+export interface IOdspSnapshotCommit {
     entries: IOdspSnapshotTreeEntry[];
     id: string;
     sequenceNumber: number;
@@ -177,7 +177,7 @@ export interface IOdspSnapshotBlob {
 
 export interface IOdspSnapshot {
     id: string;
-    trees: IOdspSnapshotTree[];
+    trees: IOdspSnapshotCommit[];
     blobs?: IOdspSnapshotBlob[];
     ops?: ISequencedDeltaOpMessage[];
 }

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -16,10 +16,9 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { IOdspResolvedUrl, TokenFetchOptions } from "@fluidframework/odsp-driver-definitions";
 import {
-    ISnapshotTree,
-    SnapshotTreeValue,
-    SnapshotTreeEntry,
-    SnapshotType,
+    IOdspSummaryTree,
+    OdspSummaryTreeValue,
+    OdspSummaryTreeEntry,
     ICreateFileResponse,
     IOdspSummaryPayload,
 } from "./contracts";
@@ -125,7 +124,7 @@ function convertSummaryIntoContainerSnapshot(createNewSummary: ISummaryTree) {
         entries: snapshotTree.entries ?? [],
         message: "app",
         sequenceNumber: documentAttributes.sequenceNumber,
-        type: SnapshotType.Container,
+        type: "container",
     };
     return snapshot;
 }
@@ -133,8 +132,8 @@ function convertSummaryIntoContainerSnapshot(createNewSummary: ISummaryTree) {
 /**
  * Converts a summary tree to ODSP tree
  */
-export function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree): ISnapshotTree {
-    const snapshotTree: ISnapshotTree = {
+export function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree): IOdspSummaryTree {
+    const snapshotTree: IOdspSummaryTree = {
         type: "tree",
         entries: [],
     };
@@ -143,7 +142,7 @@ export function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree):
     for (const key of keys) {
         const summaryObject = summary.tree[key];
 
-        let value: SnapshotTreeValue;
+        let value: OdspSummaryTreeValue;
 
         switch (summaryObject.type) {
             case SummaryType.Tree: {
@@ -170,7 +169,7 @@ export function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree):
             }
         }
 
-        const entry: SnapshotTreeEntry = {
+        const entry: OdspSummaryTreeEntry = {
             path: encodeURIComponent(key),
             type: getGitType(summaryObject),
             value,

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -6,13 +6,13 @@
 import { v4 as uuid } from "uuid";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { Uint8ArrayToString, unreachableCase } from "@fluidframework/common-utils";
-import { IBlob, IOdspSnapshot, ITreeEntry } from "./contracts";
+import { IOdspSnapshotBlob, IOdspSnapshot, IOdspSnapshotTreeEntry } from "./contracts";
 
 /**
  * Converts a summary(ISummaryTree) taken in detached container to IOdspSnapshot tree
  */
 export function convertSummaryTreeToIOdspSnapshot(summary: ISummaryTree): IOdspSnapshot {
-    const blobs: IBlob[] = [];
+    const blobs: IOdspSnapshotBlob[] = [];
     const treeId = uuid();
     const snapshotTree: IOdspSnapshot = {
         trees: [
@@ -32,8 +32,8 @@ export function convertSummaryTreeToIOdspSnapshot(summary: ISummaryTree): IOdspS
 
 function convertSummaryTreeToIOdspSnapshotCore(
     summary: ISummaryTree,
-    trees: ITreeEntry[],
-    blobs: IBlob[],
+    trees: IOdspSnapshotTreeEntry[],
+    blobs: IOdspSnapshotBlob[],
     path: string = "",
 ) {
     const keys = Object.keys(summary.tree);
@@ -44,7 +44,6 @@ function convertSummaryTreeToIOdspSnapshotCore(
         switch (summaryObject.type) {
             case SummaryType.Tree: {
                 trees.push({
-                    id: uuid(),
                     type: "tree",
                     path: currentPath,
                 });
@@ -54,7 +53,7 @@ function convertSummaryTreeToIOdspSnapshotCore(
             case SummaryType.Blob: {
                 const content = typeof summaryObject.content === "string" ?
                     summaryObject.content : Uint8ArrayToString(summaryObject.content, "base64");
-                const blob: IBlob = {
+                const blob: IOdspSnapshotBlob = {
                     id: uuid(),
                     encoding: typeof summaryObject.content === "string" ? undefined : "base64",
                     content,

--- a/packages/drivers/odsp-driver/src/test/odspSummaryUploadManagerTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspSummaryUploadManagerTests.spec.ts
@@ -15,7 +15,7 @@ import { ISummaryContext } from "@fluidframework/driver-definitions";
 import { IOdspResolvedUrl, TokenFetchOptions } from "@fluidframework/odsp-driver-definitions";
 import { EpochTracker } from "../epochTracker";
 import { IDedupCaches, OdspSummaryUploadManager } from "../odspSummaryUploadManager";
-import { IBlob } from "../contracts";
+import { IOdspSnapshotBlob } from "../contracts";
 import { LocalPersistentCache } from "../odspCache";
 import { mockFetchOk } from "./mockFetch";
 
@@ -38,7 +38,7 @@ describe("Odsp Summary Upload Manager Tests", () => {
     });
 
     it("Should populate caches properly", async () => {
-        const blobCache = new Map<string, IBlob>();
+        const blobCache = new Map<string, IOdspSnapshotBlob>();
 
         blobCache.set("blob1", { content: "blob1", id: "blob1", size: 5, encoding: undefined });
         blobCache.set("blob2", { content: "blob2", id: "blob2", size: 5, encoding: undefined });


### PR DESCRIPTION
Renaming a bunch of structures in contracts.ts to better reflect what they are.
Also get rid of ID on trees as it's not used anywhere, and storage is planning to stop propagating it