### PR TITLE
Assign area labels to PRs based on changed paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@
 # for more details.
 
 "area: dds":
-  - any: ["/packages/dds/**", "!/packages/dds/sequence/**"]
+  - "/packages/dds/**"
 
 "area: dds: sharedstring":
   - /packages/dds/sequence/**
@@ -32,6 +32,9 @@
 "area: server":
   - /server/**
 
+"area: test":
+  - packages/test/**
+
 "area: tools":
   - /tools/**
 
@@ -45,6 +48,3 @@
 
 documentation:
   - /docs/content/**
-
-testing:
-- packages/test/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,50 @@
+# This file is a map of labels to repo glob paths. See https://github.com/marketplace/actions/labeler
+# for more details.
+
+"area: dds":
+  - any: ["/packages/dds/**", "!/packages/dds/sequence/**"]
+
+"area: dds: sharedstring":
+  - /packages/dds/sequence/**
+
+"area: driver":
+  - /packages/drivers/**
+
+"area: examples":
+  - /examples/**
+
+"area: framework":
+  - /packages/framework/**
+
+"area: host":
+  - /packages/hosts/**
+
+"area: loader":
+  - /packages/hosts/**
+
+# Add "area: repo" label to any root or .github changes
+"area: repo":
+  - any: ["./*", "./.github/**", "!./BREAKING.md"]
+
+"area: runtime":
+  - /packages/runtime/**
+
+"area: server":
+  - /server/**
+
+"area: tools":
+  - /tools/**
+
+"area: website":
+  - any: ["/docs/**", "!/docs/content/**"]
+
+# Any change to BREAKING.md or to any api-report path in the repo
+"breaking change":
+  - ./BREAKING.md
+  - api-report/*
+
+documentation:
+  - /docs/content/**
+
+testing:
+- packages/test/**

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true # add/remove labels as modified paths in the PR change


### PR DESCRIPTION
This PR will enable a GitHub action to automatically assign area labels to PRs based on changed paths. This will help triage and changelog reporting.