### PR TITLE
Decouple Driver Definitions from Core Interfaces

### DIFF
--- a/packages/loader/container-definitions/src/loader.ts
+++ b/packages/loader/container-definitions/src/loader.ts
@@ -18,7 +18,7 @@ import {
     IQuorum,
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
-import { IResolvedUrl } from "@fluidframework/driver-definitions";
+import { IDriverHeader, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
 import { IDeltaManager } from "./deltas";
 import { ICriticalContainerError, ContainerWarning } from "./error";
@@ -326,7 +326,7 @@ export interface IContainerLoadMode {
 /**
  * Set of Request Headers that the Loader understands and may inspect or modify
  */
-export interface ILoaderHeader {
+export interface ILoaderHeader extends IDriverHeader {
     [LoaderHeader.cache]: boolean;
     [LoaderHeader.clientDetails]: IClientDetails;
     [LoaderHeader.loadMode]: IContainerLoadMode;

--- a/packages/loader/driver-definitions/package.json
+++ b/packages/loader/driver-definitions/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1024.0"
   },
   "devDependencies": {

--- a/packages/loader/driver-definitions/src/urlResolver.ts
+++ b/packages/loader/driver-definitions/src/urlResolver.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, IFluidCodeDetails } from "@fluidframework/core-interfaces";
-
 export type IResolvedUrl = IWebResolvedUrl | IFluidResolvedUrl;
 
 export interface IResolvedUrlBase {
@@ -32,13 +30,13 @@ export interface IUrlResolver {
     // Like DNS should be able to cache resolution requests. Then possibly just have a token provider go and do stuff?
     // the expiration of it could be relative to the lifetime of the token? Requests after need to refresh?
     // or do we split the token access from this?
-    resolve(request: IRequest): Promise<IResolvedUrl | undefined>;
+    resolve(request: IResolverRequest): Promise<IResolvedUrl | undefined>;
 
     // Creates a url for the created container with any data store path given in the relative url.
     getAbsoluteUrl(
         resolvedUrl: IResolvedUrl,
         relativeUrl: string,
-        codeDetails?: IFluidCodeDetails,
+        codeDetails?: any,
     ): Promise<string>;
 }
 
@@ -76,11 +74,12 @@ export enum DriverHeader {
 }
 
 export interface IDriverHeader {
-    [DriverHeader.summarizingClient]: boolean;
-    [DriverHeader.createNew]: any;
+    [DriverHeader.summarizingClient]?: boolean;
+    [DriverHeader.createNew]?: any;
+    [index: string]: any;
 }
 
-declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IRequestHeader extends Partial<IDriverHeader> { }
+export interface IResolverRequest {
+    url: string;
+    headers?: IDriverHeader;
 }


### PR DESCRIPTION
This change decouples the driver definitions from core interfaces. This change in effect duplicates the IRequest interface. However, it keeps duck typed compatibility with IRequest, so the change is non-breaking, and shouldn't have bundle size impact, as this only changes interfaces which do not exist a runtime. I plan to back port this change to 0.39 as well. 