### PR TITLE
Fixing race condition for token refresh.

### DIFF
--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -3,13 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import { getAadTenant } from "./odspDocLibUtils";
 import { throwOdspNetworkError } from "./odspErrorUtils";
 import { unauthPostAsync } from "./odspRequest";
 
 export interface IOdspTokens {
-    accessToken: string;
-    refreshToken: string;
+    readonly accessToken: string;
+    readonly refreshToken: string;
 }
 
 export interface IClientConfig {
@@ -68,8 +69,8 @@ export const getPushRefreshTokenFn = (server: string, clientConfig: IClientConfi
     getRefreshTokenFn(pushScope, server, clientConfig, tokens);
 export const getRefreshTokenFn = (scope: string, server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
     async () => {
-        await refreshTokens(server, scope, clientConfig, tokens);
-        return tokens.accessToken;
+        const newTokens = await refreshTokens(server, scope, clientConfig, tokens);
+        return newTokens.accessToken;
     };
 
 /**
@@ -106,22 +107,23 @@ export async function fetchTokens(
 }
 
 /**
- * Fetch fresh tokens and update the provided tokens object with them
+ * Fetch fresh tokens.
  * @param server - The server to auth against
  * @param scope - The desired oauth scope
  * @param clientConfig - Info about this client's identity
- * @param tokens - The tokens object to update with fresh tokens. Also provides the refresh token for the request
+ * @param tokens - The tokens object provides the refresh token for the request
+ *
+ * @returns The tokens object with refreshed tokens.
  */
 export async function refreshTokens(
     server: string,
     scope: string,
     clientConfig: IClientConfig,
     tokens: IOdspTokens,
-): Promise<void> {
+): Promise<IOdspTokens> {
     // Clear out the old tokens while awaiting the new tokens
     const refresh_token = tokens.refreshToken;
-    tokens.accessToken = "";
-    tokens.refreshToken = "";
+    assert(refresh_token.length > 0, "No refresh token provided.");
 
     const credentials: TokenRequestCredentials = {
         grant_type: "refresh_token",
@@ -130,8 +132,7 @@ export async function refreshTokens(
     const newTokens = await fetchTokens(server, scope, clientConfig, credentials);
 
     // Instead of returning, update the passed in tokens object
-    tokens.accessToken = newTokens.accessToken;
-    tokens.refreshToken = newTokens.refreshToken;
+    return { accessToken: newTokens.accessToken, refreshToken: newTokens.refreshToken };
 }
 
 /**

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -60,6 +60,7 @@
     "@fluidframework/odsp-doclib-utils": "^0.40.0",
     "@fluidframework/protocol-base": "^0.1025.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "async-mutex": "^0.3.1",
     "debug": "^4.1.1",
     "jwt-decode": "^2.2.0",
     "proper-lockfile": "^4.1.2"

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -15,6 +15,7 @@ import {
     TokenRequestCredentials,
 } from "@fluidframework/odsp-doclib-utils";
 import jwtDecode from "jwt-decode";
+import { Mutex } from "async-mutex";
 import { debug } from "./debug";
 import { IAsyncCache, loadRC, saveRC, lockRC } from "./fluidToolRC";
 import { serverListenAndHandle, endResponse } from "./httpHelpers";
@@ -48,9 +49,17 @@ export type OdspTokenConfig = {
     redirectUriCallback?: (tokens: IOdspTokens) => Promise<string>;
 };
 
-export interface IOdspTokenManagerCacheKey { isPush: boolean; server: string; }
+export interface IOdspTokenManagerCacheKey {
+    readonly isPush: boolean;
+    readonly server: string;
+}
 
 const isValidToken = (token: string) => {
+    // Return false for undefined or empty tokens.
+    if (!token || token.length === 0) {
+        return false;
+    }
+
     const decodedToken = jwtDecode<any>(token);
     // Give it a 60s buffer
     return (decodedToken.exp - 60 >= (new Date().getTime() / 1000));
@@ -63,11 +72,18 @@ const cacheKeyToString = (key: IOdspTokenManagerCacheKey) => {
 export class OdspTokenManager {
     private readonly storageCache = new Map<string, IOdspTokens>();
     private readonly pushCache = new Map<string, IOdspTokens>();
+    private readonly cacheMutex = new Mutex();
     constructor(
         private readonly tokenCache?: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens>,
     ) { }
 
     public async updateTokensCache(key: IOdspTokenManagerCacheKey, value: IOdspTokens) {
+        await this.cacheMutex.runExclusive(async () => {
+            await this.updateTokensCacheWithoutLock(key, value);
+        });
+    }
+
+    private async updateTokensCacheWithoutLock(key: IOdspTokenManagerCacheKey, value: IOdspTokens) {
         debug(`${cacheKeyToString(key)}: Saving tokens`);
         const memoryCache = key.isPush ? this.pushCache : this.storageCache;
         memoryCache.set(key.server, value);
@@ -134,13 +150,17 @@ export class OdspTokenManager {
         forceReauth: boolean,
     ): Promise<IOdspTokens> {
         const invokeGetTokensCore = async () => {
-            return this.getTokensCore(
-                isPush,
-                server,
-                clientConfig,
-                tokenConfig,
-                forceRefresh,
-                forceReauth);
+            // Don't solely rely on tokenCache lock, ensure serialized execution of
+            // cache update to avoid multiple fetch.
+            return this.cacheMutex.runExclusive(async () => {
+                return this.getTokensCore(
+                    isPush,
+                    server,
+                    clientConfig,
+                    tokenConfig,
+                    forceRefresh,
+                    forceReauth);
+            });
         };
         if (!forceReauth && !forceRefresh) {
             // check and return if it exists without lock
@@ -172,30 +192,31 @@ export class OdspTokenManager {
     ): Promise<IOdspTokens> {
         const scope = isPush ? pushScope : getOdspScope(server);
         const cacheKey: IOdspTokenManagerCacheKey = { isPush, server };
+        let tokens: IOdspTokens | undefined;
         if (!forceReauth) {
             // check the cache again under the lock (if it is there)
             const tokensFromCache = await this.getTokenFromCache(cacheKey);
             if (tokensFromCache) {
-                let canReturn = true;
                 if (forceRefresh || !isValidToken(tokensFromCache.accessToken)) {
                     try {
                         // This updates the tokens in tokensFromCache
-                        await refreshTokens(server, scope, clientConfig, tokensFromCache);
+                        tokens = await refreshTokens(server, scope, clientConfig, tokensFromCache);
+                        await this.updateTokensCacheWithoutLock(cacheKey, tokens);
                     } catch (error) {
-                        canReturn = false;
+                        debug(`${cacheKeyToString(cacheKey)}: Error in refreshing token. ${error}`);
                     }
-                    await this.updateTokensCache(cacheKey, tokensFromCache);
                 } else {
+                    tokens = tokensFromCache;
                     debug(`${cacheKeyToString(cacheKey)}: Token reused from locked cache `);
-                }
-                if (canReturn) {
-                    await this.onTokenRetrievalFromCache(tokenConfig, tokensFromCache);
-                    return tokensFromCache;
                 }
             }
         }
 
-        let tokens: IOdspTokens | undefined;
+        if (tokens) {
+            await this.onTokenRetrievalFromCache(tokenConfig, tokens);
+            return tokens;
+        }
+
         switch (tokenConfig.type) {
             case "password":
                 tokens = await this.acquireTokensWithPassword(
@@ -220,8 +241,7 @@ export class OdspTokenManager {
                 unreachableCase(tokenConfig);
         }
 
-        await this.updateTokensCache(cacheKey, tokens);
-
+        await this.updateTokensCacheWithoutLock(cacheKey, tokens);
         return tokens;
     }
 


### PR DESCRIPTION
Issue
-----
For some runs, an error was reported "Cannot read property 'replace' of
undefined" which was caused due to a race condition. One execution path
was setting access token (mutable cache value) to empty string, which was
read by another path (in absence of mutex) before fetched token is set by
first path. Second path was then calling `isValidToken` with the empty string
causing `jwt-decode` to throw the above error.

Fix
---
1. Made keys and values for token cache as immutable to avoid related issues.
2. `isValidToken` to return `false` on `undefined` or empty string to avoid error
   from `jwt-decode`.
3. Adding a mutex for refreshing the cache using fetched token, instead of
   just relying on `tokenCache` lock which might not be available.

Related To
----------
Fixes https://github.com/microsoft/FluidFramework/issues/5664