### PR TITLE
update test package versioning

### DIFF
--- a/tools/pipelines/scripts/build-version.js
+++ b/tools/pipelines/scripts/build-version.js
@@ -168,7 +168,14 @@ function main() {
     // Generate and print the version to console
     let version = getSimpleVersion(file_version, arg_build_num, arg_release, arg_patch);
     if (arg_test_build) {
-        version += "-test";
+        const split = version.split("-");
+        if (split.length !== 2) {
+            console.error(`ERROR: Invalid format for test version ${version}`);
+            process.exit(8);
+        }
+        // '0.' prefix so test build versions have lower precedence
+        split[1] = `0.${split[1]}-test`;
+        version = split.join("-");
     }
     console.log(`version=${version}`);
     console.log(`##vso[task.setvariable variable=version;isOutput=true]${version}`);


### PR DESCRIPTION
Update the versioning scheme for test packages to ensure they have a lower precedence than prerelease packages.

**Before**: 0.1025.0-buildId-test
**After**: 0.1025.0-0.buildId-test
**Sample comparison**: 0.1025.0 > 0.1025.0-124 > 0.1025.0-123 > 0.1025.0-122 > 0.1025.0-0.123-test                                                                                                                                                                                                                            
