### PR TITLE
[main] Remove extra container-definitions dep from experimental/dds/tree

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.40.0",
     "@fluidframework/build-common": "^0.22.0-0",
-    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.40.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.40.0",


### PR DESCRIPTION
Remove extra reference to `container-definitions` in same package.json - port of https://github.com/microsoft/FluidFramework/pull/6143.