### PR TITLE
GC test mode: When deleting data stores, delete their summarizer nodes as well + gcTestMode incorrectly determined

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -792,7 +792,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // deleted as soon as GC runs.
     public get gcTestMode(): boolean {
         return getLocalStorageFeatureGate(gcTestModeKey)
-            ?? this.runtimeOptions.gcOptions?.runGCInTestMode !== undefined;
+            ?? this.runtimeOptions.gcOptions?.runGCInTestMode === true;
     }
 
     private constructor(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -877,6 +877,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     getGCDataFn,
                     getInitialGCSummaryDetailsFn,
                 ),
+            (id: string) => this.summarizerNode.deleteChild(id),
             this._logger);
 
         this.blobManager = new BlobManager(

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -80,6 +80,7 @@ export class DataStores implements IDisposable {
         private readonly submitAttachFn: (attachContent: any) => void,
         private readonly getCreateChildSummarizerNodeFn:
             (id: string, createParam: CreateChildSummarizerNodeParam)  => CreateChildSummarizerNodeFn,
+        private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
@@ -509,9 +510,11 @@ export class DataStores implements IDisposable {
     public deleteUnusedRoutes(unusedRoutes: string[]) {
         assert(this.runtime.gcTestMode, 0x1df /* "Data stores should be deleted only in GC test mode" */);
         for (const route of unusedRoutes) {
-            // Delete the contexts of unused data stores.
             const dataStoreId = route.split("/")[1];
+            // Delete the contexts of unused data stores.
             this.contexts.delete(dataStoreId);
+            // Delete the summarizer node of the unused data stores.
+            this.deleteChildSummarizerNodeFn(dataStoreId);
         }
     }
 

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -160,6 +160,7 @@ export interface ISummarizerNode {
  * - createChild - Added the following params:
  *   - getGCDataFn - This gets the GC data from the caller. This must be provided in order for getGCData to work.
  *   - getInitialGCDetailsFn - This gets the initial GC details from the caller.
+ * - deleteChild - Deletes a child node.
  * - isReferenced - This tells whether this node is referenced in the document or not.
  * - updateUsedRoutes - Used to notify this node of routes that are currently in use in it.
  */
@@ -185,6 +186,11 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
         getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
         getInitialGCSummaryDetailsFn?: () => Promise<IGarbageCollectionSummaryDetails>,
     ): ISummarizerNodeWithGC;
+
+    /**
+     * Delete the child with the given id..
+     */
+    deleteChild(id: string): void;
 
     getChild(id: string): ISummarizerNodeWithGC | undefined;
 

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -353,6 +353,13 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     }
 
     /**
+     * Deletes the child node with the given id.
+     */
+    public deleteChild(id: string): void {
+        this.children.delete(id);
+    }
+
+    /**
      * Override the getChild method to return an instance of SummarizerNodeWithGC.
      */
     public getChild(id: string): ISummarizerNodeWithGC | undefined {


### PR DESCRIPTION
In GC test mode, we are currently deleting the contexts from the container runtime's list but not deleting the corresponding summarizer nodes. So, when summarize happens, the summarizer node for the deleted data stores expects summarize to have run for them creating issues.
This change deletes the summarizer node for the deleted data stores as well.

Also, `gcTestMode` getter in container runtime incorrectly returns true when the value of `runGCInTestMode` option is false.