### PR TITLE
Guarantee that client leave and noClient messages are generated from deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -35,7 +35,11 @@ export class CheckpointContext {
         this.pendingUpdateP = this.checkpointCore(checkpoint);
         this.pendingUpdateP?.then(
             () => {
-                this.context.checkpoint(checkpoint.queuedMessage);
+                // kafka checkpoint
+                if (checkpoint.kafkaCheckpointMessage) {
+                    this.context.checkpoint(checkpoint.kafkaCheckpointMessage);
+                }
+
                 this.pendingUpdateP = undefined;
 
                 // Trigger another round if there is a pending update
@@ -74,7 +78,8 @@ export class CheckpointContext {
         if (checkpoint.clear) {
             updateP = this.checkpointManager.deleteCheckpoint(checkpoint);
         } else {
-            const deliCheckpoint: IDeliState = { ...checkpoint };
+            // clone the checkpoint
+            const deliCheckpoint: IDeliState = { ...checkpoint.deliState };
 
             updateP = this.checkpointManager.writeCheckpoint(deliCheckpoint);
         }

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointManager.ts
@@ -12,8 +12,25 @@ export interface IDeliCheckpointManager {
     deleteCheckpoint(checkpointParams: ICheckpointParams): Promise<void>;
 }
 
-export interface ICheckpointParams extends IDeliState {
-    queuedMessage: IQueuedMessage;
+export interface ICheckpointParams {
+    /**
+     * The deli checkpoint state @ deliCheckpointMessage
+     */
+    deliState: IDeliState;
+
+    /**
+     * The message to checkpoint for deli (mongodb)
+     */
+    deliCheckpointMessage: IQueuedMessage;
+
+    /**
+     * The message to checkpoint for kafka
+     */
+    kafkaCheckpointMessage: IQueuedMessage | undefined;
+
+    /**
+     * Flag that decides if the deli checkpoint should be deleted
+     */
     clear?: boolean;
 }
 

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -17,21 +17,26 @@ describe("Routerlicious", () => {
             let testContext: testUtils.TestContext;
 
             function createCheckpoint(logOffset: number, sequenceNumber: number): ICheckpointParams {
+                const queuedMessage = {
+                    offset: logOffset,
+                    partition: 1,
+                    topic: "topic",
+                    value: "",
+                };
+
                 return {
-                    clients: null,
-                    durableSequenceNumber: 0,
-                    epoch: 0,
-                    logOffset,
-                    sequenceNumber,
-                    term: 1,
-                    lastSentMSN: 0,
-                    nackMessages: undefined,
-                    queuedMessage: {
-                        offset: logOffset,
-                        partition: 1,
-                        topic: "topic",
-                        value: "",
+                    deliState: {
+                        clients: undefined,
+                        durableSequenceNumber: 0,
+                        epoch: 0,
+                        logOffset,
+                        sequenceNumber,
+                        term: 1,
+                        lastSentMSN: 0,
+                        nackMessages: undefined,
                     },
+                    deliCheckpointMessage: queuedMessage,
+                    kafkaCheckpointMessage: queuedMessage,
                 };
             }
 

--- a/server/routerlicious/packages/test-utils/src/testContext.ts
+++ b/server/routerlicious/packages/test-utils/src/testContext.ts
@@ -15,7 +15,7 @@ interface IWaitOffset {
 }
 
 export class TestContext extends EventEmitter implements IContext {
-    public offset: number = Number.NEGATIVE_INFINITY;
+    public offset: number = -1;
     private waits: IWaitOffset[] = [];
 
     constructor(public readonly log: ILogger = DebugLogger.create("fluid-server:TestContext")) {


### PR DESCRIPTION
It is not guaranteed that deli will insert a leave & noClient message for a document in some specific cases. Here's one case:
1. The deli lambda is running and there's at least 1 client connected to the document.
2. Assume the deli checkpoint is fully up to date.
3. Let's say that the alfred processes crash. This means alfred did not insert a leave message for the clients that were connected

Deli normally handles this fine. It has an idle timer, which will cause it to detect that the client is no longer active and it will create a leave op for them. However that is not perfect.

4. If the deli lambda is stopped (due to a kafka rebalance or crash), the deli lambda will not start up again. It doesn't start up again because it already checkpointed it's latest kafka message

At this point we have a document in the system that won't have a leave op / noClient op inserted until a new client connects to it.

The fix is to make deli's Kafka checkpoint always stay behind by 1 message until it sends the noClient message. Once deli has no clients remaining and sends noClient, it will start making the kafka checkpoint the current latest message.
This makes it so deli will spawn again even after a rebalance.

Changes:
- Make deli's kafka checkpoint stay 1 behind until no clients are active
- Start the idle timer when deli is created
- Remove the queuedMessage from being included in the deli mongodb checkpoint
- Rehydrate `noActiveClients` property when deli is created. Before it was always set to `false` even though that may have not been correct.

