### PR TITLE
ODSP: Sharing link redemption fall back during trees/latest call

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -75,7 +75,7 @@ export async function redeemSharingLink(
         assert(shareId !== undefined, "ShareId should be present for share link");
         const redeemUrl = `${odspResolvedUrl.siteUrl}/_api/v2.0/shares/${shareId}`;
         const { url, headers } = getUrlAndHeadersWithAuth(redeemUrl, storageToken);
-        headers["prefer"] = "redeemSharingLink";
+        headers.prefer = "redeemSharingLink";
         return fetchAndParseAsJSONHelper(url, { headers });
     });
 }

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -67,29 +67,6 @@ export async function fetchSnapshot(
     );
 }
 
-async function redeemSharingLink(
-    odspResolvedUrl: IOdspResolvedUrl,
-    storageTokenFetcher: (options: TokenFetchOptions, name: string) => Promise<string | null>,
-    logger: ITelemetryLogger,
-) {
-    return PerformanceEvent.timedExecAsync(
-        logger,
-        {
-            eventName: "RedeemShareLink",
-        },
-        async () => {
-            await getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
-                assert(odspResolvedUrl.sharingLinkToRedeem !== undefined, "Share link should be present");
-                const storageToken = await storageTokenFetcher(tokenFetchOptions, "TreesLatest");
-                const encodedShareUrl = getEncodedShareUrl(odspResolvedUrl.sharingLinkToRedeem);
-                const redeemUrl = `${odspResolvedUrl.siteUrl}/_api/v2.0/shares/${encodedShareUrl}`;
-                const { url, headers } = getUrlAndHeadersWithAuth(redeemUrl, storageToken);
-                headers.prefer = "redeemSharingLink";
-                return fetchAndParseAsJSONHelper(url, { headers });
-            });
-    });
-}
-
 export async function fetchSnapshotWithRedeem(
     odspResolvedUrl: IOdspResolvedUrl,
     storageTokenFetcher: (options: TokenFetchOptions, name: string) => Promise<string | null>,
@@ -143,7 +120,30 @@ export async function fetchSnapshotWithRedeem(
     }
 }
 
-export async function fetchLatestSnapshotCore(
+async function redeemSharingLink(
+    odspResolvedUrl: IOdspResolvedUrl,
+    storageTokenFetcher: (options: TokenFetchOptions, name: string) => Promise<string | null>,
+    logger: ITelemetryLogger,
+) {
+    return PerformanceEvent.timedExecAsync(
+        logger,
+        {
+            eventName: "RedeemShareLink",
+        },
+        async () => {
+            await getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
+                assert(odspResolvedUrl.sharingLinkToRedeem !== undefined, "Share link should be present");
+                const storageToken = await storageTokenFetcher(tokenFetchOptions, "TreesLatest");
+                const encodedShareUrl = getEncodedShareUrl(odspResolvedUrl.sharingLinkToRedeem);
+                const redeemUrl = `${odspResolvedUrl.siteUrl}/_api/v2.0/shares/${encodedShareUrl}`;
+                const { url, headers } = getUrlAndHeadersWithAuth(redeemUrl, storageToken);
+                headers.prefer = "redeemSharingLink";
+                return fetchAndParseAsJSONHelper(url, { headers });
+            });
+    });
+}
+
+async function fetchLatestSnapshotCore(
     odspResolvedUrl: IOdspResolvedUrl,
     storageTokenFetcher: (options: TokenFetchOptions, name: string) => Promise<string | null>,
     snapshotOptions: ISnapshotOptions | undefined,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -101,6 +101,10 @@ export async function fetchSnapshotWithRedeem(
     } catch(error) {
         if (isRedeemSharingLinkError(odspResolvedUrl, error)) {
             await redeemSharingLink(odspResolvedUrl, storageTokenFetcher);
+            logger.sendErrorEvent({
+                eventName: "TreeLatest_SecondCall",
+                errorType: error.errorType,
+            });
             odspSnapshot = await fetchLatestSnapshotCore(
                 odspResolvedUrl,
                 storageTokenFetcher,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -3,9 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-internal-modules
-import cloneDeep from "lodash/cloneDeep";
-
 import { default as AbortController } from "abort-controller";
 import { v4 as uuid } from "uuid";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -94,8 +91,8 @@ export async function fetchSnapshotWithRedeem(
                     errorType: error.errorType,
                 });
                 await redeemSharingLink(odspResolvedUrl, storageTokenFetcher, logger);
-                const odspResolvedUrlWithoutShareLink = cloneDeep(odspResolvedUrl);
-                odspResolvedUrlWithoutShareLink.sharingLinkToRedeem = undefined;
+                const odspResolvedUrlWithoutShareLink: IOdspResolvedUrl =
+                    { ...odspResolvedUrl, sharingLinkToRedeem: undefined };
                 const odspSnapshot = await fetchLatestSnapshotCore(
                     odspResolvedUrlWithoutShareLink,
                     storageTokenFetcher,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -73,7 +73,7 @@ export async function fetchSnapshotWithRedeem(
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
     removeEntries: () => Promise<void>,
 ): Promise<ISnapshotCacheValue> {
-    return await fetchLatestSnapshotCore(
+    let odspSnapshot = await fetchLatestSnapshotCore(
         odspResolvedUrl,
         storageTokenFetcher,
         snapshotOptions,
@@ -89,7 +89,7 @@ export async function fetchSnapshotWithRedeem(
             await redeemSharingLink(odspResolvedUrl, storageTokenFetcher, logger);
             const odspResolvedUrlWithoutShareLink: IOdspResolvedUrl =
                 { ...odspResolvedUrl, sharingLinkToRedeem: undefined };
-            return await fetchLatestSnapshotCore(
+            odspSnapshot = await fetchLatestSnapshotCore(
                 odspResolvedUrlWithoutShareLink,
                 storageTokenFetcher,
                 snapshotOptions,
@@ -109,6 +109,7 @@ export async function fetchSnapshotWithRedeem(
         }
         throw error;
     });
+    return odspSnapshot;
 }
 
 async function redeemSharingLink(

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -17,7 +17,6 @@ import * as api from "@fluidframework/protocol-definitions";
 import {
     ISummaryContext,
     IDocumentStorageService,
-    DriverErrorType,
     LoaderCachingPolicy,
 } from "@fluidframework/driver-definitions";
 import { throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -36,7 +36,7 @@ import {
     IOdspSnapshotBlob,
     IVersionedValueWithEpoch,
 } from "./contracts";
-import { fetchLatestSnapshotCore, fetchSnapshot } from "./fetchSnapshot";
+import { fetchSnapshot, fetchSnapshotWithRedeem } from "./fetchSnapshot";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { IOdspCache } from "./odspCache";
 import { createCacheSnapshotKey, getWithRetryForTokenRefresh, ISnapshotCacheValue } from "./odspUtils";
@@ -604,7 +604,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             );
         };
         try {
-            const odspSnapshot = await fetchLatestSnapshotCore(
+            const odspSnapshot = await fetchSnapshotWithRedeem(
                 this.odspResolvedUrl,
                 this.getStorageToken,
                 snapshotOptions,
@@ -625,7 +625,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     errorType,
                 });
                 const snapshotOptionsWithoutBlobs: ISnapshotOptions = { ...snapshotOptions, blobs: 0, mds: undefined, timeout: undefined };
-                const odspSnapshot = await fetchLatestSnapshotCore(
+                const odspSnapshot = await fetchSnapshotWithRedeem(
                     this.odspResolvedUrl,
                     this.getStorageToken,
                     snapshotOptionsWithoutBlobs,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -603,6 +603,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 valueWithEpoch.value,
             );
         };
+        const removeEntries = async () => {
+            await this.cache.persistedCache.removeEntries();
+        }
         try {
             const odspSnapshot = await fetchSnapshotWithRedeem(
                 this.odspResolvedUrl,
@@ -610,7 +613,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 snapshotOptions,
                 this.logger,
                 snapshotDownloader,
-                putInCache);
+                putInCache,
+                removeEntries);
             return odspSnapshot;
         } catch (error) {
             const errorType = error.errorType;
@@ -631,13 +635,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     snapshotOptionsWithoutBlobs,
                     this.logger,
                     snapshotDownloader,
-                    putInCache);
+                    putInCache,
+                    removeEntries);
                 return odspSnapshot;
-            }
-            // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have
-            // permissions for the file or it was deleted. So, if we do not clear cache, we will continue fetching snapshot from cache in the future.
-            if (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
-                await this.cache.persistedCache.removeEntries();
             }
             throw error;
         }

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -604,7 +604,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         };
         const removeEntries = async () => {
             await this.cache.persistedCache.removeEntries();
-        }
+        };
         try {
             const odspSnapshot = await fetchSnapshotWithRedeem(
                 this.odspResolvedUrl,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -602,9 +602,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 valueWithEpoch.value,
             );
         };
-        const removeEntries = async () => {
-            await this.cache.persistedCache.removeEntries();
-        };
+        const removeEntries = async () => this.cache.persistedCache.removeEntries();
         try {
             const odspSnapshot = await fetchSnapshotWithRedeem(
                 this.odspResolvedUrl,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -137,7 +137,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         const odspResolvedUrl = await new OdspDriverUrlResolver().resolve(requestToBeResolved);
 
         if (isSharingLinkToRedeem) {
-            odspResolvedUrl.sharingLinkToRedeem = request.url.split("?")[0];
+            odspResolvedUrl.sharingLinkToRedeem = request.url;
         }
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't have it already as a performance optimization.

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -5,7 +5,7 @@
 
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { assert } from "@fluidframework/common-utils";
-import { DriverErrorType, IResolvedUrl } from "@fluidframework/driver-definitions";
+import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import {
     IPersistedCache,
     ISnapshotOptions,
@@ -68,7 +68,7 @@ export async function prefetchLatestSnapshot(
     };
     const removeEntries = async () => {
         await persistedCache.removeEntries(snapshotKey.file);
-    }
+    };
     return PerformanceEvent.timedExecAsync(
         odspLogger,
         { eventName: "PrefetchLatestSnapshot" },

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -83,9 +83,11 @@ export async function prefetchLatestSnapshot(
             return true;
     }).catch(async (error) => {
         const errorType = error.errorType;
-        // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't have
-        // permissions for the file or it was deleted. So, if we do not clear cache, we will continue fetching snapshot from cache in the future.
-        if (errorType === DriverErrorType.authorizationError || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
+        // Clear the cache on 401/403/404 on snapshot fetch from network because this means either the user doesn't
+        // have permissions for the file or it was deleted. So, if we do not clear cache, we will continue fetching
+        // snapshot from cache in the future.
+        if (errorType === DriverErrorType.authorizationError
+            || errorType === DriverErrorType.fileNotFoundOrAccessDeniedError) {
             await persistedCache.removeEntries(snapshotKey.file);
         }
         return false;

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -66,9 +66,7 @@ export async function prefetchLatestSnapshot(
         );
         return cacheP;
     };
-    const removeEntries = async () => {
-        await persistedCache.removeEntries(snapshotKey.file);
-    };
+    const removeEntries = async () => persistedCache.removeEntries(snapshotKey.file);
     return PerformanceEvent.timedExecAsync(
         odspLogger,
         { eventName: "PrefetchLatestSnapshot" },

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -176,13 +176,13 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     });
 
     it("Sharing link should be set when isSharingLinkToRedeem header is set", async () => {
+        const url = new URL(sharelink);
         const resolvedUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
-            const url = new URL(sharelink);
             storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId, dataStorePath });
             return urlResolverWithShareLinkFetcher.resolve(
                 { url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
-        assert.strictEqual(resolvedUrl.sharingLinkToRedeem, sharelink, "Sharing link should be set in resolved url");
+        assert.strictEqual(resolvedUrl.sharingLinkToRedeem, url.toString(), "Sharing link should be set in resolved url");
     });
 
     it("Encode and decode nav param", async () => {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/5994
Sometimes the redemption within the trees/latest call fails due to some bug on server side. So we need to have a fallback where we do a redeem separately and then make the trees latest call.

I tested the redeem call by generating a share link in bohemia and then use the postman to make the redeem call.