### PR TITLE
Close container on critical error during attach

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -841,7 +841,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             }
         } catch(error) {
             if (!canRetryOnError(error)) {
-                this.logger.sendErrorEvent({ eventName: "AttachFail", attachState: this._attachState }, error);
                 this.close(error);
             }
             throw error;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -50,6 +50,7 @@ import {
     ensureFluidResolvedUrl,
     combineAppAndProtocolSummary,
     readAndParseFromBlobs,
+    canRetryOnError,
 } from "@fluidframework/driver-utils";
 import {
     isSystemMessage,
@@ -838,6 +839,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             if (!this.closed) {
                 this.resumeInternal({ fetchOpsFromStorage: false, reason: "createDetached" });
             }
+        } catch(error) {
+            if (!canRetryOnError(error)) {
+                this.logger.sendErrorEvent({ eventName: "AttachFail", attachState: this._attachState }, error);
+                this.close(error);
+            }
+            throw error;
         } finally {
             this.attachInProgress = false;
         }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4782
Close container on non retriable errors. This will also allow logging for correlation ids from the driver present on error.