### PR TITLE
Telemetry changes to better track issues in stress tests related to ops fetching

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -29,6 +29,7 @@ import { ITaggableTelemetryProperties } from '@fluidframework/telemetry-utils';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryErrorEvent } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
+import { ITelemetryProperties } from '@fluidframework/common-definitions';
 import { IThrottlingWarning } from '@fluidframework/driver-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { ITreeEntry } from '@fluidframework/protocol-definitions';
@@ -38,7 +39,7 @@ import { LoggingError } from '@fluidframework/telemetry-utils';
 
 // @public (undocumented)
 export class AuthorizationError extends LoggingError implements IAuthorizationError {
-    constructor(errorMessage: string, claims: string | undefined, tenantId: string | undefined, statusCode: number);
+    constructor(errorMessage: string, claims: string | undefined, tenantId: string | undefined, props?: ITaggableTelemetryProperties);
     // (undocumented)
     readonly canRetry = false;
     // (undocumented)
@@ -112,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterSeconds?: number, statusCode?: number): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterSeconds?: number, props?: ITaggableTelemetryProperties): GenericNetworkError | ThrottlingError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType>;
@@ -148,7 +149,7 @@ export function ensureFluidResolvedUrl(resolved: IResolvedUrl | undefined): asse
 
 // @public
 export class GenericNetworkError extends LoggingError implements IDriverErrorBase {
-    constructor(errorMessage: string, canRetry: boolean, statusCode: number | undefined);
+    constructor(errorMessage: string, canRetry: boolean, props?: ITaggableTelemetryProperties);
     // (undocumented)
     readonly canRetry: boolean;
     // (undocumented)
@@ -224,7 +225,7 @@ export enum OnlineStatus {
 
 // @public
 export class ParallelRequests<T> {
-    constructor(from: number, to: number | undefined, payloadSize: number, logger: ITelemetryLogger, requestCallback: (request: number, from: number, to: number, strongTo: boolean) => Promise<{
+    constructor(from: number, to: number | undefined, payloadSize: number, logger: ITelemetryLogger, requestCallback: (request: number, from: number, to: number, strongTo: boolean, props: ITelemetryProperties) => Promise<{
         partial: boolean;
         cancel: boolean;
         payload: T[];
@@ -258,7 +259,7 @@ export function readAndParseFromBlobs<T>(blobs: {
 }, id: string): T;
 
 // @public (undocumented)
-export function requestOps(get: (from: number, to: number) => Promise<IDeltasFetchResult>, concurrency: number, from: number, to: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal): IStream<ISequencedDocumentMessage[]>;
+export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal): IStream<ISequencedDocumentMessage[]>;
 
 // @public (undocumented)
 export class RetryableError<T> extends NetworkErrorBasic<T> {
@@ -293,7 +294,7 @@ export function streamObserver<T>(stream: IStream<T>, handler: (value: IStreamRe
 
 // @public
 export class ThrottlingError extends LoggingError implements IThrottlingWarning {
-    constructor(errorMessage: string, retryAfterSeconds: number, statusCode?: number);
+    constructor(errorMessage: string, retryAfterSeconds: number, props?: ITaggableTelemetryProperties);
     // (undocumented)
     readonly canRetry = true;
     // (undocumented)

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -268,7 +268,7 @@ export class EpochTracker implements IPersistedFileCache {
             // then it was coherency 409, so rethrow it as throttling error so that it can retried. Default throttling
             // time is 1s.
             this.logger.sendErrorEvent({ eventName: "Coherency409" }, error);
-            throw new ThrottlingError(error.errorMessage ?? "Coherency409", 1000, 429);
+            throw new ThrottlingError(error.errorMessage ?? "Coherency409", 1000);
         }
     }
 

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -6,7 +6,7 @@
 import { default as AbortController } from "abort-controller";
 import { v4 as uuid } from "uuid";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert } from "@fluidframework/common-utils";
+import { assert, performance } from "@fluidframework/common-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
     IOdspResolvedUrl,

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -4,7 +4,7 @@
  */
 
 import { v4 as uuid } from "uuid";
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { TokenFetchOptions } from "@fluidframework/odsp-driver-definitions";
@@ -32,6 +32,7 @@ export class OdspDeltaStorageService {
     public async get(
         from: number,
         to: number,
+        telemetryProps: ITelemetryProperties,
     ): Promise<IDeltasFetchResult> {
         return getWithRetryForTokenRefresh(async (options) => {
             // Note - this call ends up in getSocketStorageDiscovery() and can refresh token
@@ -68,7 +69,7 @@ export class OdspDeltaStorageService {
             }
 
             this.logger.sendPerformanceEvent({
-                eventName: "DeltaStorageOpsFetch",
+                eventName: "OpsFetch",
                 headers: Object.keys(headers).length !== 0 ? true : undefined,
                 count: messages.length,
                 duration: response.duration, // this duration for single attempt!
@@ -76,6 +77,7 @@ export class OdspDeltaStorageService {
                 attempts: options.refresh ? 2 : 1,
                 from,
                 to,
+                ...telemetryProps,
             });
 
             // It is assumed that server always returns all the ops that it has in the range that was requested.
@@ -99,7 +101,10 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
         private readonly logger: ITelemetryLogger,
         private readonly batchSize: number,
         private readonly concurrency: number,
-        private readonly getFromStorage: (from: number, to: number) => Promise<IDeltasFetchResult>,
+        private readonly getFromStorage: (
+            from: number,
+            to: number,
+            telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>,
         private readonly getCached: (from: number, to: number) => Promise<ISequencedDocumentMessage[]>,
         private readonly opsReceived: (ops: ISequencedDocumentMessage[]) => void,
     ) {
@@ -122,7 +127,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
         let opsFromStorage = 0;
 
         const stream = requestOps(
-            async (from: number, to: number) => {
+            async (from: number, to: number, telemetryProps: ITelemetryProperties) => {
                 if (this.snapshotOps !== undefined && this.snapshotOps.length !== 0) {
                     const messages = this.snapshotOps.filter((op) =>
                         op.sequenceNumber >= from && op.sequenceNumber < to);
@@ -152,7 +157,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
                     return { messages: [], partialResult: false };
                 }
 
-                const ops = await this.getFromStorage(from, to);
+                const ops = await this.getFromStorage(from, to, telemetryProps);
                 opsFromStorage += ops.messages.length;
                 this.opsReceived(ops.messages);
                 return ops;

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -182,7 +182,7 @@ export class OdspDocumentService implements IDocumentService {
             this.logger,
             batchSize,
             concurrency,
-            async (from, to) => service.get(from, to),
+            async (from, to, telemetryProps) => service.get(from, to, telemetryProps),
             async (from, to) => {
                 const res = await this.opsCache?.get(from, to);
                 return res as ISequencedDocumentMessage[] ?? [];

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -86,7 +86,7 @@ describe("DeltaStorageService", () => {
 
         it("Should deserialize the delta feed response correctly", async () => {
             const { messages, partialResult } = await mockFetchOk(
-                async () => deltaStorageService.get(2, 8),
+                async () => deltaStorageService.get(2, 8, {}),
                 expectedDeltaFeedResponse,
             );
             assert(!partialResult, "partialResult === false");
@@ -142,7 +142,7 @@ describe("DeltaStorageService", () => {
 
         it("Should deserialize the delta feed response correctly", async () => {
             const { messages, partialResult } = await mockFetchOk(
-                async () => deltaStorageService.get(2, 8),
+                async () => deltaStorageService.get(2, 8, {}),
                 expectedDeltaFeedResponse,
             );
             assert(!partialResult, "partialResult === false");

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -56,21 +56,21 @@ export function createR11sNetworkError(
             // If a service is temporarily down or a browser resource limit is reached, Axios will throw
             // a network error with no status code (e.g. err:ERR_CONN_REFUSED or err:ERR_FAILED) and
             // error message, "Network Error".
-            return new GenericNetworkError(errorMessage, errorMessage === "Network Error", statusCode);
+            return new GenericNetworkError(errorMessage, errorMessage === "Network Error", { statusCode });
         case 401:
         case 403:
-            return new AuthorizationError(errorMessage, undefined, undefined, statusCode);
+            return new AuthorizationError(errorMessage, undefined, undefined, { statusCode });
         case 404:
             return new NonRetryableError(
                 errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, { statusCode });
         case 429:
             return createGenericNetworkError(
-                errorMessage, true, retryAfterSeconds, statusCode);
+                errorMessage, true, retryAfterSeconds, { statusCode });
         case 500:
-            return new GenericNetworkError(errorMessage, true, statusCode);
+            return new GenericNetworkError(errorMessage, true, { statusCode });
         default:
             return createGenericNetworkError(
-                errorMessage, retryAfterSeconds !== undefined, retryAfterSeconds, statusCode);
+                errorMessage, retryAfterSeconds !== undefined, retryAfterSeconds, { statusCode });
     }
 }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1056,6 +1056,10 @@ export class DeltaManager
         connection.on("error", this.errorHandler);
         connection.on("pong", this.pongHandler);
 
+        // Initial messages are always sorted. However, due to early op handler installed by drivers and appending those
+        // ops to initialMessages, resulting set is no longer sorted, which would result in client hitting storage to
+        // fill in gap. We will recover by cancelling this request once we process remaining ops, but it's a waste that
+        // we could avoid
         const initialMessages = connection.initialMessages.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
 
         this.connectionStateProps = {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -954,7 +954,7 @@ export class DeltaManager
         const messages = messagesArg instanceof Array ? messagesArg : [messagesArg];
         const sequence = messages[0].sequenceNumber;
         const last = messages[messages.length - 1].sequenceNumber;
-        if (this.lastSequenceFromSocket !== undefined && sequence !== this.lastSequenceFromSocket + 1) {
+        if (this.lastSequenceFromSocket !== undefined && sequence > this.lastSequenceFromSocket + 1) {
             this.logger.sendErrorEvent({
                 eventName: "UnorderedSocketOps",
                 sequence,
@@ -963,7 +963,10 @@ export class DeltaManager
                 last,
             });
         }
-        this.lastSequenceFromSocket = last;
+
+        if (this.lastSequenceFromSocket === undefined || last > this.lastSequenceFromSocket) {
+            this.lastSequenceFromSocket = last;
+        }
         this.enqueueMessages(messages, "opHandler");
     };
 

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -37,9 +37,9 @@ export class GenericNetworkError extends LoggingError implements IDriverErrorBas
     constructor(
         errorMessage: string,
         readonly canRetry: boolean,
-        statusCode: number | undefined,
+        props?: ITaggableTelemetryProperties,
     ) {
-        super(errorMessage, { statusCode });
+        super(errorMessage, props);
     }
 }
 
@@ -51,9 +51,9 @@ export class AuthorizationError extends LoggingError implements IAuthorizationEr
         errorMessage: string,
         readonly claims: string | undefined,
         readonly tenantId: string | undefined,
-        statusCode: number,
+        props?: ITaggableTelemetryProperties,
     ) {
-        super(errorMessage, { statusCode });
+        super(errorMessage, props);
     }
 }
 
@@ -98,9 +98,9 @@ export class ThrottlingError extends LoggingError implements IThrottlingWarning 
     constructor(
         errorMessage: string,
         readonly retryAfterSeconds: number,
-        statusCode?: number,
+        props?: ITaggableTelemetryProperties,
     ) {
-        super(errorMessage, { statusCode });
+        super(errorMessage, props);
     }
 }
 
@@ -111,11 +111,11 @@ export function createGenericNetworkError(
     errorMessage: string,
     canRetry: boolean,
     retryAfterSeconds?: number,
-    statusCode?: number) {
+    props?: ITaggableTelemetryProperties) {
     if (retryAfterSeconds !== undefined && canRetry) {
-        return new ThrottlingError(errorMessage, retryAfterSeconds, statusCode);
+        return new ThrottlingError(errorMessage, retryAfterSeconds, props);
     }
-    return new GenericNetworkError(errorMessage, canRetry, statusCode);
+    return new GenericNetworkError(errorMessage, canRetry, props);
 }
 
 /**

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { assert, Deferred, performance } from "@fluidframework/common-utils";
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { PerformanceEvent, TelemetryLogger } from "@fluidframework/telemetry-utils";
+import { assert, Deferred } from "@fluidframework/common-utils";
+import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
+import { PerformanceEvent} from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IDeltasFetchResult, IStream, IStreamResult } from "@fluidframework/driver-definitions";
 import { getRetryDelayFromError, canRetryOnError, createGenericNetworkError } from "./network";
@@ -40,8 +40,12 @@ export class ParallelRequests<T> {
         private to: number | undefined,
         private readonly payloadSize: number,
         private readonly logger: ITelemetryLogger,
-        private readonly requestCallback: (request: number, from: number, to: number, strongTo: boolean) =>
-            Promise<{ partial: boolean, cancel: boolean, payload: T[] }>,
+        private readonly requestCallback: (
+            request: number,
+            from: number,
+            to: number,
+            strongTo: boolean,
+            props: ITelemetryProperties) => Promise<{ partial: boolean, cancel: boolean, payload: T[] }>,
         private readonly responseCallback: (payload: T[]) => void)
     {
         this.latestRequested = from;
@@ -162,7 +166,7 @@ export class ParallelRequests<T> {
 
             this.requests++;
 
-            const promise = this.requestCallback(this.requests, from, to, this.to !== undefined);
+            const promise = this.requestCallback(this.requests, from, to, this.to !== undefined, {});
 
             // dispatch any prior received data
             this.dispatch();
@@ -341,11 +345,8 @@ export class Queue<T> implements IStream<T> {
  * @returns - an object with resulting ops and cancellation / partial result flags
  */
 async function getSingleOpBatch(
-    get: (from: number, to: number) => Promise<IDeltasFetchResult>,
-    request: number,
-    from: number,
-    to: number,
-    telemetryEvent: PerformanceEvent,
+    get: (telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>,
+    props: ITelemetryProperties,
     strongTo: boolean,
     signal?: AbortSignal):
         Promise<{ partial: boolean, cancel: boolean, payload: ISequencedDocumentMessage[] }>
@@ -354,10 +355,7 @@ async function getSingleOpBatch(
 
     let retry: number = 0;
     const deltas: ISequencedDocumentMessage[] = [];
-    let deltasRetrievedTotal = 0;
     const nothing = { partial: false, cancel: true, payload: []};
-
-    const start = performance.now();
 
     while (signal?.aborted !== true) {
         retry++;
@@ -367,22 +365,14 @@ async function getSingleOpBatch(
         try {
             // Issue async request for deltas - limit the number fetched to MaxBatchDeltas
             canRetry = true;
-            const deltasP = get(from, to);
+            const deltasP = get({ ...props, retry } /* telemetry props */);
 
             const { messages, partialResult } = await deltasP;
             deltas.push(...messages);
 
             const deltasRetrievedLast = messages.length;
-            deltasRetrievedTotal += deltasRetrievedLast;
 
             if (deltasRetrievedLast !== 0 || !strongTo) {
-                telemetryEvent.reportProgress({
-                    chunkDeltas: deltasRetrievedTotal,
-                    chunkFrom: from,
-                    chunkTo: to,
-                    chunkRequests: retry,
-                    chunkDuration: TelemetryLogger.formatTick(performance.now() - start),
-                });
                 return { payload: deltas, cancel: false, partial: partialResult};
             }
 
@@ -397,18 +387,14 @@ async function getSingleOpBatch(
                 // then give up after some time. This likely indicates the issue with ordering service not flushing
                 // ops to storage quick enough, and possibly waiting for summaries, while summarizer can't get
                 // current as it can't get ops.
-                telemetryEvent.cancel({
-                    category: "error",
-                    error: "too many retries",
-                    retry,
-                    request,
-                    deltasRetrievedTotal,
-                    replayFrom: from,
-                    to,
-                });
                 throw createGenericNetworkError(
-                    "Failed to retrieve ops from storage: giving up after too many retries",
+                    "Failed to retrieve ops from storage: too many retries",
                     false /* canRetry */,
+                    undefined /* retryAfterSeconds */,
+                    {
+                        retry,
+                        ...props,
+                    },
                 );
             }
         } catch (error) {
@@ -421,9 +407,7 @@ async function getSingleOpBatch(
                 this.logger,
                 {
                     eventName: "GetDeltas_Error",
-                    fetchTo: to,
-                    from,
-                    request,
+                    ...props,
                     retry,
                 },
                 error);
@@ -431,7 +415,6 @@ async function getSingleOpBatch(
 
             if (!canRetry) {
                 // It's game over scenario.
-                telemetryEvent.cancel({ category: "error" }, error);
                 throw error;
             }
             const retryAfter = getRetryDelayFromError(error);
@@ -441,27 +424,17 @@ async function getSingleOpBatch(
             }
         }
 
-        /*
-        if (to !== undefined && this.lastQueuedSequenceNumber >= to) {
-            // the client caught up while we were trying to fetch ops from storage
-            // bail out since we no longer need to request these ops
-            return nothing;
-        }
-        */
-
         await waitForConnectedState(delay * 1000);
     }
 
-    // Might need to change to non-error event
-    telemetryEvent.cancel({ error: "container closed" });
     return nothing;
 }
 
 export function requestOps(
-    get: (from: number, to: number) => Promise<IDeltasFetchResult>,
+    get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>,
     concurrency: number,
-    from: number,
-    to: number | undefined,
+    fromTotal: number,
+    toTotal: number | undefined,
     payloadSize: number,
     logger: ITelemetryLogger,
     signal?: AbortSignal,
@@ -471,20 +444,29 @@ export function requestOps(
     let deltasRetrievedTotal = 0;
     const queue = new Queue<ISequencedDocumentMessage[]>();
 
+    const propsTotal: ITelemetryProperties = {
+        fromTotal,
+        toTotal,
+    };
+
     const telemetryEvent = PerformanceEvent.start(logger, {
         eventName: `GetDeltas`,
-        from,
-        to,
+        ...propsTotal,
     });
 
     const manager = new ParallelRequests<ISequencedDocumentMessage>(
-        from,
-        to,
+        fromTotal,
+        toTotal,
         payloadSize,
         logger,
-        async (request: number, _from: number, _to: number, strongTo: boolean) => {
+        async (request: number, from: number, to: number, strongTo: boolean, propsPerRequest: ITelemetryProperties) => {
             requests++;
-            return getSingleOpBatch(get, request, _from, _to, telemetryEvent, strongTo, signal);
+            return getSingleOpBatch(
+                async (propsAll) => get(from, to, propsAll),
+                { request, from, to, ...propsTotal, ...propsPerRequest },
+                strongTo,
+                signal,
+            );
         },
         (deltas: ISequencedDocumentMessage[]) => {
             lastFetch = deltas[deltas.length - 1].sequenceNumber;

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -73,13 +73,13 @@ export function createOdspNetworkError(
     let error: OdspError & LoggingError;
     switch (statusCode) {
         case 400:
-            error = new GenericNetworkError(errorMessage, false, statusCode);
+            error = new GenericNetworkError(errorMessage, false, { statusCode });
             break;
         case 401:
         case 403:
             const claims = response?.headers ? parseAuthErrorClaims(response.headers) : undefined;
             const tenantId = response?.headers ? parseAuthErrorTenant(response.headers) : undefined;
-            error = new AuthorizationError(errorMessage, claims, tenantId, statusCode);
+            error = new AuthorizationError(errorMessage, claims, tenantId, { statusCode });
             break;
         case 404:
             error = new NonRetryableError(
@@ -103,7 +103,7 @@ export function createOdspNetworkError(
             error = new NonRetryableError(errorMessage, OdspErrorType.invalidFileNameError, { statusCode });
             break;
         case 500:
-            error = new GenericNetworkError(errorMessage, true, statusCode);
+            error = new GenericNetworkError(errorMessage, true, { statusCode });
             break;
         case 501:
             error = new NonRetryableError(errorMessage, OdspErrorType.fluidNotEnabled, { statusCode });
@@ -128,7 +128,7 @@ export function createOdspNetworkError(
             error = new NonRetryableError(errorMessage, OdspErrorType.fetchTokenError, { statusCode });
             break;
         default:
-            error = createGenericNetworkError(errorMessage, true, retryAfterSeconds, statusCode);
+            error = createGenericNetworkError(errorMessage, true, retryAfterSeconds, { statusCode });
     }
 
     error.online = OnlineStatus[isOnline()];


### PR DESCRIPTION
More telemetry to help find issues. Two buckets:
1. Validation that ops on the socket come in order
2. Changing how we do telemetry when fetching ops - propagating props through the stack such that different layers record same background info about origination of request.
   - part of it - finishing converting various error classes to use generic props vs. prior use of statusCode
3. resetting previous reason for enqueueMessages event if we had any pending ops - helps to ensure that any reported reason indeed reports prior & current reasons for processing ops, and thus correctly (in all cases) identifies the offender that caused gap in ops.

Back compat considerations: there is no changes in public API surface for the driver factory.
Errors returned from various methods of driver did not change their shape (only constructors changed, and error class ctors are not part of back compat layer).
