### PR TITLE
No data corruption on Noops

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1745,7 +1745,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 this.getQuorum().getMember(message.clientId);
             if (client === undefined && message.type !== MessageType.ClientJoin) {
                 errorMsg = "messageClientIdMissingFromQuorum";
-            } else if (client?.shouldHaveLeft === true) {
+            } else if (client?.shouldHaveLeft === true && message.type !== MessageType.NoOp) {
                 errorMsg = "messageClientIdShouldHaveLeft";
             }
             if (errorMsg !== undefined) {


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/5866
We faced a Data corruption error in prod: https://portal.microsofticm.com/imp/v3/incidents/details/237050313/home
We hit a rare case there, where noop caused us to throw data corruption error. So when the issue occurred in prod, we did not wait for leave op because our check said that we have received acks for all of our ops. But we don't check acks for trailing noops in delta manager.
`public shouldJoinWrite(): boolean { // We don't have to wait for ack for topmost NoOps. So subtract those. return this.clientSequenceNumberObserved < (this.clientSequenceNumber - this.trailingNoopCount); }`
So lets say clientseqNum observed was 9 and client seq number was 10 and last op was noop. Then it should be fine to not wait. So looks like we can add a check when we throw the error.