### PR TITLE
VS Code: Fix Ctrl-Shift-B

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,11 @@
     "typescript.format.placeOpenBraceOnNewLineForFunctions": false,
     "typescript.format.placeOpenBraceOnNewLineForControlBlocks": false,
     "typescript.tsdk": "node_modules/typescript/lib",
+
+    // Autodetecting TSC tasks on a repo this size makes 'Tasks: Run Build Task' unusably slow.
+    // (See https://github.com/Microsoft/vscode/issues/34387)
+    "typescript.tsc.autoDetect": "off",
+
     "files.associations": {
         "tools/pipelines/*.yml": "azure-pipelines"
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,11 +13,14 @@
                 "${workspaceRoot}",
                 "--vscode"
             ],
-            "group": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": [
                 {
                     "base": "$tsc",
-                    "fileLocation": "absolute",
+                    "fileLocation": "absolute"
                 },
                 "$tslint5"
             ]
@@ -41,7 +44,7 @@
             "problemMatcher": [
                 {
                     "base": "$tsc",
-                    "fileLocation": "absolute",
+                    "fileLocation": "absolute"
                 },
                 "$tslint5"
             ]


### PR DESCRIPTION
Two fixes:
1. Makes 'fluid-build' the default build task (makes Ctrl-Shift-B work)
2. Disables autogenerating VS Code tasks from TypeScript files (avoids long delay when invoking build task).
