### PR TITLE
Add note about bump-version needing an HTTPS git ref

### DIFF
--- a/tools/build-tools/README.md
+++ b/tools/build-tools/README.md
@@ -123,3 +123,7 @@ Currently, this task recognize whether it is the default tsc build to commonjs m
 #### Tslint/Eslint Task
 
 Tslint task only wait for the type definition from it's package dependencies.
+
+## Note about `fluid-bump-version`
+
+This tool assumes that you have a set a remote git ref to `microsoft/FluidFramework`. Note that this ref must be an HTTPS URL - if you are using an SSH ref and get an error saying that a remote cannot be found for the repo, then make sure you add another ref specifically for the HTTPS URL

--- a/tools/build-tools/README.md
+++ b/tools/build-tools/README.md
@@ -126,4 +126,4 @@ Tslint task only wait for the type definition from it's package dependencies.
 
 ## Note about `fluid-bump-version`
 
-This tool assumes that you have a set a remote git ref to `microsoft/FluidFramework`. Note that this ref must be an HTTPS URL - if you are using an SSH ref and get an error saying that a remote cannot be found for the repo, then make sure you add another ref specifically for the HTTPS URL
+This tool assumes that you have a set a remote git ref to `microsoft/FluidFramework`. Note that this ref must be an HTTPS URL - if you are using an SSH ref and get an error saying that a remote cannot be found for the repo, then make sure you add another ref specifically for the HTTPS URL (even if you do not use it otherwise).


### PR DESCRIPTION
I have run into this a few times since I auth using SSH URLs. Figure I'd put a note about this here.