### PR TITLE
Test AgentScheduler as a standalone data store

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -36,19 +36,10 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
         beforeEach(async () => {
             const container = await createContainer();
             scheduler = await requestFluidObject<IAgentScheduler>(container, "default");
-
-            // const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
-
-            // // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick
-            // // tasks. Sending an op will switch it to "write" mode.
-            // dataObject._root.set("tempKey", "tempValue");
-
-            // if (!dataObject._context.leader) {
-            //     // Wait until we are the leader before we proceed.
-            //     await timeoutPromise((res) => dataObject._context.on("leader", res), {
-            //         durationMs: leaderTimeout,
-            //     });
-            // }
+            // By default, the container loads in read mode.  However, pick() attempts silently fail if not in write
+            // mode.  To overcome this and test pick(), we can register a fake task (which always tries to perform
+            // a write) so we get nack'd and bumped into write mode.
+            await scheduler.register("makeWriteMode");
         });
 
         it("No tasks initially", async () => {
@@ -115,22 +106,18 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
             // Create a new Container for the first document.
             container1 = await createContainer();
             scheduler1 = await requestFluidObject<IAgentScheduler>(container1, "default");
-
-            // const dataObject1 = await requestFluidObject<ITestDataObject>(container1, "default");
-
-            // // Set a key in the root map. The Container is created in "read" mode and so it cannot currently pick
-            // // tasks. Sending an op will switch it to "write" mode.
-            // dataObject1._root.set("tempKey1", "tempValue1");
-            // if (!dataObject1._context.leader) {
-            //     // Wait until we are the leader before we proceed.
-            //     await timeoutPromise((res) => dataObject1._context.on("leader", res), {
-            //         durationMs: leaderTimeout,
-            //     });
-            // }
+            // By default, the container loads in read mode.  However, pick() attempts silently fail if not in write
+            // mode.  To overcome this and test pick(), we can register a fake task (which always tries to perform
+            // a write) so we get nack'd and bumped into write mode.
+            await scheduler1.register("makeWriteMode");
 
             // Load existing Container for the second document.
             container2 = await loadContainer();
             scheduler2 = await requestFluidObject<IAgentScheduler>(container2, "default");
+            // By default, the container loads in read mode.  However, pick() attempts silently fail if not in write
+            // mode.  To overcome this and test pick(), we can register a fake task (which always tries to perform
+            // a write) so we get nack'd and bumped into write mode.
+            await scheduler2.register("makeWriteMode");
 
             // const dataObject2 = await requestFluidObject<ITestDataObject>(container2, "default");
 

--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -87,13 +87,6 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
             await scheduler.pick("task1", async () => { });
             assert.deepStrictEqual(scheduler.pickedTasks(), ["task1"]);
         });
-
-        it("Single client must be the leader", async () => {
-            assert.deepStrictEqual(scheduler.pickedTasks(), []);
-            await scheduler.pick("task1", async () => { });
-            await scheduler.release("task1");
-            assert.deepStrictEqual(scheduler.pickedTasks(), []);
-        });
     });
 
     describe("Multiple clients", () => {


### PR DESCRIPTION
After the built-in `AgentScheduler` is removed, we'll still want to test `AgentScheduler` functionality (customers will still be able to use it as a normal data store).  This change updates the end-to-end test to opt-out of the built-in and test it in the forward-looking mode.

As a result, the "leader" task doesn't need to be accounted for in the test expectations (leadership is still tested by leader.spec.ts).