### PR TITLE
Bring back redemption code that was accidently wiped out as part of refactoring

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -402,7 +402,7 @@ export function createOdspCacheAndTracker(
     fileEntry: IFileEntry,
     logger: ITelemetryLogger): ICacheAndTracker
 {
-    const epochTracker = new EpochTracker(persistedCacheArg, fileEntry, logger);
+    const epochTracker = new EpochTrackerWithRedemption(persistedCacheArg, fileEntry, logger);
     return {
         cache: {
             ...nonpersistentCache,


### PR DESCRIPTION
Porting  PR #6123 to 0.39

We do not have any end-to-end tests that hits this path.
UTs are only testing object itself, but if it's not used, we can only detect if we have sharing scenarios, but we do not have them.
Code originally was added per Sumedh request, I wonder if / why we are not seeing regression in that flow ( I assume regression is fresh and that flow did not pick up latest bits).

Bohemia regression is combination of this bug, and 0.38 bump switching (accidently) to establishing PUSH connection earlier than it used to be, exposing to this workflow.

### -- FYI: This fix was pushed out in patch 0.39.3
