### PR TITLE
Fix: instanceOf in DeltaManager::opHandler does not always work in iframes

### DIFF
--- a/experimental/dds/tree/src/SnapshotUtilities.ts
+++ b/experimental/dds/tree/src/SnapshotUtilities.ts
@@ -88,13 +88,13 @@ export function comparePayloads(a: Payload, b: Payload): boolean {
 	}
 
 	// make sure objects with numeric keys (or no keys) compare unequal to arrays.
-	if (a instanceof Array !== b instanceof Array) {
+	if (Array.isArray(a) !== Array.isArray(b)) {
 		return false;
 	}
 
 	// Fluid Serialization (like Json) orders object fields arbitrarily, so reordering fields is not considered considered a change.
 	// Therefor the keys arrays must be sorted here.
-	if (!(a instanceof Array)) {
+	if (!(Array.isArray(a))) {
 		aKeys.sort();
 		bKeys.sort();
 	}

--- a/experimental/dds/tree/src/SnapshotUtilities.ts
+++ b/experimental/dds/tree/src/SnapshotUtilities.ts
@@ -94,7 +94,7 @@ export function comparePayloads(a: Payload, b: Payload): boolean {
 
 	// Fluid Serialization (like Json) orders object fields arbitrarily, so reordering fields is not considered considered a change.
 	// Therefor the keys arrays must be sorted here.
-	if (!(Array.isArray(a))) {
+	if (!Array.isArray(a)) {
 		aKeys.sort();
 		bKeys.sort();
 	}

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -941,7 +941,7 @@ export class DeltaManager
     }
 
     private readonly opHandler = (documentId: string, messagesArg: ISequencedDocumentMessage[]) => {
-        const messages = messagesArg instanceof Array ? messagesArg : [messagesArg];
+        const messages = Array.isArray(messagesArg) ? messagesArg : [messagesArg];
         this.enqueueMessages(messages, "opHandler");
     };
 

--- a/packages/utils/tool-utils/src/snapshotNormalizer.ts
+++ b/packages/utils/tool-utils/src/snapshotNormalizer.ts
@@ -27,7 +27,7 @@ function getDeepSortedArray(array: any[]): any[] {
     const sortedArray: any[] = [];
     // Sort arrays and objects, if any, in the array.
     for (const element of array) {
-        if (element instanceof Array) {
+        if (Array.isArray(element)) {
             sortedArray.push(getDeepSortedArray(element));
         } else if (element instanceof Object) {
             sortedArray.push(getDeepSortedObject(element));
@@ -57,7 +57,7 @@ function getDeepSortedObject(obj: any): any {
     const keys = Object.keys(obj).sort();
     for (const key of keys) {
         const value = obj[key];
-        if (value instanceof Array) {
+        if (Array.isArray(value)) {
             sortedObj[key] = getDeepSortedArray(value);
         } else if (value instanceof Object) {
             sortedObj[key] = getDeepSortedObject(value);
@@ -78,7 +78,7 @@ function getSortedBlobContent(content: string): string {
     // Deep sort the content if it's parseable.
     try {
         let contentObj = JSON.parse(content);
-        if (contentObj instanceof Array) {
+        if (Array.isArray(contentObj)) {
             contentObj = getDeepSortedArray(contentObj);
         } else if (contentObj instanceof Object) {
             contentObj = getDeepSortedObject(contentObj);


### PR DESCRIPTION
Fixes #6344

`instanceOf` doesn't always work inside iframes. I updated the code to use `Array.isArray` instead. This seems to be a known issue - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
