### PR TITLE
Build: Fix incremental build (#6068)

### DIFF
--- a/tools/build-tools/src/fluidBuild/tscUtils.ts
+++ b/tools/build-tools/src/fluidBuild/tscUtils.ts
@@ -12,13 +12,26 @@ export const findConfigFile = defaultTscUtil.findConfigFile;
 export const readConfigFile = defaultTscUtil.readConfigFile;
 
 export function convertToOptionsWithAbsolutePath(options: ts.CompilerOptions, cwd: string) {
+    // Shallow clone 'CompilerOptions' before modifying.
     const result = { ...options };
-    for (const key of ["configFilePath", "declarationDir", "outDir", "rootDir", "project"]) {
+
+    // Expand 'string' properties that potentially contain relative paths.
+    for (const key of ["baseUrl", "configFilePath", "declarationDir", "outDir", "rootDir", "project"]) {
         const value = result[key] as string;
         if (value !== undefined) {
             result[key] = path.resolve(cwd, value);
         }
     }
+
+    // Expand 'string[]' properties that potentially contain relative paths.
+    for (const key of ["typeRoots"]) {
+        const value = result[key] as string[];
+        if (value !== undefined) {
+            // Note that this also shallow clones the array.
+            result[key] = value.map((relative) => path.resolve(cwd, relative));
+        }
+    }
+
     return result;
 }
 


### PR DESCRIPTION
As part of the algorithm for determining if TSC needs to be invoked, Fluid-Build compares the project's *.tsconfig file with the compiler options cached in the *.tsbuildinfo file.

When doing this comparison, Fluid-Build has a hardcoded list of compiler options that contain paths that must be expanded to absolute paths.

This change expands that hardcoded list to include a couple of compiler options that have recently come into use.