### PR TITLE
Address scalability issues / "too many retries" failures

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -74,6 +74,8 @@ export class OdspDeltaStorageService {
                 duration: response.duration, // this duration for single attempt!
                 ...response.commonSpoHeaders,
                 attempts: options.refresh ? 2 : 1,
+                from,
+                to,
             });
 
             // It is assumed that server always returns all the ops that it has in the range that was requested.
@@ -129,13 +131,6 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
                         opsFromSnapshot = messages.length;
                         return { messages, partialResult: true };
                     }
-                    this.logger.sendErrorEvent({
-                        eventName: "SnapshotOpsNotUsed",
-                        length: this.snapshotOps.length,
-                        first: this.snapshotOps[0].sequenceNumber,
-                        from,
-                        to,
-                    });
                     this.snapshotOps = undefined;
                 }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -500,8 +500,6 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         // If count is one, we can use the trees/latest API, which returns the latest version and trees in a single request for better performance
         // Do it only once - we might get more here due to summarizer - it needs only container tree, not full snapshot.
         if (this.firstVersionCall && count === 1 && (blobid === null || blobid === this.documentId)) {
-            this.firstVersionCall = false;
-
             return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
                 if (tokenFetchOptions.refresh) {
                     // This is the most critical code path for boot.
@@ -553,6 +551,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                             return cachedSnapshot;
                         });
                 }
+
+                // Successful call, redirect future calls to getVersion only!
+                this.firstVersionCall = false;
 
                 const odspSnapshot: IOdspSnapshot = cachedSnapshot.snapshot;
                 this._snapshotSequenceNumber = cachedSnapshot.sequenceNumber;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -829,7 +829,7 @@ export class DeltaManager
         if (to !== undefined) {
             controller = new AbortController();
 
-            assert(this.closeAbortController.signal.onabort === null, "reentrancy");
+            assert(this.closeAbortController.signal.onabort === null, 0x1e8 /* "reentrancy" */);
             this.closeAbortController.signal.onabort = () => controller.abort();
 
             const listener = (op: ISequencedDocumentMessage) => {
@@ -1230,7 +1230,7 @@ export class DeltaManager
         // It's responsibility of
         // - attachOpHandler()
         // - fetchMissingDeltas() after it's done with querying storage
-        assert(this.pending.length === 0 || this.fetchReason !== undefined, "Pending ops");
+        assert(this.pending.length === 0 || this.fetchReason !== undefined, 0x1e9 /* "Pending ops" */);
 
         if (messages.length === 0) {
             return;


### PR DESCRIPTION
Porting #5687 to 0.39

That's exact port, no modifications.
While original change was mostly about adding telemetry, it had some functional changes that made address underlying "too many retries" issue on the client (there is PUSH bug that leads to same errors, i.e. not all errors of that type will be addressed by this change).
