### PR TITLE
Use CODEOWNERS for docs reviews instead of GitHub action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,14 @@
-# Documentation
-/docs/                      @microsoft/fluid-cr-docs @tylerbutler
-/api-report/                @microsoft/fluid-cr-docs @tylerbutler
+# DOCUMENTATION
+# Folders
+/.github/ISSUE_TEMPLATE/                                                  @microsoft/fluid-cr-docs @tylerbutler
+/docs/                                                                    @microsoft/fluid-cr-docs @tylerbutler
 
-/api-report/container*      @microsoft/fluid-cr-docs @tylerbutler
+# Files
+/.github/workflows/azure-static-web-apps-agreeable-hill-0eeff5b10.yml     @microsoft/fluid-cr-docs @tylerbutler
+/README.md                                                                @microsoft/fluid-cr-docs @tylerbutler
+/.markdownlint.json                                                       @microsoft/fluid-cr-docs @tylerbutler
+api-extractor.json                                                        @microsoft/fluid-cr-docs @tylerbutler
+md-magic.config.*                                                         @microsoft/fluid-cr-docs @tylerbutler
+
+# Shared ESLint config
+common\build\eslint-config-fluid                                          @tylerbutler

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,39 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+# *       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+# *.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+# /build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+# apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository and any of its
+# subdirectories.
+#/docs/ @doctocat
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,39 +1,5 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
+# Documentation
+/docs/                      @microsoft/fluid-cr-docs @tylerbutler
+/api-report/                @microsoft/fluid-cr-docs @tylerbutler
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-# *       @global-owner1 @global-owner2
-
-# Order is important; the last matching pattern takes the most
-# precedence. When someone opens a pull request that only
-# modifies JS files, only @js-owner and not the global
-# owner(s) will be requested for a review.
-# *.js    @js-owner
-
-# You can also use email addresses if you prefer. They'll be
-# used to look up users just like we do for commit author
-# emails.
-# *.go docs@example.com
-
-# In this example, @doctocat owns any files in the build/logs
-# directory at the root of the repository and any of its
-# subdirectories.
-# /build/logs/ @doctocat
-
-# The `docs/*` pattern will match files like
-# `docs/getting-started.md` but not further nested files like
-# `docs/build-app/troubleshooting.md`.
-# docs/*  docs@example.com
-
-# In this example, @octocat owns any file in an apps directory
-# anywhere in your repository.
-# apps/ @octocat
-
-# In this example, @doctocat owns any file in the `/docs`
-# directory in the root of your repository and any of its
-# subdirectories.
-#/docs/ @doctocat
-
+/api-report/container*      @microsoft/fluid-cr-docs @tylerbutler

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@ api-extractor.json                                                        @micro
 md-magic.config.*                                                         @microsoft/fluid-cr-docs @tylerbutler
 
 # Shared ESLint config
-common\build\eslint-config-fluid                                          @tylerbutler
+common/build/eslint-config-fluid/                                         @tylerbutler

--- a/.github/code_owners.yml
+++ b/.github/code_owners.yml
@@ -92,12 +92,6 @@ experimental/dds/tree/**:
 - CraigMacomber
 - Abe27342
 
-# docs
-docs/**:
-- tylerbutler
-"**/README*.md":
-- tylerbutler
-
 # tools
 tools/**:
 - curtisman


### PR DESCRIPTION
I'd like to start using it for *some* code review assignments because it offers [round-robin pull request review assignment](https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-assignment-for-your-team#routing-algorithms).