### PR TITLE
Emit events from deli based on some heuristics

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -101,7 +101,7 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
     private activityIdleTimer: any;
     private noopEvent: any;
 
-    // Op timer properties
+    // Op event properties
     private opIdleTimer: any | undefined;
     private opMaxTimeTimer: any | undefined;
     private messagesSinceLastOpEvent: number = 0;

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -15,6 +15,23 @@ export interface IDeliServerConfiguration {
 
     // Timeout for sending consolidated no-ops
     noOpConsolidationTimeout: number;
+
+    // Controls how deli should track of certain op events
+    opEvent: IDeliOpEventServerConfiguration;
+}
+
+export interface IDeliOpEventServerConfiguration {
+    // Enables emitting events based on the heuristics
+    enable: boolean;
+
+    // Causes an event to fire after deli doesn't process any ops after this amount of time
+    idleTime: number;
+
+    // Causes an event to fire based on the time since the last emit
+    maxTime: number;
+
+    // Causes an event to fire based on the number of ops since the last emit
+    maxOps: number;
 }
 
 // Scribe lambda configuration
@@ -94,6 +111,12 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         clientTimeout: 5 * 60 * 1000,
         activityTimeout: 30 * 1000,
         noOpConsolidationTimeout: 250,
+        opEvent: {
+            enable: false,
+            idleTime: 15 * 1000,
+            maxTime: 5 * 60 * 1000,
+            maxOps: 1500,
+        },
     },
     scribe: {
         generateServiceSummary: true,


### PR DESCRIPTION
Allows deli to emit events based on the following heuristics:
- "idle" - emit when there have been no sequenced ops for X milliseconds since the last message
- "maxOps" - emit when more than X amount of ops have been ticketed since the emit
- "maxTime"  - emit when there was no previous emit for the last X milliseconds

The `IDeliOpEventServerConfiguration` allows enabling this system and controlling X.

Other changes:
- Rename `idleTimer` to `activityIdleTimer`