### PR TITLE
Jsonable is dead, long live Jsonable!

### DIFF
--- a/examples/apps/spaces/src/fluid-object/index.tsx
+++ b/examples/apps/spaces/src/fluid-object/index.tsx
@@ -15,7 +15,7 @@ import {
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
-import { AsSerializable } from "@fluidframework/datastore-definitions";
+import { Serializable } from "@fluidframework/datastore-definitions";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 
 import { RequestParser } from "@fluidframework/runtime-utils";
@@ -39,7 +39,7 @@ export interface ISpacesItem {
     /**
      * The unknown blob of data that backs the instance of the item.  Probably contains handles, etc.
      */
-    serializableObject: AsSerializable<any>;
+    serializableObject: Serializable;
     /**
      * A key matching an entry in the spacesItemMap, which we'll use to pair the unknown blob with an entry that
      * knows how to deal with it.

--- a/examples/apps/spaces/src/fluid-object/spacesItemMap.ts
+++ b/examples/apps/spaces/src/fluid-object/spacesItemMap.ts
@@ -4,7 +4,7 @@
  */
 
 import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
-import { AsSerializable, Serializable } from "@fluidframework/datastore-definitions";
+import { Serializable } from "@fluidframework/datastore-definitions";
 import {
     NamedFluidDataStoreRegistryEntries,
     IFluidDataStoreFactory,
@@ -53,44 +53,44 @@ const getSliderCoordinateView = async (serializableObject: ISingleHandleItem) =>
 /**
  * A registry entry, with extra metadata.
  */
-export interface ISpacesItemEntry<T extends Serializable = AsSerializable<any>> {
+export interface ISpacesItemEntry<T = any> {
     // Would be better if items to bring their own subregistries, and their own ability to create components
     // This might be done by integrating these items with the Spaces subcomponent registry?
-    create: (context: IFluidDataStoreContext) => Promise<T>;
-    getView: (serializableObject: T) => Promise<JSX.Element>;
+    create: (context: IFluidDataStoreContext) => Promise<Serializable<T>>;
+    getView: (serializableObject: Serializable<T>) => Promise<JSX.Element>;
     friendlyName: string;
     fabricIconName: string;
 }
 
-const clickerItemEntry: ISpacesItemEntry<AsSerializable<ISingleHandleItem>> = {
+const clickerItemEntry: ISpacesItemEntry<ISingleHandleItem> = {
     create: createSingleHandleItem(ClickerInstantiationFactory),
     getView: getAdaptedViewForSingleHandleItem,
     friendlyName: "Clicker",
     fabricIconName: "Touch",
 };
 
-const codemirrorItemEntry: ISpacesItemEntry<AsSerializable<ISingleHandleItem>> = {
+const codemirrorItemEntry: ISpacesItemEntry<ISingleHandleItem> = {
     create: createSingleHandleItem(cmfe),
     getView: getAdaptedViewForSingleHandleItem,
     friendlyName: "Code",
     fabricIconName: "Code",
 };
 
-const textboxItemEntry: ISpacesItemEntry<AsSerializable<ISingleHandleItem>> = {
+const textboxItemEntry: ISpacesItemEntry<ISingleHandleItem> = {
     create: createSingleHandleItem(CollaborativeText.getFactory()),
     getView: getAdaptedViewForSingleHandleItem,
     friendlyName: "Text Box",
     fabricIconName: "Edit",
 };
 
-const prosemirrorItemEntry: ISpacesItemEntry<AsSerializable<ISingleHandleItem>> = {
+const prosemirrorItemEntry: ISpacesItemEntry<ISingleHandleItem> = {
     create: createSingleHandleItem(pmfe),
     getView: getAdaptedViewForSingleHandleItem,
     friendlyName: "Rich Text",
     fabricIconName: "FabricTextHighlight",
 };
 
-const sliderCoordinateItemEntry: ISpacesItemEntry<AsSerializable<ISingleHandleItem>> = {
+const sliderCoordinateItemEntry: ISpacesItemEntry<ISingleHandleItem> = {
     create: createSingleHandleItem(Coordinate.getFactory()),
     getView: getSliderCoordinateView,
     friendlyName: "Coordinate",

--- a/examples/apps/spaces/src/fluid-object/storage/spacesStorage.ts
+++ b/examples/apps/spaces/src/fluid-object/storage/spacesStorage.ts
@@ -9,7 +9,7 @@ import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
 import { IEvent } from "@fluidframework/common-definitions";
-import { AsSerializable } from "@fluidframework/datastore-definitions";
+import { Serializable } from "@fluidframework/datastore-definitions";
 import { Layout } from "react-grid-layout";
 import { v4 as uuid } from "uuid";
 import { ISpacesItem } from "../index";
@@ -21,13 +21,13 @@ export interface ISpacesStorage<T> extends EventEmitter {
     /**
      * The list of items being stored.
      */
-    readonly itemList: Map<string, ISpacesStoredItem<AsSerializable<T>>>;
+    readonly itemList: Map<string, ISpacesStoredItem<T>>;
     /**
      * Adds a item to the storage using the given data.
      * @param serializableItemData - The data of the item to add.
      * @returns A unique key corresponding to the added item.
      */
-    addItem(serializableItemData: AsSerializable<T>, layout?: Layout): string
+    addItem(serializableItemData: Serializable<T>, layout?: Layout): string
     /**
      * Removes the item specified by the given key.
      * @param key - The key referring to the item to remove.
@@ -45,7 +45,7 @@ export interface ISpacesStorage<T> extends EventEmitter {
  * Spaces collects serializable formats of items and stores them with grid-based layout information.
  */
 export interface ISpacesStoredItem<T> {
-    serializableItemData: AsSerializable<T>;
+    serializableItemData: Serializable<T>;
     layout: Layout;
 }
 
@@ -69,11 +69,11 @@ export class SpacesStorage extends DataObject implements ISpacesStorage<ISpacesI
         return SpacesStorage.factory;
     }
 
-    public get itemList(): Map<string, ISpacesStoredItem<AsSerializable<ISpacesItem>>> {
+    public get itemList(): Map<string, ISpacesStoredItem<ISpacesItem>> {
         return this.root;
     }
 
-    public addItem(serializableItemData: AsSerializable<ISpacesItem>, layout?: Layout): string {
+    public addItem(serializableItemData: Serializable<ISpacesItem>, layout?: Layout): string {
         const model: ISpacesStoredItem<ISpacesItem> = {
             serializableItemData,
             layout: layout ?? { x: 0, y: 0, w: 6, h: 2 },

--- a/examples/apps/spaces/src/fluid-object/storage/spacesStorageView.tsx
+++ b/examples/apps/spaces/src/fluid-object/storage/spacesStorageView.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AsSerializable } from "@fluidframework/datastore-definitions";
+import { Serializable } from "@fluidframework/datastore-definitions";
 
 import React from "react";
 import RGL, { WidthProvider, Layout } from "react-grid-layout";
@@ -89,8 +89,8 @@ const SpacesItemView: React.FC<ISpacesItemViewProps> =
     };
 
 // Stronger typing here maybe?
-interface ISpacesStorageViewProps<T = AsSerializable<any>> {
-    getViewForItem: (item: T) => Promise<JSX.Element | undefined>,
+interface ISpacesStorageViewProps<T = any> {
+    getViewForItem: (item: Serializable<T>) => Promise<JSX.Element | undefined>,
     getUrlForItem: (itemId: string) => string;
     storage: ISpacesStorage<T>;
     editable: boolean;
@@ -100,7 +100,7 @@ export const SpacesStorageView: React.FC<ISpacesStorageViewProps> =
     (props: React.PropsWithChildren<ISpacesStorageViewProps>) => {
         // Again stronger typing would be good
         const [itemMap, setItemMap] =
-            React.useState<Map<string, ISpacesStoredItem<AsSerializable<any>>>>(props.storage.itemList);
+            React.useState<Map<string, ISpacesStoredItem<any>>>(props.storage.itemList);
 
         React.useEffect(() => {
             const onItemListChanged = (newMap: Map<string, Layout>) => {

--- a/examples/data-objects/badge/src/Badge.types.ts
+++ b/examples/data-objects/badge/src/Badge.types.ts
@@ -6,7 +6,6 @@ import { IColor } from "office-ui-fabric-react";
 import { SharedCell } from "@fluidframework/cell";
 import { SharedMap } from "@fluidframework/map";
 import { SharedObjectSequence } from "@fluidframework/sequence";
-import { AsSerializable } from "@fluidframework/datastore-definitions";
 
 export interface IBadgeType {
     key: string;
@@ -21,11 +20,11 @@ export interface IBadgeIcon {
 }
 export interface IBadgeHistory {
     value: IBadgeType;
-    timestamp: Date;
+    timestamp: string;  // String encoded UTC timestamp in ISO format
 }
 
 export interface IBadgeModel {
-    currentCell: SharedCell<AsSerializable<IBadgeType>>;
+    currentCell: SharedCell<IBadgeType>;
     optionsMap: SharedMap;
     historySequence: SharedObjectSequence<IBadgeHistory>;
 }

--- a/examples/data-objects/badge/src/BadgeClient.tsx
+++ b/examples/data-objects/badge/src/BadgeClient.tsx
@@ -22,7 +22,7 @@ export const BadgeClient: React.FC<IBadgeClientProps> = ({ model }: IBadgeClient
             model.historySequence.insert(len, [
                 {
                     value: newItem,
-                    timestamp: new Date(),
+                    timestamp: new Date().toJSON(),
                 },
             ]);
             model.currentCell.set(newItem);

--- a/examples/data-objects/badge/src/BadgeModel.tsx
+++ b/examples/data-objects/badge/src/BadgeModel.tsx
@@ -10,13 +10,12 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedMap } from "@fluidframework/map";
 import { SharedObjectSequence } from "@fluidframework/sequence";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
-import { AsSerializable } from "@fluidframework/datastore-definitions";
 import { IBadgeModel, IBadgeHistory, IBadgeType } from "./Badge.types";
 import { defaultItems } from "./helpers";
 import { BadgeClient } from "./BadgeClient";
 
 export class Badge extends DataObject implements IBadgeModel, IFluidHTMLView {
-    private _currentCell: SharedCell<AsSerializable<IBadgeType>> | undefined;
+    private _currentCell: SharedCell<IBadgeType> | undefined;
     private _optionsMap: SharedMap | undefined;
     private _historySequence: SharedObjectSequence<IBadgeHistory> | undefined;
 
@@ -60,7 +59,7 @@ export class Badge extends DataObject implements IBadgeModel, IFluidHTMLView {
         const badgeHistory = SharedObjectSequence.create<IBadgeHistory>(this.runtime);
         badgeHistory.insert(0, [{
             value: current.get(),
-            timestamp: new Date(),
+            timestamp: new Date().toJSON(),
         }]);
         this.root.set(this.historyId, badgeHistory.handle);
     }

--- a/examples/data-objects/badge/src/helpers.ts
+++ b/examples/data-objects/badge/src/helpers.ts
@@ -124,10 +124,12 @@ export const getButtonStyles = (baseColor: string): IButtonStyles => {
     };
 };
 
-export const getRelativeDate = (timestamp: Date): string => {
+export const getRelativeDate = (timestamp: string): string => {
+    const date = new Date(timestamp);
+
     // https://stackoverflow.com/questions/7641791/javascript-library-for-human-friendly-relative-date-formatting
     const delta = Math.round(
-        (new Date().getTime() - new Date(timestamp).getTime()) / 1000,
+        (new Date().getTime() - date.getTime()) / 1000,
     );
 
     const minute = 60;
@@ -147,6 +149,6 @@ export const getRelativeDate = (timestamp: Date): string => {
     } else if (delta < day * 2) {
         return "yesterday";
     } else {
-        return timestamp.toUTCString();
+        return date.toUTCString();
     }
 };

--- a/examples/data-objects/table-document/src/slice.ts
+++ b/examples/data-objects/table-document/src/slice.ts
@@ -47,6 +47,8 @@ export class TableSlice extends DataObject<{}, ITableSliceConfig> implements ITa
 
     public getCellValue(row: number, col: number): TableDocumentItem {
         this.validateInSlice(row, col);
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this.doc.getCellValue(row, col);
     }
 

--- a/examples/data-objects/table-document/src/table.ts
+++ b/examples/data-objects/table-document/src/table.ts
@@ -3,18 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ICombiningOp, PropertySet } from "@fluidframework/merge-tree";
-import {
-    Jsonable,
-    JsonablePrimitive,
-} from "@fluidframework/datastore-definitions";
 
-export type TableDocumentItem = Jsonable<JsonablePrimitive | IFluidHandle>;
+export type TableDocumentItem = any;
 
 /**
  * @deprecated - ITable is an abandoned prototype.  Please use SharedMatrix with
- *               the IMatrixProducer/Consumer interfaces instead. */
+ *               the IMatrixProducer/Consumer interfaces instead.
+ */
 export interface ITable {
     readonly numRows: number;
     readonly numCols: number;

--- a/examples/data-objects/table-document/src/test/table.spec.ts
+++ b/examples/data-objects/table-document/src/test/table.spec.ts
@@ -50,7 +50,8 @@ describeLoaderCompat("TableDocument", (getTestObjectProvider) => {
 
     it("Initially empty", async () => {
         await expect([]);
-        assert.throws(() => tableDocument.getCellValue(0, 0));
+
+        assert.throws(() => { tableDocument.getCellValue(0, 0); });
     });
 
     it("Insert row", async () => {
@@ -140,10 +141,12 @@ describeLoaderCompat("TableDocument", (getTestObjectProvider) => {
             tableDocument.insertCols(0, 7);
 
             const slice = await tableDocument.createSlice(makeId("Table-Slice"), "unnamed-slice", 0, 0, 2, 2);
+            /* eslint-disable @typescript-eslint/no-unsafe-return */
             assert.throws(() => slice.getCellValue(-1, 0));
             assert.throws(() => slice.getCellValue(3, 0));
             assert.throws(() => slice.getCellValue(0, -1));
             assert.throws(() => slice.getCellValue(0, 3));
+            /* eslint-enable @typescript-eslint/no-unsafe-return */
         });
 
         it("Annotations work when proxied through table slice", async () => {

--- a/examples/data-objects/table-view/src/grid.ts
+++ b/examples/data-objects/table-view/src/grid.ts
@@ -106,6 +106,8 @@ export class GridView {
             get colCount() { return doc.numCols; },
             getCell: (row, col) => {
                 const raw = doc.getCellValue(row, col);
+
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
                 return typeof raw === "object"
                     ? undefined
                     : raw;

--- a/examples/data-objects/table-view/src/tableview.ts
+++ b/examples/data-objects/table-view/src/tableview.ts
@@ -108,6 +108,5 @@ const factory = new DataObjectFactory<TableView, undefined, undefined, IEvent>(
     [],
     {},
     [
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         [TableDocumentType, import("@fluid-example/table-document").then((m) => m.TableDocument.getFactory())],
     ]);

--- a/experimental/dds/tree/src/TreeNodeHandle.ts
+++ b/experimental/dds/tree/src/TreeNodeHandle.ts
@@ -26,6 +26,7 @@ export class TreeNodeHandle implements TreeNode<TreeNodeHandle> {
 	}
 
 	public get payload(): Payload | undefined {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return this.node.payload;
 	}
 

--- a/experimental/examples/bubblebench/sharedtree/src/proxy/tree.ts
+++ b/experimental/examples/bubblebench/sharedtree/src/proxy/tree.ts
@@ -15,6 +15,7 @@ import {
     TraitLabel,
 } from "@fluid-experimental/tree";
 import { IArrayish } from "@fluid-experimental/bubblebench-common";
+import { Serializable } from "@fluidframework/datastore-definitions";
 import { fromJson, NodeKind } from "./treeutils";
 
 function getChild(tree: SharedTree, nodeId: NodeId, update: (...change: Change[]) => void): unknown {
@@ -128,7 +129,7 @@ export class TreeArrayProxy<T> implements IArrayish<T> {
     toString(): string { return this.items.toString(); }
     toLocaleString(): string { return this.items.toLocaleString(); }
 
-    pop(): T | undefined {
+    pop(): Serializable<T> | undefined {
         const itemIds = this.itemIds;
         if (itemIds.length === 0) {
             return undefined;
@@ -137,10 +138,10 @@ export class TreeArrayProxy<T> implements IArrayish<T> {
         const removedId = itemIds[itemIds.length - 1];
         const removed = getChild(this.tree, removedId, this.update);
         this.update(Delete.create(StableRange.only(this.tree.currentView.getChangeNode(removedId))));
-        return removed as T;
+        return removed as Serializable<T>;
     }
 
-    push(...item: T[]): number {
+    push(...item: Serializable<T>[]): number {
         this.update(
             ...Insert.create(
                 item.map(fromJson), StablePlace.atEndOf({

--- a/experimental/examples/bubblebench/sharedtree/src/proxy/treeutils.ts
+++ b/experimental/examples/bubblebench/sharedtree/src/proxy/treeutils.ts
@@ -9,7 +9,7 @@ import {
     NodeId,
     TreeNode,
 } from "@fluid-experimental/tree";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Serializable } from "@fluidframework/datastore-definitions";
 
 export const enum NodeKind {
     scalar = "s",
@@ -20,7 +20,7 @@ export const enum NodeKind {
 export const nodeId = () => Math.random().toString(36).slice(2) as NodeId;
 
 // Helper for creating Scalar nodes in SharedTree
-export const makeScalar = (value: Jsonable): TreeNode<EditNode> => ({
+export const makeScalar = <T>(value: Serializable<T>): TreeNode<EditNode> => ({
     identifier: nodeId(),
     definition: NodeKind.scalar as Definition,
     traits: {},
@@ -29,7 +29,7 @@ export const makeScalar = (value: Jsonable): TreeNode<EditNode> => ({
 
 /* eslint-disable no-null/no-null */
 
-export function fromJson(value: Partial<Jsonable>): TreeNode<EditNode> {
+export function fromJson<T>(value: Serializable<T>): TreeNode<EditNode> {
     if (typeof value === "object") {
         if (Array.isArray(value)) {
             return {

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -97,7 +97,7 @@ const snapshotFileName = "header";
  * register for these events and respond appropriately as the data is modified. `valueChanged` will be emitted
  * in response to a `set`, and `delete` will be emitted in response to a `delete`.
  */
-export class SharedCell<T extends Serializable = any> extends SharedObject<ISharedCellEvents<T>>
+export class SharedCell<T = any> extends SharedObject<ISharedCellEvents<T>>
     implements ISharedCell<T> {
     /**
      * Create a new shared cell
@@ -121,7 +121,7 @@ export class SharedCell<T extends Serializable = any> extends SharedObject<IShar
     /**
      * The data held by this cell.
      */
-    private data: T | undefined;
+    private data: Serializable<T> | undefined;
 
     /**
      * This is used to assign a unique id to outgoing messages. It is used to track messages until
@@ -149,14 +149,14 @@ export class SharedCell<T extends Serializable = any> extends SharedObject<IShar
     /**
      * {@inheritDoc ISharedCell.get}
      */
-    public get() {
+    public get(): Serializable<T> | undefined {
         return this.data;
     }
 
     /**
      * {@inheritDoc ISharedCell.set}
      */
-    public set(value: T) {
+    public set(value: Serializable<T>) {
         if (SharedObject.is(value)) {
             throw new Error("SharedObject sets are no longer supported. Instead set the SharedObject handle.");
         }
@@ -309,7 +309,7 @@ export class SharedCell<T extends Serializable = any> extends SharedObject<IShar
         }
     }
 
-    private setCore(value: T) {
+    private setCore(value: Serializable<T>) {
         this.data = value;
         this.emit("valueChanged", value);
     }

--- a/packages/dds/cell/src/interfaces.ts
+++ b/packages/dds/cell/src/interfaces.ts
@@ -6,8 +6,8 @@
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 import { Serializable } from "@fluidframework/datastore-definitions";
 
-export interface ISharedCellEvents<T extends Serializable> extends ISharedObjectEvents {
-    (event: "valueChanged", listener: (value: T) => void);
+export interface ISharedCellEvents<T> extends ISharedObjectEvents {
+    (event: "valueChanged", listener: (value: Serializable<T>) => void);
     (event: "delete", listener: () => void);
 }
 
@@ -15,20 +15,20 @@ export interface ISharedCellEvents<T extends Serializable> extends ISharedObject
  * Shared cell interface
  */
 
-export interface ISharedCell<T extends Serializable = any> extends ISharedObject<ISharedCellEvents<T>> {
+export interface ISharedCell<T = any> extends ISharedObject<ISharedCellEvents<T>> {
     /**
      * Retrieves the cell value.
      *
      * @returns - the value of the cell
      */
-    get(): T | undefined;
+    get(): Serializable<T> | undefined;
 
     /**
      * Sets the cell value.
      *
      * @param value - a JSON-able or SharedObject value to set the cell to
      */
-    set(value: T): void;
+    set(value: Serializable<T>): void;
 
     /**
      * Checks whether cell is empty or not.

--- a/packages/dds/matrix/src/index.ts
+++ b/packages/dds/matrix/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { SharedMatrix } from "./matrix";
+export { SharedMatrix, MatrixItem } from "./matrix";
 export { SharedMatrixFactory } from "./runtime";
 
 // TODO: We temporarily duplicate these contracts from 'framework/undo-redo' to unblock development

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -53,7 +53,7 @@ interface ISetOp<T> {
     type: MatrixOp.set,
     row: number,
     col: number,
-    value: T,
+    value: MatrixItem<T>,
 }
 
 interface ISetOpMetadata {
@@ -61,6 +61,12 @@ interface ISetOpMetadata {
     colHandle: Handle,
     localSeq: number,
 }
+
+/**
+ * A matrix cell value may be undefined (indicating an empty cell) or any serializable type,
+ * excluding null.  (However, nulls may be embedded inside objects and arrays.)
+ */
+export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
 
 /**
  * A SharedMatrix holds a rectangular 2D array of values.  Supported operations
@@ -74,21 +80,21 @@ interface ISetOpMetadata {
  * prefetching when reading in either row or column major order.  (See README.md
  * for more details.)
  */
-export class SharedMatrix<T extends Serializable = Serializable>
+export class SharedMatrix<T = any>
     extends SharedObject
-    implements IMatrixProducer<T | undefined | null>,
-    IMatrixReader<T | undefined | null>,
-    IMatrixWriter<T | undefined>
+    implements IMatrixProducer<MatrixItem<T>>,
+    IMatrixReader<MatrixItem<T>>,
+    IMatrixWriter<MatrixItem<T>>
 {
-    private readonly consumers = new Set<IMatrixConsumer<T | undefined | null>>();
+    private readonly consumers = new Set<IMatrixConsumer<MatrixItem<T>>>();
 
     public static getFactory() { return new SharedMatrixFactory(); }
 
     private readonly rows: PermutationVector;   // Map logical row to storage handle (if any)
     private readonly cols: PermutationVector;   // Map logical col to storage handle (if any)
 
-    private cells = new SparseArray2D<T>();         // Stores cell values.
-    private pending = new SparseArray2D<number>();  // Tracks pending writes.
+    private cells = new SparseArray2D<MatrixItem<T>>();     // Stores cell values.
+    private pending = new SparseArray2D<number>();          // Tracks pending writes.
 
     constructor(runtime: IFluidDataStoreRuntime, public id: string, attributes: IChannelAttributes) {
         super(id, runtime, attributes);
@@ -108,7 +114,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
             this.onColHandlesRecycled);
     }
 
-    private undo?: MatrixUndoProvider;
+    private undo?: MatrixUndoProvider<T>;
 
     /**
      * Subscribes the given IUndoConsumer to the matrix.
@@ -128,18 +134,20 @@ export class SharedMatrix<T extends Serializable = Serializable>
     /**
      * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
      */
-    public static create<T extends Serializable = Serializable>(runtime: IFluidDataStoreRuntime, id?: string) {
+    public static create<T>(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SharedMatrixFactory.Type) as SharedMatrix<T>;
     }
 
     // #region IMatrixProducer
 
-    openMatrix(consumer: IMatrixConsumer<T | undefined | null>): IMatrixReader<T | undefined | null> {
+    openMatrix(
+        consumer: IMatrixConsumer<MatrixItem<T>>,
+    ): IMatrixReader<MatrixItem<T>> {
         this.consumers.add(consumer);
         return this;
     }
 
-    closeMatrix(consumer: IMatrixConsumer<T | undefined | null>): void {
+    closeMatrix(consumer: IMatrixConsumer<MatrixItem<T>>): void {
         this.consumers.delete(consumer);
     }
 
@@ -150,7 +158,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
     public get rowCount() { return this.rows.getLength(); }
     public get colCount() { return this.cols.getLength(); }
 
-    public getCell(row: number, col: number): T | undefined | null {
+    public getCell(row: number, col: number): MatrixItem<T> {
         // Perf: When possible, bounds checking is performed inside the implementation for
         //       'getHandle()' so that it can be elided in the case of a cache hit.  This
         //       yields an ~40% improvement in the case of a cache hit (node v12 x64)
@@ -171,11 +179,11 @@ export class SharedMatrix<T extends Serializable = Serializable>
         return undefined;
     }
 
-    public get matrixProducer(): IMatrixProducer<T | undefined | null> { return this; }
+    public get matrixProducer(): IMatrixProducer<MatrixItem<T>> { return this; }
 
     // #endregion IMatrixReader
 
-    public setCell(row: number, col: number, value: T) {
+    public setCell(row: number, col: number, value: MatrixItem<T>) {
         assert(0 <= row && row < this.rowCount
             && 0 <= col && col < this.colCount,
             0x01a /* "Trying to set out-of-bounds cell!" */);
@@ -188,7 +196,12 @@ export class SharedMatrix<T extends Serializable = Serializable>
         }
     }
 
-    public setCells(rowStart: number, colStart: number, colCount: number, values: readonly T[]) {
+    public setCells(
+        rowStart: number,
+        colStart: number,
+        colCount: number,
+        values: readonly (MatrixItem<T>)[],
+    ) {
         const rowCount = Math.ceil(values.length / colCount);
 
         assert((0 <= rowStart && rowStart < this.rowCount)
@@ -219,15 +232,22 @@ export class SharedMatrix<T extends Serializable = Serializable>
     private setCellCore(
         row: number,
         col: number,
-        value: T,
+        value: MatrixItem<T>,
         rowHandle = this.rows.getAllocatedHandle(row),
         colHandle = this.cols.getAllocatedHandle(col),
     ) {
         if (this.undo !== undefined) {
+            let oldValue = this.cells.getCell(rowHandle, colHandle);
+
+            // eslint-disable-next-line no-null/no-null
+            if (oldValue === null) {
+                oldValue = undefined;
+            }
+
             this.undo.cellSet(
                 rowHandle,
                 colHandle,
-                /* oldvalue: */ this.cells.getCell(rowHandle, colHandle));
+                oldValue);
         }
 
         this.cells.setCell(rowHandle, colHandle, value);
@@ -240,7 +260,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
     private sendSetCellOp(
         row: number,
         col: number,
-        value: T,
+        value: MatrixItem<T>,
         rowHandle: Handle,
         colHandle: Handle,
         localSeq = this.nextLocalSeq(),
@@ -522,7 +542,7 @@ export class SharedMatrix<T extends Serializable = Serializable>
             default: {
                 assert(content.type === MatrixOp.set, 0x020 /* "Unknown SharedMatrix 'op' type." */);
 
-                const setOp = content as ISetOp<T>;
+                const setOp = content as ISetOp<Serializable<T>>;
                 const { rowHandle, colHandle, localSeq } = localOpMetadata as ISetOpMetadata;
 
                 // If there are more pending local writes to the same row/col handle, it is important

--- a/packages/dds/matrix/src/sparsearray2d.ts
+++ b/packages/dds/matrix/src/sparsearray2d.ts
@@ -42,6 +42,7 @@ const r0c0ToMorton2x16 = (row: number, col: number) => (r0ToMorton16(row) | c0To
 type RecurArrayHelper<T> = RecurArray<T> | T;
 type RecurArray<T> = RecurArrayHelper<T>[];
 
+/** Undo JSON serialization's coercion of 'undefined' to null. */
 const nullToUndefined = <T>(array: RecurArray<T | null>): RecurArray<T | undefined> => array.map((value) => {
     // eslint-disable-next-line no-null/no-null
     return value === null
@@ -56,13 +57,13 @@ type UA<T> = (T | undefined)[];
 /**
  * A sparse 4 billion x 4 billion array stored as 16x16 tiles.
  */
-export class SparseArray2D<T> implements IMatrixReader<T | undefined | null>, IMatrixWriter<T | undefined> {
+export class SparseArray2D<T> implements IMatrixReader<T | undefined>, IMatrixWriter<T | undefined> {
     constructor(private readonly root: UA<UA<UA<UA<UA<T>>>>> = [undefined]) { }
 
     public get rowCount() { return 0xFFFFFFFF; }
     public get colCount() { return 0xFFFFFFFF; }
 
-    public getCell(row: number, col: number): T | undefined | null {
+    public getCell(row: number, col: number): T | undefined {
         const keyHi = r0c0ToMorton2x16(row >>> 16, col >>> 16);
         const level0 = this.root[keyHi];
         if (level0 !== undefined) {

--- a/packages/dds/matrix/src/test/matrix.big.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.big.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IChannelServices, Serializable } from "@fluidframework/datastore-definitions";
+import { IChannelServices } from "@fluidframework/datastore-definitions";
 import {
     MockFluidDataStoreRuntime,
     MockContainerRuntimeFactory,
@@ -21,7 +21,7 @@ const enum Const {
 
 // Summarizes the given `SharedMatrix`, loads the summary into a 2nd SharedMatrix, vets that the two are
 // equivalent, and then returns the 2nd matrix.
-async function summarize<T extends Serializable>(matrix: SharedMatrix<T>) {
+async function summarize<T>(matrix: SharedMatrix<T>) {
     // Create a summary
     const objectStorage = MockStorage.createFromSummary(matrix.summarize().summary);
 

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { Serializable } from "@fluidframework/datastore-definitions";
 import { IGCTestProvider, runGCTests } from "@fluid-internal/test-dds-utils";
 import {
     MockFluidDataStoreRuntime,
@@ -16,7 +15,7 @@ import {
     MockHandle,
 } from "@fluidframework/test-runtime-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { SharedMatrix, SharedMatrixFactory } from "..";
+import { MatrixItem, SharedMatrix, SharedMatrixFactory } from "..";
 import { fill, check, insertFragmented, extract, expectSize } from "./utils";
 import { TestConsumer } from "./testconsumer";
 
@@ -59,7 +58,7 @@ describe("Matrix", () => {
 
         // Summarizes the given `SharedMatrix`, loads the summarize into a 2nd SharedMatrix, vets that the two are
         // equivalent, and then returns the 2nd matrix.
-        async function summarize<T extends Serializable>(matrix: SharedMatrix<T>) {
+        async function summarize<T>(matrix: SharedMatrix<T>) {
             // Create a summary
             const objectStorage = MockStorage.createFromSummary(matrix.summarize().summary);
 
@@ -81,7 +80,7 @@ describe("Matrix", () => {
             return matrix2;
         }
 
-        async function expect<T extends Serializable>(expected: readonly (readonly T[])[]) {
+        async function expect<T>(expected: readonly (readonly (MatrixItem<T>)[])[]) {
             const actual = extract(matrix);
             assert.deepEqual(actual, expected, "Matrix must match expected.");
             assert.deepEqual(extract(consumer), actual, "Matrix must notify IMatrixConsumers of all changes.");

--- a/packages/dds/matrix/src/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.undo.spec.ts
@@ -4,14 +4,13 @@
  */
 
 import { strict as assert } from "assert";
-import { Serializable } from "@fluidframework/datastore-definitions";
 import {
     MockFluidDataStoreRuntime,
     MockEmptyDeltaConnection,
     MockStorage,
     MockContainerRuntimeFactory,
 } from "@fluidframework/test-runtime-utils";
-import { SharedMatrix, SharedMatrixFactory } from "..";
+import { MatrixItem, SharedMatrix, SharedMatrixFactory } from "..";
 import { extract, expectSize } from "./utils";
 import { TestConsumer } from "./testconsumer";
 import { UndoRedoStackManager } from "./undoRedoStackManager";
@@ -23,7 +22,7 @@ describe("Matrix", () => {
         // Test IMatrixConsumer that builds a copy of `matrix` via observed events.
         let consumer1: TestConsumer<undefined | null | number>;
         let undo1: UndoRedoStackManager;
-        let expect: <T extends Serializable>(expected: readonly (readonly T[])[]) => Promise<void>;
+        let expect: <T>(expected: readonly (readonly (MatrixItem<T>)[])[]) => Promise<void>;
 
         function singleClientTests() {
             it("undo/redo setCell", async () => {
@@ -436,7 +435,7 @@ describe("Matrix", () => {
         describe("local client", () => {
             // Summarizes the given `SharedMatrix`, loads the summary into a 2nd SharedMatrix, vets that the two are
             // equivalent, and then returns the 2nd matrix.
-            async function summarize<T extends Serializable>(matrix: SharedMatrix<T>) {
+            async function summarize<T>(matrix: SharedMatrix<T>) {
                 // Create a summay
                 const objectStorage = MockStorage.createFromSummary(matrix.summarize().summary);
 
@@ -467,7 +466,7 @@ describe("Matrix", () => {
             }
 
             before(() => {
-                expect = async <T extends Serializable>(expected: readonly (readonly T[])[]) => {
+                expect = async <T>(expected: readonly (readonly (MatrixItem<T>)[])[]) => {
                     const actual = extract(matrix1);
                     assert.deepEqual(actual, expected, "Matrix must match expected.");
                     assert.deepEqual(extract(consumer1), actual, "Matrix must notify IMatrixConsumers of all changes.");

--- a/packages/dds/matrix/src/test/sparsearray2d.spec.ts
+++ b/packages/dds/matrix/src/test/sparsearray2d.spec.ts
@@ -4,11 +4,10 @@
  */
 
 import { strict as assert } from "assert";
-import { Serializable } from "@fluidframework/datastore-definitions";
 import { SparseArray2D } from "../sparsearray2d";
 import { fill, check, extract } from "./utils";
 
-function expectEqual<T extends Serializable>(
+function expectEqual<T>(
     actual: SparseArray2D<T>,
     expected: SparseArray2D<T>,
     rowStart: number,
@@ -98,12 +97,12 @@ describe("SparseArray2D", () => {
                 : "";
 
             it(`${rowClearRange}${colClearRange} (filled: ${fillRange})`, () => {
-                const actual = new SparseArray2D<Serializable>();
+                const actual = new SparseArray2D();
                 fill(actual, rowStart, colStart, rowCount, colCount);
                 actual.clearRows(rowClearStart, rowClearCount);
                 actual.clearCols(colClearStart, colClearCount);
 
-                const expected = new SparseArray2D<Serializable>();
+                const expected = new SparseArray2D();
                 fill(expected, rowStart, colStart, rowCount, colCount);
 
                 for (let row = rowClearStart; row < rowClearStart + rowClearCount; row++) {

--- a/packages/dds/matrix/src/test/testconsumer.ts
+++ b/packages/dds/matrix/src/test/testconsumer.ts
@@ -5,7 +5,7 @@
 
 import { IMatrixConsumer, IMatrixReader, IMatrixProducer } from "@tiny-calc/nano";
 import { DenseVector, RowMajorMatrix } from "@tiny-calc/micro";
-import { Serializable } from "@fluidframework/datastore-definitions";
+import { MatrixItem } from "..";
 
 /**
  * IMatrixConsumer implementation that applies change notifications to it's own
@@ -14,13 +14,16 @@ import { Serializable } from "@fluidframework/datastore-definitions";
  * Comparing the state of the TestConsumer with the original IMatrixProducer is a
  * convenient way to vet that the producer is emitting the correct change notifications.
  */
-export class TestConsumer<T extends Serializable = Serializable> implements IMatrixConsumer<T>, IMatrixReader<T> {
+export class TestConsumer<T = any> implements
+    IMatrixConsumer<MatrixItem<T>>,
+    IMatrixReader<MatrixItem<T>>
+{
     private readonly rows: DenseVector<void> = new DenseVector<void>();
     private readonly cols: DenseVector<void> = new DenseVector<void>();
-    private readonly actual: RowMajorMatrix<T> = new RowMajorMatrix<T>(this.rows, this.cols);
-    private readonly expected: IMatrixReader<T>;
+    private readonly actual: RowMajorMatrix<MatrixItem<T>> = new RowMajorMatrix(this.rows, this.cols);
+    private readonly expected: IMatrixReader<MatrixItem<T>>;
 
-    constructor(producer: IMatrixProducer<T>) {
+    constructor(producer: IMatrixProducer<MatrixItem<T>>) {
         this.expected = producer.openMatrix(this);
 
         this.rows.splice(/* start: */ 0, /* deleteCount: */ 0, /* insertCount: */ this.expected.rowCount);
@@ -84,7 +87,7 @@ export class TestConsumer<T extends Serializable = Serializable> implements IMat
 
     // #region IMatrixReader
 
-    getCell(row: number, col: number): T {
+    getCell(row: number, col: number): MatrixItem<T> {
         return this.expected.getCell(row, col);
     }
 

--- a/packages/dds/matrix/src/test/utils.ts
+++ b/packages/dds/matrix/src/test/utils.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "assert";
 import { IMatrixProducer, IMatrixReader, IMatrixConsumer, IMatrixWriter } from "@tiny-calc/nano";
-import { Serializable } from "@fluidframework/datastore-definitions";
 import { SharedMatrix } from "..";
 
 export type IMatrix<T> = IMatrixReader<T> & IMatrixWriter<T>;
@@ -119,7 +118,7 @@ function withReader<TCells, TResult>(
  * Extracts the contents of the given `matrix` as a jagged 2D array.  This is convenient for
  * comparing matrices via `assert.deepEqual()`.
  */
-export const extract = <T extends Serializable>(
+export const extract = <T>(
     matrix: IMatrixReader<T> | IMatrixProducer<T>,
     rowStart = 0,
     colStart = 0,
@@ -146,7 +145,7 @@ export const extract = <T extends Serializable>(
  * Asserts that given `matrix` has the specified dimensions.  This is useful for distinguishing
  * between variants of empty matrices (zero rows vs. zero cols vs. zero rows and zero cols).
  */
-export function expectSize<T extends Serializable>(
+export function expectSize<T>(
     matrix: IMatrixReader<T> | IMatrixProducer<T>,
     rowCount: number,
     colCount: number,

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -4,9 +4,8 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { Serializable } from "@fluidframework/datastore-definitions";
 import { TrackingGroup, MergeTreeDeltaOperationType, MergeTreeDeltaType } from "@fluidframework/merge-tree";
-import { SharedMatrix } from "./matrix";
+import { MatrixItem, SharedMatrix } from "./matrix";
 import { Handle, isHandleValid } from "./handletable";
 import { PermutationSegment, PermutationVector } from "./permutationvector";
 import { IUndoConsumer } from "./types";
@@ -108,7 +107,7 @@ export class VectorUndoProvider {
     }
 }
 
-export class MatrixUndoProvider<T extends Serializable = Serializable> {
+export class MatrixUndoProvider<T> {
     constructor(
         private readonly consumer: IUndoConsumer,
         private readonly matrix: SharedMatrix<T>,
@@ -137,7 +136,7 @@ export class MatrixUndoProvider<T extends Serializable = Serializable> {
         );
     }
 
-    cellSet(rowHandle: Handle, colHandle: Handle, oldValue: T) {
+    cellSet(rowHandle: Handle, colHandle: Handle, oldValue: MatrixItem<T>) {
         assert(isHandleValid(rowHandle) && isHandleValid(colHandle),
             0x02c /* "On cellSet(), invalid row and/or column handles!" */);
 

--- a/packages/dds/sequence/src/sharedObjectSequence.ts
+++ b/packages/dds/sequence/src/sharedObjectSequence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidDataStoreRuntime, IChannelAttributes } from "@fluidframework/datastore-definitions";
+import { IFluidDataStoreRuntime, IChannelAttributes, Serializable } from "@fluidframework/datastore-definitions";
 import { SharedObjectSequenceFactory } from "./sequenceFactory";
 import { SharedSequence } from "./sharedSequence";
 
@@ -39,7 +39,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
         super(document, id, attributes, SharedObjectSequenceFactory.segmentFromSpec);
     }
 
-    public getRange(start: number, end?: number) {
+    public getRange(start: number, end?: number): Serializable<T>[] {
         return this.getItems(start, end);
     }
 }

--- a/packages/dds/sequence/src/sparsematrix.ts
+++ b/packages/dds/sequence/src/sparsematrix.ts
@@ -9,16 +9,16 @@ import {
     createGroupOp,
     IJSONSegment,
     ISegment,
-    PropertySet,
     LocalReferenceCollection,
+    PropertySet,
 } from "@fluidframework/merge-tree";
 import {
     IChannelAttributes,
     IFluidDataStoreRuntime,
     IChannelServices,
-    Jsonable,
-    JsonablePrimitive,
     IChannelFactory,
+    Serializable,
+    Jsonable,
 } from "@fluidframework/datastore-definitions";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 import { pkgVersion } from "./packageVersion";
@@ -93,7 +93,7 @@ export class PaddingSegment extends BaseSegment {
     }
 }
 
-export type SparseMatrixItem = Jsonable<JsonablePrimitive | IFluidHandle>;
+export type SparseMatrixItem = Serializable;
 export class RunSegment extends SubSequence<SparseMatrixItem> {
     public static readonly typeString = "RunSegment";
     public static is(segment: ISegment): segment is RunSegment {
@@ -192,7 +192,7 @@ export function positionToRowCol(position: number) {
 /**
  * @deprecated - SparseMatrix is an abandoned prototype.  Please use SharedMatrix instead.
  */
- export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
+export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     /**
      * Create a new sparse matrix
      *
@@ -245,6 +245,7 @@ export function positionToRowCol(position: number) {
         const { segment, offset } =
             this.getContainingSegment(pos);
         if (RunSegment.is(segment)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             return segment.items[offset];
         } else if (PaddingSegment.is(segment)) {
             return undefined;

--- a/packages/dds/sequence/src/test/subSequence.spec.ts
+++ b/packages/dds/sequence/src/test/subSequence.spec.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { Serializable } from "@fluidframework/datastore-definitions";
 import { createInsertSegmentOp, createRemoveRangeOp, PropertySet } from "@fluidframework/merge-tree";
 // eslint-disable-next-line import/no-internal-modules
 import { TestClient } from "@fluidframework/merge-tree/dist/test";
@@ -19,7 +20,7 @@ class SubSequenceTestClient extends TestClient {
 
     public insertItemsRemote<T>(
         pos: number,
-        items: T[],
+        items: Serializable<T>[],
         props: PropertySet,
         seq: number,
         refSeq: number,

--- a/packages/dds/shared-summary-block/src/interfaces.ts
+++ b/packages/dds/shared-summary-block/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AsJsonable, Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/datastore-definitions";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 
 /**
@@ -18,12 +18,12 @@ export interface ISharedSummaryBlock extends ISharedObject {
      * @param key - Key to retrieve from.
      * @returns The stored value, or undefined if the key is not set.
      */
-    get<T = Jsonable>(key: string): T;
+    get<T>(key: string): Jsonable<T>;
 
     /**
      * Sets the value stored at key to the provided value.
      * @param key - Key to set at.
      * @param value - Jsonable type value to set.
      */
-    set<T>(key: string, value: AsJsonable<T>): void;
+    set<T>(key: string, value: Jsonable<T>): void;
 }

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -15,7 +15,6 @@ import {
     IFluidDataStoreRuntime,
     IChannelStorageService,
     Jsonable,
-    AsJsonable,
     IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
@@ -80,16 +79,14 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
     /**
      * {@inheritDoc ISharedSummaryBlock.get}
      */
-    public get<T = Jsonable>(key: string): T {
-        // The cast to unknown is needed because of a limitation in TypeScript where an interface cannot be cast to
-        // Jsonable: https://github.com/Microsoft/TypeScript/issues/15300
-        return this.data.get(key) as unknown as T;
+    public get<T>(key: string): Jsonable<T> {
+        return this.data.get(key) as Jsonable<T>;
     }
 
     /**
      * {@inheritDoc ISharedSummaryBlock.set}
      */
-    public set<T extends any = Jsonable>(key: string, value: AsJsonable<T>): void {
+    public set<T>(key: string, value: Jsonable<T>): void {
         this.data.set(key, value);
         // Set this object as dirty so that it is part of the next summary.
         this.dirty();

--- a/packages/runtime/datastore-definitions/src/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/jsonable.ts
@@ -3,64 +3,35 @@
  * Licensed under the MIT License.
  */
 
-export type JsonablePrimitive = undefined | null | boolean | number | string;
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type JsonableObject<T> = {
-    [key: string]: Jsonable<T>
-    [key: number]: Jsonable<T>
-};
-
-export type JsonableArray<T> = Jsonable<T>[];
-
 /**
- * Used to constrain a value to types that are serializable as JSON.  The `T` type parameter may be used to
- * customize the type of the leaves to support situations where a `replacer` is used to handle special values.
- * (e.g., `Json<JsonPrimitive | IFluidHandle>`)
+ * Used to constrain a type 'T' to types that are JSON serializable as JSON.  Produces an
+ * error if `T` contains non-Jsonable members.
  *
- * Note that the Json type does not protect against the following pitfalls when serializing `undefined` and
- * non-finite numbers:
+ * Typical usage:
+ * ```ts
+ *      function foo<T>(value: Jsonable<T>) { ... }
+ * ```
+ *
+ * Important: `T extends Jsonable<T>` is a *superset* of `Jsonable<T>` and usually incorrect.
+ *
+ * The optional 'TReplaced' parameter may be used to permit additional leaf types to support
+ * situations where a `replacer` is used to handle special values (e.g., `Jsonable<{ x: IFluidHandle }, IFluidHandle>`).
+ *
+ * Note that the Jsonable type does not protect against the following pitfalls when serializing
+ * `undefined` and non-finite numbers:
  *
  *  - `undefined` properties on objects are omitted (i.e., properties become undefined instead of equal to undefined).
  *  - When `undefined` appears as the root object or as an array element it is coerced to `null`.
  *  - Non-finite numbers (`NaN`, `+/-Infinity`) are also coerced to `null`.
- *  - (`null` always serializes as `null`.)
  */
-export type Jsonable<T = JsonablePrimitive> = T | JsonableArray<T> | JsonableObject<T>;
-
-/**
- * Take a type, usually an interface and tries to map it to a compatible jsonable type.
- * This is basically taking advantage of duck typing. We are generating a type we know
- * is jsonable from the input type, but setting anything not serializable to never,
- * which will cause compile time issues with objects of the original type if they
- * have properties that are not jsonable.
- *
- * The usage looks like `foo<T>(input: AsJsonable<T>)`
- *
- * if T isn't jsonable then all values of input will be invalid,
- * as all the properties will need to be never which isn't possible.
- *
- * This won't be fool proof, but if someone modifies a type used in an
- * AsJsonable to add a property that isn't Jsonable, they should get a compile time
- * break, which is pretty good.
- *
- * What this type does:
- * If T is Jsonable<J>
- *      return T
- *      Else if f T is not a function,
- *          For each property K of T recursively
- *              if property K is not a symbol
- *                  return AsJsonable of the property
- *                  Else return never
- *          Else return never
- */
-export type AsJsonable<T, J = JsonablePrimitive> =
-    T extends Jsonable<J> ?
-    T :
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    Extract<T, Function> extends never ?
-    { [K in keyof T]: Extract<K, symbol> extends never ?
-        AsJsonable<T[K], J> :
-        never
-    } :
-    never;
+export type Jsonable<T = any, TReplaced = void> =
+    T extends undefined | null | boolean | number | string | TReplaced
+        ? T
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        : Extract<T, Function> extends never
+            ? {
+                [K in keyof T]: Extract<K, symbol> extends never
+                    ? Jsonable<T[K], TReplaced>
+                    : never
+            }
+            : never;

--- a/packages/runtime/datastore-definitions/src/serializable.ts
+++ b/packages/runtime/datastore-definitions/src/serializable.ts
@@ -4,16 +4,19 @@
  */
 
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { AsJsonable, Jsonable, JsonablePrimitive } from "./jsonable";
+import { Jsonable } from "./jsonable";
 
 /**
- * A union of the types that Fluid can intrinsically serialize, which is any type is that is
- * Json serializable + Json serializable objects/arrays with IFluidHandles at the leaves.
+ * Used to constrain a type 'T' to types that Fluid can intrinsically serialize.  Produces an
+ * error if `T` contains non-Jsonable members.
  *
- * Convenient when declaring type constraints, such as `<T extends Serializable>`.
+ * Typical usage:
+ * ```ts
+ *      function serialize<T>(value: Serializable<T>) { ... }
+ * ```
+ *
+ * Important: `T extends Serializable<T>` is a *superset* of `Serializable<T>` and almost always incorrect.
  *
  * (See Jsonable for caveats regarding serialization of `undefined` and non-finite numbers.)
  */
-export type Serializable = Jsonable<JsonablePrimitive | IFluidHandle>;
-
-export type AsSerializable<T> = AsJsonable<T, JsonablePrimitive | IFluidHandle>;
+export type Serializable<T = any> = Jsonable<T, IFluidHandle>;

--- a/packages/runtime/datastore-definitions/test-d/jsonable.test-d.ts
+++ b/packages/runtime/datastore-definitions/test-d/jsonable.test-d.ts
@@ -4,9 +4,9 @@
  */
 
 import {expectError} from 'tsd';
-import { Jsonable, AsJsonable } from '../dist/jsonable';
+import { Jsonable } from '../dist/jsonable';
 
-declare function foo<T>(a: AsJsonable<T>): void;
+declare function foo<T>(a: Jsonable<T>): void;
 
 // --- ideally wouldn't work but do as we don't know how to just exclude classes
 

--- a/packages/runtime/runtime-utils/src/test/utils.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { IFluidHandleContext, IRequest } from "@fluidframework/core-interfaces";
+import { Serializable } from "@fluidframework/datastore-definitions";
 import { create404Response } from "../dataStoreHelpers";
 
 export class MockHandleContext implements IFluidHandleContext {
@@ -27,10 +28,9 @@ export class MockHandleContext implements IFluidHandleContext {
  * Creates a Jsonable object graph of a specified breadth/depth.  The 'createLeaf' callback
  * is a factory that is invoked to create the leaves of the graph.
  */
-export function makeJson(breadth: number, depth: number, createLeaf: () => any) {
+export function makeJson<T>(breadth: number, depth: number, createLeaf: () => Serializable<T>) {
     let depthInternal = depth;
     if (--depthInternal === 0) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return createLeaf();
     }
 


### PR DESCRIPTION
This is the same change as draft #5681, slightly scaled back to reduce noise, plus incorporating some feedback from @anthony-murphy.

The changes are:
* The flawed Jsonable and Serializable types are removed.
* The useful AsJsonable and AsSerializable types have been renamed Jsonable<T> and Serializable<T>.

Separately, I went ahead and converted Map's get/set/wait to Serializable<T>.  Doing so uncovered a second place we were passing storing non-serializable types in a SharedMap.  With two legit bugs and zero false positives, I'm pretty sold on the new Serializable<T> at this point.

(However, if I'm wrong, we can always go with plan B of using 'any', since making the API more permissive is a non-breaking change.)

@CraigMacomber - FYI.