### PR TITLE
more efficient getBlobSize()

### DIFF
--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -44,7 +44,7 @@ export function mergeStats(...stats: ISummaryStats[]): ISummaryStats {
     return results;
 }
 
-function byteLength(str: string): number {
+export function utf8ByteLength(str: string): number {
   // returns the byte length of an utf8 string
   let s = str.length;
   for (let i = str.length - 1; i >= 0; i--) {
@@ -63,7 +63,7 @@ function byteLength(str: string): number {
 
 export function getBlobSize(content: ISummaryBlob["content"]): number {
     if (typeof content === "string") {
-        return byteLength(content);
+        return utf8ByteLength(content);
     } else {
         return content.byteLength;
     }

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -9,7 +9,6 @@ import {
     IsoBuffer,
     Uint8ArrayToString,
     unreachableCase,
-    stringToBuffer,
 } from "@fluidframework/common-utils";
 import { AttachmentTreeEntry, BlobTreeEntry, TreeTreeEntry } from "@fluidframework/protocol-base";
 import {
@@ -45,9 +44,26 @@ export function mergeStats(...stats: ISummaryStats[]): ISummaryStats {
     return results;
 }
 
+function byteLength(str: string): number {
+  // returns the byte length of an utf8 string
+  let s = str.length;
+  for (let i = str.length - 1; i >= 0; i--) {
+    const code = str.charCodeAt(i);
+    if (code > 0x7f && code <= 0x7ff) {
+        s++;
+    } else if (code > 0x7ff && code <= 0xffff) {
+        s += 2;
+    }
+    if (code >= 0xDC00 && code <= 0xDFFF) {
+        i--; // trail surrogate
+    }
+  }
+  return s;
+}
+
 export function getBlobSize(content: ISummaryBlob["content"]): number {
     if (typeof content === "string") {
-        return stringToBuffer(content, "utf8").byteLength;
+        return byteLength(content);
     } else {
         return content.byteLength;
     }

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IsoBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
+import { IsoBuffer, stringToBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
 import {
     SummaryObject,
     ISummaryTree,
@@ -14,7 +14,7 @@ import {
     ITree,
 } from "@fluidframework/protocol-definitions";
 import { BlobTreeEntry, TreeTreeEntry } from "@fluidframework/protocol-base";
-import { convertToSummaryTree } from "../summaryUtils";
+import { convertToSummaryTree, utf8ByteLength } from "../summaryUtils";
 
 describe("Summary Utils", () => {
     describe("Convert to Summary Tree", () => {
@@ -117,6 +117,26 @@ describe("Summary Utils", () => {
             assert.strictEqual(summaryResults.stats.treeNodeCount, 2);
             assert.strictEqual(summaryResults.stats.totalBlobSize,
                 bufferLength + IsoBuffer.from("test-blob").byteLength + IsoBuffer.from("test-u8").byteLength);
+        });
+    });
+
+    describe("utf8ByteLength()", () => {
+        it("gives correct utf8 byte length", () => {
+            const a = [
+                "prague is a city in europe",
+                "ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ",
+                "Τὴ γλῶσσα μοῦ ἔδωσαν ἑλληνικὴ",
+                "На берегу пустынных волн",
+                "⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑",
+                "أنا قادر على أكل الزجاج و هذا لا يؤلمني.",
+                " 我能吞下玻璃而不傷身體。",
+                "ᐊᓕᒍᖅ ᓂᕆᔭᕌᖓᒃᑯ ᓱᕋᙱᑦᑐᓐᓇᖅᑐᖓ",
+                "🤦🏼‍♂️",
+                "🏴󠁧󠁢󠁷󠁬󠁳󠁿", // the flag of wales
+                "���",
+                "������",
+            ];
+            a.map((s) => assert.strictEqual(utf8ByteLength(s), stringToBuffer(s, "utf8").byteLength, s));
         });
     });
 });


### PR DESCRIPTION
fix #5261
From a cursory investigation, it seems to be faster by about 44% on average (from 7.8 ms down to 3.45 ms).