### PR TITLE
Documentation and testing for double createSubDirectory handling

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -974,17 +974,11 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
             throw new Error(`SubDirectory name may not contain ${posix.sep}`);
         }
 
-        let subDir: IDirectory | undefined = this._subdirectories.get(subdirName);
-        // If the subdirectory already exists, return without submitting a useless op
-        if (subDir !== undefined) {
-            return subDir;
-        }
-
         // Create the sub directory locally first.
         this.createSubDirectoryCore(subdirName, true, null);
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        subDir = this._subdirectories.get(subdirName)!;
+        const subDir: IDirectory = this._subdirectories.get(subdirName)!;
 
         // If we are not attached, don't submit the op.
         if (!this.directory.isAttached()) {

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -974,11 +974,17 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
             throw new Error(`SubDirectory name may not contain ${posix.sep}`);
         }
 
+        let subDir: IDirectory | undefined = this._subdirectories.get(subdirName);
+        // If the subdirectory already exists, return without submitting a useless op
+        if (subDir !== undefined) {
+            return subDir;
+        }
+
         // Create the sub directory locally first.
         this.createSubDirectoryCore(subdirName, true, null);
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const subDir: IDirectory = this._subdirectories.get(subdirName)!;
+        subDir = this._subdirectories.get(subdirName)!;
 
         // If we are not attached, don't submit the op.
         if (!this.directory.isAttached()) {

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -150,9 +150,10 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     set<T = any>(key: string, value: T): this;
 
     /**
-     * Creates an IDirectory child of this IDirectory.
+     * Creates an IDirectory child of this IDirectory, or retrieves the existing IDirectory child if one with the
+     * same name already exists.
      * @param subdirName - Name of the new child directory to create
-     * @returns The newly created IDirectory
+     * @returns The IDirectory child that was created or retrieved
      */
     createSubDirectory(subdirName: string): IDirectory;
 

--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -1172,6 +1172,16 @@ describe("Directory", () => {
                 }
                 assert.ok(expectedDirectories2.size === 0);
             });
+
+            it("Only creates a subdirectory once", () => {
+                const fooDirectory = directory1.createSubDirectory("foo");
+                fooDirectory.set("testKey", "testValue");
+                const fooDirectory2 = directory1.createSubDirectory("foo");
+                fooDirectory2.set("testKey2", "testValue2");
+                assert.strictEqual(fooDirectory, fooDirectory2, "Created two separate subdirectories");
+                assert.strictEqual(fooDirectory.get("testKey2"), "testValue2", "Value 2 not present");
+                assert.strictEqual(fooDirectory2.get("testKey"), "testValue", "Value 1 not present");
+            });
         });
     });
 

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -545,6 +545,22 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 expectAllSize(1, "/testSubDir");
             });
         });
+
+        it("Only creates a subdirectory once when simultaneously created", async () => {
+            const root1SubDir = sharedDirectory1.createSubDirectory("testSubDir");
+            root1SubDir.set("testKey", "testValue");
+            const root2SubDir = sharedDirectory2.createSubDirectory("testSubDir");
+            root2SubDir.set("testKey2", "testValue2");
+
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(sharedDirectory1.getSubDirectory("testSubDir"), root1SubDir,
+                "Created two separate subdirectories in root1");
+            assert.strictEqual(sharedDirectory2.getSubDirectory("testSubDir"), root2SubDir,
+                "Created two separate subdirectories in root2");
+            assert.strictEqual(root1SubDir.get("testKey2"), "testValue2", "Value 2 not present");
+            assert.strictEqual(root2SubDir.get("testKey"), "testValue", "Value 1 not present");
+        });
     });
 
     describe("Operations in local state", () => {


### PR DESCRIPTION
Resolves #6015

If `createSubDirectory()` is called with a subdirectory name that already exists, we retrieve the already-existing subdirectory and return it rather than creating a new one.  This PR documents that more explicitly, plus adds a couple tests that prove it more explicitly (it was tangentially tested in other cases, but this is more exhaustive).

~~While looking at this, I noticed that we would still submit a `createSubDirectory` op in the case that it already existed -- this was benign since all collaborators would just ignore it basically, but we can eliminate this op traffic as unnecessary.~~

Actually this is revealing we have some eventual consistency bugs for simultaneous delete/create subdirectory in combination with key sets within that deleted/created subdirectory.  Reverting the directory changes in favor of sorting those out before changing behavior -- so this is just a documentation and test PR now.