### PR TITLE
Test: Tag disabled 'pendingOps' test with issue #

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -86,7 +86,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
     // Observing non-deterministic timeouts in CI only.
     // Temporarily disabling pending investigation:
     //
-    // https://github.com/microsoft/FluidFramework/issues/6006
+    // https://github.com/microsoft/FluidFramework/issues/6157
     before(function() {
         this.skip();
     });


### PR DESCRIPTION
@wes-carlson - Unfortunately I had to disable the 'pendingOps' test in order to get the RealSvc tests back online.

Initially the tests were just timing out at 2s.  After extending the timeouts to 20s I started to get assertion failures.  :(

Issue #6157 for logs.
