### PR TITLE
[release/0.39] Remove extra container-definitions dep from experimental/dds/tree

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.39.4",
     "@fluidframework/build-common": "^0.22.0",
-    "@fluidframework/container-definitions": "^0.39.3",
+    "@fluidframework/container-definitions": "^0.39.4",
     "@fluidframework/container-loader": "^0.39.4",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.39.4",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.39.4",
     "@fluidframework/build-common": "^0.22.0",
-    "@fluidframework/container-definitions": "^0.39.4",
     "@fluidframework/container-loader": "^0.39.4",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.39.4",


### PR DESCRIPTION
This `container-definitions` dependency does not get updated by bumpVersion because there are two of them in the same package.json.