### PR TITLE
Expose auth/connection helpers from OdspTestDriver

### DIFF
--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -30,9 +30,9 @@ export interface IOdspTestLoginInfo {
     password: string;
 }
 
-type TokenConfig = IOdspTestLoginInfo & IClientConfig;
+export type TokenConfig = IOdspTestLoginInfo & IClientConfig;
 
-interface IOdspTestDriverConfig extends TokenConfig {
+export interface IOdspTestDriverConfig extends TokenConfig {
     directory: string;
     driveId: string;
     options: HostStoragePolicy | undefined
@@ -130,7 +130,7 @@ export class OdspTestDriver implements ITestDriver {
     public get version() { return this.api.version; }
     private readonly testIdToUrl = new Map<string, string>();
     private constructor(
-        private readonly config: Readonly<IOdspTestDriverConfig>,
+        public readonly config: Readonly<IOdspTestDriverConfig>,
         private readonly api = OdspDriverApi) { }
 
     async createContainerUrl(testId: string): Promise<string> {
@@ -161,8 +161,8 @@ export class OdspTestDriver implements ITestDriver {
 
     createDocumentServiceFactory(): IDocumentServiceFactory {
         return new this.api.OdspDocumentServiceFactory(
-            this.getStorageToken.bind(this),
-            this.getPushToken.bind(this),
+            this.getStorageToken,
+            this.getPushToken,
             undefined,
             this.config.options,
         );
@@ -180,10 +180,10 @@ export class OdspTestDriver implements ITestDriver {
         );
     }
 
-    private async getStorageToken(options: OdspResourceTokenFetchOptions) {
+    public readonly getStorageToken = async (options: OdspResourceTokenFetchOptions) => {
         return OdspTestDriver.getStorageToken(options, this.config);
-    }
-    private async getPushToken(options: OdspResourceTokenFetchOptions) {
+    };
+    public readonly getPushToken = async (options: OdspResourceTokenFetchOptions) => {
         const tokens = await OdspTestDriver.odspTokenManager.getPushTokens(
             new URL(options.siteUrl).hostname,
             this.config,
@@ -192,5 +192,5 @@ export class OdspTestDriver implements ITestDriver {
         );
 
         return tokens.accessToken;
-    }
+    };
 }


### PR DESCRIPTION
Expose some functionality from OdspTestDriver to facilitate reusing it in automation targeting Odsp outside the main repo, specifically FluidM365Integration repo..

odsp-client/m365-utils project's existing entry points can't easily make use of the whole test-driver right now, so until it is, expose the parts of the test-driver that are needed at odsp-client's entry points for automation (which seems easier than writing more auth code).

Pending conclusions on what to do about all this service-specific code and changes in in odsp-client to better work with existing test tooling, this change can probably be reverted.