### PR TITLE
Ignore externalRequest flag if GC is not enabled

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1064,14 +1064,15 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 }
             } else if (requestParser.pathParts.length > 0) {
                 /**
-                 * If this an external app request with "externalRequest" header, we need to return an error if the
-                 * data store being requested is marked as unreferenced as per the data store's initial summary.
+                 * If GC is enabled and this an external app request with "externalRequest" header, we need to return
+                 * an error if the data store being requested is marked as unreferenced as per the data store's initial
+                 * summary.
                  *
                  * This is a workaround to handle scenarios where a data store shared with an external app is deleted
                  * and marked as unreferenced by GC. Returning an error will fail to load the data store for the app.
                  */
                 const wait = typeof request.headers?.wait === "boolean" ? request.headers.wait : undefined;
-                const dataStore = request.headers?.externalRequest
+                const dataStore = request.headers?.externalRequest && this.shouldRunGC
                     ? await this.getDataStoreIfInitiallyReferenced(id, wait)
                     : await this.getDataStore(id, wait);
                 const subRequest = requestParser.createSubRequest(1);

--- a/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gcSummaryTests.spec.ts
@@ -84,7 +84,6 @@ describeNoCompat("Garbage Collection", (getTestObjectProvider) => {
          */
         function validateDataStoreInSummary(summary: ISummaryTree, dataStoreId: string, referenced: boolean) {
             let dataStoreTree: ISummaryTree | undefined;
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             const channelsTree = (summary.tree[".channels"] as ISummaryTree)?.tree ?? summary.tree;
             for (const [ id, summaryObject ] of Object.entries(channelsTree)) {
                 if (id === dataStoreId) {


### PR DESCRIPTION
Fixes #6203.

If GC is disabled, we need to ignore the `externalRequest` flag. This will ensure that old documents that had GC disabled won't fail requests with `externalRequest` flag.