### PR TITLE
Support iteration over the contents of an IntervalCollection.

### DIFF
--- a/packages/dds/merge-tree/src/test/collections.intervalTree.ts
+++ b/packages/dds/merge-tree/src/test/collections.intervalTree.ts
@@ -16,12 +16,20 @@ class TestInterval implements IInterval {
     }
 
     public compare(b: TestInterval) {
-        const startResult = this.start - b.start;
+        const startResult = this.compareStart(b);
         if (startResult === 0) {
-            return (this.end - b.end);
+            return this.compareEnd(b);
         } else {
             return startResult;
         }
+    }
+
+    public compareStart(b: TestInterval) {
+        return this.start - b.start;
+    }
+
+    public compareEnd(b: TestInterval) {
+        return this.end - b.end;
     }
 
     public overlaps(b: TestInterval) {

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -10,6 +10,7 @@ export {
     ISerializableInterval,
     ISerializedInterval,
     IntervalCollection,
+    IntervalCollectionIterator,
     IntervalCollectionValueType,
     IntervalCollectionView,
     SequenceInterval,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -76,12 +76,20 @@ export class Interval implements ISerializableInterval {
     }
 
     public compare(b: Interval) {
-        const startResult = this.start - b.start;
+        const startResult = this.compareStart(b);
         if (startResult === 0) {
-            return (this.end - b.end);
+            return this.compareEnd(b);
         } else {
             return startResult;
         }
+    }
+
+    public compareStart(b: Interval) {
+        return this.start - b.start;
+    }
+
+    public compareEnd(b: Interval) {
+        return this.end - b.end;
     }
 
     public overlaps(b: Interval) {
@@ -138,12 +146,20 @@ export class SequenceInterval implements ISerializableInterval {
     }
 
     public compare(b: SequenceInterval) {
-        const startResult = this.start.compare(b.start);
+        const startResult = this.compareStart(b);
         if (startResult === 0) {
-            return (this.end.compare(b.end));
+            return this.compareEnd(b);
         } else {
             return startResult;
         }
+    }
+
+    public compareStart(b: SequenceInterval) {
+        return this.start.compare(b.start);
+    }
+
+    public compareEnd(b: SequenceInterval) {
+        return this.end.compare(b.end);
     }
 
     public overlaps(b: SequenceInterval) {
@@ -290,6 +306,86 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 
     public map(fn: (interval: TInterval) => void) {
         this.intervalTree.map(fn);
+    }
+
+    public gatherIterationResults(
+        results: TInterval[],
+        iteratesForward: boolean,
+        start?: number,
+        end?: number) {
+        if (this.intervalTree.intervals.isEmpty()) {
+            return;
+        }
+
+        if (start === undefined && end === undefined) {
+            // No start/end provided. Gather the whole tree in the specified order.
+            if (iteratesForward) {
+                this.intervalTree.map((interval: TInterval) => {
+                    results.push(interval);
+                });
+            }
+            else {
+                this.intervalTree.mapBackward((interval: TInterval) => {
+                    results.push(interval);
+                });
+            }
+        }
+        else {
+            const transientInterval: TInterval = this.helpers.create(
+                "transient",
+                start,
+                end,
+                this.client,
+                MergeTree.IntervalType.Transient,
+            );
+
+            if (start === undefined) {
+                // Only end position provided. Since the tree is not sorted by end position,
+                // walk the whole tree in the specified order, gathering intervals that match the end.
+                if (iteratesForward) {
+                    this.intervalTree.map((interval: TInterval) => {
+                        if (transientInterval.compareEnd(interval) === 0) {
+                            results.push(interval);
+                        }
+                    });
+                }
+                else {
+                    this.intervalTree.mapBackward((interval: TInterval) => {
+                        if (transientInterval.compareEnd(interval) === 0) {
+                            results.push(interval);
+                        }
+                    });
+                }
+            }
+            else {
+                // Start and (possibly) end provided. Walk the subtrees that may contain
+                // this start position.
+                const compareFn =
+                    end === undefined ?
+                        (node: MergeTree.IntervalNode<TInterval>) => {
+                            return transientInterval.compareStart(node.key);
+                        } :
+                        (node: MergeTree.IntervalNode<TInterval>) => {
+                            return transientInterval.compare(node.key);
+                        };
+                const continueLeftFn = (cmpResult: number) => cmpResult <= 0;
+                const continueRightFn = (cmpResult: number) => cmpResult >= 0;
+                const actionFn = (node: MergeTree.IntervalNode<TInterval>) => {
+                    results.push(node.key);
+                };
+
+                if (iteratesForward) {
+                    this.intervalTree.intervals.walkExactMatchesForward(
+                        compareFn, actionFn, continueLeftFn, continueRightFn,
+                    );
+                }
+                else {
+                    this.intervalTree.intervals.walkExactMatchesBackward(
+                        compareFn, actionFn, continueLeftFn, continueRightFn,
+                    );
+                }
+            }
+        }
     }
 
     public findOverlappingIntervals(startPosition: number, endPosition: number) {
@@ -552,6 +648,14 @@ export class IntervalCollectionView<TInterval extends ISerializableInterval> ext
         this.localCollection.map(fn);
     }
 
+    public gatherIterationResults(
+        results: TInterval[],
+        iteratesForward: boolean,
+        start?: number,
+        end?: number) {
+        this.localCollection.gatherIterationResults(results, iteratesForward, start, end);
+    }
+
     public previousInterval(pos: number): TInterval {
         return this.localCollection.previousInterval(pos);
     }
@@ -585,7 +689,7 @@ export class IntervalCollectionView<TInterval extends ISerializableInterval> ext
             start,
         };
 
-        this.addInternal(serializedInterval, true, undefined);
+        return this.addInternal(serializedInterval, true, undefined);
     }
 
     public delete(
@@ -627,7 +731,7 @@ export class IntervalCollectionView<TInterval extends ISerializableInterval> ext
 
         this.emit("addInterval", interval, local, op);
 
-        return this;
+        return interval;
     }
 
     public deleteInterval(serializedInterval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) {
@@ -670,6 +774,37 @@ export class IntervalCollectionView<TInterval extends ISerializableInterval> ext
     }
 }
 
+export class IntervalCollectionIterator<TInterval extends ISerializableInterval> {
+    private readonly results: TInterval[];
+    private index: number;
+
+    constructor(
+        collection: IntervalCollection<TInterval>,
+        iteratesForward: boolean = true,
+        start?: number,
+        end?: number) {
+        this.results = [];
+        this.index = 0;
+
+        collection.gatherIterationResults(this.results, iteratesForward, start, end);
+    }
+
+    public next() {
+        let _value: TInterval | undefined;
+        let _done: boolean = true;
+
+        if (this.index < this.results.length) {
+            _value = this.results[this.index++];
+            _done = false;
+        }
+
+        return {
+            value: _value,
+            done: _done,
+        };
+    }
+}
+
 export class IntervalCollection<TInterval extends ISerializableInterval> {
     private savedSerializedIntervals?: ISerializedInterval[];
     private view: IntervalCollectionView<TInterval>;
@@ -708,7 +843,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> {
             throw new Error("attach must be called prior to adding intervals");
         }
 
-        this.view.add(startPosition, endPosition, intervalType, props);
+        return this.view.add(startPosition, endPosition, intervalType, props);
     }
 
     public delete(
@@ -767,5 +902,42 @@ export class IntervalCollection<TInterval extends ISerializableInterval> {
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this.view.serializeInternal();
+    }
+
+    public [Symbol.iterator](): IntervalCollectionIterator<TInterval> {
+        const iterator = new IntervalCollectionIterator<TInterval>(this);
+        return iterator;
+    }
+
+    public CreateForwardIteratorWithStartPosition(startPosition: number): IntervalCollectionIterator<TInterval> {
+        const iterator = new IntervalCollectionIterator<TInterval>(this, true, startPosition);
+        return iterator;
+    }
+
+    public CreateBackwardIteratorWithStartPosition(startPosition: number): IntervalCollectionIterator<TInterval> {
+        const iterator = new IntervalCollectionIterator<TInterval>(this, false, startPosition);
+        return iterator;
+    }
+
+    public CreateForwardIteratorWithEndPosition(endPosition: number): IntervalCollectionIterator<TInterval> {
+        const iterator = new IntervalCollectionIterator<TInterval>(this, true, undefined, endPosition);
+        return iterator;
+    }
+
+    public CreateBackwardIteratorWithEndPosition(endPosition: number): IntervalCollectionIterator<TInterval> {
+        const iterator = new IntervalCollectionIterator<TInterval>(this, false, undefined, endPosition);
+        return iterator;
+    }
+
+    public gatherIterationResults(
+        results: TInterval[],
+        iteratesForward: boolean,
+        start?: number,
+        end?: number) {
+        if (!this.view) {
+            return;
+        }
+
+        this.view.gatherIterationResults(results, iteratesForward, start, end);
     }
 }


### PR DESCRIPTION
Iteration over the contents of an IntervalCollection will be supported by an iterator object. The object returned by the [Symbol.iterator] method will support JS-style for...of. We'll also support iterating, either forward or backward, over all intervals in the collection with a given start or end position. Iterator objects that support this "special" iteration are returned by additional methods Create[Forward,Backward]IteratorWith[Start,End]Position.