### PR TITLE
Custom implementation of getting GC data for Sequence and SharedMatrix.

### DIFF
--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -61,6 +61,7 @@
     "@fluidframework/merge-tree": "^0.40.0",
     "@fluidframework/protocol-base": "^0.1025.0-0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/runtime-definitions": "^0.40.0",
     "@fluidframework/runtime-utils": "^0.40.0",
     "@fluidframework/shared-object-base": "^0.40.0",
     "@fluidframework/telemetry-utils": "^0.40.0",

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -446,9 +446,9 @@ export class SharedMatrix<T extends Serializable = Serializable>
         // serializes.
         const serializer = new SummarySerializer(this.runtime.channelsRoutingContext);
 
-        for (let r = 0; r < this.rowCount; r++) {
-            for (let c = 0; c < this.colCount; c++) {
-                serializer.stringify(this.getCell(r, c), this.handle);
+        for (let row = 0; row < this.rowCount; row++) {
+            for (let col = 0; col < this.colCount; col++) {
+                serializer.stringify(this.getCell(row, col), this.handle);
             }
         }
 

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -292,6 +292,26 @@ export class Client {
             accum, start, end, splitRange);
     }
 
+    /**
+     * Generates the data required for garbage collection. The IFluidHandles stored in all segements that haven't
+     * been removed represent routes to other objects. We serialize the data in these segments using the passed in
+     * serializer which keeps track of all serialized handles.
+     */
+    public generateGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void {
+        this.mergeTree.walkAllSegments(
+            this.mergeTree.root,
+            (seg) => {
+                // Only serialize segments that have not been removed.
+                if (seg.removedSeq === undefined) {
+                    handleCollectingSerializer.stringify(
+                        seg.clone().toJSONObject(),
+                        handle);
+                }
+                return true;
+            },
+        );
+    }
+
     public getCollabWindow() {
         return this.mergeTree.getCollabWindow();
     }

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -293,11 +293,11 @@ export class Client {
     }
 
     /**
-     * Generates the data required for garbage collection. The IFluidHandles stored in all segements that haven't
+     * Serializes the data required for garbage collection. The IFluidHandles stored in all segements that haven't
      * been removed represent routes to other objects. We serialize the data in these segments using the passed in
      * serializer which keeps track of all serialized handles.
      */
-    public generateGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void {
+    public serializeGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void {
         this.mergeTree.walkAllSegments(
             this.mergeTree.root,
             (seg) => {

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -64,6 +64,7 @@
     "@fluidframework/map": "^0.40.0",
     "@fluidframework/merge-tree": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/runtime-definitions": "^0.40.0",
     "@fluidframework/runtime-utils": "^0.40.0",
     "@fluidframework/shared-object-base": "^0.40.0",
     "@fluidframework/telemetry-utils": "^0.40.0",

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -25,8 +25,10 @@ import {
     parseHandles,
     SharedObject,
     ISharedObjectEvents,
+    SummarySerializer,
 } from "@fluidframework/shared-object-base";
 import { IEventThisPlaceHolder } from "@fluidframework/common-definitions";
+import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
 
 import { debug } from "./debug";
 import {
@@ -442,6 +444,27 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
         };
 
         return tree;
+    }
+
+    /**
+     * Returns the GC data for this SharedMatrix. All the IFluidHandle's represent routes to other objects.
+     */
+    protected getGCDataCore(): IGarbageCollectionData {
+        // Create a SummarySerializer and use it to serialize all the cells. It keeps track of all IFluidHandles that it
+        // serializes.
+        const serializer = new SummarySerializer(this.runtime.channelsRoutingContext);
+
+        if (this.intervalMapKernel.size > 0) {
+            this.intervalMapKernel.serialize(serializer);
+        }
+
+        this.client.generateGCData(this.handle, serializer);
+
+        return {
+            gcNodes:{
+                ["/"]: serializer.getSerializedRoutes(),
+            },
+        };
     }
 
     /**

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -458,7 +458,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
             this.intervalMapKernel.serialize(serializer);
         }
 
-        this.client.generateGCData(this.handle, serializer);
+        this.client.serializeGCData(this.handle, serializer);
 
         return {
             gcNodes:{

--- a/packages/dds/shared-object-base/src/index.ts
+++ b/packages/dds/shared-object-base/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from "./sharedObject";
+export * from "./summarySerializer";
 export * from "./types";
 export * from "./utils";
 export * from "./valueType";


### PR DESCRIPTION
Fixes #6228 and #6229.

Added custom implementation of `getGCDataCore` for `Sequence` and `SharedMatrix`:
- Sequence ignores segments that have been deleted. So, deleted handles are removed in the GC data the next time it is generated.
- SharedMatrix only includes cells as per the "current state" of the world. Any deleted rows or columns in the underlying merge trees deleted segments are not included.