### PR TITLE
fix: Port changes from #5962 to common-definitions 0.20

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-definitions",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-definitions",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Fluid common definitions",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",


### PR DESCRIPTION
Port tagging changes (which are backward-compatible) to common-definitions 0.20 - to be then released in patch 0.20.1.