### PR TITLE
Avoid committing empty changes by default

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -165,10 +165,12 @@ export class SharedPropertyTree extends SharedObject {
 		return this._root as NodeProperty;
 	}
 
-	public commit() {
+	public commit(submitEmptyChange = false) {
 		const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.PENDING_CHANGE);
-		this.applyChangeSet(changes);
-		this.root.cleanDirty();
+        if (submitEmptyChange || !_.isEmpty(changes)) {
+            this.applyChangeSet(changes);
+            this.root.cleanDirty();
+        }
 	}
 
 	private applyChangeSet(changeSet: SerializedChangeSet) {

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import _ from "lodash";
+
 import { expect } from "chai";
 import { IContainer, ILoader, IHostLoader, ILoaderOptions } from "@fluidframework/container-definitions";
 import { IFluidCodeDetails, IFluidSerializer } from "@fluidframework/core-interfaces";
@@ -108,6 +110,26 @@ describe("PropertyTree", () => {
 
 				expect((sharedPropertyTree2.root.get("test") as StringProperty).getValue()).to.equal("Magic");
 			});
+
+            it("Should not commit empty change by default", async () => {
+				await opProcessingController.pauseProcessing();
+
+				sharedPropertyTree1.commit();
+
+				await opProcessingController.process(container1.deltaManager, container2.deltaManager);
+				expect(sharedPropertyTree2.remoteChanges.length).to.equal(0);
+			});
+
+            it("Should commit empty change", async () => {
+				await opProcessingController.pauseProcessing();
+
+				sharedPropertyTree1.commit(true);
+
+				await opProcessingController.process(container1.deltaManager, container2.deltaManager);
+				expect(sharedPropertyTree2.remoteChanges.length).to.equal(1);
+				expect(_.isEmpty(_.last(sharedPropertyTree2.remoteChanges)?.changeSet)).to.equal(true);
+			});
+
 			it("Can start/stopTransmission", async () => {
 				sharedPropertyTree1.stopTransmission(true);
 				sharedPropertyTree1.root.insert("test", PropertyFactory.create("String", undefined, "Magic"));


### PR DESCRIPTION
Changing default behaviour of  `SharedPropertyTree.commit` to not submit empty changes to the server which is probably the most common use case.
If users are still interested in submitting an empty change they could  call `.commit(true)` and then it should submit all changes including empty changes. 
