### PR TITLE
Clear quorum values cache when committing a proposal

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -387,6 +387,9 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
                 .forEach((pendingCommit) => {
                     pendingCommit.commitSequenceNumber = message.sequenceNumber;
 
+                    // clear the values cache
+                    this.snapshotCache.values = undefined;
+
                     this.emit(
                         "commitProposal",
                         pendingCommit.sequenceNumber,


### PR DESCRIPTION
Due to these lines:
```
                this.values.set(committedProposal.key, committedProposal);
                this.pendingCommit.set(committedProposal.key, committedProposal);
```
The object in `pendingCommit` is the same as the one in `values`. So clear the `values` cache when that `committedProposal` object changes.