### PR TITLE
Improve rdkafka producing in error scenarios

### DIFF
--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -219,18 +219,17 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	 * Sends all pending messages
 	 */
 	private sendPendingMessages() {
-		for (const [, value] of this.messages) {
-			this.sendBoxcars(value);
-		}
+		const messages = Array.from(this.messages.values());
 
+		// clear messages now because sendBoxcars may insert some
 		this.messages.clear();
+
+		for (const message of messages) {
+			this.sendBoxcars(message);
+		}
 	}
 
 	private sendBoxcars(boxcars: IPendingBoxcar[]) {
-		if (!this.producer) {
-			throw new Error("Invalid producer");
-		}
-
 		for (const boxcar of boxcars) {
 			const boxcarMessage: IBoxcarMessage = {
 				contents: boxcar.messages,
@@ -242,24 +241,32 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			const message = Buffer.from(JSON.stringify(boxcarMessage));
 
 			try {
-				this.producer.produce(
-					this.topic, // topic
-					boxcar.partitionId ?? null, // partition id or null for consistent random for keyed messages
-					message, // message
-					boxcar.documentId, // key
-					undefined, // timestamp
-					(err: any, offset?: number) => {
-						if (err) {
-							boxcar.deferred.reject(err);
+				if (this.producer && this.connected) {
+					this.producer.produce(
+						this.topic, // topic
+						boxcar.partitionId ?? null, // partition id or null for consistent random for keyed messages
+						message, // message
+						boxcar.documentId, // key
+						undefined, // timestamp
+						(err: any, offset?: number) => {
+							if (err) {
+								boxcar.deferred.reject(err);
 
-							// eslint-disable-next-line @typescript-eslint/no-floating-promises
-							this.handleError(err);
-						} else {
-							boxcar.deferred.resolve();
-							this.emit("produced", boxcarMessage, offset, message.length);
-						}
-					},
-				);
+								// eslint-disable-next-line @typescript-eslint/no-floating-promises
+								this.handleError(err);
+							} else {
+								boxcar.deferred.resolve();
+								this.emit("produced", boxcarMessage, offset, message.length);
+							}
+						},
+					);
+				} else {
+					// we don't have a producer or we are not connected
+					// normally sendBoxcars would not be called in this scenario, but it could happen if
+					// the above this.producer.produce call errors out and calls this.handleError within this for loop
+					// when this happens, let's requeue the messages for later
+					void this.send(boxcar.messages, boxcar.tenantId, boxcar.documentId, boxcar.partitionId);
+				}
 			} catch (ex) {
 				// produce can throw if the outgoing message queue is full
 				boxcar.deferred.reject(ex);


### PR DESCRIPTION
We had a case where a producer was sending boxcars and the producer disconnected/closed, which caused this error:
```
Cannot read property 'produce' of undefined
Stack: TypeError: Cannot read property 'produce' of undefined
    at RdkafkaProducer.sendBoxcars (index.js:2:8347949)
    at RdkafkaProducer.sendPendingMessages (index.js:2:8347581)
    at HighLevelProducer.<anonymous> (index.js:2:8345724)
    at HighLevelProducer.emit (events.js:327:22)
    at index.js:2:6815421
    at index.js:2:6816501
```

Changes:
- Check if the producer exists and is connected before calling `produce`. If it does not exist, requeue the message so it will be sent once the producer reconnects.
