### PR TITLE
Prevent excess logs to telemetry

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -127,6 +127,8 @@ export class SummaryManager extends EventEmitter implements IDisposable {
 
                 // In future we will change the elected client.
                 // this.orderedClients.incrementCurrentClient();
+
+                this.hasLoggedTelemetry = true;
             }
         });
         this.summaryCollection.on(MessageType.SummaryAck, (op) => {


### PR DESCRIPTION
This is simply missing; it causes excess logs to telemetry. Also gets fixed further in #6335