### PR TITLE
Updated disabling tenant to tenant deletion

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -124,11 +124,11 @@ export function create(
     });
 
     /**
-     * Deletes a tenant by adding a disabled flag
+     * Deletes the given tenant
      */
     router.delete("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const tenantP = manager.disableTenant(tenantId);
+        const tenantP = manager.deleteTenant(tenantId);
         returnResponse(tenantP, response);
     });
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -278,13 +278,13 @@ export class TenantManager {
     }
 
     /**
-     * Flags the given tenant as disabled
+     * Deletes the given tenant
      */
-    public async disableTenant(tenantId: string): Promise<void> {
+    public async deleteTenant(tenantId: string): Promise<void> {
         const db = await this.mongoManager.getDatabase();
         const collection = db.collection<ITenantDocument>(this.collectionName);
 
-        await collection.update({ _id: tenantId }, { disabled: true }, null);
+        await collection.deleteOne({ _id: tenantId });
     }
 
     private encryptAccessInfo(accessInfo: any): string {


### PR DESCRIPTION
Currently when a tenant deletion is requested, we are only marking that entry as disabled, to be Privacy Compliant, we need to actually delete the tenant information rather than only flagging it as disabled.