### PR TITLE
Make stress tests a bit less noisy. 

### DIFF
--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -325,7 +325,7 @@ export class Loader implements IHostLoader {
                     this.containers.delete(key);
                 });
             }
-        }).catch((error) => { console.error("Error during caching Container on the Loader", error); });
+        }).catch((error) => {});
     }
 
     private async resolveCore(

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -23,6 +23,7 @@
     "debug:runner": "node ./dist/nodeStressTest.js --debug --profile debug",
     "eslint": "eslint --format stylish src",
     "eslint:fix": "eslint --format stylish src --fix",
+    "full": "node ./dist/nodeStressTest.js --profile full",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
     "start": "node ./dist/nodeStressTest.js",

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -49,6 +49,7 @@ async function orchestratorProcess(
     args: { testId?: string, debug?: true, verbose?: true, seed?: number },
 ) {
     const seed = args.seed ?? Date.now();
+    const seedArg = `0x${seed.toString(16)}`;
 
     const testDriver = await createTestDriver(
         driver,
@@ -62,7 +63,8 @@ async function orchestratorProcess(
 
     const estRunningTimeMin = Math.floor(2 * profile.totalSendCount / (profile.opRatePerMin * profile.numClients));
     console.log(`Connecting to ${args.testId ? "existing" : "new"} with seed 0x${seed.toString(16)}`);
-    console.log(`Container targeting with url:\n${url }`);
+    console.log(`Container targeting with url: ${url }`);
+    console.log("Seed: ", seedArg);
     console.log(`Selected test profile: ${profile.name}`);
     console.log(`Estimated run time: ${estRunningTimeMin} minutes\n`);
 
@@ -74,7 +76,7 @@ async function orchestratorProcess(
             "--profile", profile.name,
             "--runId", i.toString(),
             "--url", url,
-            "--seed", `0x${seed.toString(16)}`,
+            "--seed", seedArg,
         ];
         if (args.debug) {
             const debugPort = 9230 + i; // 9229 is the default and will be used for the root orchestrator process
@@ -82,9 +84,9 @@ async function orchestratorProcess(
         }
         if(args.verbose) {
             childArgs.push("--verbose");
+            console.log(childArgs.join(" "));
         }
 
-        console.log(childArgs.join(" "));
         runnerArgs.push(childArgs);
     }
     try{

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -8,10 +8,10 @@
             "readWriteCycleMs": 30000
         },
         "full": {
-            "opRatePerMin": 30,
-            "progressIntervalMs": 15000,
-            "numClients": 240,
-            "totalSendCount": 10000000,
+            "opRatePerMin": 1920,
+            "progressIntervalMs": 1500000,
+            "numClients": 60,
+            "totalSendCount": 200000,
             "readWriteCycleMs": 30000
         },
         "mini": {


### PR DESCRIPTION
Also stretching tests to maximum I can get them on single machine (reducing client count not to hit storage 429s)