### PR TITLE
fix stashed ops test

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1223,11 +1223,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private readonly onOp = (op: ISequencedDocumentMessage) => {
         assert(!this.paused, 0x128 /* "Container should not already be paused before applying stashed ops" */);
         this.paused = true;
-        this.scheduleManager.setPaused(true);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.context.deltaManager.inbound.pause();
         const stashP = this.pendingStateManager.applyStashedOpsAt(op.sequenceNumber);
         stashP.then(() => {
             this.paused = false;
-            this.scheduleManager.setPaused(false);
+            this.context.deltaManager.inbound.resume();
         }, (error) => {
             this.closeFn(CreateContainerError(error));
         });

--- a/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingOps.spec.ts
@@ -83,14 +83,6 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
     let container1: IContainer;
     let map1: SharedMap;
 
-    // Observing non-deterministic timeouts in CI only.
-    // Temporarily disabling pending investigation:
-    //
-    // https://github.com/microsoft/FluidFramework/issues/6006
-    before(function() {
-        this.skip();
-    });
-
     beforeEach(async () => {
         provider = getTestObjectProvider();
         loader = provider.makeTestLoader(testContainerConfig);


### PR DESCRIPTION
fix #6157
Running the stashed ops tests against ODSP, I saw the assert in `ContainerRuntime.onOp()` being tripped. This was due to calling `scheduleManager.setPaused()` in `onOp()`, which caused ScheduleManager itself to sometimes unpause DeltaManager and the assert would fail. 

I don't know why the tests were being flaky on CI but not locally, or why they are now but weren't in the past, but they seem to be passing after this change.