### PR TITLE
reverting #6041

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -119,11 +119,11 @@ export function create(
     });
 
     /**
-     * Deletes the given tenant
+     * Deletes a tenant by adding a disabled flag
      */
     router.delete("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const tenantP = manager.deleteTenant(tenantId);
+        const tenantP = manager.disableTenant(tenantId);
         handleResponse(tenantP, response);
     });
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -282,13 +282,13 @@ export class TenantManager {
     }
 
     /**
-     * Deletes the given tenant
+     * Flags the given tenant as disabled
      */
-    public async deleteTenant(tenantId: string): Promise<void> {
+    public async disableTenant(tenantId: string): Promise<void> {
         const db = await this.mongoManager.getDatabase();
         const collection = db.collection<ITenantDocument>(this.collectionName);
 
-        await collection.deleteOne({ _id: tenantId });
+        await collection.update({ _id: tenantId }, { disabled: true }, null);
     }
 
     private encryptAccessInfo(accessInfo: any): string {


### PR DESCRIPTION
Reverting PR #6041 "Updated disabling tenant to tenant deletion."

Reason: when we delete tenant, we also need to delete the related tenant data like operations (in mongoDb) and summaries (in git). So, we will take up this work along with a larger work item to delete the tenant data (both, mongodb and git) in the coming months.