### PR TITLE
change retryAfter to be in milliseconds.

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterSeconds?: number, props?: ITaggableTelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITaggableTelemetryProperties): GenericNetworkError | ThrottlingError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType>;

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -49,7 +49,7 @@ export type R11sError = DriverError | IR11sError;
 export function createR11sNetworkError(
     errorMessage: string,
     statusCode?: number,
-    retryAfterSeconds?: number,
+    retryAfterMs?: number,
 ): R11sError {
     switch (statusCode) {
         case undefined:
@@ -65,24 +65,24 @@ export function createR11sNetworkError(
                 errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, { statusCode });
         case 429:
             return createGenericNetworkError(
-                errorMessage, true, retryAfterSeconds, { statusCode });
+                errorMessage, true, retryAfterMs, { statusCode });
         case 500:
             return new GenericNetworkError(errorMessage, true, { statusCode });
         default:
             return createGenericNetworkError(
-                errorMessage, retryAfterSeconds !== undefined, retryAfterSeconds, { statusCode });
+                errorMessage, retryAfterMs !== undefined, retryAfterMs, { statusCode });
     }
 }
 
 export function throwR11sNetworkError(
     errorMessage: string,
     statusCode?: number,
-    retryAfterSeconds?: number,
+    retryAfterMs?: number,
 ): never {
     const networkError = createR11sNetworkError(
         errorMessage,
         statusCode,
-        retryAfterSeconds);
+        retryAfterMs);
 
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw networkError;

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -35,7 +35,7 @@ export interface IR11sSocketError {
      * Optional Retry-After time in seconds.
      * The client should wait this many seconds before retrying its request.
      */
-    retryAfter?: number;
+    retryAfterMs?: number;
 }
 
 export interface IR11sError {
@@ -96,6 +96,6 @@ export function errorObjectFromSocketError(socketError: IR11sSocketError, handle
     return createR11sNetworkError(
         message,
         socketError.code,
-        socketError.retryAfter,
+        socketError.retryAfterMs,
     );
 }

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -34,7 +34,7 @@ describe("ErrorUtils", () => {
         });
         it("creates retriable error on 429 with retry-after", () => {
             const message = "test error";
-            const error = createR11sNetworkError(message, 429, 5);
+            const error = createR11sNetworkError(message, 429, 5000);
             assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
             assert.strictEqual(error.canRetry, true);
             assert.strictEqual((error as IThrottlingWarning).retryAfterSeconds, 5);
@@ -59,7 +59,7 @@ describe("ErrorUtils", () => {
         });
         it("creates retriable error on anything else with retryAfter", () => {
             const message = "test error";
-            const error = createR11sNetworkError(message, 400, 100);
+            const error = createR11sNetworkError(message, 400, 100000);
             assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
             assert.strictEqual(error.canRetry, true);
             assert.strictEqual((error as any).retryAfterSeconds, 100);
@@ -109,7 +109,7 @@ describe("ErrorUtils", () => {
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
-                retryAfterSeconds: 5000,
+                retryAfterSeconds: 5,
             });
         });
         it("throws retriable error on 429 without retry-after", () => {
@@ -146,7 +146,7 @@ describe("ErrorUtils", () => {
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
-                retryAfterSeconds: 200000,
+                retryAfterSeconds: 200,
             });
         });
         it("throws non-retriable error on anything else", () => {

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -105,11 +105,11 @@ describe("ErrorUtils", () => {
         it("throws retriable error on 429 with retry-after", () => {
             const message = "test error";
             assert.throws(() => {
-                throwR11sNetworkError(message, 429, 5);
+                throwR11sNetworkError(message, 429, 5000);
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
-                retryAfterSeconds: 5,
+                retryAfterMs: 5000,
             });
         });
         it("throws retriable error on 429 without retry-after", () => {
@@ -142,11 +142,11 @@ describe("ErrorUtils", () => {
         it("throws retriable error on anything else with retryAfter", () => {
             const message = "test error";
             assert.throws(() => {
-                throwR11sNetworkError(message, 400, 200);
+                throwR11sNetworkError(message, 400, 200000);
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
-                retryAfterSeconds: 200,
+                retryAfterMs: 200000,
             });
         });
         it("throws non-retriable error on anything else", () => {

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -206,7 +206,7 @@ describe("ErrorUtils", () => {
             const error = errorObjectFromSocketError({
                 code: 429,
                 message,
-                retryAfter: 5,
+                retryAfterMs: 5000,
             }, handler);
             assertExpectedMessage(error.message);
             assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
@@ -237,7 +237,7 @@ describe("ErrorUtils", () => {
             const error = errorObjectFromSocketError({
                 code: 400,
                 message,
-                retryAfter: 300,
+                retryAfterMs: 300000,
             }, handler);
             assertExpectedMessage(error.message);
             assert.strictEqual(error.errorType, DriverErrorType.throttlingError);

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -109,7 +109,7 @@ describe("ErrorUtils", () => {
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
-                retryAfterMs: 5000,
+                retryAfterSeconds: 5000,
             });
         });
         it("throws retriable error on 429 without retry-after", () => {
@@ -146,7 +146,7 @@ describe("ErrorUtils", () => {
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
-                retryAfterMs: 200000,
+                retryAfterSeconds: 200000,
             });
         });
         it("throws non-retriable error on anything else", () => {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -67,7 +67,8 @@ const DefaultChunkSize = 16 * 1024;
 function getNackReconnectInfo(nackContent: INackContent) {
     const reason = `Nack: ${nackContent.message}`;
     const canRetry = nackContent.code !== 403;
-    return createGenericNetworkError(reason, canRetry, nackContent.retryAfter, { statusCode: nackContent.code });
+    const retryAfterMs = nackContent.retryAfter !== undefined ? nackContent.retryAfter * 1000 : undefined;
+    return createGenericNetworkError(reason, canRetry, retryAfterMs, { statusCode: nackContent.code });
 }
 
 function createReconnectError(prefix: string, err: any) {

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -127,10 +127,10 @@ export const createWriteError = (errorMessage: string) =>
 export function createGenericNetworkError(
     errorMessage: string,
     canRetry: boolean,
-    retryAfterSeconds?: number,
+    retryAfterMs?: number,
     props?: ITaggableTelemetryProperties) {
-    if (retryAfterSeconds !== undefined && canRetry) {
-        return new ThrottlingError(errorMessage, retryAfterSeconds, props);
+    if (retryAfterMs !== undefined && canRetry) {
+        return new ThrottlingError(errorMessage, retryAfterMs, props);
     }
     return new GenericNetworkError(errorMessage, canRetry, props);
 }

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -130,7 +130,7 @@ export function createGenericNetworkError(
     retryAfterMs?: number,
     props?: ITaggableTelemetryProperties) {
     if (retryAfterMs !== undefined && canRetry) {
-        return new ThrottlingError(errorMessage, retryAfterMs, props);
+        return new ThrottlingError(errorMessage, retryAfterMs / 1000, props);
     }
     return new GenericNetworkError(errorMessage, canRetry, props);
 }

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -128,7 +128,8 @@ export function createOdspNetworkError(
             error = new NonRetryableError(errorMessage, OdspErrorType.fetchTokenError, { statusCode });
             break;
         default:
-            error = createGenericNetworkError(errorMessage, true, retryAfterSeconds, { statusCode });
+            const retryAfterMs = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : undefined;
+            error = createGenericNetworkError(errorMessage, true, retryAfterMs, { statusCode });
     }
 
     error.online = OnlineStatus[isOnline()];


### PR DESCRIPTION
 Fixes #5881 
changing the methods like createGenericNetworkError and throwR11sNetworkError