### PR TITLE
rater limiter bug / 0.39

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -186,7 +186,7 @@ export class EpochTracker implements IPersistedFileCache {
         let epochFromResponse: string | undefined;
         try {
             const response = await this.rateLimiter.schedule(
-                async () => fetchArray(request.url, request.fetchOptions, this.rateLimiter),
+                async () => fetchArray(request.url, request.fetchOptions),
             );
             epochFromResponse = response.headers.get("x-fluid-epoch");
             this.validateEpochFromResponse(epochFromResponse, fetchType);

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -23,7 +23,6 @@ import {
 } from "@fluidframework/odsp-driver-definitions";
 import { debug } from "./debug";
 import { fetch } from "./fetch";
-import { RateLimiter } from "./rateLimiter";
 import { pkgVersion } from "./packageVersion";
 
 /** Parse the given url and return the origin (host name) */
@@ -134,11 +133,8 @@ export async function fetchHelper(
 export async function fetchArray(
     requestInfo: RequestInfo,
     requestInit: RequestInit | undefined,
-    rateLimiter: RateLimiter,
 ): Promise<IOdspResponse<ArrayBuffer>> {
-    const { content, headers, commonSpoHeaders, duration } = await rateLimiter.schedule(
-        async () => fetchHelper(requestInfo, requestInit),
-    );
+    const { content, headers, commonSpoHeaders, duration } = await fetchHelper(requestInfo, requestInit);
 
     const arrayBuffer = await content.arrayBuffer();
     commonSpoHeaders.bodySize = arrayBuffer.byteLength;


### PR DESCRIPTION
We have a recursive usage of rate limiter in ODSP driver when fetching blobs.
This results in deadlock (image will not load) if we have more than 23 images in the document.
 
### Post-merge note:
This fix was rolled out in the 0.39.1 patch.