### PR TITLE
Fix reset for test-service-load runner

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -133,14 +133,21 @@ async function runnerProcess(
         const logger = ChildLogger.create(
             baseLogger, undefined, {all: { runId: runConfig.runId, driverType: testDriver.type }});
 
-        let iteration = 0;
+        // Cycle between creating new factory vs. reusing factory.
+        // Certain behavior (like driver caches) are per factory instance, and by reusing it we hit those code paths
+        // At the same time we want to test newly created factory.
         const iterator = factoryPermutations(
             () => new FaultInjectionDocumentServiceFactory(testDriver.createDocumentServiceFactory()));
 
-        for (const {documentServiceFactory, headers} of iterator) {
-            // Switch between creating new factory vs. reusing factory.
-            // Certain behavior (like driver caches) are per factory instance, and by reusing it we hit those code paths
-            // At the same time we want to test newly created factory.
+        let done = false;
+        // Reset the workload once, on the first iteration
+        let reset = true;
+        while (!done) {
+            const nextFactoryPermutation = iterator.next();
+            if (nextFactoryPermutation.done === true) {
+                throw new Error("Factory permutation iterator is expected to cycle forever");
+            }
+            const { documentServiceFactory, headers } = nextFactoryPermutation.value;
 
             // Construct the loader
             const loader = new Loader({
@@ -157,26 +164,21 @@ async function runnerProcess(
 
             scheduleContainerClose(container, runConfig);
             scheduleFaultInjection(documentServiceFactory, container, runConfig);
-            try{
+            try {
                 printStatus(runConfig, `running`);
-                const done = await test.run(runConfig, iteration === 0 /* reset */);
-                printStatus(runConfig, done ?  `finished` : "closed");
-                if (done) {
-                    break;
-                }
-            }catch(error) {
+                done = await test.run(runConfig, reset);
+                reset = false;
+                printStatus(runConfig, done ? `finished` : "closed");
+            } catch (error) {
                 await loggerP.then(
-                    async (l)=>l.sendErrorEvent({eventName: "RunnerFailed", runId: runConfig.runId}, error));
+                    async (l) => l.sendErrorEvent({eventName: "RunnerFailed", runId: runConfig.runId}, error));
                 throw error;
-            }
-            finally {
-                if(!container.closed) {
+            } finally {
+                if (!container.closed) {
                     container.close();
                 }
                 await baseLogger.flush({url, runId: runConfig.runId});
             }
-
-            iteration++;
         }
         return 0;
     } catch (e) {

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -138,8 +138,6 @@ async function runnerProcess(
             () => new FaultInjectionDocumentServiceFactory(testDriver.createDocumentServiceFactory()));
 
         for (const {documentServiceFactory, headers} of iterator) {
-            iteration++;
-
             // Switch between creating new factory vs. reusing factory.
             // Certain behavior (like driver caches) are per factory instance, and by reusing it we hit those code paths
             // At the same time we want to test newly created factory.
@@ -177,6 +175,8 @@ async function runnerProcess(
                 }
                 await baseLogger.flush({url, runId: runConfig.runId});
             }
+
+            iteration++;
         }
         return 0;
     } catch (e) {


### PR DESCRIPTION
Since the iteration is currently happening at the top of the loop, the reset condition is never met (it originally would reset on the first iteration of the loop only).  This change restores the reset behavior, and also tweaks the loop a bit to make the reset and loop exit conditions more obvious to a new reader of the code.