### PR TITLE
catch floating promise in odspDocumentStorageManager

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -492,6 +492,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         if (cachedSnapshot === undefined) {
                             cachedSnapshot = await snapshotP;
                         }
+                        else {
+                            snapshotP.catch(() => {});
+                        }
 
                         method = promiseRaceWinner.index === 0 && promiseRaceWinner.value !== undefined ? "cache" : "network";
                     } else {


### PR DESCRIPTION
Fixes #5758 
In `getVersions()` , when `cachedSnapShot` is defined, we need to handle `snapshotP`