### PR TITLE
More formally expose IClient override in Container and use in tinylicious-client

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -169,9 +169,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree): ISnapshotTree;
 
 // @public
-export const defaultClient: Readonly<IClient>;
-
-// @public
 export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, IEventProvider<IDeltaManagerInternalEvents> {
     constructor(serviceProvider: () => IDocumentService | undefined, client: IClient, logger: ITelemetryLogger, reconnectAllowed: boolean, _active: () => boolean);
     // (undocumented)
@@ -241,6 +238,9 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     // (undocumented)
     get version(): string;
 }
+
+// @public
+export const getDefaultClient: () => IClient;
 
 // @public (undocumented)
 export const getSnapshotTreeFromSerializedContainer: (detachedContainerSnapshot: ISummaryTree) => ISnapshotTree;

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -169,6 +169,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree): ISnapshotTree;
 
 // @public
+export const defaultClient: IClient;
+
+// @public
 export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, IEventProvider<IDeltaManagerInternalEvents> {
     constructor(serviceProvider: () => IDocumentService | undefined, client: IClient, logger: ITelemetryLogger, reconnectAllowed: boolean, _active: () => boolean);
     // (undocumented)

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -169,7 +169,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree): ISnapshotTree;
 
 // @public
-export const defaultClient: IClient;
+export const defaultClient: Readonly<IClient>;
 
 // @public
 export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, IEventProvider<IDeltaManagerInternalEvents> {

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -385,6 +385,7 @@ export type ILoaderOptions = {
     noopTimeFrequency?: number;
     noopCountFrequency?: number;
     maxClientLeaveWaitTime?: number;
+    client?: IClient;
 };
 
 // @public (undocumented)

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -12,6 +12,7 @@ import {
     IProvideFluidCodeDetailsComparer,
 } from "@fluidframework/core-interfaces";
 import {
+    IClient,
     IClientDetails,
     IDocumentMessage,
     IPendingProposal,
@@ -252,6 +253,11 @@ export type ILoaderOptions = {
      * Max time(in ms) container will wait for a leave message of a disconnected client.
     */
     maxClientLeaveWaitTime?: number,
+
+    /**
+     * Sets a client configuration created containers will use instead of the default.
+     */
+     client?: IClient,
 };
 
 /**

--- a/experimental/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/experimental/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -3,22 +3,27 @@
  * Licensed under the MIT License.
  */
 
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IRuntimeFactory } from "@fluidframework/container-definitions";
+import {
+    Container,
+    defaultClient,
+    Loader,
+} from "@fluidframework/container-loader";
+import {
+    IDocumentServiceFactory,
+    IUrlResolver,
+} from "@fluidframework/driver-definitions";
 import {
     ContainerSchema,
     DOProviderContainerRuntimeFactory,
     FluidContainer,
 } from "@fluid-experimental/fluid-static";
-import {
-    IDocumentServiceFactory,
-    IUrlResolver,
-} from "@fluidframework/driver-definitions";
+import { IClient } from "@fluidframework/protocol-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import {
     InsecureTinyliciousTokenProvider,
     InsecureTinyliciousUrlResolver,
 } from "@fluidframework/tinylicious-driver";
-import { IRuntimeFactory } from "@fluidframework/container-definitions";
 import {
     TinyliciousConnectionConfig,
     TinyliciousContainerConfig,
@@ -98,12 +103,20 @@ export class TinyliciousClientInstance {
     ): Promise<Container> {
         const module = { fluidExport: containerRuntimeFactory };
         const codeLoader = { load: async () => module };
+        // Override the default client config to connect with write permissions
+        const clientOverride: IClient = {
+            ...defaultClient,
+            mode: "write",
+        };
 
         const loader = new Loader({
             urlResolver: this.urlResolver,
             documentServiceFactory: this.documentServiceFactory,
             codeLoader,
             logger: tinyliciousContainerConfig.logger,
+            options: {
+                client: clientOverride,
+            },
         });
 
         let container: Container;

--- a/experimental/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/experimental/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -6,7 +6,7 @@
 import { IRuntimeFactory } from "@fluidframework/container-definitions";
 import {
     Container,
-    defaultClient,
+    getDefaultClient,
     Loader,
 } from "@fluidframework/container-loader";
 import {
@@ -105,7 +105,7 @@ export class TinyliciousClientInstance {
         const codeLoader = { load: async () => module };
         // Override the default client config to connect with write permissions
         const clientOverride: IClient = {
-            ...defaultClient,
+            ...getDefaultClient(),
             mode: "write",
         };
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -162,7 +162,7 @@ export enum ConnectionState {
  * through ILoaderOptions for all Containers created by a Loader, or just the `details` member
  * may be overridden for individual requests through ILoaderHeader or IContainerConfig.
  */
-export const defaultClient: IClient = {
+export const defaultClient: Readonly<IClient> = {
     details: {
         capabilities: { interactive: true },
     },
@@ -1526,7 +1526,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     private get client(): IClient {
         const client: IClient = this.options?.client !== undefined
             ? this.options.client
-            : defaultClient;
+            : { ...defaultClient };
 
         if (this.clientDetailsOverride !== undefined) {
             merge(client.details, this.clientDetailsOverride);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -157,6 +157,21 @@ export enum ConnectionState {
     Connected,
 }
 
+/**
+ * The default client configuration used by a container.  This default may be overridden
+ * through ILoaderOptions for all Containers created by a Loader, or just the `details` member
+ * may be overridden for individual requests through ILoaderHeader or IContainerConfig.
+ */
+export const defaultClient: IClient = {
+    details: {
+        capabilities: { interactive: true },
+    },
+    mode: "read", // default reconnection mode on lost connection / connection error
+    permission: [],
+    scopes: [],
+    user: { id: "" },
+};
+
 // This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
 // a detached container can be rehydrated.
 export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot: ISummaryTree) => {
@@ -1510,16 +1525,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     private get client(): IClient {
         const client: IClient = this.options?.client !== undefined
-            ? (this.options.client as IClient)
-            : {
-                details: {
-                    capabilities: { interactive: true },
-                },
-                mode: "read", // default reconnection mode on lost connection / connection error
-                permission: [],
-                scopes: [],
-                user: { id: "" },
-            };
+            ? this.options.client
+            : defaultClient;
 
         if (this.clientDetailsOverride !== undefined) {
             merge(client.details, this.clientDetailsOverride);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -162,14 +162,16 @@ export enum ConnectionState {
  * through ILoaderOptions for all Containers created by a Loader, or just the `details` member
  * may be overridden for individual requests through ILoaderHeader or IContainerConfig.
  */
-export const defaultClient: Readonly<IClient> = {
-    details: {
-        capabilities: { interactive: true },
-    },
-    mode: "read", // default reconnection mode on lost connection / connection error
-    permission: [],
-    scopes: [],
-    user: { id: "" },
+export const getDefaultClient = (): IClient => {
+    return {
+        details: {
+            capabilities: { interactive: true },
+        },
+        mode: "read", // default reconnection mode on lost connection / connection error
+        permission: [],
+        scopes: [],
+        user: { id: "" },
+    };
 };
 
 // This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
@@ -1526,7 +1528,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     private get client(): IClient {
         const client: IClient = this.options?.client !== undefined
             ? this.options.client
-            : { ...defaultClient };
+            : getDefaultClient();
 
         if (this.clientDetailsOverride !== undefined) {
             merge(client.details, this.clientDetailsOverride);


### PR DESCRIPTION
fluid-static wants clients to connect in "write" mode by default instead of doing the "read" mode to "write" mode switch for odsp specifically.  There already is a way to do this through loader options, but it's undocumented.  _On the assumption that this functionality is intentional and not a hidden API_, formalize access to this API and use it in tinylicious-client here.  If we actually don't want anyone using it I can look at some other solutions 🙃