### PR TITLE
Add container storage adapter to handle storage in detached container

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -3,6 +3,7 @@
 - [Package renames](#0.41-package-renames)
 - [LoaderHeader.version could not be null](#LoaderHeader.version-could-not-be-null)
 - [Leadership API surface removed](#Leadership-API-surface-removed)
+- [IContainerContext storage API return type changed](#IContainerContext-storage-API-return-type-changed)
 
 ### 0.41 package renames
 
@@ -19,6 +20,9 @@ the npm scopes.
 In 0.38, the leadership API surface was deprecated, and in 0.40 it was turned off by default.  In 0.41 it has now been removed.  If you still require leadership functionality, you can use a `TaskSubscription` in combination with an `AgentScheduler`.
 
 See [AgentScheduler-related deprecations](#AgentScheduler-related-deprecations) for more information on how to use `TaskSubscription` to migrate away from leadership election.
+
+### IContainerContext storage API return type changed
+IContainerContext now will always have storage even in Detached mode, so its return type has changed and undefined is removed.
 
 ## 0.40 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -3,7 +3,7 @@
 - [Package renames](#0.41-package-renames)
 - [LoaderHeader.version could not be null](#LoaderHeader.version-could-not-be-null)
 - [Leadership API surface removed](#Leadership-API-surface-removed)
-- [IContainerContext storage API return type changed](#IContainerContext-storage-API-return-type-changed)
+- [IContainerContext and Container storage API return type changed](#IContainerContext-and-Container-storage-API-return-type-changed)
 
 ### 0.41 package renames
 
@@ -21,8 +21,8 @@ In 0.38, the leadership API surface was deprecated, and in 0.40 it was turned of
 
 See [AgentScheduler-related deprecations](#AgentScheduler-related-deprecations) for more information on how to use `TaskSubscription` to migrate away from leadership election.
 
-### IContainerContext storage API return type changed
-IContainerContext now will always have storage even in Detached mode, so its return type has changed and undefined is removed.
+### IContainerContext and Container storage API return type changed
+IContainerContext and Container now will always have storage even in Detached mode, so its return type has changed and undefined is removed.
 
 ## 0.40 Breaking changes
 

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -158,7 +158,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     // (undocumented)
     snapshot(tagMessage: string, fullTree?: boolean): Promise<void>;
     // (undocumented)
-    get storage(): IDocumentStorageService | undefined;
+    get storage(): IDocumentStorageService;
     // (undocumented)
     subLogger: TelemetryLogger;
     // (undocumented)

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -158,7 +158,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     // (undocumented)
     snapshot(tagMessage: string, fullTree?: boolean): Promise<void>;
     // (undocumented)
-    get storage(): IDocumentStorageService;
+    readonly storage: IDocumentStorageService;
     // (undocumented)
     subLogger: TelemetryLogger;
     // (undocumented)

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -174,7 +174,7 @@ export interface IContainerContext extends IDisposable {
     // (undocumented)
     readonly serviceConfiguration: IClientConfiguration | undefined;
     // (undocumented)
-    readonly storage: IDocumentStorageService | undefined;
+    readonly storage: IDocumentStorageService;
     // (undocumented)
     readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
     // (undocumented)

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -111,7 +111,7 @@ export interface IContainerContext extends IDisposable {
     readonly configuration: IFluidConfiguration;
     readonly clientId: string | undefined;
     readonly clientDetails: IClientDetails;
-    readonly storage: IDocumentStorageService | undefined;
+    readonly storage: IDocumentStorageService;
     readonly connected: boolean;
     readonly baseSnapshot: ISnapshotTree | undefined;
     readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -655,7 +655,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 if (this.attachState !== AttachState.Attached) {
                     this.logger.sendErrorEvent({
                         eventName: "NoRealStorageInDetachedContainer",
-                    })
+                    });
                     throw new Error("Real storage calls not allowed in Unattached container");
                 }
                 return this.storageService;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -398,7 +398,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     private loaded = false;
     private _attachState = AttachState.Detached;
 
-    private readonly storageServiceAdapter: ContainerStorageAdapter;
+    public readonly storage: IDocumentStorageService;
     private readonly storageBlobs = new Map<string, ArrayBufferLike>();
     // Active chaincode and associated runtime
     private _storageService: IDocumentStorageService & IDisposable | undefined;
@@ -650,7 +650,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         });
 
         this._deltaManager = this.createDeltaManager();
-        this.storageServiceAdapter = new ContainerStorageAdapter(
+        this.storage = new ContainerStorageAdapter(
             () => this.storageService,
             () => this.attachState,
             this.storageBlobs,
@@ -946,10 +946,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // Ensure connection to web socket
         // All errors are reported through events ("error" / "disconnected") and telemetry in DeltaManager
         this.connectToDeltaStream(args).catch(() => { });
-    }
-
-    public get storage(): IDocumentStorageService {
-        return this.storageServiceAdapter;
     }
 
     /**

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -399,6 +399,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     private _attachState = AttachState.Detached;
 
     private readonly storageServiceAdapter: ContainerStorageAdapter;
+    private readonly storageBlobs = new Map<string, ArrayBufferLike>();
     // Active chaincode and associated runtime
     private _storageService: IDocumentStorageService & IDisposable | undefined;
     private get storageService(): IDocumentStorageService  {
@@ -652,6 +653,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.storageServiceAdapter = new ContainerStorageAdapter(
             () => this.storageService,
             () => this.attachState,
+            this.storageBlobs,
         );
 
         const isDomAvailable = typeof document === "object" &&

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -651,8 +651,15 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         this._deltaManager = this.createDeltaManager();
         this.storage = new ContainerStorageAdapter(
-            () => this.storageService,
-            () => this.attachState,
+            () => {
+                if (this.attachState !== AttachState.Attached) {
+                    this.logger.sendErrorEvent({
+                        eventName: "NoRealStorageInDetachedContainer",
+                    })
+                    throw new Error("Real storage calls not allowed in Unattached container");
+                }
+                return this.storageService;
+            },
             this.storageBlobs,
         );
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -139,7 +139,7 @@ export class ContainerContext implements IContainerContext {
         return this._baseSnapshot;
     }
 
-    public get storage(): IDocumentStorageService | undefined {
+    public get storage(): IDocumentStorageService {
         return this.container.storage;
     }
 

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    IDocumentStorageService,
+    IDocumentStorageServicePolicies,
+    ISummaryContext,
+} from "@fluidframework/driver-definitions";
+import {
+    ICreateBlobResponse,
+    ISnapshotTree,
+    ISummaryHandle,
+    ISummaryTree,
+    ITree,
+    IVersion,
+} from "@fluidframework/protocol-definitions";
+import { IDisposable } from "@fluidframework/common-definitions";
+import { AttachState } from "@fluidframework/container-definitions";
+
+/**
+ * This class wraps the actual storage and make sure no wrong apis are called according to
+ * container attach state.
+ */
+export class ContainerStorageAdapter implements IDocumentStorageService, IDisposable {
+    private _disposed = false;
+    constructor(
+        private readonly storageGetter: () => IDocumentStorageService,
+        private readonly attachState: () => AttachState,
+    ) {
+    }
+
+    private throwOnNotAttached() {
+        const attachState = this.attachState();
+        if (attachState !== AttachState.Attached) {
+            throw new Error("Function not allowed in Unattached container");
+        }
+    }
+
+    public get policies(): IDocumentStorageServicePolicies | undefined {
+        return this.storageGetter().policies;
+    }
+
+    public get disposed() {return this._disposed;}
+    public dispose() {
+        this._disposed = true;
+    }
+
+    public get repositoryUrl(): string {
+        return this.storageGetter().repositoryUrl;
+    }
+
+    public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null> {
+        this.throwOnNotAttached();
+        return this.storageGetter().getSnapshotTree(version);
+    }
+
+    public async readBlob(id: string): Promise<ArrayBufferLike> {
+        return this.storageGetter().readBlob(id);
+    }
+
+    public async getVersions(versionId: string, count: number): Promise<IVersion[]> {
+        this.throwOnNotAttached();
+        return this.storageGetter().getVersions(versionId, count);
+    }
+
+    public async write(tree: ITree, parents: string[], message: string, ref: string): Promise<IVersion> {
+        this.throwOnNotAttached();
+        return this.storageGetter().write(tree, parents, message, ref);
+    }
+
+    public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
+        this.throwOnNotAttached();
+        return this.storageGetter().uploadSummaryWithContext(summary, context);
+    }
+
+    public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
+        this.throwOnNotAttached();
+        return this.storageGetter().downloadSummary(handle);
+    }
+
+    public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+        this.throwOnNotAttached();
+        return this.createBlob(file);
+    }
+}

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -28,13 +28,14 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
     constructor(
         private readonly storageGetter: () => IDocumentStorageService,
         private readonly attachState: () => AttachState,
+        private readonly blobs: Map<string, ArrayBufferLike>,
     ) {
     }
 
-    private throwOnNotAttached() {
+    private throwOnNotAttached(name: string) {
         const attachState = this.attachState();
         if (attachState !== AttachState.Attached) {
-            throw new Error("Function not allowed in Unattached container");
+            throw new Error(`${name} not allowed in Unattached container`);
         }
     }
 
@@ -52,36 +53,42 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
     }
 
     public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null> {
-        this.throwOnNotAttached();
+        this.throwOnNotAttached("getSnapshotTree");
         return this.storageGetter().getSnapshotTree(version);
     }
 
     public async readBlob(id: string): Promise<ArrayBufferLike> {
+        const blob = this.blobs.get(id);
+        if (blob !== undefined) {
+            return blob;
+        }
+        // Could not read from storage in unattached container.
+        this.throwOnNotAttached("readBlob");
         return this.storageGetter().readBlob(id);
     }
 
     public async getVersions(versionId: string, count: number): Promise<IVersion[]> {
-        this.throwOnNotAttached();
+        this.throwOnNotAttached("getVersions");
         return this.storageGetter().getVersions(versionId, count);
     }
 
     public async write(tree: ITree, parents: string[], message: string, ref: string): Promise<IVersion> {
-        this.throwOnNotAttached();
+        this.throwOnNotAttached("write");
         return this.storageGetter().write(tree, parents, message, ref);
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
-        this.throwOnNotAttached();
+        this.throwOnNotAttached("uploadSummaryWithContext");
         return this.storageGetter().uploadSummaryWithContext(summary, context);
     }
 
     public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
-        this.throwOnNotAttached();
+        this.throwOnNotAttached("downloadSummary");
         return this.storageGetter().downloadSummary(handle);
     }
 
     public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
-        this.throwOnNotAttached();
+        this.throwOnNotAttached("createBlob");
         return this.createBlob(file);
     }
 }

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -89,6 +89,6 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 
     public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
         this.throwOnNotAttached("createBlob");
-        return this.createBlob(file);
+        return this.storageGetter().createBlob(file);
     }
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -591,7 +591,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const tryFetchBlob = async <T>(blobName: string): Promise<T | undefined> => {
             const blobId = context.baseSnapshot?.blobs[blobName];
             if (context.baseSnapshot && blobId) {
-                return storage ?
+                return context.attachState === AttachState.Attached && storage ?
                     readAndParse<T>(storage, blobId) :
                     readAndParseFromBlobs<T>(context.baseSnapshot.blobs, blobId);
             }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -559,7 +559,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             // pack & unpack aggregated blobs.
             // Note that if storage is provided later by loader layer, we will wrap storage in this.storage getter.
             // BlobAggregationStorage is smart enough for double-wrapping to be no-op
-            if (context.attachState === AttachState.Attached && context.storage !== undefined) {
+            if (context.attachState === AttachState.Attached) {
+                assert(context.storage !== undefined, "Attached state should have storage");
                 const aggrStorage = BlobAggregationStorage.wrap(context.storage, logger);
                 await aggrStorage.unpackSnapshot(context.baseSnapshot);
                 storage = aggrStorage;
@@ -649,7 +650,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // This code is plain wrong. It lies that it never returns undefined!!!
         // All callers should be fixed, as this API is called in detached state of container when we have
         // no storage and it's passed down the stack without right typing.
-        // back-compat 0.40 NoContainerStorageAdapter
+        // back-compat 0.40 NoStorageInDetachedMode
         if (!this._storage && this.context.storage) {
             // Note: BlobAggregationStorage is smart enough for double-wrapping to be no-op
             this._storage = BlobAggregationStorage.wrap(this.context.storage, this.logger);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -559,7 +559,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             // pack & unpack aggregated blobs.
             // Note that if storage is provided later by loader layer, we will wrap storage in this.storage getter.
             // BlobAggregationStorage is smart enough for double-wrapping to be no-op
-            if (context.storage) {
+            if (context.attachState === AttachState.Attached && context.storage !== undefined) {
                 const aggrStorage = BlobAggregationStorage.wrap(context.storage, logger);
                 await aggrStorage.unpackSnapshot(context.baseSnapshot);
                 storage = aggrStorage;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -560,6 +560,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             // Note that if storage is provided later by loader layer, we will wrap storage in this.storage getter.
             // BlobAggregationStorage is smart enough for double-wrapping to be no-op
             if (context.attachState === AttachState.Attached) {
+                // IContainerContext storage api return type still has undefined in 0.39 package version.
+                // So once we release 0.40 container-defn package we can remove this check.
                 assert(context.storage !== undefined, "Attached state should have storage");
                 const aggrStorage = BlobAggregationStorage.wrap(context.storage, logger);
                 await aggrStorage.unpackSnapshot(context.baseSnapshot);
@@ -591,9 +593,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const tryFetchBlob = async <T>(blobName: string): Promise<T | undefined> => {
             const blobId = context.baseSnapshot?.blobs[blobName];
             if (context.baseSnapshot && blobId) {
-                return context.attachState === AttachState.Attached && storage ?
-                    readAndParse<T>(storage, blobId) :
-                    readAndParseFromBlobs<T>(context.baseSnapshot.blobs, blobId);
+                if (context.attachState === AttachState.Attached) {
+                    // IContainerContext storage api return type still has undefined in 0.39 package version.
+                    // So once we release 0.40 container-defn package we can remove this check.
+                    assert(storage !== undefined, "Attached state should have storage");
+                    return readAndParse<T>(storage, blobId);
+                }
+                return readAndParseFromBlobs<T>(context.baseSnapshot.blobs, blobId);
             }
         };
         const chunks = await tryFetchBlob<[string, string[]][]>(chunksBlobName) ?? [];
@@ -650,7 +656,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // This code is plain wrong. It lies that it never returns undefined!!!
         // All callers should be fixed, as this API is called in detached state of container when we have
         // no storage and it's passed down the stack without right typing.
-        // back-compat 0.40 NoStorageInDetachedMode
+        // back-compat 0.40 NoStorageInDetachedMode. Also, IContainerContext storage api return type still
+        // has undefined in 0.39 package version.
+        // So once we release 0.40 container-defn package we can remove this check.
         if (!this._storage && this.context.storage) {
             // Note: BlobAggregationStorage is smart enough for double-wrapping to be no-op
             this._storage = BlobAggregationStorage.wrap(this.context.storage, this.logger);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -649,6 +649,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // This code is plain wrong. It lies that it never returns undefined!!!
         // All callers should be fixed, as this API is called in detached state of container when we have
         // no storage and it's passed down the stack without right typing.
+        // back-compat 0.40 NoContainerStorageAdapter
         if (!this._storage && this.context.storage) {
             // Note: BlobAggregationStorage is smart enough for double-wrapping to be no-op
             this._storage = BlobAggregationStorage.wrap(this.context.storage, this.logger);

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -301,6 +301,31 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             assert.strictEqual(sparseMatrix.id, sparseMatrixId, "Sparse matrix should exist!!");
         });
 
+        it("Storage in detached container", async () => {
+            const { container } =
+                await createDetachedContainerAndGetRootDataStore();
+
+            const snapshotTree = container.serialize();
+            assert(container.storage !== undefined, "Storage should be present in detached container");
+            const response = await container.request({ url: "/" });
+            const defaultDataStore = response.value as TestFluidObject;
+            assert(defaultDataStore.context.storage !== undefined,
+                "Storage should be present in detached data store");
+            let success1: boolean | undefined;
+            await defaultDataStore.context.storage.getSnapshotTree(undefined).catch((err) => success1 = false);
+            assert(success1 === false, "Snapshot fetch should not be allowed in detached data store");
+
+            const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
+            assert(container2.storage !== undefined, "Storage should be present in rehydrated container");
+            const response2 = await container2.request({ url: "/" });
+            const defaultDataStore2 = response2.value as TestFluidObject;
+            assert(defaultDataStore2.context.storage !== undefined,
+                "Storage should be present in rehydrated data store");
+            let success2: boolean | undefined;
+            await defaultDataStore2.context.storage.getSnapshotTree(undefined).catch((err) => success2 = false);
+            assert(success2 === false, "Snapshot fetch should not be allowed in rehydrated data store");
+        });
+
         it("Change contents of dds, then rehydrate and then check summary", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -123,7 +123,6 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         // Create a sub dataStore of type TestFluidObject and verify that it is attached.
         const subDataStore = await createFluidObject(dataStore.context, "default");
         dataStore.root.set("attachKey", subDataStore.handle);
-        assert.strictEqual(subDataStore.context.storage, undefined, "No storage should be there!!");
 
         // Get the sub dataStore's root channel and verify that it is attached.
         const testChannel = await subDataStore.runtime.getChannel("root");


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/6342
Container runtime bluff other layers below it that it always have storage. With this change we will always have a storage which could be called in detached container mode to read blobs . 
Work related to reading blobs will be done in next PR as that was related to other issue. https://github.com/microsoft/FluidFramework/issues/4746