### PR TITLE
Removed LoaderHeader.version === null for loading from just ops

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,6 +1,7 @@
 ## 0.41 Breaking changes
 
 - [Package renames](#0.41-package-renames)
+- [LoaderHeader.version could not be null](#LoaderHeader.version-could-not-be-null)
 
 ### 0.41 package renames
 
@@ -9,6 +10,9 @@ scopes](https://github.com/microsoft/FluidFramework/wiki/npm-package-scopes) pag
 the npm scopes.
 
 - `@fluidframework/last-edited-experimental` is renamed to `@fluid-experimental/last-edited`
+
+### LoaderHeader.version could not be null
+`LoaderHeader.version` in ILoader cann't be null as we always load from existing snapshot in `container.load()`;
 
 ## 0.40 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,7 +12,7 @@ the npm scopes.
 - `@fluidframework/last-edited-experimental` is renamed to `@fluid-experimental/last-edited`
 
 ### LoaderHeader.version could not be null
-`LoaderHeader.version` in ILoader cann't be null as we always load from existing snapshot in `container.load()`;
+`LoaderHeader.version` in ILoader can not be null as we always load from existing snapshot in `container.load()`;
 
 ## 0.40 Breaking changes
 

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -268,7 +268,7 @@ export interface IContainerLoadOptions {
     loadMode?: IContainerLoadMode;
     // (undocumented)
     resolvedUrl: IFluidResolvedUrl;
-    version?: string | undefined;
+    version: string | undefined;
 }
 
 // @public

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -268,7 +268,7 @@ export interface IContainerLoadOptions {
     loadMode?: IContainerLoadMode;
     // (undocumented)
     resolvedUrl: IFluidResolvedUrl;
-    version?: string | null | undefined;
+    version?: string | undefined;
 }
 
 // @public

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -373,7 +373,7 @@ export interface ILoaderHeader {
     // (undocumented)
     [LoaderHeader.loadMode]: IContainerLoadMode;
     // (undocumented)
-    [LoaderHeader.version]: string | undefined | null;
+    [LoaderHeader.version]: string | undefined;
 }
 
 // @public (undocumented)

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -332,7 +332,7 @@ export interface ILoaderHeader {
     [LoaderHeader.loadMode]: IContainerLoadMode;
     [LoaderHeader.sequenceNumber]: number;
     [LoaderHeader.reconnect]: boolean;
-    [LoaderHeader.version]: string | undefined | null;
+    [LoaderHeader.version]: string | undefined;
 }
 
 interface IProvideLoader {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -124,7 +124,7 @@ export interface IContainerLoadOptions {
     /**
      * Control which snapshot version to load from.  See IParsedUrl for detailed information.
      */
-    version?: string | undefined;
+    version: string | undefined;
     /**
      * Loads the Container in paused state if true, unpaused otherwise.
      */

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -122,9 +122,9 @@ export interface IContainerLoadOptions {
     clientDetailsOverride?: IClientDetails;
     resolvedUrl: IFluidResolvedUrl;
     /**
-     * Control whether to load from snapshot or ops.  See IParsedUrl for detailed information.
+     * Control which snapshot version to load from.  See IParsedUrl for detailed information.
      */
-    version?: string | null | undefined;
+    version?: string | undefined;
     /**
      * Loads the Container in paused state if true, unpaused otherwise.
      */
@@ -1112,13 +1112,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * Load container.
      *
      * @param specifiedVersion - one of the following
-     *   - null: use ops, no snapshots
      *   - undefined - fetch latest snapshot
      *   - otherwise, version sha to load snapshot
      * @param pause - start the container in a paused state
      */
     private async load(
-        specifiedVersion: string | null | undefined,
+        specifiedVersion: string | undefined,
         loadMode: IContainerLoadMode,
         pendingLocalState?: unknown)
     {
@@ -1150,7 +1149,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         await this.connectStorageService();
         this._attachState = AttachState.Attached;
 
-        // Fetch specified snapshot, but intentionally do not load from snapshot if specifiedVersion is null
+        // Fetch specified snapshot.
         const { snapshot, versionId } = await this.fetchSnapshotTree(specifiedVersion);
 
         const attributes = await this.getDocumentAttributes(this.storageService, snapshot);
@@ -1778,12 +1777,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * @param specifiedVersion - The specific version of the snapshot to retrieve
      * @returns The snapshot requested, or the latest snapshot if no version was specified, plus version ID
      */
-    private async fetchSnapshotTree(specifiedVersion: string | undefined | null):
+    private async fetchSnapshotTree(specifiedVersion: string | undefined):
         Promise<{snapshot?: ISnapshotTree; versionId?: string}>
     {
-        if (specifiedVersion === null) {
-            return {};
-        }
         const version = await this.getVersion(specifiedVersion ?? this.id);
 
         if (version === undefined && specifiedVersion !== undefined) {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -71,7 +71,7 @@ export class RelativeLoader implements ILoader {
                         canReconnect: request.headers?.[LoaderHeader.reconnect],
                         clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
                         resolvedUrl: {...resolvedUrl},
-                        version: request.headers?.[LoaderHeader.version],
+                        version: request.headers?.[LoaderHeader.version] ?? undefined,
                         loadMode: request.headers?.[LoaderHeader.loadMode],
                     },
                 );
@@ -412,11 +412,6 @@ export class Loader implements IHostLoader {
         // If set in both query string and headers, use query string
         request.headers[LoaderHeader.version] = parsed.version ?? request.headers[LoaderHeader.version];
 
-        // Version === null means not use any snapshot.
-        if (request.headers[LoaderHeader.version] === "null") {
-            request.headers[LoaderHeader.version] = null;
-        }
-
         const canCache = this.canCacheForRequest(request.headers);
         debug(`${canCache} ${request.headers[LoaderHeader.version]}`);
 
@@ -437,7 +432,7 @@ export class Loader implements IHostLoader {
                 canReconnect: request.headers?.[LoaderHeader.reconnect],
                 clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
                 resolvedUrl: resolved,
-                version: request.headers?.[LoaderHeader.version],
+                version: request.headers?.[LoaderHeader.version] ?? undefined,
                 loadMode: request.headers?.[LoaderHeader.loadMode],
             },
             pendingLocalState,

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -89,7 +89,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
                 canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                 clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
                 resolvedUrl: testResolved,
-                version: testRequest.headers?.[LoaderHeader.version],
+                version: testRequest.headers?.[LoaderHeader.version] ?? undefined,
                 loadMode: testRequest.headers?.[LoaderHeader.loadMode],
             },
         );

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -85,7 +85,7 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                     canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
                     clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
                     resolvedUrl: testResolved,
-                    version: testRequest.headers?.[LoaderHeader.version],
+                    version: testRequest.headers?.[LoaderHeader.version] ?? undefined,
                     loadMode: testRequest.headers?.[LoaderHeader.loadMode],
                 },
             );


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/4049
We always load from snapshot in load flow. So we can now remove version as null to just load from ops.