### PR TITLE
Implement scribe nack messages logic

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -17,6 +17,7 @@ import {
     MessageType,
     ISequencedDocumentAugmentedMessage,
     IProtocolState,
+    ScopeType,
 } from "@fluidframework/protocol-definitions";
 import {
     ControlMessageType,
@@ -32,6 +33,7 @@ import {
     SequencedOperationType,
     IQueuedMessage,
     IPartitionLambda,
+    INackMessagesControlMessageContents,
 } from "@fluidframework/server-services-core";
 import Deque from "double-ended-queue";
 import * as _ from "lodash";
@@ -110,7 +112,7 @@ export class ScribeLambda implements IPartitionLambda {
                         }
                         this.term = lastSummary.term;
                         const lastScribe = JSON.parse(lastSummary.scribe) as IScribe;
-                        this.protocolHead = lastSummary.protocolHead;
+                        await this.updateProtocolHead(lastSummary.protocolHead);
                         this.protocolHandler = initializeProtocol(lastScribe.protocolState, this.term);
                         this.setStateFromCheckpoint(lastScribe);
                         this.pendingMessages = new Deque<ISequencedDocumentMessage>(
@@ -208,7 +210,7 @@ export class ScribeLambda implements IPartitionLambda {
                                 if (summaryResponse.status) {
                                     await this.sendSummaryAck(summaryResponse.message as ISummaryAck);
                                     await this.sendSummaryConfirmationMessage(operation.sequenceNumber, false);
-                                    this.protocolHead = this.protocolHandler.sequenceNumber;
+                                    await this.updateProtocolHead(this.protocolHandler.sequenceNumber);
                                     this.context.log?.info(
                                         `Client summary success @${value.operation.sequenceNumber}`,
                                         {
@@ -312,8 +314,20 @@ export class ScribeLambda implements IPartitionLambda {
                     // An external summary writer can only update the protocolHead when the ack is sequenced
                     // back to the stream.
                     if (this.summaryWriter.isExternal) {
-                        this.protocolHead = content.summaryProposal.summarySequenceNumber;
+                        await this.updateProtocolHead(content.summaryProposal.summarySequenceNumber);
                     }
+                }
+
+                // check to see if this exact sequence number causes us to hit the max ops since last summary nack limit
+                if (this.serviceConfiguration.scribe.nackMessages.enable &&
+                    this.serviceConfiguration.scribe.nackMessages.maxOps === this.sequenceNumber - this.protocolHead) {
+                    // this op brings us over the limit
+                    // tell deli to start nacking non-system ops and ops that are submitted by non-summarizers
+                    await this.sendNackMessagesMessage({
+                        content: this.serviceConfiguration.scribe.nackMessages.nackContent,
+                        allowSystemMessages: true,
+                        allowedScopes: [ScopeType.SummaryWrite],
+                    });
                 }
             }
         }
@@ -427,6 +441,17 @@ export class ScribeLambda implements IPartitionLambda {
         }
     }
 
+    private async updateProtocolHead(protocolHead: number) {
+        if (this.serviceConfiguration.scribe.nackMessages.enable &&
+            this.serviceConfiguration.scribe.nackMessages.maxOps >= (this.sequenceNumber - this.protocolHead)) {
+            // we were over the limit, so we must have been nacking messages
+            // tell deli to stop
+            await this.sendNackMessagesMessage(undefined);
+        }
+
+        this.protocolHead = protocolHead;
+    }
+
     private async sendSummaryAck(contents: ISummaryAck) {
         const operation: IDocumentMessage = {
             clientSequenceNumber: -1,
@@ -462,6 +487,24 @@ export class ScribeLambda implements IPartitionLambda {
                 durableSequenceNumber,
                 clearCache,
             },
+        };
+
+        const operation: IDocumentSystemMessage = {
+            clientSequenceNumber: -1,
+            contents: null,
+            data: JSON.stringify(controlMessage),
+            referenceSequenceNumber: -1,
+            traces: this.serviceConfiguration.enableTraces ? [] : undefined,
+            type: MessageType.Control,
+        };
+
+        return this.sendToDeli(operation);
+    }
+
+    private async sendNackMessagesMessage(contents: INackMessagesControlMessageContents | undefined) {
+        const controlMessage: IControlMessage = {
+            type: ControlMessageType.NackMessages,
+            contents,
         };
 
         const operation: IDocumentSystemMessage = {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -323,7 +323,7 @@ export class ScribeLambda implements IPartitionLambda {
                     this.serviceConfiguration.scribe.nackMessages.maxOps === this.sequenceNumber - this.protocolHead) {
                     // this op brings us over the limit
                     // tell deli to start nacking non-system ops and ops that are submitted by non-summarizers
-                    await this.sendNackMessagesMessage({
+                    await this.sendNackMessage({
                         content: this.serviceConfiguration.scribe.nackMessages.nackContent,
                         allowSystemMessages: true,
                         allowedScopes: [ScopeType.SummaryWrite],
@@ -446,7 +446,7 @@ export class ScribeLambda implements IPartitionLambda {
             this.serviceConfiguration.scribe.nackMessages.maxOps >= (this.sequenceNumber - this.protocolHead)) {
             // we were over the limit, so we must have been nacking messages
             // tell deli to stop
-            await this.sendNackMessagesMessage(undefined);
+            await this.sendNackMessage(undefined);
         }
 
         this.protocolHead = protocolHead;
@@ -501,7 +501,7 @@ export class ScribeLambda implements IPartitionLambda {
         return this.sendToDeli(operation);
     }
 
-    private async sendNackMessagesMessage(contents: INackMessagesControlMessageContents | undefined) {
+    private async sendNackMessage(contents: INackMessagesControlMessageContents | undefined) {
         const controlMessage: IControlMessage = {
             type: ControlMessageType.NackMessages,
             contents,

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IClientConfiguration } from "@fluidframework/protocol-definitions";
+import { IClientConfiguration, INackContent, NackErrorType } from "@fluidframework/protocol-definitions";
 
 // Deli lambda configuration
 export interface IDeliServerConfiguration {
@@ -30,6 +30,21 @@ export interface IScribeServerConfiguration {
 
     // Enables writing a summary nack when an exception occurs during summary creation
     ignoreStorageException: boolean;
+
+    // Controls if ops should be nacked if a summarizer hasn't been made for a while
+    nackMessages: IScribeNackMessagesServerConfiguration;
+}
+
+export interface IScribeNackMessagesServerConfiguration {
+    // Enables nacking non-system & non-summarizer client message if
+    // the op count since the last summary exceeds this limit
+    enable: boolean;
+
+    // Amount of ops since the last summary before starting to nack
+    maxOps: number;
+
+    // The contents of the nack to send after the limit is hit
+    nackContent: INackContent;
 }
 
 // Document lambda configuration
@@ -85,6 +100,16 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         enablePendingCheckpointMessages: true,
         clearCacheAfterServiceSummary: false,
         ignoreStorageException: false,
+        nackMessages: {
+            enable: false,
+            maxOps: 5000,
+            nackContent: {
+                code: 429,
+                type: NackErrorType.ThrottlingError,
+                retryAfter: 10,
+                message: "Submit a summary before inserting additional operations",
+            },
+        },
     },
     documentLambda: {
         partitionActivityTimeout: 10 * 60 * 1000,


### PR DESCRIPTION
Next step after #6009. Related to #5376

Scribe will detect if it's been X number of ops since the last summary. Once a certain limit is exceeded, scribe will tell deli (via the nack control message), that it should start nacking certain messages. Once scribe sees a summary, it will tell deli to stop nacking.

The behavior is configurable via the `IScribeServerConfiguration` object.