### PR TITLE
VS Code: Use source maps when debugging mocha tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -269,6 +269,8 @@
             "program": "${file}",
             "stopOnEntry": false,
             "args": [
+                "--require",
+                "source-map-support/register",
                 "--no-timeouts",
                 "--exit",
             ],


### PR DESCRIPTION
Show TypeScript files in callstacks when debugging mocha tests via F5.