### PR TITLE
Remove branch map from deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable no-null/no-null */
 
-import { RangeTracker } from "@fluidframework/common-utils";
 import { isServiceMessageType } from "@fluidframework/protocol-base";
 import {
     ISequencedDocumentAugmentedMessage,
@@ -92,7 +91,6 @@ export class DeliLambda implements IPartitionLambda {
     // Client sequence number mapping
     private readonly clientSeqManager = new ClientSequenceNumberManager();
     private minimumSequenceNumber = 0;
-    private readonly branchMap: RangeTracker | undefined;
     private readonly checkpointContext: CheckpointContext;
     private lastSendP = Promise.resolve();
     private lastSentMSN = 0;
@@ -736,7 +734,6 @@ export class DeliLambda implements IPartitionLambda {
 
     private generateDeliCheckpoint(): IDeliState {
         return {
-            branchMap: this.branchMap?.serialize(),
             clients: this.clientSeqManager.cloneValues(),
             durableSequenceNumber: this.durableSequenceNumber,
             epoch: this.epoch,

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -33,7 +33,6 @@ const FlipTerm = false;
 
 const getDefaultCheckpooint = (epoch: number): IDeliState => {
     return {
-        branchMap: undefined,
         clients: undefined,
         durableSequenceNumber: 0,
         epoch,

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -18,7 +18,6 @@ describe("Routerlicious", () => {
 
             function createCheckpoint(logOffset: number, sequenceNumber: number): ICheckpointParams {
                 return {
-                    branchMap: null,
                     clients: null,
                     durableSequenceNumber: 0,
                     epoch: 0,

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -55,7 +55,6 @@ const DefaultScribe: IScribe = {
 };
 
 const DefaultDeli: IDeliState = {
-    branchMap: undefined,
     clients: undefined,
     durableSequenceNumber: 0,
     epoch: 0,

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IRangeTrackerSnapshot } from "@fluidframework/common-utils";
 import { ICommit, ICommitDetails } from "@fluidframework/gitresources";
 import { IProtocolState, ISummaryTree, ICommittedProposal } from "@fluidframework/protocol-definitions";
 import { IGitCache } from "@fluidframework/server-services-client";
@@ -48,9 +47,6 @@ export interface IClientSequenceNumber {
 }
 
 export interface IDeliState {
-    // Branch related mapping
-    branchMap: IRangeTrackerSnapshot | undefined;
-
     // List of connected clients
     clients: IClientSequenceNumber[] | undefined;
 

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -104,7 +104,6 @@ export class DocumentStorage implements IDocumentStorage {
         winston.info(`commit sha: ${JSON.stringify(commit.sha)}`, { messageMetaData });
 
         const deli: IDeliState = {
-            branchMap: undefined,
             clients: undefined,
             durableSequenceNumber: sequenceNumber,
             logOffset: -1,

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -98,7 +98,6 @@ export class TestDocumentStorage implements IDocumentStorage {
         await gitManager.createRef(documentId, commit.sha);
 
         const deli: IDeliState = {
-            branchMap: undefined,
             clients: undefined,
             durableSequenceNumber: sequenceNumber,
             logOffset: -1,


### PR DESCRIPTION
It's not used so it would always end up as `branchMap: undefined` in deli checkpoints