### PR TITLE
Adding Additional Check for document.addEventListener to Prevent Container Construction Failures

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -645,7 +645,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this._deltaManager = this.createDeltaManager();
 
         // keep track of last time page was visible for telemetry
-        if (typeof document === "object" && document !== null) {
+        if (
+            typeof document === "object" &&
+            document !== null &&
+            typeof document.addEventListener === "function" &&
+            document.addEventListener !== null
+        ) {
             this.lastVisible = document.hidden ? performance.now() : undefined;
             document.addEventListener("visibilitychange", () => {
                 if (document.hidden) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -644,13 +644,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         this._deltaManager = this.createDeltaManager();
 
-        // keep track of last time page was visible for telemetry
-        if (
-            typeof document === "object" &&
+        const isDomAvailable = typeof document === "object" &&
             document !== null &&
             typeof document.addEventListener === "function" &&
-            document.addEventListener !== null
-        ) {
+            document.addEventListener !== null;
+        // keep track of last time page was visible for telemetry
+        if (isDomAvailable) {
             this.lastVisible = document.hidden ? performance.now() : undefined;
             document.addEventListener("visibilitychange", () => {
                 if (document.hidden) {


### PR DESCRIPTION
Adding Additional Check for document.addEventListener to Prevent Container Construction Failures

This is due to the container failing when addEventListener is not defined in non-browser contexts (e.g. React Native)