### PR TITLE
Add name to the user object returned in Tinylicious' audience

### DIFF
--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@fluid-experimental/fluid-framework": "^0.40.0",
     "@fluid-experimental/tinylicious-client": "^0.40.0",
+    "@fluidframework/container-definitions": "^0.40.0",
     "css-loader": "^1.0.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -5,7 +5,7 @@
 import TinyliciousClient from "@fluid-experimental/tinylicious-client";
 import { SharedMap } from "@fluid-experimental/fluid-framework";
 import { DiceRollerController } from "./controller";
-import { renderDiceRoller } from "./view";
+import { renderAudience, renderDiceRoller } from "./view";
 
 // Define the server we will be using and initialize Fluid
 TinyliciousClient.init();
@@ -60,6 +60,9 @@ async function start(): Promise<void> {
     contentDiv.appendChild(div2);
     // We render a view which uses the controller.
     renderDiceRoller(diceRollerController2, div2);
+
+    // Render the user names for the members currently in the session
+    renderAudience(fluidContainer.audience, contentDiv);
 }
 
 start().catch((error) => console.error(error));

--- a/examples/hosts/app-integration/external-controller/src/view.ts
+++ b/examples/hosts/app-integration/external-controller/src/view.ts
@@ -53,7 +53,7 @@ export function renderAudience(audience: IAudience, div: HTMLDivElement) {
     const audienceDiv = document.createElement("div");
     audienceDiv.style.fontSize = "20px";
 
-    const setAudienceMemberIds = () => {
+    const onAudienceChange = () => {
         const members = audience.getMembers();
         const memberNames: string[] = [];
         members.forEach((member) => {
@@ -64,10 +64,10 @@ export function renderAudience(audience: IAudience, div: HTMLDivElement) {
         audienceDiv.textContent = `Users: ${memberNames.join(", ")}`;
     };
 
-    setAudienceMemberIds();
+    onAudienceChange();
 
-    audience.on("addMember", setAudienceMemberIds);
-    audience.on("removeMember", setAudienceMemberIds);
+    audience.on("addMember", onAudienceChange);
+    audience.on("removeMember", onAudienceChange);
 
     wrapperDiv.appendChild(audienceDiv);
 }

--- a/examples/hosts/app-integration/external-controller/src/view.ts
+++ b/examples/hosts/app-integration/external-controller/src/view.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { IAudience } from "@fluidframework/container-definitions";
 import { IDiceRollerController } from "./controller";
 
 /**
@@ -36,4 +37,37 @@ export function renderDiceRoller(diceRoller: IDiceRollerController, div: HTMLDiv
 
     // Use the diceRolled event to trigger the rerender whenever the value changes.
     diceRoller.on("diceRolled", updateDiceChar);
+}
+
+/**
+ * Render the user names of the members currently active in the session into the provided div
+ * @param audience - Object that provides the list of current members and listeners for when the list changes
+ * @param div - The div to render into
+ */
+export function renderAudience(audience: IAudience, div: HTMLDivElement) {
+    const wrapperDiv = document.createElement("div");
+    wrapperDiv.style.textAlign = "center";
+    wrapperDiv.style.margin = "70px";
+    div.appendChild(wrapperDiv);
+
+    const audienceDiv = document.createElement("div");
+    audienceDiv.style.fontSize = "20px";
+
+    const setAudienceMemberIds = () => {
+        const members = audience.getMembers();
+        const memberNames: string[] = [];
+        members.forEach((member) => {
+            if (member.details.capabilities.interactive) {
+                memberNames.push((member.user as any).name);
+            }
+        });
+        audienceDiv.textContent = `Users: ${memberNames.join(", ")}`;
+    };
+
+    setAudienceMemberIds();
+
+    audience.on("addMember", setAudienceMemberIds);
+    audience.on("removeMember", setAudienceMemberIds);
+
+    wrapperDiv.appendChild(audienceDiv);
 }

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -32,6 +32,7 @@
     "@fluidframework/driver-utils": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0-0",
     "@fluidframework/routerlicious-driver": "^0.40.0",
+    "@fluidframework/server-services-client": "^0.1025.0-0",
     "jsrsasign": "^10.0.2",
     "uuid": "^8.3.1"
   },

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
@@ -5,6 +5,7 @@
 
 import { ScopeType, ITokenClaims } from "@fluidframework/protocol-definitions";
 import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+import { getRandomName } from "@fluidframework/server-services-client";
 import { KJUR as jsrsasign } from "jsrsasign";
 import { v4 as uuid } from "uuid";
 
@@ -34,12 +35,13 @@ export class InsecureTinyliciousTokenProvider implements ITokenProvider {
         ver: string = "1.0"): string {
         // Current time in seconds
         const now = Math.round((new Date()).getTime() / 1000);
+        const user = { id: uuid(), name: getRandomName() };
 
         const claims: ITokenClaims = {
             documentId,
             scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
             tenantId,
-            user: { id: uuid() },
+            user,
             iat: now,
             exp: now + lifetime,
             ver,


### PR DESCRIPTION
- Generates a random name for the new user that gets encoded into the token in `InsecureTinyliciousTokenProvider`. This allows UI-friendly values to be accessible when developing with the Tinylicious service, without needing to switch over to `InsecureTokenProvider` 
- Adds example for the change being consumed by rendering the audience information in `external-controller`