### PR TITLE
Bug fix when using registerOnValues with primitive collections

### DIFF
--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/data_binding.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/data_binding.js
@@ -1734,8 +1734,24 @@ class DataBinding {
    * @hidden
    */
   static _registerOnValues(in_path, in_events, in_callback, in_options = {}) {
-    this.registerOnProperty(in_path, in_events, function(property) {
-      in_callback.call(this, property.isPrimitiveType() ? property.getValue() : property.getValues());
+    this.registerOnProperty(in_path, in_events, function(propertyOrKey, parent) {
+
+      // propertyOrIndex could be a primitive value when registering callbacks on primitive collection,
+      // then it value represent the index/key of the entry involved in the registered event.
+      if (propertyOrKey instanceof BaseProperty ) {
+        const property = propertyOrKey;
+        const values = propertyOrKey.isPrimitiveType() ? propertyOrKey.getValue() : propertyOrKey.getValues();
+        in_callback.call(this, values);
+      } else {
+        const key = propertyOrKey;
+        let values;
+        // parent won't be available upon removal
+        if (parent) {
+          values = parent.get(key);
+        }
+        in_callback.call(this, key, values);
+      }
+
     }, in_options);
   }
 

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/testTemplates.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/testTemplates.js
@@ -172,6 +172,11 @@ const MapContainerTemplate = {
   inherits: 'NamedProperty',
   properties: [
     {
+      id: "mapPrimitive",
+      typeid: "String",
+      context: 'map'
+    },
+    {
       id: 'subMap',
       typeid: 'Test:ChildID-0.0.1',
       context: 'map'


### PR DESCRIPTION
- Adding test case for primitive collections for `registerOnPath`
- Fixing an issue which occur when using the combination of `registerOnValue` with primitive collection 

CC: @ruiterr @evaliyev  @karlbom @DLehenbauer 