### PR TITLE
fix: correctly handle riddler's jwt verification failures

### DIFF
--- a/server/historian/packages/historian-base/src/services/riddlerService.ts
+++ b/server/historian/packages/historian-base/src/services/riddlerService.ts
@@ -71,7 +71,11 @@ export class RiddlerService implements ITenantService {
 
         const tokenValidationUrl = `/api/tenants/${tenantId}/validate`;
         await this.restWrapper.post(tokenValidationUrl, { token })
-            .catch(getRequestErrorTranslator(tokenValidationUrl, "POST", new NetworkError(403, "Invalid token")));
+            .catch(getRequestErrorTranslator(
+                tokenValidationUrl,
+                "POST",
+                // TODO: Remove once Riddler returns 401/403 instead of always 400
+                new NetworkError(401, "Invalid or expired token")));
 
         // TODO: ensure token expiration validity as well using `validateTokenClaimsExpiration` from `services-client`
         let tokenLifetimeInSec = getTokenLifetimeInSec(token);

--- a/server/historian/packages/historian-base/src/services/riddlerService.ts
+++ b/server/historian/packages/historian-base/src/services/riddlerService.ts
@@ -6,7 +6,7 @@
 import { AsyncLocalStorage } from "async_hooks";
 import { ITenantConfig } from "@fluidframework/server-services-core";
 import { getCorrelationId } from "@fluidframework/server-services-utils";
-import { BasicRestWrapper, NetworkError, RestWrapper } from "@fluidframework/server-services-client";
+import { BasicRestWrapper, RestWrapper } from "@fluidframework/server-services-client";
 import * as uuid from "uuid";
 import * as winston from "winston";
 import { getRequestErrorTranslator, getTokenLifetimeInSec } from "../utils";
@@ -71,11 +71,7 @@ export class RiddlerService implements ITenantService {
 
         const tokenValidationUrl = `/api/tenants/${tenantId}/validate`;
         await this.restWrapper.post(tokenValidationUrl, { token })
-            .catch(getRequestErrorTranslator(
-                tokenValidationUrl,
-                "POST",
-                // TODO: Remove once Riddler returns 401/403 instead of always 400
-                new NetworkError(401, "Invalid or expired token")));
+            .catch(getRequestErrorTranslator(tokenValidationUrl, "POST"));
 
         // TODO: ensure token expiration validity as well using `validateTokenClaimsExpiration` from `services-client`
         let tokenLifetimeInSec = getTokenLifetimeInSec(token);

--- a/server/historian/packages/historian-base/src/utils.ts
+++ b/server/historian/packages/historian-base/src/utils.ts
@@ -58,8 +58,7 @@ export function getTenantIdFromRequest(params: Params) {
  */
 export function getRequestErrorTranslator(
     url: string,
-    method: string,
-    networkErrorOverride?: NetworkError): (error: any) => never {
+    method: string): (error: any) => never {
     const getStandardLogErrorMessage = (message: string) =>
         `[${method}] Request to [${url}] failed: ${message}`;
     const requestErrorTranslator = (error: any): never => {
@@ -68,14 +67,14 @@ export function getRequestErrorTranslator(
         if (typeof error === "number" || !Number.isNaN(Number.parseInt(error, 10)))  {
             const errorCode = typeof error === "number" ? error : Number.parseInt(error, 10);
             winston.error(getStandardLogErrorMessage(`${errorCode}`));
-            throw (networkErrorOverride ?? new NetworkError(
+            throw new NetworkError(
                 errorCode,
                 "Internal Service Request Failed",
-            ));
+            );
         }
         // Treat anything else as an internal error, but log for debugging purposes
         winston.error(getStandardLogErrorMessage(safeStringify(error)));
-        throw (networkErrorOverride ?? new NetworkError(500, "Internal Server Error"));
+        throw new NetworkError(500, "Internal Server Error");
     };
     return requestErrorTranslator;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -14,12 +14,12 @@ import {
     IThrottleMiddlewareOptions,
     getParam,
 } from "@fluidframework/server-services-utils";
-import { Request, Response, Router } from "express";
+import { Request, Router } from "express";
 import * as moniker from "moniker";
 import { Provider } from "nconf";
 import requestAPI from "request";
 import winston from "winston";
-import { Constants } from "../../../utils";
+import { Constants, handleResponse } from "../../../utils";
 import {
     craftClientJoinMessage,
     craftClientLeaveMessage,
@@ -42,20 +42,16 @@ export function create(
         throttleIdSuffix: Constants.alfredRestThrottleIdSuffix,
     };
 
-    function returnResponse<T>(
-        resultP: Promise<T>,
+    function handlePatchRootSuccess(
         request: Request,
-        response: Response,
-        opBuilder: (request: Request) => any[]) {
-        resultP.then(() => {
-            const tenantId = getParam(request.params, "tenantId");
-            const documentId = getParam(request.params, "id");
-            const clientId = moniker.choose();
-            sendJoin(tenantId, documentId, clientId, producer);
-            sendOp(request, tenantId, documentId, clientId, producer, opBuilder);
-            sendLeave(tenantId, documentId, clientId, producer);
-            response.status(200).json();
-        }, (error) => response.status(400).end(error.toString()));
+        opBuilder: (request: Request) => any[],
+    ) {
+        const tenantId = getParam(request.params, "tenantId");
+        const documentId = getParam(request.params, "id");
+        const clientId = moniker.choose();
+        sendJoin(tenantId, documentId, clientId, producer);
+        sendOp(request, tenantId, documentId, clientId, producer, opBuilder);
+        sendLeave(tenantId, documentId, clientId, producer);
     }
 
     router.get("/ping", throttle(throttler, winston, {
@@ -72,7 +68,12 @@ export function create(
             const maxTokenLifetimeSec = config.get("auth:maxTokenLifetimeSec") as number;
             const isTokenExpiryEnabled = config.get("auth:enableTokenExpiration") as boolean;
             const validP = verifyRequest(request, tenantManager, storage, maxTokenLifetimeSec, isTokenExpiryEnabled);
-            returnResponse(validP, request, response, mapSetBuilder);
+            handleResponse(
+                validP.then(() => undefined),
+                response,
+                undefined,
+                200,
+                () => handlePatchRootSuccess(request, mapSetBuilder));
         },
     );
 
@@ -89,11 +90,8 @@ export function create(
                 content: blobData.content,
                 encoding: "base64",
             };
-            uploadBlob(uri, requestBody).then((data: git.ICreateBlobResponse) => {
-                response.status(200).json(data);
-            }, (err) => {
-                response.status(400).end(err.toString());
-            });
+            const dataP = uploadBlob(uri, requestBody);
+            handleResponse(dataP, response);
         },
     );
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -90,8 +90,11 @@ export function create(
                 content: blobData.content,
                 encoding: "base64",
             };
-            const dataP = uploadBlob(uri, requestBody);
-            handleResponse(dataP, response);
+            uploadBlob(uri, requestBody).then((data: git.ICreateBlobResponse) => {
+                response.status(200).json(data);
+            }, (err) => {
+                response.status(400).end(err.toString());
+            });
         },
     );
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -22,7 +22,7 @@ import { Router } from "express";
 import { Provider } from "nconf";
 import winston from "winston";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
-import { Constants } from "../../../utils";
+import { Constants, handleResponse } from "../../../utils";
 
 async function getDeltas(
     mongoManager: MongoManager,
@@ -214,13 +214,7 @@ export function create(
                 from,
                 to);
 
-            deltasP.then(
-                (deltas) => {
-                    response.status(200).json(deltas);
-                },
-                (error) => {
-                    response.status(500).json(error);
-                });
+            handleResponse(deltasP, response, 500);
         },
     );
 
@@ -241,13 +235,7 @@ export function create(
                 tenantId,
                 getParam(request.params, "id"));
 
-            deltasP.then(
-                (deltas) => {
-                    response.status(200).json(deltas);
-                },
-                (error) => {
-                    response.status(500).json(error);
-                });
+            handleResponse(deltasP, response, 500);
         },
     );
 
@@ -272,13 +260,7 @@ export function create(
                 from,
                 to);
 
-            deltasP.then(
-                (deltas) => {
-                    response.status(200).json(deltas);
-                },
-                (error) => {
-                    response.status(500).json(error);
-                });
+            handleResponse(deltasP, response, 500);
         },
     );
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -14,7 +14,7 @@ import { Router } from "express";
 import winston from "winston";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { Provider } from "nconf";
-import { Constants } from "../../../utils";
+import { Constants, handleResponse } from "../../../utils";
 
 export function create(
     storage: IDocumentStorage,
@@ -56,7 +56,7 @@ export function create(
         (request, response, next) => {
             // Tenant and document
             const tenantId = getParam(request.params, "tenantId");
-            const id = request.body.id;
+            const id = request.body.id as string;
 
             // Summary information
             const summary = request.body.summary;
@@ -73,13 +73,7 @@ export function create(
                 1,
                 values);
 
-            createP.then(
-                () => {
-                    response.status(201).json(id);
-                },
-                (error) => {
-                    response.status(400).json(error);
-                });
+            handleResponse(createP.then(() => id), response, undefined, 201);
         });
 
     return router;

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -11,8 +11,9 @@ import {
     ITenantOrderer,
     ITenantCustomData,
 } from "@fluidframework/server-services-core";
-import { Response, Router } from "express";
+import { Router } from "express";
 import { getParam } from "@fluidframework/server-services-utils";
+import { handleResponse } from "../utils";
 import { TenantManager } from "./tenantManager";
 
 export function create(
@@ -32,19 +33,13 @@ export function create(
         defaultInternalHistorianUrl,
         secretManager);
 
-    function returnResponse<T>(resultP: Promise<T>, response: Response) {
-        resultP.then(
-            (result) => response.status(200).json(result),
-            (error) => response.status(400).end(error.toString()));
-    }
-
     /**
      * Validates a tenant token. This only confirms that the token was correctly signed by the given tenant.
      * Clients still need to verify the claims.
      */
     router.post("/tenants/:id/validate", (request, response) => {
         const validP = manager.validateToken(getParam(request.params, "id"), request.body.token);
-        returnResponse(validP, response);
+        handleResponse(validP, response);
     });
 
     /**
@@ -53,7 +48,7 @@ export function create(
     router.get("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
         const tenantP = manager.getTenant(tenantId);
-        returnResponse(tenantP, response);
+        handleResponse(tenantP, response);
     });
 
     /**
@@ -61,7 +56,7 @@ export function create(
      */
     router.get("/tenants", (request, response) => {
         const tenantP = manager.getAllTenants();
-        returnResponse(tenantP, response);
+        handleResponse(tenantP, response);
     });
 
     /**
@@ -69,7 +64,7 @@ export function create(
      */
     router.get("/tenants/:id/key", (request, response) => {
         const tenantP = manager.getTenantKey(getParam(request.params, "id"));
-        returnResponse(tenantP, response);
+        handleResponse(tenantP, response);
     });
 
     /**
@@ -77,7 +72,7 @@ export function create(
      */
     router.put("/tenants/:id/storage", (request, response) => {
         const storageP = manager.updateStorage(getParam(request.params, "id"), request.body);
-        returnResponse(storageP, response);
+        handleResponse(storageP, response);
     });
 
     /**
@@ -85,7 +80,7 @@ export function create(
      */
     router.put("/tenants/:id/orderer", (request, response) => {
         const storageP = manager.updateOrderer(getParam(request.params, "id"), request.body);
-        returnResponse(storageP, response);
+        handleResponse(storageP, response);
     });
 
     /**
@@ -94,7 +89,7 @@ export function create(
     router.put("/tenants/:id/customData", (request, response) => {
         const tenantId = getParam(request.params, "id");
         const customDataP = manager.updateCustomData(tenantId, request.body);
-        returnResponse(customDataP, response);
+        handleResponse(customDataP, response);
     });
 
     /**
@@ -103,7 +98,7 @@ export function create(
     router.put("/tenants/:id/key", (request, response) => {
         const tenantId = getParam(request.params, "id");
         const refreshKeyP = manager.refreshTenantKey(tenantId);
-        return returnResponse(refreshKeyP, response);
+        return handleResponse(refreshKeyP, response);
     });
 
     /**
@@ -120,7 +115,7 @@ export function create(
             tenantOrderer,
             tenantCustomData,
         );
-        returnResponse(tenantP, response);
+        handleResponse(tenantP, response);
     });
 
     /**
@@ -129,7 +124,7 @@ export function create(
     router.delete("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
         const tenantP = manager.deleteTenant(tenantId);
-        returnResponse(tenantP, response);
+        handleResponse(tenantP, response);
     });
 
     return router;

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -12,6 +12,7 @@ import {
     MongoManager,
     ISecretManager,
 } from "@fluidframework/server-services-core";
+import { NetworkError } from "@fluidframework/server-services-client";
 import * as jwt from "jsonwebtoken";
 import * as _ from "lodash";
 import * as winston from "winston";
@@ -60,7 +61,10 @@ export class TenantManager {
         return new Promise<void>((resolve, reject) => {
             jwt.verify(token, tenantKey, (error) => {
                 if (error) {
-                    reject(error);
+                    // When `exp` claim exists in token claims, jsonwebtoken verifies token expiration.
+                    reject(error instanceof jwt.TokenExpiredError
+                        ? new NetworkError(401, "Token expired.")
+                        : new NetworkError(403, "Invalid token."));
                 } else {
                     resolve();
                 }

--- a/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
@@ -7,4 +7,5 @@ export * from "./constants";
 export * from "./documentRouter";
 export * from "./middleware";
 export * from "./params";
+export * from "./rest";
 export * from "./runner";

--- a/server/routerlicious/packages/routerlicious-base/src/utils/rest.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/rest.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Response } from "express";
+
+/**
+ * Helper function to handle a promise that should be returned to the user
+ */
+ export function handleResponse<T>(
+    resultP: Promise<T>,
+    response: Response,
+    errorStatus?: number,
+    successStatus: number = 200,
+    onSuccess: (value: T) => void = () => {},
+) {
+    resultP.then(
+        (result) => {
+            onSuccess(result);
+            response.status(successStatus).json(result);
+        },
+        (error) => {
+            response.status(errorStatus ?? error?.code ?? 400).json(error?.message ?? error);
+        });
+}

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -54,16 +54,19 @@ export class TenantManager implements core.ITenantManager {
             Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`),
             this.getKey(tenantId)]);
 
-        const credentials: ICredentials = {
-            password: generateToken(tenantId, null, key, null),
-            user: tenantId,
-        };
         const defaultQueryString = {
-            token: fromUtf8ToBase64(`${credentials.user}`),
+            token: fromUtf8ToBase64(`${tenantId}`),
         };
-        const defaultHeaders = {
-            Authorization: getAuthorizationTokenFromCredentials(credentials),
+        const getDefaultHeaders = () => {
+            const credentials: ICredentials = {
+                password: generateToken(tenantId, null, key, null),
+                user: tenantId,
+            };
+            return ({
+                Authorization: getAuthorizationTokenFromCredentials(credentials),
+            });
         };
+        const defaultHeaders = getDefaultHeaders();
         const baseUrl = `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`;
         const restWrapper = new BasicRestWrapper(
             baseUrl,
@@ -73,7 +76,7 @@ export class TenantManager implements core.ITenantManager {
             defaultHeaders,
             undefined,
             undefined,
-            undefined,
+            getDefaultHeaders,
             getCorrelationId);
         const historian = new Historian(
             `${details.data.storage.internalHistorianUrl}/repos/${encodeURIComponent(tenantId)}`,


### PR DESCRIPTION
### Problem

Credit to @pradeepvairamani for finding this bug.

When a client summary write is with an expired token, the document can become marked as corrupted due to a 403 error when accessing git storage.

### Root Cause

When the `exp` claim is present in a JWT token, [jsonwebtoken.verify](https://www.npmjs.com/package/jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback) validates token expiry as well as token signature. In Historian, we are treating all Riddler (jwt.verify) failures as non-retriable, invalid token errors, but they can actually be retriable, token expired errors.

Additionally, even if a 401 (Unauthorized, retriable) error were thrown from Historian to Scribe, Scribe did not have the BasicRestWrapper token-refresh-retry functionality enabled, it would still fail and corrupt the doc regardless.

### Fix(es)

1. Return more informative error codes and messages from Riddler's /api/tenants/<tenant-id>/validate endpoint depending on type of error received from `jsonwebtoken`
    - Additionally unified the handling of responses across routerlicious-base REST APIs which allows us to expose more accurate error information and error codes than the previously hardcoded 400 code
2. Switch Historian's overwrite of Riddler's error code to a 401 (from a 403)
   - @tanviraumi should I remove this override altogether? My reasoning was that until this Riddler change is released, Riddler will only expose a "400 - undefined" error on failure, so without the override we lose some amount of information about failure. However, 400s and 403s are essentially treated the same with regards to retries, and removing it now will allow both 403 and 401 errors to be bubbled up from Riddler as soon as the Riddler change is released, which would realistically be simultaneous, at least for FRS.
3. Enable token-refresh-retry functionality within the service's TenantManager