### PR TITLE
Make error handling/token refresh better in trees latest

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -16,7 +16,7 @@ import {
 import { IOdspSnapshot, IVersionedValueWithEpoch } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
-import { IOdspResponse, ISnapshotCacheValue } from "./odspUtils";
+import { getWithRetryForTokenRefresh, IOdspResponse, ISnapshotCacheValue } from "./odspUtils";
 
 /**
  * Fetches a snapshot from the server with a given version id.
@@ -61,171 +61,183 @@ export async function fetchSnapshot(
 export async function fetchLatestSnapshotCore(
     odspResolvedUrl: IOdspResolvedUrl,
     storageTokenFetcher: (options: TokenFetchOptions, name: string) => Promise<string | null>,
-    tokenFetchOptions: TokenFetchOptions,
     snapshotOptions: ISnapshotOptions | undefined,
     logger: ITelemetryLogger,
     snapshotDownloader: (url: string, fetchOptions: {[index: string]: any}) => Promise<IOdspResponse<IOdspSnapshot>>,
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
 ): Promise<ISnapshotCacheValue> {
-    const snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-    const url = `${snapshotUrl}/trees/latest?ump=1`;
-    const storageToken = await storageTokenFetcher(tokenFetchOptions, "TreesLatest");
-    assert(storageToken !== null, "Storage token should not be null");
-    const formBoundary = uuid();
-    const formParams: string[] = [];
-    formParams.push(`--${formBoundary}`);
-    formParams.push(`Authorization: Bearer ${storageToken}`);
-    formParams.push(`X-HTTP-Method-Override: GET`);
-    const logOptions = {};
-    if (snapshotOptions !== undefined) {
-        Object.entries(snapshotOptions).forEach(([key, value]) => {
-            if (value !== undefined) {
-                formParams.push(`${key}: ${value}`);
-                logOptions[`snapshotOption_${key}`] = value;
-            }
-        });
-    }
-    if (odspResolvedUrl.sharingLinkToRedeem) {
-        formParams.push(`sl: ${odspResolvedUrl.sharingLinkToRedeem}`);
-    }
-    formParams.push(`_post: 1`);
-    formParams.push(`\r\n--${formBoundary}--`);
-    const postBody = formParams.join("\r\n");
-    const headers: {[index: string]: any} = {
-        "Content-Type": `multipart/form-data;boundary=${formBoundary}`,
-    };
-
-    let controller: AbortController | undefined;
-    if (snapshotOptions?.timeout !== undefined) {
-        controller = new AbortController();
-        setTimeout(
-            () => controller!.abort(),
-            snapshotOptions.timeout,
-        );
-    }
-
-    // This event measures only successful cases of getLatest call (no tokens, no retries).
-    return PerformanceEvent.timedExecAsync(
-        logger,
-        {
-            eventName: "TreesLatest",
-            ...logOptions,
-        },
-        async (event) => {
-            const startTime = performance.now();
-            const response: IOdspResponse<IOdspSnapshot> = await snapshotDownloader(
-                url,
-                {
-                    body: postBody,
-                    headers,
-                    signal: controller?.signal,
-                    method: "POST",
-                },
-            );
-            const endTime = performance.now();
-            const overallTime = endTime - startTime;
-            const snapshot: IOdspSnapshot = response.content;
-            let dnstime: number | undefined; // domainLookupEnd - domainLookupStart
-            let redirectTime: number | undefined; // redirectEnd -redirectStart
-            let tcpHandshakeTime: number | undefined; // connectEnd  - connectStart
-            let secureConntime: number | undefined; // connectEnd  - secureConnectionStart
-            let responseTime: number | undefined; // responsEnd - responseStart
-            let fetchStToRespEndTime: number | undefined; // responseEnd  - fetchStart
-            let reqStToRespEndTime: number | undefined; // responseEnd - requestStart
-            let networkTime: number | undefined; // responseEnd - startTime
-            const spReqDuration = response.headers.get("sprequestduration");
-
-            // getEntriesByType is only available in browser performance object
-            const resources1 = performance.getEntriesByType?.("resource") ?? [];
-            // Usually the latest fetch call is to the end of resources, so we start from the end.
-            for (let i = resources1.length - 1; i > 0; i--) {
-                const indResTime = resources1[i] as PerformanceResourceTiming;
-                const resource_name = indResTime.name;
-                const resource_initiatortype = indResTime.initiatorType;
-                if ((resource_initiatortype.localeCompare("fetch") === 0) && (resource_name.localeCompare(url) === 0)) {
-                    redirectTime = indResTime.redirectEnd - indResTime.redirectStart;
-                    dnstime = indResTime.domainLookupEnd - indResTime.domainLookupStart;
-                    tcpHandshakeTime = indResTime.connectEnd - indResTime.connectStart;
-                    secureConntime = (indResTime.secureConnectionStart > 0) ?
-                        (indResTime.connectEnd - indResTime.secureConnectionStart) : 0;
-                    responseTime = indResTime.responseEnd - indResTime.responseStart;
-                    fetchStToRespEndTime = (indResTime.fetchStart > 0) ?
-                        (indResTime.responseEnd - indResTime.fetchStart) : 0;
-                    reqStToRespEndTime = (indResTime.requestStart > 0) ?
-                        (indResTime.responseEnd - indResTime.requestStart) : 0;
-                    networkTime = (indResTime.startTime > 0) ? (indResTime.responseEnd - indResTime.startTime) : 0;
-                    if (spReqDuration) {
-                        networkTime = networkTime - parseInt(spReqDuration, 10);
-                    }
-                    break;
-                }
-            }
-
-            const { numTrees, numBlobs, encodedBlobsSize, decodedBlobsSize } = evalBlobsAndTrees(snapshot);
-            const clientTime = networkTime ? overallTime - networkTime : undefined;
-
-            // There are some scenarios in ODSP where we cannot cache, trees/latest will explicitly tell us when we
-            // cannot cache using an HTTP response header.
-            const canCache = response.headers.get("disablebrowsercachingofusercontent") !== "true";
-            // There maybe no snapshot - TreesLatest would return just ops.
-            const sequenceNumber: number = (snapshot.trees && (snapshot.trees[0] as any).sequenceNumber) ?? 0;
-            const seqNumberFromOps = snapshot.ops && snapshot.ops.length > 0 ?
-                snapshot.ops[0].sequenceNumber - 1 :
-                undefined;
-
-            const value: ISnapshotCacheValue = { snapshot, sequenceNumber };
-            if (!Number.isInteger(sequenceNumber)
-                || seqNumberFromOps !== undefined && seqNumberFromOps !== sequenceNumber) {
-                logger.sendErrorEvent({ eventName: "fetchSnapshotError", sequenceNumber, seqNumberFromOps });
-                value.sequenceNumber = undefined;
-            } else if (canCache) {
-                const fluidEpoch = response.headers.get("x-fluid-epoch");
-                assert(fluidEpoch !== undefined, "Epoch  should be present in response");
-                const valueWithEpoch: IVersionedValueWithEpoch = {
-                    value,
-                    fluidEpoch,
-                    version: 2,
-                };
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                putInCache(valueWithEpoch);
-            }
-            event.end({
-                trees: numTrees,
-                blobs: snapshot.blobs?.length ?? 0,
-                leafNodes: numBlobs,
-                encodedBlobsSize,
-                decodedBlobsSize,
-                sequenceNumber,
-                ops: snapshot.ops?.length ?? 0,
-                headers: Object.keys(headers).length !== 0 ? true : undefined,
-                redirecttime: redirectTime,
-                dnsLookuptime: dnstime,
-                responsenetworkTime: responseTime,
-                tcphandshakeTime: tcpHandshakeTime,
-                secureconnectiontime: secureConntime,
-                fetchstarttorespendtime: fetchStToRespEndTime,
-                reqstarttorespendtime: reqStToRespEndTime,
-                overalltime: overallTime,
-                networktime: networkTime,
-                clienttime: clientTime,
-                // Sharing link telemetry regarding sharing link redeem status and performance. Ex: FRL; dur=100, FRS;
-                // desc=S, FRP; desc=False. Here, FRL is the duration taken for redeem, FRS is the redeem
-                // status (S means success), and FRP is a flag to indicate if the permission has changed.
-                sltelemetry: response.headers.get("x-fluid-sltelemetry"),
-                ...response.commonSpoHeaders,
+    return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
+        if (tokenFetchOptions.refresh) {
+            // This is the most critical code path for boot.
+            // If we get incorrect / expired token first time, that adds up to latency of boot
+            logger.sendErrorEvent({
+                eventName: "TreeLatest_SecondCall",
+                hasClaims: !!tokenFetchOptions.claims,
+                hasTenantId: !!tokenFetchOptions.tenantId,
             });
-            return value;
-        },
-    ).catch((error) => {
-        // Issue #5895:
-        // If we are offline, this error is retryable. But that means that RetriableDocumentStorageService
-        // will run in circles calling getSnapshotTree, which would result in OdspDocumentStorageService class
-        // going getVersions / individual blob download path. This path is very slow, and will not work with
-        // delay-loaded data stores and ODSP storage deleting old snapshots and blobs.
-        if (typeof error === "object" && error !== null) {
-            error.canRetry = false;
         }
-        throw error;
+        const snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
+        const url = `${snapshotUrl}/trees/latest?ump=1`;
+        const storageToken = await storageTokenFetcher(tokenFetchOptions, "TreesLatest");
+        assert(storageToken !== null, "Storage token should not be null");
+        const formBoundary = uuid();
+        const formParams: string[] = [];
+        formParams.push(`--${formBoundary}`);
+        formParams.push(`Authorization: Bearer ${storageToken}`);
+        formParams.push(`X-HTTP-Method-Override: GET`);
+        const logOptions = {};
+        if (snapshotOptions !== undefined) {
+            Object.entries(snapshotOptions).forEach(([key, value]) => {
+                if (value !== undefined) {
+                    formParams.push(`${key}: ${value}`);
+                    logOptions[`snapshotOption_${key}`] = value;
+                }
+            });
+        }
+        if (odspResolvedUrl.sharingLinkToRedeem) {
+            formParams.push(`sl: ${odspResolvedUrl.sharingLinkToRedeem}`);
+        }
+        formParams.push(`_post: 1`);
+        formParams.push(`\r\n--${formBoundary}--`);
+        const postBody = formParams.join("\r\n");
+        const headers: {[index: string]: any} = {
+            "Content-Type": `multipart/form-data;boundary=${formBoundary}`,
+        };
+
+        let controller: AbortController | undefined;
+        if (snapshotOptions?.timeout !== undefined) {
+            controller = new AbortController();
+            setTimeout(
+                () => controller!.abort(),
+                snapshotOptions.timeout,
+            );
+        }
+
+        // This event measures only successful cases of getLatest call (no tokens, no retries).
+        return PerformanceEvent.timedExecAsync(
+            logger,
+            {
+                eventName: "TreesLatest",
+                ...logOptions,
+            },
+            async (event) => {
+                const startTime = performance.now();
+                const response: IOdspResponse<IOdspSnapshot> = await snapshotDownloader(
+                    url,
+                    {
+                        body: postBody,
+                        headers,
+                        signal: controller?.signal,
+                        method: "POST",
+                    },
+                );
+                const endTime = performance.now();
+                const overallTime = endTime - startTime;
+                const snapshot: IOdspSnapshot = response.content;
+                let dnstime: number | undefined; // domainLookupEnd - domainLookupStart
+                let redirectTime: number | undefined; // redirectEnd -redirectStart
+                let tcpHandshakeTime: number | undefined; // connectEnd  - connectStart
+                let secureConntime: number | undefined; // connectEnd  - secureConnectionStart
+                let responseTime: number | undefined; // responsEnd - responseStart
+                let fetchStToRespEndTime: number | undefined; // responseEnd  - fetchStart
+                let reqStToRespEndTime: number | undefined; // responseEnd - requestStart
+                let networkTime: number | undefined; // responseEnd - startTime
+                const spReqDuration = response.headers.get("sprequestduration");
+
+                // getEntriesByType is only available in browser performance object
+                const resources1 = performance.getEntriesByType?.("resource") ?? [];
+                // Usually the latest fetch call is to the end of resources, so we start from the end.
+                for (let i = resources1.length - 1; i > 0; i--) {
+                    const indResTime = resources1[i] as PerformanceResourceTiming;
+                    const resource_name = indResTime.name;
+                    const resource_initiatortype = indResTime.initiatorType;
+                    if ((resource_initiatortype.localeCompare("fetch") === 0)
+                        && (resource_name.localeCompare(url) === 0)) {
+                        redirectTime = indResTime.redirectEnd - indResTime.redirectStart;
+                        dnstime = indResTime.domainLookupEnd - indResTime.domainLookupStart;
+                        tcpHandshakeTime = indResTime.connectEnd - indResTime.connectStart;
+                        secureConntime = (indResTime.secureConnectionStart > 0) ?
+                            (indResTime.connectEnd - indResTime.secureConnectionStart) : 0;
+                        responseTime = indResTime.responseEnd - indResTime.responseStart;
+                        fetchStToRespEndTime = (indResTime.fetchStart > 0) ?
+                            (indResTime.responseEnd - indResTime.fetchStart) : 0;
+                        reqStToRespEndTime = (indResTime.requestStart > 0) ?
+                            (indResTime.responseEnd - indResTime.requestStart) : 0;
+                        networkTime = (indResTime.startTime > 0) ? (indResTime.responseEnd - indResTime.startTime) : 0;
+                        if (spReqDuration) {
+                            networkTime = networkTime - parseInt(spReqDuration, 10);
+                        }
+                        break;
+                    }
+                }
+
+                const { numTrees, numBlobs, encodedBlobsSize, decodedBlobsSize } = evalBlobsAndTrees(snapshot);
+                const clientTime = networkTime ? overallTime - networkTime : undefined;
+
+                // There are some scenarios in ODSP where we cannot cache, trees/latest will explicitly tell us when we
+                // cannot cache using an HTTP response header.
+                const canCache = response.headers.get("disablebrowsercachingofusercontent") !== "true";
+                // There maybe no snapshot - TreesLatest would return just ops.
+                const sequenceNumber: number = (snapshot.trees && (snapshot.trees[0] as any).sequenceNumber) ?? 0;
+                const seqNumberFromOps = snapshot.ops && snapshot.ops.length > 0 ?
+                    snapshot.ops[0].sequenceNumber - 1 :
+                    undefined;
+
+                const value: ISnapshotCacheValue = { snapshot, sequenceNumber };
+                if (!Number.isInteger(sequenceNumber)
+                    || seqNumberFromOps !== undefined && seqNumberFromOps !== sequenceNumber) {
+                    logger.sendErrorEvent({ eventName: "fetchSnapshotError", sequenceNumber, seqNumberFromOps });
+                    value.sequenceNumber = undefined;
+                } else if (canCache) {
+                    const fluidEpoch = response.headers.get("x-fluid-epoch");
+                    assert(fluidEpoch !== undefined, "Epoch  should be present in response");
+                    const valueWithEpoch: IVersionedValueWithEpoch = {
+                        value,
+                        fluidEpoch,
+                        version: 2,
+                    };
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    putInCache(valueWithEpoch);
+                }
+                event.end({
+                    trees: numTrees,
+                    blobs: snapshot.blobs?.length ?? 0,
+                    leafNodes: numBlobs,
+                    encodedBlobsSize,
+                    decodedBlobsSize,
+                    sequenceNumber,
+                    ops: snapshot.ops?.length ?? 0,
+                    headers: Object.keys(headers).length !== 0 ? true : undefined,
+                    redirecttime: redirectTime,
+                    dnsLookuptime: dnstime,
+                    responsenetworkTime: responseTime,
+                    tcphandshakeTime: tcpHandshakeTime,
+                    secureconnectiontime: secureConntime,
+                    fetchstarttorespendtime: fetchStToRespEndTime,
+                    reqstarttorespendtime: reqStToRespEndTime,
+                    overalltime: overallTime,
+                    networktime: networkTime,
+                    clienttime: clientTime,
+                    // Sharing link telemetry regarding sharing link redeem status and performance. Ex: FRL; dur=100,
+                    // FRS; desc=S, FRP; desc=False. Here, FRL is the duration taken for redeem, FRS is the redeem
+                    // status (S means success), and FRP is a flag to indicate if the permission has changed.
+                    sltelemetry: response.headers.get("x-fluid-sltelemetry"),
+                    attempts: tokenFetchOptions.refresh ? 2 : 1,
+                    ...response.commonSpoHeaders,
+                });
+                return value;
+            },
+        ).catch((error) => {
+            // Issue #5895:
+            // If we are offline, this error is retryable. But that means that RetriableDocumentStorageService
+            // will run in circles calling getSnapshotTree, which would result in OdspDocumentStorageService class
+            // going getVersions / individual blob download path. This path is very slow, and will not work with
+            // delay-loaded data stores and ODSP storage deleting old snapshots and blobs.
+            if (typeof error === "object" && error !== null) {
+                error.canRetry = false;
+            }
+            throw error;
+        });
     });
 }
 

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -227,17 +227,17 @@ export async function fetchLatestSnapshotCore(
                 });
                 return value;
             },
-        ).catch((error) => {
-            // Issue #5895:
-            // If we are offline, this error is retryable. But that means that RetriableDocumentStorageService
-            // will run in circles calling getSnapshotTree, which would result in OdspDocumentStorageService class
-            // going getVersions / individual blob download path. This path is very slow, and will not work with
-            // delay-loaded data stores and ODSP storage deleting old snapshots and blobs.
-            if (typeof error === "object" && error !== null) {
-                error.canRetry = false;
-            }
-            throw error;
-        });
+        );
+    }).catch((error) => {
+        // Issue #5895:
+        // If we are offline, this error is retryable. But that means that RetriableDocumentStorageService
+        // will run in circles calling getSnapshotTree, which would result in OdspDocumentStorageService class
+        // going getVersions / individual blob download path. This path is very slow, and will not work with
+        // delay-loaded data stores and ODSP storage deleting old snapshots and blobs.
+        if (typeof error === "object" && error !== null) {
+            error.canRetry = false;
+        }
+        throw error;
     });
 }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -475,90 +475,65 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         // If count is one, we can use the trees/latest API, which returns the latest version and trees in a single request for better performance
         // Do it only once - we might get more here due to summarizer - it needs only container tree, not full snapshot.
         if (this.firstVersionCall && count === 1 && (blobid === null || blobid === this.documentId)) {
-            return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
-                if (tokenFetchOptions.refresh) {
-                    // This is the most critical code path for boot.
-                    // If we get incorrect / expired token first time, that adds up to latency of boot
-                    this.logger.sendErrorEvent({
-                        eventName: "TreeLatest_SecondCall",
-                        hasClaims: !!tokenFetchOptions.claims,
-                        hasTenantId: !!tokenFetchOptions.tenantId,
-                    });
-                }
+            const hostSnapshotOptions = this.hostPolicy.snapshotOptions;
+            const odspSnapshotCacheValue: ISnapshotCacheValue = await PerformanceEvent.timedExecAsync(
+                this.logger,
+                { eventName: "ObtainSnapshot" },
+                async (event: PerformanceEvent) => {
+                    let cachedSnapshot: ISnapshotCacheValue | undefined;
+                    const cachedSnapshotP: Promise<ISnapshotCacheValue | undefined> =
+                        this.epochTracker.get(createCacheSnapshotKey(this.odspResolvedUrl));
 
-                const hostSnapshotOptions = this.hostPolicy.snapshotOptions;
-                let cachedSnapshot: ISnapshotCacheValue | undefined;
-                // No need to ask cache twice - if first request was unsuccessful, cache unlikely to have data on second turn.
-                if (tokenFetchOptions.refresh) {
-                    cachedSnapshot = await this.fetchSnapshot(hostSnapshotOptions, undefined, tokenFetchOptions);
-                } else {
-                    cachedSnapshot = await PerformanceEvent.timedExecAsync(
-                        this.logger,
-                        { eventName: "ObtainSnapshot" },
-                        async (event: PerformanceEvent) => {
-                            const cachedSnapshotP: Promise<ISnapshotCacheValue | undefined> =
-                                this.epochTracker.get(createCacheSnapshotKey(this.odspResolvedUrl));
+                    let method: string;
+                    if (this.hostPolicy.concurrentSnapshotFetch && !this.hostPolicy.summarizerClient) {
+                        const snapshotP = this.fetchSnapshot(hostSnapshotOptions);
 
-                            let method: string;
-                            if (this.hostPolicy.concurrentSnapshotFetch && !this.hostPolicy.summarizerClient) {
-                                const snapshotP = this.fetchSnapshot(hostSnapshotOptions, undefined, tokenFetchOptions);
+                        const promiseRaceWinner = await promiseRaceWithWinner([cachedSnapshotP, snapshotP]);
+                        cachedSnapshot = promiseRaceWinner.value;
 
-                                const promiseRaceWinner = await promiseRaceWithWinner([cachedSnapshotP, snapshotP]);
-                                cachedSnapshot = promiseRaceWinner.value;
+                        if (cachedSnapshot === undefined) {
+                            cachedSnapshot = await snapshotP;
+                        }
 
-                                if (cachedSnapshot === undefined) {
-                                    cachedSnapshot = await snapshotP;
-                                }
+                        method = promiseRaceWinner.index === 0 && promiseRaceWinner.value !== undefined ? "cache" : "network";
+                    } else {
+                        // Note: There's a race condition here - another caller may come past the undefined check
+                        // while the first caller is awaiting later async code in this block.
 
-                                method = promiseRaceWinner.index === 0 && promiseRaceWinner.value !== undefined ? "cache" : "network";
-                            } else {
-                                // Note: There's a race condition here - another caller may come past the undefined check
-                                // while the first caller is awaiting later async code in this block.
+                        cachedSnapshot = await cachedSnapshotP;
 
-                                cachedSnapshot = await cachedSnapshotP;
+                        method = cachedSnapshot !== undefined ? "cache" : "network";
 
-                                method = cachedSnapshot !== undefined ? "cache" : "network";
-
-                                if (cachedSnapshot === undefined) {
-                                    cachedSnapshot = await this.fetchSnapshot(hostSnapshotOptions, undefined, tokenFetchOptions);
-                                }
-                            }
-                            event.end({ method });
-                            return cachedSnapshot;
-                        });
-                }
-
-                // Successful call, redirect future calls to getVersion only!
-                this.firstVersionCall = false;
-
-                const odspSnapshot: IOdspSnapshot = cachedSnapshot.snapshot;
-                this._snapshotSequenceNumber = cachedSnapshot.sequenceNumber;
-
-                const { trees, blobs, ops } = odspSnapshot;
-                // id should be undefined in case of just ops in snapshot.
-                let id: string | undefined;
-                if (trees) {
-                    this.initCommitCache(trees);
-                    // versionId is the id of the first tree
-                    if (trees.length > 0) {
-                        id = trees[0].id;
+                        if (cachedSnapshot === undefined) {
+                            cachedSnapshot = await this.fetchSnapshot(hostSnapshotOptions);
+                        }
                     }
-                }
-                if (blobs) {
-                    this.initBlobsCache(blobs);
-                }
+                    event.end({ method });
+                    return cachedSnapshot;
+                });
 
-                this.ops = ops;
-                return id ? [{ id, treeId: undefined! }] : [];
-            }).catch(async (error) => {
-                const errorType = error.errorType;
-                // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have
-                // permissions for the file or it was deleted. So the user will again try to fetch from cache on any failure in future.
-                if (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
-                    await this.cache.persistedCache.removeEntries();
+            // Successful call, redirect future calls to getVersion only!
+            this.firstVersionCall = false;
+
+            const odspSnapshot: IOdspSnapshot = odspSnapshotCacheValue.snapshot;
+            this._snapshotSequenceNumber = odspSnapshotCacheValue.sequenceNumber;
+
+            const { trees, blobs, ops } = odspSnapshot;
+            // id should be undefined in case of just ops in snapshot.
+            let id: string | undefined;
+            if (trees) {
+                this.initCommitCache(trees);
+                // versionId is the id of the first tree
+                if (trees.length > 0) {
+                    id = trees[0].id;
                 }
-                throw error;
-            });
+            }
+            if (blobs) {
+                this.initBlobsCache(blobs);
+            }
+
+            this.ops = ops;
+            return id ? [{ id, treeId: undefined! }] : [];
         }
 
         return getWithRetryForTokenRefresh(async (options) => {
@@ -600,12 +575,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         });
     }
 
-    private async fetchSnapshot(
-        hostSnapshotOptions: ISnapshotOptions | undefined,
-        driverSnapshotOptions: ISnapshotOptions | undefined,
-        tokenFetchOptions: TokenFetchOptions,
-    ) {
-        const snapshotOptions: ISnapshotOptions = driverSnapshotOptions ?? {
+    private async fetchSnapshot(hostSnapshotOptions: ISnapshotOptions | undefined) {
+        const snapshotOptions: ISnapshotOptions = {
             mds: this.maxSnapshotSizeLimit,
             ...hostSnapshotOptions,
             timeout: hostSnapshotOptions?.timeout ? Math.min(hostSnapshotOptions.timeout, this.maxSnapshotFetchTimeout) : this.maxSnapshotFetchTimeout,
@@ -636,7 +607,6 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             const odspSnapshot = await fetchLatestSnapshotCore(
                 this.odspResolvedUrl,
                 this.getStorageToken,
-                tokenFetchOptions,
                 snapshotOptions,
                 this.logger,
                 snapshotDownloader,
@@ -658,12 +628,16 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 const odspSnapshot = await fetchLatestSnapshotCore(
                     this.odspResolvedUrl,
                     this.getStorageToken,
-                    tokenFetchOptions,
                     snapshotOptionsWithoutBlobs,
                     this.logger,
                     snapshotDownloader,
                     putInCache);
                 return odspSnapshot;
+            }
+            // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have
+            // permissions for the file or it was deleted. So the user will again try to fetch from cache on any failure in future.
+            if (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
+                await this.cache.persistedCache.removeEntries();
             }
             throw error;
         }

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -635,7 +635,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 return odspSnapshot;
             }
             // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have
-            // permissions for the file or it was deleted. So the user will again try to fetch from cache on any failure in future.
+            // permissions for the file or it was deleted. So, if we do not clear cache, we will continue fetching snapshot from cache in the future.
             if (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
                 await this.cache.persistedCache.removeEntries();
             }

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -41,7 +41,7 @@ export async function prefetchLatestSnapshot(
     logger: ITelemetryBaseLogger,
     hostSnapshotFetchOptions: ISnapshotOptions | undefined,
 ): Promise<boolean> {
-    const odspLogger = createOdspLogger(ChildLogger.create(logger, "PrefetchSnapshot", { all: { prefetch: true }}));
+    const odspLogger = createOdspLogger(ChildLogger.create(logger, "PrefetchSnapshot"));
     const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
 
     const storageTokenFetcher = toInstrumentedOdspTokenFetcher(


### PR DESCRIPTION
I don't think there is need to have token refresh code so up the ladder in trees latest call. So moved it to the lowest level.