### PR TITLE
Assert cleanup for browser usages of routerlicious

### DIFF
--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -71,7 +71,6 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@types/events": "^3.0.0",
-    "assert": "^2.0.0",
     "base64-js": "^1.3.1",
     "events": "^3.1.0",
     "lodash": "^4.17.21",

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { assert } from "@fluidframework/common-utils";
 import * as resources from "@fluidframework/gitresources";
 import { buildHierarchy } from "@fluidframework/protocol-base";
 import * as api from "@fluidframework/protocol-definitions";
@@ -271,7 +271,7 @@ export class GitManager implements IGitManager {
         // Wait for them all to resolve
         const entries = await Promise.all(entriesP);
         const tree: resources.ICreateTreeEntry[] = [];
-        assert(entries.length === files.entries.length);
+        assert(entries.length === files.entries.length, "File entries length is not correct");
 
         // Construct a new tree from the collection of hashes
         for (let i = 0; i < files.entries.length; i++) {


### PR DESCRIPTION
We started consuming code from a partner that uses routerlicious. This resulted in a large bundle size regression since r11s depends on the assert package. This PR updates the usage to instead use the browser friendly assert utility