### PR TITLE
Removing "fluid/component" mimetype support #2934

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -832,6 +832,7 @@ All renames are 1-1, and global case senstive and whole word find replace for al
         },
         "types": {
             "IComponent": "IFluidObject",
+            "fluid/component": "fluid/object",
 
             "SharedObjectComponentHandle": "SharedObjectHandle",
             "RemoteComponentHandle": "RemoteFluidObjectHandle",
@@ -951,14 +952,18 @@ As part of the Fluid Data Library (FDL) and Fluid Component Library (FCL) split 
 -   `IComponentSerializer `will become `IFluidSerializer`
 -   `IComponentTokenProvider` will become `IFluidTokenProvider`
 
-`IComponent` will also become `IFluidObject`
+`IComponent` will also become `IFluidObject`, and the mime type for for requests will change from `fluid/component` to `fluid/object`
 
 To ensure forward compatability when accessing the above interfaces outside the context of a container e.g. from the host, you should use the nullish coalesing operator (??).
 
 For example
 
 ```typescript
-        if (response.status !== 200 || response.mimeType !== "fluid/object") {
+        if (response.status !== 200 ||
+            !(
+                response.mimeType === "fluid/component" ||
+                response.mimeType === "fluid/object"
+            )) {
             return undefined;
         }
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -832,7 +832,6 @@ All renames are 1-1, and global case senstive and whole word find replace for al
         },
         "types": {
             "IComponent": "IFluidObject",
-            "fluid/component": "fluid/object",
 
             "SharedObjectComponentHandle": "SharedObjectHandle",
             "RemoteComponentHandle": "RemoteFluidObjectHandle",
@@ -952,18 +951,14 @@ As part of the Fluid Data Library (FDL) and Fluid Component Library (FCL) split 
 -   `IComponentSerializer `will become `IFluidSerializer`
 -   `IComponentTokenProvider` will become `IFluidTokenProvider`
 
-`IComponent` will also become `IFluidObject`, and the mime type for for requests will change from `fluid/component` to `fluid/object`
+`IComponent` will also become `IFluidObject`
 
 To ensure forward compatability when accessing the above interfaces outside the context of a container e.g. from the host, you should use the nullish coalesing operator (??).
 
 For example
 
 ```typescript
-        if (response.status !== 200 ||
-            !(
-                response.mimeType === "fluid/component" ||
-                response.mimeType === "fluid/object"
-            )) {
+        if (response.status !== 200 || response.mimeType !== "fluid/object") {
             return undefined;
         }
 

--- a/examples/hosts/iframe-host/src/inner.ts
+++ b/examples/hosts/iframe-host/src/inner.ts
@@ -19,11 +19,7 @@ const containers: Map<string, Container> = new Map();
 
 async function getFluidObjectAndRender(container: Container, div: HTMLDivElement) {
     const response = await container.request({ url: "/" });
-    if (response.status !== 200 ||
-        !(
-            response.mimeType === "fluid/component" ||
-            response.mimeType === "fluid/object"
-        )) {
+    if (response.status !== 200 || response.mimeType !== "fluid/object") {
         return undefined;
     }
     const fluidObject = response.value as IFluidObject;

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -84,11 +84,7 @@ export async function loadFrame(
 
 async function getFluidObjectAndRender(container: IContainer, div: HTMLDivElement) {
     const response = await container.request({ url: "/" });
-    if (response.status !== 200 ||
-        !(
-            response.mimeType === "fluid/component" ||
-            response.mimeType === "fluid/object"
-        )) {
+    if (response.status !== 200 || response.mimeType !== "fluid/object") {
         return undefined;
     }
     const fluidObject = response.value as IFluidObject;

--- a/packages/hosts/base-host/src/host.ts
+++ b/packages/hosts/base-host/src/host.ts
@@ -82,11 +82,7 @@ export class BaseHost {
     public async requestFluidObjectFromContainer(container: Container, url: string) {
         const response = await container.request({ url });
 
-        if (response.status !== 200 ||
-            !(
-                response.mimeType === "fluid/component" ||
-                response.mimeType === "fluid/object"
-            )) {
+        if (response.status !== 200 || response.mimeType !== "fluid/object") {
             return undefined;
         }
 
@@ -97,11 +93,7 @@ export class BaseHost {
         const loader = await this.getLoader();
         const response = await loader.request({ url });
 
-        if (response.status !== 200 ||
-            !(
-                response.mimeType === "fluid/component" ||
-                response.mimeType === "fluid/object"
-            )) {
+        if (response.status !== 200 || response.mimeType !== "fluid/object") {
             return undefined;
         }
 

--- a/packages/loader/execution-context-loader/src/webWorkerLoader.ts
+++ b/packages/loader/execution-context-loader/src/webWorkerLoader.ts
@@ -53,8 +53,7 @@ export class WebWorkerLoader implements IHostLoader, IFluidRunnable, IFluidRoute
 
     public async request(request: IRequest): Promise<IResponse> {
         const response = await this.proxy.request(request);
-        if (response.status !== 200
-            || (response.mimeType !== "fluid/component" && response.mimeType !== "fluid/object")) {
+        if (response.status !== 200 || response.mimeType !== "fluid/object") {
             return response;
         }
         return { status: 200, mimeType: "fluid/object", value: this };

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -376,8 +376,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
 
         const response = await loader.request(request);
 
-        if (response.status !== 200
-            || (response.mimeType !== "fluid/object" && response.mimeType !== "fluid/component")) {
+        if (response.status !== 200 || response.mimeType !== "fluid/object") {
             return Promise.reject(new Error("Invalid summarizer route"));
         }
 

--- a/server/gateway/src/childLoader.ts
+++ b/server/gateway/src/childLoader.ts
@@ -123,8 +123,7 @@ class KeyValueLoader {
 
     private async attach(loader: Loader, docUrl: string) {
         const response = await loader.request({ url: docUrl });
-        if (response.status !== 200 ||
-            (response.mimeType !== "fluid/component" && response.mimeType !== "fluid/object")) {
+        if (response.status !== 200 || response.mimeType !== "fluid/object") {
             return;
         }
         const fluidObject = response.value as IFluidObject;

--- a/server/gateway/src/controllers/workerLoader.ts
+++ b/server/gateway/src/controllers/workerLoader.ts
@@ -65,8 +65,7 @@ class WorkerLoader implements ILoader, IFluidRunnable {
         }
 
         const response = await this.container.request(request);
-        if (response.status !== 200 ||
-            (response.mimeType !== "fluid/component" && response.mimeType !== "fluid/object")) {
+        if (response.status !== 200 || response.mimeType !== "fluid/object") {
             return { status: 404, mimeType: "text/plain", value: `${request.url} not found` };
         }
         this.runnable = response.value as IFluidRunnable;


### PR DESCRIPTION
Deleting all references of fluid/component, as it is already exists with appropriate duplicated check for fluid/object.