### PR TITLE
Cache protocol state in Quorum

### DIFF
--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -120,7 +120,6 @@ export class ProtocolOpHandler {
     constructor(minimumSequenceNumber: number, sequenceNumber: number, term: number | undefined, members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number, sendReject: (sequenceNumber: number) => void);
     // (undocumented)
     close(): void;
-    // (undocumented)
     getProtocolState(): IScribeProtocolState;
     // (undocumented)
     minimumSequenceNumber: number;
@@ -136,7 +135,7 @@ export class ProtocolOpHandler {
 
 // @public
 export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum {
-    constructor(minimumSequenceNumber: number | undefined, members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number, sendReject: (sequenceNumber: number) => void);
+    constructor(members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number, sendReject: (sequenceNumber: number) => void);
     addMember(clientId: string, details: ISequencedClient): void;
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
     // (undocumented)
@@ -155,8 +154,10 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     removeMember(clientId: string): void;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
-    // (undocumented)
     snapshot(): IQuorumSnapshot;
+    snapshotMembers(): IQuorumSnapshot["members"];
+    snapshotProposals(): IQuorumSnapshot["proposals"];
+    snapshotValues(): IQuorumSnapshot["values"];
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
     }
 

--- a/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IQuorumSnapshot } from "@fluidframework/protocol-base";
+import { IQuorumSnapshot, IScribeProtocolState } from "@fluidframework/protocol-base";
 import {
     ISummaryAck,
     ISummaryNack,
@@ -39,9 +39,6 @@ export interface ISummaryWriter {
     writeClientSummary(
         op: ISequencedDocumentAugmentedMessage,
         lastSummaryHead: string | undefined,
-        protocolMinimumSequenceNumber: number,
-        protocolSequenceNumber: number,
-        quorumSnapshot: IQuorumSnapshot,
         checkpoint: IScribe,
         pendingOps: ISequencedOperationMessage[]): Promise<ISummaryWriteResponse>;
 
@@ -63,7 +60,7 @@ export interface IPendingMessageReader {
      * @param from Starting sequence number (inclusive)
      * @param to End sequence number (inclusive)
      */
-     readMessages(from: number, to: number): Promise<ISequencedDocumentMessage[]>;
+    readMessages(from: number, to: number): Promise<ISequencedDocumentMessage[]>;
 }
 
 /**

--- a/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/interfaces.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IQuorumSnapshot, IScribeProtocolState } from "@fluidframework/protocol-base";
 import {
     ISummaryAck,
     ISummaryNack,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -194,9 +194,6 @@ export class ScribeLambda implements IPartitionLambda {
                             const summaryResponse = await this.summaryWriter.writeClientSummary(
                                 operation,
                                 this.lastClientSummaryHead,
-                                this.protocolHandler.minimumSequenceNumber,
-                                this.protocolHandler.sequenceNumber,
-                                this.protocolHandler.quorum.snapshot(),
                                 scribeCheckpoint,
                                 this.pendingCheckpointMessages.toArray(),
                             );

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -116,11 +116,11 @@ export class SummaryWriter implements ISummaryWriter {
             };
         }
 
-        // We should not accept a summary earlier than our current protocol state
+        // We should not accept this summary if it is less than current protocol sequence number
         if (op.referenceSequenceNumber < checkpoint.protocolState.sequenceNumber) {
             return {
                 message: {
-                    errorMessage: `Proposed summary reference sequence number ${op.referenceSequenceNumber} is less than current sequence number ${op.sequenceNumber}`,
+                    errorMessage: `Proposed summary reference sequence number ${op.referenceSequenceNumber} is less than current sequence number ${checkpoint.protocolState.sequenceNumber}`,
                     summaryProposal: {
                         summarySequenceNumber: op.sequenceNumber,
                     },

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -6,7 +6,6 @@
 import { ICreateCommitParams, ICreateTreeEntry } from "@fluidframework/gitresources";
 import {
     generateServiceProtocolEntries,
-    IQuorumSnapshot,
     getQuorumTreeEntries,
     mergeAppAndProtocolTree,
 } from "@fluidframework/protocol-base";
@@ -55,9 +54,6 @@ export class SummaryWriter implements ISummaryWriter {
      * a git summary, commits the change, and finalizes the ref.
      * @param op - Operation that triggered the write
      * @param lastSummaryHead - Points to the last summary head if available
-     * @param protocolMinimumSequenceNumber - Minimum sequence number of current protocol state
-     * @param protocolSequenceNumber - Sequence number of current protocol state
-     * @param protocolSequenceNumber - State of quourum at protocol sequence number
      * @param checkpoint - State of the scribe service at current sequence number
      * @param pendingOps - List of unprocessed ops currently present in memory
      * @returns ISummaryWriteResponse; that represents the success or failure of the write, along with an
@@ -67,9 +63,6 @@ export class SummaryWriter implements ISummaryWriter {
     public async writeClientSummary(
         op: ISequencedDocumentAugmentedMessage,
         lastSummaryHead: string | undefined,
-        protocolMinimumSequenceNumber: number,
-        protocolSequenceNumber: number,
-        quorumSnapshot: IQuorumSnapshot,
         checkpoint: IScribe,
         pendingOps: ISequencedOperationMessage[],
     ): Promise<ISummaryWriteResponse> {
@@ -124,7 +117,7 @@ export class SummaryWriter implements ISummaryWriter {
         }
 
         // We should not accept a summary earlier than our current protocol state
-        if (op.referenceSequenceNumber < protocolSequenceNumber) {
+        if (op.referenceSequenceNumber < checkpoint.protocolState.sequenceNumber) {
             return {
                 message: {
                     errorMessage: `Proposed summary reference sequence number ${op.referenceSequenceNumber} is less than current sequence number ${op.sequenceNumber}`,
@@ -140,13 +133,13 @@ export class SummaryWriter implements ISummaryWriter {
         const protocolEntries: ITreeEntry[] =
             getQuorumTreeEntries(
                 this.documentId,
-                protocolMinimumSequenceNumber,
-                protocolSequenceNumber,
+                checkpoint.protocolState.minimumSequenceNumber,
+                checkpoint.protocolState.sequenceNumber,
                 op.term ?? 1,
-                quorumSnapshot);
+                checkpoint.protocolState);
 
         // Generate a tree of logTail starting from protocol sequence number to summarySequenceNumber
-        const logTailEntries = await this.generateLogtailEntries(protocolSequenceNumber, op.sequenceNumber + 1, pendingOps);
+        const logTailEntries = await this.generateLogtailEntries(checkpoint.protocolState.sequenceNumber, op.sequenceNumber + 1, pendingOps);
 
         // Create service protocol entries combining scribe and deli states.
         const serviceProtocolEntries = generateServiceProtocolEntries(

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -24,10 +24,7 @@ export interface IScribeProtocolState {
     values: [string, ICommittedProposal][];
 }
 
-interface ICachedScribeProtocolState extends Partial<IScribeProtocolState> {
-    sequenceNumber: number;
-    minimumSequenceNumber: number;
-}
+type CachedScribeProtocolState = Partial<Pick<IScribeProtocolState, "members" | "proposals" | "values">>;
 
 export function isSystemMessage(message: ISequencedDocumentMessage) {
     switch (message.type) {
@@ -59,7 +56,7 @@ export class ProtocolOpHandler {
      * Depending on the op being processed, some or none of those properties may change.
      * Each property will be cached and the cache for each property will be cleared when an op causes a change.
      */
-    private cachedProtocolState: ICachedScribeProtocolState;
+    private cachedProtocolState: CachedScribeProtocolState;
 
     constructor(
         public minimumSequenceNumber: number,
@@ -78,10 +75,7 @@ export class ProtocolOpHandler {
             values,
             sendProposal,
             sendReject);
-        this.cachedProtocolState = {
-            sequenceNumber,
-            minimumSequenceNumber,
-        };
+        this.cachedProtocolState = {};
     }
 
     public close() {
@@ -148,9 +142,6 @@ export class ProtocolOpHandler {
         // Update tracked sequence numbers
         this.minimumSequenceNumber = message.minimumSequenceNumber;
         this.sequenceNumber = message.sequenceNumber;
-
-        this.cachedProtocolState.minimumSequenceNumber = this.minimumSequenceNumber;
-        this.cachedProtocolState.sequenceNumber = this.sequenceNumber;
 
         // Notify the quorum of the MSN from the message. We rely on it to handle duplicate values but may
         // want to move that logic to this class.

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -99,7 +99,7 @@ export class ProtocolOpHandler {
                 };
                 this.quorum.addMember(join.clientId, member);
 
-                // quorum members is changing
+                // members are changing
                 this.cachedProtocolState.members = undefined;
 
                 break;
@@ -109,7 +109,7 @@ export class ProtocolOpHandler {
                 const clientId = JSON.parse(systemLeaveMessage.data) as string;
                 this.quorum.removeMember(clientId);
 
-                // quorum members is changing
+                // members are changing
                 this.cachedProtocolState.members = undefined;
 
                 break;
@@ -159,12 +159,12 @@ export class ProtocolOpHandler {
             }
 
             if (updateMsnResult.proposals) {
-                // clear the proposals cache
+                // proposals are changing
                 this.cachedProtocolState.proposals = undefined;
             }
 
             if (updateMsnResult.values) {
-                // clear the values cache
+                // values are changing
                 this.cachedProtocolState.values = undefined;
             }
         }

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -55,7 +55,9 @@ export class ProtocolOpHandler {
 
     /**
      * Cached protocol state
-     * Parts of it will be updated/cleared depending on the message being processed
+     * The quorum consists of 3 properties: members, values, and proposals.
+     * Depending on the op being processed, some or none of those properties may change.
+     * Each property will be cached and the cache for each property will be cleared when an op causes a change.
      */
     private cachedProtocolState: ICachedScribeProtocolState;
 

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -71,8 +71,11 @@ export class ProtocolOpHandler {
     }
 
     public processMessage(message: ISequencedDocumentMessage, local: boolean): IProcessMessageResult {
+        // verify it's moving sequentially
         if (message.sequenceNumber !== this.sequenceNumber + 1) {
-            // verify it's moving sequentially
+            throw new Error(
+                `Protocol state is not moving sequentially. ` +
+                `Current is ${this.sequenceNumber}. Next is ${message.sequenceNumber}`);
         }
 
         let immediateNoOp = false;

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -78,6 +78,10 @@ export class ProtocolOpHandler {
                 `Current is ${this.sequenceNumber}. Next is ${message.sequenceNumber}`);
         }
 
+        // Update tracked sequence numbers
+        this.sequenceNumber = message.sequenceNumber;
+        this.minimumSequenceNumber = message.minimumSequenceNumber;
+
         let immediateNoOp = false;
 
         switch (message.type) {
@@ -117,10 +121,6 @@ export class ProtocolOpHandler {
 
             default:
         }
-
-        // Update tracked sequence numbers
-        this.minimumSequenceNumber = message.minimumSequenceNumber;
-        this.sequenceNumber = message.sequenceNumber;
 
         // Notify the quorum of the MSN from the message. We rely on it to handle duplicate values but may
         // want to move that logic to this class.

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -145,13 +145,11 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
      * @returns a deep cloned array of proposals
      */
     public snapshotProposals(): IQuorumSnapshot["proposals"] {
-        const serializedProposals = Array.from(this.proposals).map(
+        return Array.from(this.proposals).map(
             ([sequenceNumber, proposal]) => [
                 sequenceNumber,
                 { sequenceNumber, key: proposal.key, value: proposal.value },
                 Array.from(proposal.rejections)] as [number, ISequencedProposal, string[]]);
-
-        return cloneDeep(serializedProposals);
     }
 
     /**

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -67,13 +67,13 @@ export interface IQuorumUpdateMsnResult {
     // immediate no-op is required
     immediateNoOp?: boolean;
 
-    // the msn changed
+    // quorum msn changed
     msn?: boolean;
 
-    // proposals cahnged
+    // quorum proposals changed
     proposals?: boolean;
 
-    // values cahnged
+    // quorum values changed
     values?: boolean;
 }
 
@@ -301,7 +301,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
      * Updates the minimum sequence number. If the MSN advances past the sequence number for any proposal without
      * a rejection then it becomes an accepted consensus value.  If the MSN advances past the sequence number
      * that the proposal was accepted, then it becomes a committed consensus value.
-     * Returns A IQuorumChanges object if something changed
+     * Returns a IQuorumUpdateMsnResult object with a list of changes, or undefined if nothing changed.
      */
     public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): IQuorumUpdateMsnResult | undefined {
         const value = message.minimumSequenceNumber;

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -11,7 +11,6 @@ describe("Loader", () => {
 
         beforeEach(() => {
             quorum = new Quorum(
-                0,
                 [],
                 [],
                 [],

--- a/server/routerlicious/packages/protocol-definitions/src/consensus.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/consensus.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { IDisposable, IErrorEvent, IEventProvider } from "@fluidframework/common-definitions";
 import { ISequencedClient } from "./clients";
 
 /**
@@ -56,7 +56,7 @@ export interface IPendingProposal extends ISequencedProposal {
     readonly rejectionDisabled: boolean;
 }
 
-export interface IQuorumEvents extends IEvent {
+export interface IQuorumEvents extends IErrorEvent {
     (event: "addMember", listener: (clientId: string, details: ISequencedClient) => void);
     (event: "removeMember", listener: (clientId: string) => void);
     (event: "addProposal", listener: (proposal: IPendingProposal) => void);

--- a/server/routerlicious/packages/protocol-definitions/src/consensus.ts
+++ b/server/routerlicious/packages/protocol-definitions/src/consensus.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, IErrorEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { IDisposable, IEvent, IEventProvider } from "@fluidframework/common-definitions";
 import { ISequencedClient } from "./clients";
 
 /**
@@ -56,7 +56,7 @@ export interface IPendingProposal extends ISequencedProposal {
     readonly rejectionDisabled: boolean;
 }
 
-export interface IQuorumEvents extends IErrorEvent {
+export interface IQuorumEvents extends IEvent {
     (event: "addMember", listener: (clientId: string, details: ISequencedClient) => void);
     (event: "removeMember", listener: (clientId: string) => void);
     (event: "addProposal", listener: (proposal: IPendingProposal) => void);


### PR DESCRIPTION
Scribe calls `getProtocolState` every time an operation is processed. Depending on how large the state is (members / quorum values/proposals), the deep object cloning done by `this.quorum.snapshot()` is very expensive. I grabbed a cpu profile during a load test run and 30% of scribe cpu usage was due to this.

The protocol state will only change when it processes messages. Scribe only calls `processMessage` when it's summarizing or when the msn changes. Caching this state until `processMessage` is called again should be a nice optimization that reduces cpu usage

Changes:
- Cache individual quorum snapshot properties within `Quorum` and only update them when they change
     - The quorum consists of 3 properties: members, values, and proposals.
     - Depending on the op being processed, some or none of those properties may change
     - Caching individually is the most efficient way for scribe
- Remove an unnecessary quorum snapshot call in scribe when it's writing a client summary