### PR TITLE
Fix for GC test mode assert not taking local storage flag into account

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -131,6 +131,7 @@ import {
     wrapSummaryInChannelsTree,
 } from "./summaryFormat";
 import { SummaryCollection, SummaryCollectionOpActions } from "./summaryCollection";
+import { gcTestModeKey, getLocalStorageFeatureGate, runGCKey } from "./localStorageFeatureGates";
 
 export enum ContainerMessageType {
     // An op to be delivered to store
@@ -266,34 +267,6 @@ export interface IContainerRuntimeOptions {
 
 interface IRuntimeMessageMetadata {
     batch?: boolean;
-}
-
-// Local storage key to turn GC on / off.
-const runGCKey = "FluidRunGC";
-// Local storage key to turn GC test mode on / off.
-const gcTestModeKey = "FluidGCTestMode";
-
-/**
- * Helper to check if the given feature key is set in local storage.
- * @returns the following:
- * - true, if the key is set and the value is "1".
- * - false, if the key is set and the value is "0".
- * - undefined, if local storage is not available or the key is not set.
- */
-function getLocalStorageFeatureGate(key: string): boolean | undefined {
-    try {
-        if (typeof localStorage === "object" && localStorage !== null) {
-            const itemValue = localStorage.getItem(key);
-            if  (itemValue === "1") {
-                return true;
-            }
-            if (itemValue === "0") {
-                return false;
-            }
-        }
-    } catch (e) {}
-
-    return undefined;
 }
 
 export function isRuntimeMessage(message: ISequencedDocumentMessage): boolean {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -59,6 +59,7 @@ import {
     ReadFluidDataStoreAttributes,
     getAttributesFormatVersion,
 } from "./summaryFormat";
+import { gcTestModeKey, getLocalStorageFeatureGate } from "./localStorageFeatureGates";
 
  /**
   * This class encapsulates data store handling. Currently it is only used by the container runtime,
@@ -508,10 +509,8 @@ export class DataStores implements IDisposable {
      * @param unusedRoutes - The routes that are unused in all data stores in this Container.
      */
     public deleteUnusedRoutes(unusedRoutes: string[]) {
-        assert(
-            this.runtimeOptions.gcOptions?.runGCInTestMode,
-            0x1df /* "Data stores should be deleted only in GC test mode" */,
-        );
+        const gcTestMode = getLocalStorageFeatureGate(gcTestModeKey) ?? this.runtimeOptions.gcOptions?.runGCInTestMode;
+        assert(gcTestMode, 0x1df /* "Data stores should be deleted only in GC test mode" */);
         for (const route of unusedRoutes) {
             // Delete the contexts of unused data stores.
             const dataStoreId = route.split("/")[1];

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -43,7 +43,7 @@ import { v4 as uuid } from "uuid";
 import { TreeTreeEntry } from "@fluidframework/protocol-base";
 import { GCDataBuilder, getChildNodesUsedRoutes } from "@fluidframework/garbage-collector";
 import { DataStoreContexts } from "./dataStoreContexts";
-import { ContainerRuntime, IContainerRuntimeOptions } from "./containerRuntime";
+import { ContainerRuntime } from "./containerRuntime";
 import {
     FluidDataStoreContext,
     RemotedFluidDataStoreContext,
@@ -59,7 +59,6 @@ import {
     ReadFluidDataStoreAttributes,
     getAttributesFormatVersion,
 } from "./summaryFormat";
-import { gcTestModeKey, getLocalStorageFeatureGate } from "./localStorageFeatureGates";
 
  /**
   * This class encapsulates data store handling. Currently it is only used by the container runtime,
@@ -82,7 +81,6 @@ export class DataStores implements IDisposable {
         private readonly getCreateChildSummarizerNodeFn:
             (id: string, createParam: CreateChildSummarizerNodeParam)  => CreateChildSummarizerNodeFn,
         baseLogger: ITelemetryBaseLogger,
-        private readonly runtimeOptions: IContainerRuntimeOptions,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
         this.logger = ChildLogger.create(baseLogger);
@@ -509,8 +507,7 @@ export class DataStores implements IDisposable {
      * @param unusedRoutes - The routes that are unused in all data stores in this Container.
      */
     public deleteUnusedRoutes(unusedRoutes: string[]) {
-        const gcTestMode = getLocalStorageFeatureGate(gcTestModeKey) ?? this.runtimeOptions.gcOptions?.runGCInTestMode;
-        assert(gcTestMode, 0x1df /* "Data stores should be deleted only in GC test mode" */);
+        assert(this.runtime.gcTestMode, 0x1df /* "Data stores should be deleted only in GC test mode" */);
         for (const route of unusedRoutes) {
             // Delete the contexts of unused data stores.
             const dataStoreId = route.split("/")[1];

--- a/packages/runtime/container-runtime/src/localStorageFeatureGates.ts
+++ b/packages/runtime/container-runtime/src/localStorageFeatureGates.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Local storage key to turn GC on / off.
+export const runGCKey = "FluidRunGC";
+// Local storage key to turn GC test mode on / off.
+export const gcTestModeKey = "FluidGCTestMode";
+
+/**
+ * Helper to check if the given feature key is set in local storage.
+ * @returns the following:
+ * - true, if the key is set and the value is "1".
+ * - false, if the key is set and the value is "0".
+ * - undefined, if local storage is not available or the key is not set.
+ */
+export function getLocalStorageFeatureGate(key: string): boolean | undefined {
+    try {
+        if (typeof localStorage === "object" && localStorage !== null) {
+            const itemValue = localStorage.getItem(key);
+            if  (itemValue === "1") {
+                return true;
+            }
+            if (itemValue === "0") {
+                return false;
+            }
+        }
+    } catch (e) {}
+
+    return undefined;
+}

--- a/packages/runtime/container-runtime/src/localStorageFeatureGates.ts
+++ b/packages/runtime/container-runtime/src/localStorageFeatureGates.ts
@@ -3,11 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// Local storage key to turn GC on / off.
-export const runGCKey = "FluidRunGC";
-// Local storage key to turn GC test mode on / off.
-export const gcTestModeKey = "FluidGCTestMode";
-
 /**
  * Helper to check if the given feature key is set in local storage.
  * @returns the following:


### PR DESCRIPTION
Fixes #6064.

The assert in `DataStores::deleteUnusedRoutes` asserts that we the gcOptions have runGCInTestMode. However, GC test mode can be enabled via local storage flag too.
Fixed it to check for both.