### PR TITLE
Allow disabling certain deli op events

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -265,7 +265,8 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
         if (this.serviceConfiguration.deli.opEvent.enable) {
             this.updateOpIdleTimer();
 
-            if (this.messagesSinceLastOpEvent > this.serviceConfiguration.deli.opEvent.maxOps) {
+            const maxOps = this.serviceConfiguration.deli.opEvent.maxOps;
+            if (maxOps !== undefined && this.messagesSinceLastOpEvent > maxOps) {
                 this.emitOpEvent(OpEventType.MaxOps);
             }
         }
@@ -869,11 +870,16 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
     }
 
     private updateOpIdleTimer() {
+        const idleTime = this.serviceConfiguration.deli.opEvent.idleTime;
+        if (idleTime === undefined) {
+            return;
+        }
+
         this.clearOpIdleTimer();
 
         this.opIdleTimer = setTimeout(() => {
             this.emitOpEvent(OpEventType.Idle);
-        }, this.serviceConfiguration.deli.opEvent.idleTime);
+        }, idleTime);
     }
 
     private clearOpIdleTimer() {
@@ -884,11 +890,16 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
     }
 
     private updateOpMaxTimeTimer() {
+        const maxTime = this.serviceConfiguration.deli.opEvent.maxTime;
+        if (maxTime === undefined) {
+            return;
+        }
+
         this.clearOpMaxTimeTimer();
 
         this.opMaxTimeTimer = setTimeout(() => {
             this.emitOpEvent(OpEventType.MaxTime);
-        }, this.serviceConfiguration.deli.opEvent.maxTime);
+        }, maxTime);
     }
 
     private clearOpMaxTimeTimer() {

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -25,13 +25,13 @@ export interface IDeliOpEventServerConfiguration {
     enable: boolean;
 
     // Causes an event to fire after deli doesn't process any ops after this amount of time
-    idleTime: number;
+    idleTime: number | undefined;
 
     // Causes an event to fire based on the time since the last emit
-    maxTime: number;
+    maxTime: number | undefined;
 
     // Causes an event to fire based on the number of ops since the last emit
-    maxOps: number;
+    maxOps: number | undefined;
 }
 
 // Scribe lambda configuration


### PR DESCRIPTION
Followup on #6204

Allows setting opEvent config values to `undefined` to disable those specific op events