### PR TITLE
Use path.join in bumpVersion/utils

### DIFF
--- a/tools/build-tools/src/bumpVersion/utils.ts
+++ b/tools/build-tools/src/bumpVersion/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { execAsync } from "../common/utils";
+import * as path from "path";
 
 export function fatal(error: string): never {
     const e = new Error(error);
@@ -239,7 +240,7 @@ export class GitRepo {
 export async function runPolicyCheckWithFix(gitRepo: GitRepo){
     console.log("Running Policy Check with Resolution(fix)");
     await exec(
-        `node ${__dirname}\\..\\repoPolicyCheck\\repoPolicyCheck.js -r -q`,
+        `node ${path.join(__dirname, '..', 'repoPolicyCheck', 'repoPolicyCheck.js')} -r -q`,
         gitRepo.resolvedRoot,
         "policy-check:fix failed");
 


### PR DESCRIPTION
Fix a bug in bump-version tooling where default slash usage (`/` and `\`) differs between platforms.