### PR TITLE
r11s-driver: Add IRouterliciousDriverPolicies with prefetch toggle

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -15,6 +15,7 @@ import { R11sDocumentDeltaConnection } from "./documentDeltaConnection";
 import { NullBlobStorageService } from "./nullBlobStorageService";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousStorageRestWrapper } from "./restWrapper";
+import { IRouterliciousDriverPolicies } from "./documentServiceFactory";
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
@@ -30,6 +31,7 @@ export class DocumentService implements api.IDocumentService {
         protected tokenProvider: ITokenProvider,
         protected tenantId: string,
         protected documentId: string,
+        private readonly driverPolicies: IRouterliciousDriverPolicies,
     ) {
     }
 
@@ -60,8 +62,17 @@ export class DocumentService implements api.IDocumentService {
             false,
             storageRestWrapper);
         const gitManager = new GitManager(historian);
+        const documentStorageServicePolicies: api.IDocumentStorageServicePolicies = {
+            caching: this.driverPolicies.enablePrefetch
+                ? api.LoaderCachingPolicy.Prefetch
+                : api.LoaderCachingPolicy.NoCaching,
+        };
 
-        this.documentStorageService = new DocumentStorageService(this.documentId, gitManager, this.logger);
+        this.documentStorageService = new DocumentStorageService(
+            this.documentId,
+            gitManager,
+            this.logger,
+            documentStorageServicePolicies);
         return this.documentStorageService;
     }
 

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -15,7 +15,7 @@ import { R11sDocumentDeltaConnection } from "./documentDeltaConnection";
 import { NullBlobStorageService } from "./nullBlobStorageService";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousStorageRestWrapper } from "./restWrapper";
-import { IRouterliciousDriverPolicies } from "./documentServiceFactory";
+import { IRouterliciousDriverPolicies } from "./policies";
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -19,16 +19,9 @@ import {
 } from "@fluidframework/driver-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { DocumentService } from "./documentService";
+import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
-
-export interface IRouterliciousDriverPolicies {
-    /**
-     * Enable prefetching entire snapshot tree into memory before it is loaded by the runtime.
-     * Default: true
-     */
-    enablePrefetch: boolean;
-}
 
 const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -22,15 +22,34 @@ import { DocumentService } from "./documentService";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 
+export interface IRouterliciousDriverPolicies {
+    /**
+     * Enable prefetching entire snapshot tree into memory before it is loaded by the runtime.
+     * Default: true
+     */
+    enablePrefetch: boolean;
+}
+
+const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
+    enablePrefetch: true,
+};
+
 /**
  * Factory for creating the routerlicious document service. Use this if you want to
  * use the routerlicious implementation.
  */
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid:";
+    private readonly driverPolicies: IRouterliciousDriverPolicies;
+
     constructor(
         private readonly tokenProvider: ITokenProvider,
+        driverPolicies: Partial<IRouterliciousDriverPolicies> = {},
     ) {
+        this.driverPolicies = {
+            ...defaultRouterliciousDriverPolicies,
+            ...driverPolicies,
+        };
     }
 
     public async createContainer(
@@ -112,6 +131,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             logger2,
             this.tokenProvider,
             tenantId,
-            documentId);
+            documentId,
+            this.driverPolicies);
     }
 }

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -3,10 +3,11 @@
  * Licensed under the MIT License.
  */
 
+export * from "./defaultTokenProvider";
 export * from "./deltaStorageService";
 export * from "./documentService";
-export * from "./documentStorageService";
-export * from "./tokens";
-export * from "./nullBlobStorageService";
 export * from "./documentServiceFactory";
-export * from "./defaultTokenProvider";
+export * from "./documentStorageService";
+export * from "./nullBlobStorageService";
+export * from "./policies";
+export * from "./tokens";

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface IRouterliciousDriverPolicies {
+    /**
+     * Enable prefetching entire snapshot tree into memory before it is loaded by the runtime.
+     * Default: true
+     */
+    enablePrefetch: boolean;
+}


### PR DESCRIPTION
Allow host to toggle prefetch in the routerlicious driver depending on their needs and introduce `IRouterliciousDriverPolicies` config param as mentioned in #6195 