### PR TITLE
Fix build break due to incorrect lockfile

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -15594,6 +15594,21 @@
             "integrity": "sha512-G+26B2jc0Gw0EG/WN2M6IczuGepBsfR1+DtqLnyFSH4p2C668qkOCtEkGNVEaaNAVlYwEMazy1+/jnLxltBkIQ==",
             "dev": true
         },
+        "async-mutex": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.1.tgz",
+            "integrity": "sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==",
+            "requires": {
+                "tslib": "^2.1.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+                    "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+                }
+            }
+        },
         "async-retry": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",


### PR DESCRIPTION
Example failure: https://dev.azure.com/fluidframework/internal/_build/results?buildId=24659&view=logs&j=189bf95d-4688-543c-ef32-29eb64497bc0&t=1c6f3587-845d-5f13-dc31-cb3212cc3bd0