### PR TITLE
make endpoint domain configurable

### DIFF
--- a/experimental/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/experimental/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -37,6 +37,7 @@ export class TinyliciousClientInstance {
         const tokenProvider = new InsecureTinyliciousTokenProvider();
         this.urlResolver = new InsecureTinyliciousUrlResolver(
             serviceConnectionConfig?.port,
+            serviceConnectionConfig?.domain,
         );
         this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
             tokenProvider,

--- a/experimental/framework/tinylicious-client/src/interfaces.ts
+++ b/experimental/framework/tinylicious-client/src/interfaces.ts
@@ -13,6 +13,7 @@ export interface TinyliciousContainerConfig {
 
 export interface TinyliciousConnectionConfig {
     port?: number;
+    domain?: string
 }
 
 /**

--- a/packages/drivers/tinylicious-driver/src/test/insecureTinyliciousUrlResolverTest.spec.ts
+++ b/packages/drivers/tinylicious-driver/src/test/insecureTinyliciousUrlResolverTest.spec.ts
@@ -30,6 +30,23 @@ describe("Insecure Url Resolver Test", () => {
         assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
     });
 
+    it("Should resolve url with custom domain and port", async () => {
+        const customEndpoint = "http://custom-endpoint.io";
+        const customFluidEndpoint = "fluid://custom-endpoint.io";
+        const customPort = 1234;
+        const customResolver = new InsecureTinyliciousUrlResolver(customPort,customEndpoint);
+        const testRequest: IRequest = {
+            url: `${documentId}`,
+            headers: {},
+        };
+
+        const resolvedUrl = await customResolver.resolve(testRequest);
+        ensureFluidResolvedUrl(resolvedUrl);
+
+        const expectedResolvedUrl = `${customFluidEndpoint}/tinylicious/${documentId}`;
+        assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
+    });
+
     it("Should resolve url with data object ids", async () => {
         const path = "dataObject1/dataObject2";
         const testRequest: IRequest = {


### PR DESCRIPTION
This extends the tinylicious driver and the tinylicious client to customize the endpoint.

I added a test that should check the changes to `InsecureTinyliciousUrlResolver` but I could find a script that actually runs them is there a way to run the tests locally?

@SamBroner 