### PR TITLE
bump dependency missed by script

### DIFF
--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/gitresources": "^0.1025.1",
     "@fluidframework/mocha-test-setup": "^0.40.1",
-    "@fluidframework/runtime-definitions": "^0.40.0",
+    "@fluidframework/runtime-definitions": "^0.40.1",
     "@fluidframework/server-services-client": "^0.1025.1",
     "@fluidframework/test-runtime-utils": "^0.40.1",
     "@microsoft/api-extractor": "^7.13.1",


### PR DESCRIPTION
The tool missed this for some reason, and it's preventing me from being able to use the tool to update the server version to 1025.2