### PR TITLE
r11s: Read 401s from Riddler in Alfred Lambda

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -213,7 +213,7 @@ export function configureWebSocketServices(
                 await tenantManager.verifyToken(claims.tenantId, token);
             } catch (err) {
                 // eslint-disable-next-line prefer-promise-reject-errors
-                return Promise.reject({ code: 403, message: "Invalid token" });
+                return Promise.reject({ code: err?.code ?? 403, message: err?.message ?? "Invalid token" });
             }
 
             const clientId = generateClientId();


### PR DESCRIPTION
Alfred Lambda views all errors from Riddler as non-retryable. This is not the case, and can lead to innacurate errors being passed to the client on document connection.