### PR TITLE
Fixing early connection failures

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -207,7 +207,12 @@ export class OdspDocumentService implements IDocumentService {
                 ? Promise.resolve(null)
                 : this.getWebsocketToken!(options);
             const joinSessionPromise = this.joinSession(requestWebsocketTokenFromJoinSession).catch((e) => {
-                const code = e?.response ? JSON.parse(e?.response)?.error?.code : undefined;
+                let code: string | undefined;
+                try {
+                    code = e?.response ? JSON.parse(e?.response)?.error?.code : undefined;
+                } catch (error) {
+                    throw e;
+                }
                 switch (code) {
                     case "sessionForbiddenOnPreservedFiles":
                     case "sessionForbiddenOnModerationEnabledLibrary":

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1234,6 +1234,15 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             }
         }
 
+        // Safety net: static version of Container.load() should have got this message through "closed" handler.
+        // But if that did not happen for some reason, fail load for sure.
+        // Otherwise we can get into situations where container is closed and does not try to connect to ordering
+        // service, but caller does not know that (callers do expect container to be not closed on successful path
+        // and listen only on "closed" event)
+        if (this.closed) {
+            throw new Error("Container was closed while load()");
+        }
+
         return {
             existing: this._existing,
             sequenceNumber: attributes.sequenceNumber,


### PR DESCRIPTION
If connection to web socket happens super fast, then it's possible it happens before we set "closed" handler on delta manager and thus miss the fact that connection failed and container was closed.
As result of it, container will never reconnect, and there is no indication to consumers on why.

Other changes are not directly related to it, but were causing trouble during debugging (can result in actual failures), or smallish cleanup to make code more readable.