### PR TITLE
409 / coherency failures result in summaries not running for 16.6 minutes

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -268,7 +268,7 @@ export class EpochTracker implements IPersistedFileCache {
             // then it was coherency 409, so rethrow it as throttling error so that it can retried. Default throttling
             // time is 1s.
             this.logger.sendErrorEvent({ eventName: "Coherency409" }, error);
-            throw new ThrottlingError(error.errorMessage ?? "Coherency409", 1000);
+            throw new ThrottlingError(error.errorMessage ?? "Coherency409", 1);
         }
     }
 


### PR DESCRIPTION
Address mismatch in expectations