### PR TITLE
Rate Limitter bug

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -177,7 +177,7 @@ export class EpochTracker implements IPersistedFileCache {
         let epochFromResponse: string | undefined;
         try {
             const response = await this.rateLimiter.schedule(
-                async () => fetchArray(request.url, request.fetchOptions, this.rateLimiter),
+                async () => fetchArray(request.url, request.fetchOptions),
             );
             epochFromResponse = response.headers.get("x-fluid-epoch");
             this.validateEpochFromResponse(epochFromResponse, fetchType);

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -27,7 +27,6 @@ import {
     TokenFetcher,
 } from "@fluidframework/odsp-driver-definitions";
 import { fetch } from "./fetch";
-import { RateLimiter } from "./rateLimiter";
 import { pkgVersion } from "./packageVersion";
 import { IOdspSnapshot } from "./contracts";
 
@@ -144,11 +143,8 @@ export async function fetchHelper(
 export async function fetchArray(
     requestInfo: RequestInfo,
     requestInit: RequestInit | undefined,
-    rateLimiter: RateLimiter,
 ): Promise<IOdspResponse<ArrayBuffer>> {
-    const { content, headers, commonSpoHeaders, duration } = await rateLimiter.schedule(
-        async () => fetchHelper(requestInfo, requestInit),
-    );
+    const { content, headers, commonSpoHeaders, duration } = await fetchHelper(requestInfo, requestInit);
 
     const arrayBuffer = await content.arrayBuffer();
     commonSpoHeaders.bodySize = arrayBuffer.byteLength;


### PR DESCRIPTION
We have a recursive usage of rate limitter in ODSP driver when fetching blobs.
This results in deadlock (image will not load) if we have more than 23 images in the document.
