### PR TITLE
Fixed a bug in the invert function for primitive type maps.

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/test/reversibleCS.spec.js
+++ b/experimental/PropertyDDS/packages/property-changeset/test/reversibleCS.spec.js
@@ -1,0 +1,48 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+/* eslint-disable no-unused-expressions*/
+/**
+ * @fileoverview In this file, we will test the path helper
+ *    functions described in /src/properties/path_helper.js
+ */
+const ChangeSet = require('../src/changeset');
+const _ = require('lodash');
+
+describe('Reversible ChangeSets', function() {
+    it('Inverting a string map insert', () => {
+        let originalCS = {
+            "map<String>":{
+                "selections": {
+                    "insert": {
+                        "target": "c6e96078-d1eb-8d41-219f-6f935794c453"
+                    }
+                }
+            }
+        };
+        let invertedCS = new ChangeSet(_.cloneDeep(originalCS));
+        invertedCS._toInverseChangeSet();
+
+        let combined = new ChangeSet(originalCS);
+        combined.applyChangeSet(invertedCS);
+    });
+
+    it('Inverting a string map remove', () => {
+        let originalCS = {
+            "map<String>":{
+                "selections": {
+                    "remove": {
+                        "target": "c6e96078-d1eb-8d41-219f-6f935794c453"
+                    }
+                }
+            }
+        };
+        let invertedCS = new ChangeSet(_.cloneDeep(originalCS));
+        invertedCS._toInverseChangeSet();
+
+        let combined = new ChangeSet(originalCS);
+        combined.applyChangeSet(invertedCS);
+    });
+
+});


### PR DESCRIPTION
This fixes a bug in the invert function for primitive type maps.

This problem is caused by a difference in the changeset format for primitive type and polymorphic maps. For primitive maps, there are no typeids in the insert/remove (i.e. `{insert: { key: value} }`). In contrast to this, polymorphic maps have a format like this: `{insert: {type:  { key: value} }}`. This difference was not taken into account so far.

@DLehenbauer CC