### PR TITLE
Matrix: Fix overlapped insert/remove in same undo group (#6288)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,33 +33,6 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Matrix Tests",
-            "cwd": "${workspaceFolder}/packages/dds/matrix",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "-r",
-                "ts-node/register",
-                "-r",
-                "source-map-support/register",
-                "--no-timeouts",
-                // "test/**/matrix.spec.ts",
-                "test/**/matrix.undo.spec.ts",
-                // "test/**/matrix.stress.spec.ts",
-                // "test/**/sparsearray2d.spec.ts",
-                // "-f",
-                // "fail",
-                "--exit"
-            ],
-            "env": {
-                "TS_NODE_PROJECT": "tsconfig.json",
-            },
-            // "skipFiles": ["<node_internals>/**"],
-            "console": "integratedTerminal",
-            "smartStep": true,
-        },
-        {
-            "type": "node",
-            "request": "launch",
             "name": "Mocha Tests",
             "cwd": "${workspaceFolder}/",
             "program": "${workspaceFolder}/common/tools/node_modules/mocha/bin/_mocha",
@@ -271,6 +244,8 @@
             "args": [
                 "--require",
                 "source-map-support/register",
+                // "--fgrep",               // Uncomment to filter by test case name
+                // "<test case name>",
                 "--no-timeouts",
                 "--exit",
             ],

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -349,7 +349,8 @@ export class SharedMatrix<T = any>
         const { op, inserted } = this.rows.insertRelative(original, original.cachedLength);
         this.submitRowMessage(op);
 
-        // Transfer handles from the original segment to the newly inserted empty segment.
+        // Transfer handles and undo/redo tracking groups from the original segment to the
+        // newly inserted segment.
         original.transferToReplacement(inserted);
 
         // Invalidate the handleCache in case it was populated during the 'rowsChanged'
@@ -392,7 +393,8 @@ export class SharedMatrix<T = any>
         const { op, inserted } = this.cols.insertRelative(original, original.cachedLength);
         this.submitColMessage(op);
 
-        // Transfer handles from the original segment to the newly inserted empty segment.
+        // Transfer handles and undo/redo tracking groups from the original segment to the
+        // newly inserted segment.
         original.transferToReplacement(inserted);
 
         // Invalidate the handleCache in case it was populated during the 'colsChanged'

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -350,7 +350,7 @@ export class SharedMatrix<T = any>
         this.submitRowMessage(op);
 
         // Transfer handles from the original segment to the newly inserted empty segment.
-        original.transferHandlesTo(inserted);
+        original.transferToReplacement(inserted);
 
         // Invalidate the handleCache in case it was populated during the 'rowsChanged'
         // callback, which occurs before the handle span is populated.
@@ -393,7 +393,7 @@ export class SharedMatrix<T = any>
         this.submitColMessage(op);
 
         // Transfer handles from the original segment to the newly inserted empty segment.
-        original.transferHandlesTo(inserted);
+        original.transferToReplacement(inserted);
 
         // Invalidate the handleCache in case it was populated during the 'colsChanged'
         // callback, which occurs before the handle span is populated.

--- a/packages/dds/matrix/src/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.undo.spec.ts
@@ -55,7 +55,7 @@ describe("Matrix", () => {
                 expectSize(matrix1, /* rowCount */ 1, /* colCount: */ 0);
             });
 
-            it("fail: undo/redo insertRow 2x1", async () => {
+            it("undo/redo insertRow 2x1", async () => {
                 matrix1.insertCols(/* start: */ 0, /* count: */ 1);
                 undo1.closeCurrentOperation();
 
@@ -245,6 +245,18 @@ describe("Matrix", () => {
                 expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 1);
             });
 
+            it("undo/redo overlapping insertCol/removeCol in single undo group", async () => {
+                matrix1.insertCols(/* start: */ 0, /* count: */ 3);
+                matrix1.removeCols(/* start: */ 0, /* count: */ 1);
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 2);
+
+                undo1.undoOperation();
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 0);
+
+                undo1.redoOperation();
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 2);
+            });
+
             it("undo/redo insertCol 1x2", async () => {
                 matrix1.insertRows(/* start: */ 0, /* count: */ 1);
                 undo1.closeCurrentOperation();
@@ -287,6 +299,18 @@ describe("Matrix", () => {
 
                 undo1.redoOperation();
                 expectSize(matrix1, /* rowCount */ 1, /* colCount: */ 0);
+            });
+
+            it("undo/redo overlapping insertRow/removeRow in single undo group", async () => {
+                matrix1.insertRows(/* start: */ 0, /* count: */ 3);
+                matrix1.removeRows(/* start: */ 0, /* count: */ 1);
+                expectSize(matrix1, /* rowCount */ 2, /* colCount: */ 0);
+
+                undo1.undoOperation();
+                expectSize(matrix1, /* rowCount */ 0, /* colCount: */ 0);
+
+                undo1.redoOperation();
+                expectSize(matrix1, /* rowCount */ 2, /* colCount: */ 0);
             });
 
             it("undo/redo removeCol 0 of 2x2", async () => {

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -122,10 +122,8 @@ export class MatrixUndoProvider<T> {
         rows.undo = new VectorUndoProvider(
             consumer,
             /* undoInsert: */ (segment: PermutationSegment) => {
-                if (segment.removedSeq === undefined) {
-                    const start = this.rows.getPosition(segment);
-                    this.matrix.removeRows(start, segment.cachedLength);
-                }
+                const start = this.rows.getPosition(segment);
+                this.matrix.removeRows(start, segment.cachedLength);
             },
             /* undoRemove: */ (segment: PermutationSegment) => {
                 this.matrix._undoRemoveRows(segment);
@@ -134,10 +132,8 @@ export class MatrixUndoProvider<T> {
         cols.undo = new VectorUndoProvider(
             consumer,
             /* undoInsert: */ (segment: PermutationSegment) => {
-                if (segment.removedSeq === undefined) {
-                    const start = this.cols.getPosition(segment);
-                    this.matrix.removeCols(start, segment.cachedLength);
-                }
+                const start = this.cols.getPosition(segment);
+                this.matrix.removeCols(start, segment.cachedLength);
             },
             /* undoRemove: */ (segment: PermutationSegment) => {
                 this.matrix._undoRemoveCols(segment);


### PR DESCRIPTION
In the following scenario, SharedMatrix's UndoProvider had a bug:
1. Insert a segment
2. Remove part of a segment  <-- Splits the original segment
3. Undo the remove   <-- Inserts a new segment as a replacement
4. Undo the insertion

The bug was that when undoing the insertion at step 4, the SharedMatrix could lose track of the fact that it should remove the segment inserted at step 3 (which replaces the fragment of the original insertion at step 1 that was split/removed.)

(The fix is to replace the split/removed segment with the newly inserted replacement in the undo/redo tracking group created at step 1.)