### PR TITLE
Marked absolutePath in IFluidHandle as readonly

### DIFF
--- a/api-report/core-interfaces.api.md
+++ b/api-report/core-interfaces.api.md
@@ -40,11 +40,11 @@ export const IFluidHandle: keyof IProvideFluidHandle;
 // @public
 export interface IFluidHandle<T = IFluidObject & IFluidLoadable> extends IProvideFluidHandle {
     // @deprecated (undocumented)
-    absolutePath: string;
+    readonly absolutePath: string;
     attachGraph(): void;
     bind(handle: IFluidHandle): void;
     get(): Promise<T>;
-    isAttached: boolean;
+    readonly isAttached: boolean;
 }
 
 // @public (undocumented)
@@ -52,12 +52,12 @@ export const IFluidHandleContext: keyof IProvideFluidHandleContext;
 
 // @public
 export interface IFluidHandleContext extends IProvideFluidHandleContext {
-    absolutePath: string;
+    readonly absolutePath: string;
     attachGraph(): void;
-    isAttached: boolean;
+    readonly isAttached: boolean;
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
-    routeContext?: IFluidHandleContext;
+    readonly routeContext?: IFluidHandleContext;
 }
 
 // @public (undocumented)

--- a/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
@@ -45,7 +45,9 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
         if (this.runtime.existing) {
             const treeHandle = await this.root.wait<IFluidHandle<SharedPropertyTree>>(propertyKey);
             if (this._queryString !== undefined) {
-                treeHandle.absolutePath += `?${  this._queryString}`;
+                // The absolutePath of the DDS should not be updated. Instead, a new handle can be created with the new
+                // path. To be fixed with this issue - https://github.com/microsoft/FluidFramework/issues/6036
+                (treeHandle as any).absolutePath += `?${  this._queryString}`;
             }
             this._tree = await treeHandle.get();
         } else {

--- a/experimental/PropertyDDS/examples/property-inspector/src/dataObject.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/src/dataObject.ts
@@ -45,7 +45,9 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
         if (this.runtime.existing) {
             const treeHandle = await this.root.wait<IFluidHandle<SharedPropertyTree>>(propertyKey);
             if (this._queryString !== undefined) {
-                treeHandle.absolutePath += `?${  this._queryString}`;
+                // The absolutePath of the DDS should not be updated. Instead, a new handle can be created with the new
+                // path. To be fixed with this issue - https://github.com/microsoft/FluidFramework/issues/6036
+                (treeHandle as any).absolutePath += `?${  this._queryString}`;
             }
             this._tree = await treeHandle.get();
         } else {

--- a/packages/loader/core-interfaces/src/handles.ts
+++ b/packages/loader/core-interfaces/src/handles.ts
@@ -20,18 +20,18 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
     /**
      * The absolute path to the handle context from the root.
      */
-    absolutePath: string;
+    readonly absolutePath: string;
 
     /**
      * The parent IFluidHandleContext that has provided a route path to this IFluidHandleContext or undefined
      * at the root.
      */
-    routeContext?: IFluidHandleContext;
+    readonly routeContext?: IFluidHandleContext;
 
     /**
      * Flag indicating whether or not the entity has services attached.
      */
-    isAttached: boolean;
+    readonly isAttached: boolean;
 
     /**
      * Runs through the graph and attach the bounded handles.
@@ -60,12 +60,12 @@ export interface IFluidHandle<
      *
      * The absolute path to the handle context from the root.
      */
-    absolutePath: string;
+    readonly absolutePath: string;
 
     /**
      * Flag indicating whether or not the entity has services attached.
      */
-    isAttached: boolean;
+    readonly isAttached: boolean;
 
     /**
      * Runs through the graph and attach the bounded handles.


### PR DESCRIPTION
`absolutePath` in `IFluidHandle` should not be modified after the handle has been created. Marking it as readonly.

Note: PropertyDDS updates the absolutePath of the underlying DDS. Created a bug to fix that - https://github.com/microsoft/FluidFramework/issues/6036