### PR TITLE
add simple reconnect logs to mongodb

### DIFF
--- a/server/routerlicious/packages/services-core/src/mongo.ts
+++ b/server/routerlicious/packages/services-core/src/mongo.ts
@@ -43,6 +43,7 @@ export class MongoManager {
      * Closes the connection to MongoDB
      */
     public async close(): Promise<void> {
+        debug("Call close connection to MongoDB");
         this.shouldReconnect = false;
         const database = await this.databaseP;
         return database.close();
@@ -73,6 +74,7 @@ export class MongoManager {
             this.reconnect(this.reconnectDelayMs);
         });
 
+        debug("Successfully connected to MongoDB");
         return databaseP;
     }
 
@@ -81,6 +83,7 @@ export class MongoManager {
      */
     private reconnect(delay) {
         if (!this.shouldReconnect) {
+            debug("Should not reconnect to MongoDB");
             return;
         }
 


### PR DESCRIPTION
Recently we got a "DB Close connection" log in FRS, and we could not tell whether we reconnected or not. Adding logs to help with debugging this in the future. 