### PR TITLE
Fix for gcTestMode returning true when runGCInTestMode is false

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -792,7 +792,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // deleted as soon as GC runs.
     public get gcTestMode(): boolean {
         return getLocalStorageFeatureGate(gcTestModeKey)
-            ?? this.runtimeOptions.gcOptions?.runGCInTestMode !== undefined;
+            ?? this.runtimeOptions.gcOptions?.runGCInTestMode === true;
     }
 
     private constructor(


### PR DESCRIPTION
Fixes this bug: `gcTestMode` getter in container runtime incorrectly returns true when the value of `runGCInTestMode` option is false.