### PR TITLE
Replace node-zookeeper-client with zookeeper

### DIFF
--- a/server/routerlicious/README.md
+++ b/server/routerlicious/README.md
@@ -84,6 +84,11 @@ An example developer flow would be to:
 Then use another command window to deliver the changes:
 * `npm run build` - build
 * `docker-compose restart {modified service}` - allow the container to pick up the changes stored on the local machine
+
+> **Note:** Some dependencies are required to be installed and built on the OS they are running on.
+> When you update one of these dependencies (e.g. change versions) you will need to fully restart the service using `npm stop && npm start`.
+> Current dependencies with this requirement: zookeeper
+
 or
 
 ### Standalone

--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -3,21 +3,28 @@ services:
     alfred:
         volumes:
             - .:/usr/src/server
+            - /usr/src/server/node_modules
     deli:
         volumes:
             - .:/usr/src/server
+            - /usr/src/server/node_modules
     scriptorium:
         volumes:
             - .:/usr/src/server
+            - /usr/src/server/node_modules
     copier:
         volumes:
             - .:/usr/src/server
+            - /usr/src/server/node_modules
     scribe:
         volumes:
             - .:/usr/src/server
+            - /usr/src/server/node_modules
     foreman:
         volumes:
             - .:/usr/src/server
+            - /usr/src/server/node_modules
     riddler:
         volumes:
             - .:/usr/src/server
+            - /usr/src/server/node_modules

--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -3,28 +3,28 @@ services:
     alfred:
         volumes:
             - .:/usr/src/server
-            - /usr/src/server/node_modules
+            - /usr/src/server/node_modules/zookeeper
     deli:
         volumes:
             - .:/usr/src/server
-            - /usr/src/server/node_modules
+            - /usr/src/server/node_modules/zookeeper
     scriptorium:
         volumes:
             - .:/usr/src/server
-            - /usr/src/server/node_modules
+            - /usr/src/server/node_modules/zookeeper
     copier:
         volumes:
             - .:/usr/src/server
-            - /usr/src/server/node_modules
+            - /usr/src/server/node_modules/zookeeper
     scribe:
         volumes:
             - .:/usr/src/server
-            - /usr/src/server/node_modules
+            - /usr/src/server/node_modules/zookeeper
     foreman:
         volumes:
             - .:/usr/src/server
-            - /usr/src/server/node_modules
+            - /usr/src/server/node_modules/zookeeper
     riddler:
         volumes:
             - .:/usr/src/server
-            - /usr/src/server/node_modules
+            - /usr/src/server/node_modules/zookeeper

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -3225,14 +3225,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.0.tgz",
 			"integrity": "sha512-4BVAE9yp5DU3ISqBInsaRp9J474HWNaNVs8eZ1Far3dI1MwS3Wk0EvBRMM4xBh3Oz+c05hUgJmcbtAVmG8bv7w=="
 		},
-		"@types/node-zookeeper-client": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@types/node-zookeeper-client/-/node-zookeeper-client-0.2.7.tgz",
-			"integrity": "sha512-ycCBzpNABcEQ+ewCWBvz9eAFalygnBhAjy0B7e8RJdALR6ChGaaIKozUsl2QKxPu/1lXUYxfjRel24JQ8pVelg==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -5052,7 +5044,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
 			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"optional": true,
 			"requires": {
 				"buffer-alloc-unsafe": "^1.1.0",
 				"buffer-fill": "^1.0.0"
@@ -5061,8 +5052,7 @@
 		"buffer-alloc-unsafe": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"optional": true
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
@@ -5077,8 +5067,7 @@
 		"buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"optional": true
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -6670,6 +6659,28 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
+		"decompress": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+			"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+			"requires": {
+				"decompress-tar": "^4.0.0",
+				"decompress-tarbz2": "^4.0.0",
+				"decompress-targz": "^4.0.0",
+				"decompress-unzip": "^4.0.1",
+				"graceful-fs": "^4.1.10",
+				"make-dir": "^1.0.0",
+				"pify": "^2.3.0",
+				"strip-dirs": "^2.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
+			}
+		},
 		"decompress-response": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -6677,6 +6688,77 @@
 			"optional": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
+			}
+		},
+		"decompress-tar": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+			"requires": {
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0",
+				"tar-stream": "^1.5.2"
+			}
+		},
+		"decompress-tarbz2": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+			"requires": {
+				"decompress-tar": "^4.1.0",
+				"file-type": "^6.1.0",
+				"is-stream": "^1.1.0",
+				"seek-bzip": "^1.0.5",
+				"unbzip2-stream": "^1.0.9"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+					"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+				}
+			}
+		},
+		"decompress-targz": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+			"requires": {
+				"decompress-tar": "^4.1.1",
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0"
+			}
+		},
+		"decompress-unzip": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+			"requires": {
+				"file-type": "^3.8.0",
+				"get-stream": "^2.2.0",
+				"pify": "^2.3.0",
+				"yauzl": "^2.4.2"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+				},
+				"get-stream": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+					"requires": {
+						"object-assign": "^4.0.1",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
 			}
 		},
 		"dedent": {
@@ -8402,6 +8484,14 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+			"requires": {
+				"pend": "~1.2.0"
+			}
+		},
 		"fecha": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
@@ -8450,6 +8540,11 @@
 			"requires": {
 				"flat-cache": "^3.0.4"
 			}
+		},
+		"file-type": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
 		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
@@ -8838,8 +8933,7 @@
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"optional": true
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"fs-exists-sync": {
 			"version": "0.1.0",
@@ -10461,6 +10555,11 @@
 				"define-properties": "^1.1.3"
 			}
 		},
+		"is-natural-number": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+		},
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -11497,7 +11596,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -12518,6 +12616,11 @@
 				}
 			}
 		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+		},
 		"node-libs-browser": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -12914,27 +13017,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
-			}
-		},
-		"node-zookeeper-client": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-1.1.0.tgz",
-			"integrity": "sha512-Vp9kP8noRV6LcNcHg4/1wjDfxLDbRfnaXoBIbw87ZkG1fPi4H/mIs9ko5dNrniAq7wK6ugBEUGZ1Wzy0VkMnFw==",
-			"requires": {
-				"async": "~0.2.7",
-				"underscore": "~1.4.4"
-			},
-			"dependencies": {
-				"async": {
-					"version": "0.2.10",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-				},
-				"underscore": {
-					"version": "1.4.4",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-					"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
 				}
 			}
 		},
@@ -14345,6 +14427,11 @@
 				"sha.js": "^2.4.8"
 			}
 		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -14358,8 +14445,7 @@
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-			"dev": true
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -14991,7 +15077,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -15371,7 +15456,6 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -15588,6 +15672,14 @@
 			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
 			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
 		},
+		"seek-bzip": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+			"requires": {
+				"commander": "^2.8.1"
+			}
+		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -15730,7 +15822,6 @@
 			"version": "0.8.4",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
 			"integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -16927,6 +17018,14 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
+		"strip-dirs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+			"requires": {
+				"is-natural-number": "^4.0.1"
+			}
+		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -17209,7 +17308,6 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
 			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"optional": true,
 			"requires": {
 				"bl": "^1.0.0",
 				"buffer-alloc": "^1.2.0",
@@ -17224,7 +17322,6 @@
 					"version": "1.2.3",
 					"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
 					"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-					"optional": true,
 					"requires": {
 						"readable-stream": "^2.3.5",
 						"safe-buffer": "^5.1.1"
@@ -17233,14 +17330,12 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"optional": true
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -17255,7 +17350,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -17505,8 +17599,7 @@
 		"to-buffer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-			"optional": true
+			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
@@ -17842,6 +17935,26 @@
 			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
 			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 			"dev": true
+		},
+		"unbzip2-stream": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+			"requires": {
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
+					}
+				}
+			}
 		},
 		"unc-path-regex": {
 			"version": "0.1.2",
@@ -19072,6 +19185,15 @@
 				}
 			}
 		},
+		"yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+			"requires": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
 		"yeast": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
@@ -19087,6 +19209,20 @@
 				"lodash.get": "^4.0.0",
 				"lodash.isequal": "^4.0.0",
 				"validator": "^8.0.0"
+			}
+		},
+		"zookeeper": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/zookeeper/-/zookeeper-4.8.2.tgz",
+			"integrity": "sha512-4S41SfMNDzjgCyShzVvQsjhQETRF4H7Hf/5LMJ8vKSRlXecrfM/tw9AKsuTqU8mPFHxznVyVROe7oW+cUTLbng==",
+			"requires": {
+				"async": "3.2.x",
+				"decompress": "4.2.x",
+				"decompress-targz": "4.1.x",
+				"lodash": "4.x",
+				"nan": "2.x",
+				"node-gyp-build": "^4.2.3",
+				"shelljs": "0.8.x"
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -38,7 +38,6 @@
     "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.19.0",
-    "@types/node-zookeeper-client": "0.2.7",
     "@types/sinon": "^9.0.9",
     "@types/socket.io": "^2.1.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -40,7 +40,6 @@
     "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.19.0",
-    "@types/node-zookeeper-client": "0.2.7",
     "@types/sinon": "^9.0.9",
     "@types/socket.io": "^2.1.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@fluidframework/server-services-core": "^0.1025.0",
-    "node-zookeeper-client": "1.1.0"
+    "zookeeper": "4.8.2"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0-0",
@@ -35,7 +35,6 @@
     "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.19.0",
-    "@types/node-zookeeper-client": "0.2.7",
     "@types/sinon": "^9.0.9",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/services-ordering-zookeeper/src/zookeeperClient.ts
+++ b/server/routerlicious/packages/services-ordering-zookeeper/src/zookeeperClient.ts
@@ -4,12 +4,10 @@
  */
 
 import { IZookeeperClient } from "@fluidframework/server-services-core";
-import * as zookeeper from "node-zookeeper-client";
-
-const RetryAttemps = 3;
+import ZooKeeper from "zookeeper";
 
 export class ZookeeperClient implements IZookeeperClient {
-    private client: zookeeper.Client;
+    private client: ZooKeeper;
 
     constructor(private readonly url: string) {
         this.connect();
@@ -17,15 +15,10 @@ export class ZookeeperClient implements IZookeeperClient {
 
     public async getPartitionLeaderEpoch(topic: string, partition: number) {
         const path = `/brokers/topics/${topic}/partitions/${partition}/state`;
-        return new Promise<number>((resolve, reject) => {
-            this.client.getData(path, (error, data, stat) => {
-                if (error) {
-                    reject(error);
-                } else {
-                    const state = data.toString("utf8");
-                    resolve(JSON.parse(state).leader_epoch);
-                }
-            });
+        return this.client.get(path, false).then((data) => {
+            // `data` is typed incorrectly. Instead of string | Buffer, it is an array like [object, Buffer].
+            const state = (data[1] as string | Buffer).toString("utf8");
+            return JSON.parse(state).leader_epoch as number;
         });
     }
 
@@ -38,13 +31,16 @@ export class ZookeeperClient implements IZookeeperClient {
     }
 
     private connect() {
-        this.client = zookeeper.createClient(this.url, { retries: RetryAttemps });
-        this.client.connect();
-        this.client.once("connected", () => {
-            this.client.once("disconnected", () => {
+        this.client = new ZooKeeper({
+            connect: this.url,
+            timeout: 30000,
+        });
+        this.client.once("connect", () => {
+            this.client.once("disconnect", () => {
                 this.close();
                 this.connect();
             });
         });
+        this.client.init({});
     }
 }

--- a/server/routerlicious/packages/services-ordering-zookeeper/src/zookeeperClient.ts
+++ b/server/routerlicious/packages/services-ordering-zookeeper/src/zookeeperClient.ts
@@ -36,7 +36,7 @@ export class ZookeeperClient implements IZookeeperClient {
             timeout: 30000,
         });
         this.client.once("connect", () => {
-            this.client.once("disconnect", () => {
+            this.client.once("close", () => {
                 this.close();
                 this.connect();
             });

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -78,7 +78,6 @@
     "@types/mocha": "^5.2.5",
     "@types/mongodb": "3.1.17",
     "@types/node": "^12.19.0",
-    "@types/node-zookeeper-client": "0.2.7",
     "@types/sinon": "^9.0.9",
     "@types/socket.io": "^2.1.1",
     "@types/uuid": "^8.3.0",


### PR DESCRIPTION
[node-zookeeper-client package](https://www.npmjs.com/package/node-zookeeper-client) is unmaintained (alexguan/node-zookeeper-client#106), but depends on a version of `underscore` with vulnerability [CVE-2021-23358](https://nvd.nist.gov/vuln/detail/CVE-2021-23358).

[zookeeper package](https://www.npmjs.com/package/zookeeper) is maintained (last published 15 days ago). While less popular (only 4.5k weekly downloads, compared to 29.5k for node-zookeeper-client), the amount of activity and maintenance in the repo is promising.