### PR TITLE
Add failure summary to fluid-build tool

### DIFF
--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -21,11 +21,6 @@ export enum BuildResult {
     Failed,
 };
 
-export interface BuildResult2 {
-    status: BuildResult,
-    description: string,
-}
-
 export function summarizeBuildResult(results: BuildResult[]) {
     let retResult = BuildResult.UpToDate;
     for (const result of results) {
@@ -186,8 +181,8 @@ export class BuildGraph {
             return "";
         }
         const summaryLines = this.buildContext.failedTaskLines;
-        summaryLines.unshift(chalk.redBright("Failed Tasks:"));
         const notRunCount = this.buildContext.taskStats.leafTotalCount - this.buildContext.taskStats.leafUpToDateCount - this.buildContext.taskStats.leafBuiltCount;
+        summaryLines.unshift(chalk.redBright("Failed Tasks:"));
         summaryLines.push(chalk.yellow(`Did not run ${notRunCount} tasks due to prior failures.`));
         return summaryLines.join("\n");
     }

--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -45,6 +45,7 @@ class TaskStats {
 class BuildContext {
     public readonly fileHashCache = new FileHashCache();
     public readonly taskStats = new TaskStats();
+    public readonly statusToRepeat: string[] = [];
     constructor(public readonly workerPool?: WorkerPool) { }
 };
 
@@ -173,6 +174,10 @@ export class BuildGraph {
 
     public get totalElapsedTime(): number {
         return this.buildContext.taskStats.leafExecTimeTotal;
+    }
+
+    public get statusToRepeat(): string {
+        return this.buildContext.statusToRepeat.join("\n");
     }
 
     private buildDependencies(getDepFilter: (pkg: Package) => (dep: Package) => boolean) {

--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -188,7 +188,7 @@ export class BuildGraph {
         const summaryLines = this.buildContext.failedTaskLines;
         summaryLines.unshift(chalk.redBright("Failed Tasks:"));
         const notRunCount = this.buildContext.taskStats.leafTotalCount - this.buildContext.taskStats.leafUpToDateCount - this.buildContext.taskStats.leafBuiltCount;
-        summaryLines.push(chalk.yellow(`Unable to run ${notRunCount} tasks due to prior failures.`));
+        summaryLines.push(chalk.yellow(`Did not run ${notRunCount} tasks due to prior failures.`));
         return summaryLines.join("\n");
     }
 

--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -21,6 +21,11 @@ export enum BuildResult {
     Failed,
 };
 
+export interface BuildResult2 {
+    status: BuildResult,
+    description: string,
+}
+
 export function summarizeBuildResult(results: BuildResult[]) {
     let retResult = BuildResult.UpToDate;
     for (const result of results) {
@@ -45,7 +50,7 @@ class TaskStats {
 class BuildContext {
     public readonly fileHashCache = new FileHashCache();
     public readonly taskStats = new TaskStats();
-    public readonly statusToRepeat: string[] = [];
+    public readonly failedTaskLines: string[] = [];
     constructor(public readonly workerPool?: WorkerPool) { }
 };
 
@@ -176,8 +181,13 @@ export class BuildGraph {
         return this.buildContext.taskStats.leafExecTimeTotal;
     }
 
-    public get statusToRepeat(): string {
-        return this.buildContext.statusToRepeat.join("\n");
+    public get taskFailureSummary(): string {
+        if (this.buildContext.failedTaskLines.length === 0) {
+            return "";
+        }
+        const summaryLines = this.buildContext.failedTaskLines;
+        summaryLines.unshift(chalk.redBright("Failed Tasks:"));
+        return summaryLines.join("\n");
     }
 
     private buildDependencies(getDepFilter: (pkg: Package) => (dep: Package) => boolean) {

--- a/tools/build-tools/src/fluidBuild/buildGraph.ts
+++ b/tools/build-tools/src/fluidBuild/buildGraph.ts
@@ -187,6 +187,8 @@ export class BuildGraph {
         }
         const summaryLines = this.buildContext.failedTaskLines;
         summaryLines.unshift(chalk.redBright("Failed Tasks:"));
+        const notRunCount = this.buildContext.taskStats.leafTotalCount - this.buildContext.taskStats.leafUpToDateCount - this.buildContext.taskStats.leafBuiltCount;
+        summaryLines.push(chalk.yellow(`Unable to run ${notRunCount} tasks due to prior failures.`));
         return summaryLines.join("\n");
     }
 

--- a/tools/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/tools/build-tools/src/fluidBuild/fluidBuild.ts
@@ -91,7 +91,7 @@ async function main() {
     await repo.checkPackages(options.fix);
     timer.time("Check scripts completed");
 
-
+    let failureSummary = "";
     if (options.clean || options.build !== false) {
         logStatus(`Symlink in ${options.fullSymlink ? "full" : options.fullSymlink === false ? "isolated" : "non-dependent"} mode`);
 
@@ -127,7 +127,7 @@ async function main() {
             } else {
                 logStatus(`Build ${buildStatus}`);
             }
-            logStatus(buildGraph.statusToRepeat);
+            failureSummary = `\n${buildGraph.taskFailureSummary}`;
         }
     }
 
@@ -137,6 +137,7 @@ async function main() {
 
     logStatus(`Total time: ${(timer.getTotalTime() / 1000).toFixed(3)}s`);
 
+    logStatus(failureSummary);
 }
 
 function buildResultString(buildResult: BuildResult) {

--- a/tools/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/tools/build-tools/src/fluidBuild/fluidBuild.ts
@@ -127,6 +127,7 @@ async function main() {
             } else {
                 logStatus(`Build ${buildStatus}`);
             }
+            logStatus(buildGraph.statusToRepeat);
         }
     }
 

--- a/tools/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/tools/build-tools/src/fluidBuild/fluidBuild.ts
@@ -127,7 +127,7 @@ async function main() {
             } else {
                 logStatus(`Build ${buildStatus}`);
             }
-            failureSummary = `\n${buildGraph.taskFailureSummary}`;
+            failureSummary = buildGraph.taskFailureSummary;
         }
     }
 
@@ -137,7 +137,9 @@ async function main() {
 
     logStatus(`Total time: ${(timer.getTotalTime() / 1000).toFixed(3)}s`);
 
-    logStatus(failureSummary);
+    if (failureSummary !== "") {
+        logStatus(`\n${failureSummary}`);
+    }
 }
 
 function buildResultString(buildResult: BuildResult) {

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -156,7 +156,7 @@ export abstract class LeafTask extends Task {
             const statusString = `[${taskNum}/${totalTask}] ${statusCharacter} ${this.node.pkg.nameColored}: ${this.command} - ${elapsedTime.toFixed(3)}s`;
             logStatus(statusString);
             if (status === BuildResult.Failed) {
-                this.node.buildContext.statusToRepeat.push(statusString);
+                this.node.buildContext.failedTaskLines.push(statusString);
             }
             this.node.buildContext.taskStats.leafExecTimeTotal += elapsedTime;
         }

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -153,7 +153,11 @@ export abstract class LeafTask extends Task {
             const taskNum = this.node.buildContext.taskStats.leafBuiltCount.toString().padStart(3, " ");
             const totalTask = this.node.buildContext.taskStats.leafTotalCount - this.node.buildContext.taskStats.leafUpToDateCount;
             const elapsedTime = (Date.now() - startTime) / 1000;
-            logStatus(`[${taskNum}/${totalTask}] ${statusCharacter} ${this.node.pkg.nameColored}: ${this.command} - ${elapsedTime.toFixed(3)}s`);
+            const statusString = `[${taskNum}/${totalTask}] ${statusCharacter} ${this.node.pkg.nameColored}: ${this.command} - ${elapsedTime.toFixed(3)}s`;
+            logStatus(statusString);
+            if (status === BuildResult.Failed) {
+                this.node.buildContext.statusToRepeat.push(statusString);
+            }
             this.node.buildContext.taskStats.leafExecTimeTotal += elapsedTime;
         }
         return status;


### PR DESCRIPTION
Collect all the failure lines and then repeat them at the end of the build.  It's bugged me when there are hundreds of lines and I have to scroll up to find which task failed.

Better approach may be to include the status lines in the BuildResponse object that's returned/coalesced throughout but this was quicker and didn't seem unreasonable :)