### PR TITLE
Removing the SharedMap object 'images' which is not being referenced in the file

### DIFF
--- a/examples/data-objects/image-gallery/src/index.tsx
+++ b/examples/data-objects/image-gallery/src/index.tsx
@@ -9,7 +9,6 @@ import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
 import { IEvent } from "@fluidframework/common-definitions";
-import { ISharedMap } from "@fluidframework/map";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
 import ReactDOM from "react-dom";

--- a/examples/data-objects/image-gallery/src/index.tsx
+++ b/examples/data-objects/image-gallery/src/index.tsx
@@ -55,7 +55,6 @@ export class ImageGalleryObject extends DataObject implements IFluidHTMLView {
     };
 
     imageGallery: ImageGallery | undefined;
-    images: ISharedMap | undefined;
 
     private readonly onSlide = (index) => {
         this.root.set("position", index);


### PR DESCRIPTION
**Problem**
Was experimenting the Image gallery example and found that ISharedMap object images has been declared but has not been used anywhere in the code. Removed it.

**Build and Test**

- Build was successful
- Verified by running the app locally