### PR TITLE
fix policy check

### DIFF
--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/local-driver": "^0.40.0",
     "@fluidframework/odsp-doclib-utils": "^0.40.0",
     "@fluidframework/odsp-driver": "^0.40.0",
-    "@fluidframework/odsp-driver-definitions": "0.40.0",
+    "@fluidframework/odsp-driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/routerlicious-driver": "^0.40.0",
     "@fluidframework/runtime-utils": "^0.40.0",


### PR DESCRIPTION
It's complaining about this now:
```
$ npm run bump-version -- --branch

> root@0.14.0 bump-version C:\Users\wecarlso\fluid
> fluid-bump-version --root . "--branch"

Repo: C:\Users\wecarlso\fluid
Running Policy Check with Resolution(fix)
  Resolving published dependencies
ERROR: Inconsistent version dependency within client monorepo in @fluidframework/webpack-fluid-loader
  actual: @fluidframework/odsp-driver-definitions@0.40.0
  expected: @fluidframework/odsp-driver-definitions@^0.40.0
```