### PR TITLE
Fix scribe requiring 2 summaries to stop nacking messages

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -303,7 +303,7 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
 
         // Check if we should nack this message
         const nackMessages = this.nackMessages;
-        if (nackMessages) {
+        if (nackMessages && this.serviceConfiguration.deli.enableNackMessages) {
             let shouldNack = true;
 
             if (nackMessages.allowSystemMessages && (isServiceMessageType(message.type) || !message.clientId)) {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -439,8 +439,8 @@ export class ScribeLambda implements IPartitionLambda {
     }
 
     /**
-     * Updates protocol head to the new summary sequence number
      * Protocol head is the sequence number of the last summary
+     * This method updates the protocol head to the new summary sequence number
      * @param protocolHead The sequence number of the new summary
      */
     private async updateProtocolHead(protocolHead: number) {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -438,12 +438,24 @@ export class ScribeLambda implements IPartitionLambda {
         }
     }
 
+    /**
+     * Updates protocol head to the new summary sequence number
+     * Protocol head is the sequence number of the last summary
+     * @param protocolHead The sequence number of the new summary
+     */
     private async updateProtocolHead(protocolHead: number) {
-        if (this.serviceConfiguration.scribe.nackMessages.enable &&
-            this.serviceConfiguration.scribe.nackMessages.maxOps >= (this.sequenceNumber - this.protocolHead)) {
-            // we were over the limit, so we must have been nacking messages
-            // tell deli to stop
-            await this.sendNackMessage(undefined);
+        if (this.serviceConfiguration.scribe.nackMessages.enable) {
+            const opsSincePreviousSummary = this.sequenceNumber - this.protocolHead;
+            if (opsSincePreviousSummary >= this.serviceConfiguration.scribe.nackMessages.maxOps) {
+                // we were over the limit, so we must have been nacking messages
+
+                // verify this new summary will get out us of this state
+                const opsSinceNewSummary = this.sequenceNumber - protocolHead;
+                if (opsSinceNewSummary < this.serviceConfiguration.scribe.nackMessages.maxOps) {
+                    // tell deli to stop nacking future messages
+                    await this.sendNackMessage(undefined);
+                }
+            }
         }
 
         this.protocolHead = protocolHead;

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -7,6 +7,9 @@ import { IClientConfiguration, INackContent, NackErrorType } from "@fluidframewo
 
 // Deli lambda configuration
 export interface IDeliServerConfiguration {
+    // Enables nack messages logic
+    enableNackMessages: boolean;
+
     // Expire clients after this amount of inactivity
     clientTimeout: number;
 
@@ -108,6 +111,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         maxAckWaitTime: 600000,
     },
     deli: {
+        enableNackMessages: true,
         clientTimeout: 5 * 60 * 1000,
         activityTimeout: 30 * 1000,
         noOpConsolidationTimeout: 250,


### PR DESCRIPTION
- Fix scribe requiring 2 summaries to stop nacking messages. The logic for controlling when to stop sending the nacks was not correct
- Add a way to make deli stop nacking messages - This would be a "break glass" procedure in case a future bug pops up and we need to disable these nacks asap.
- Add comments to updateProtocolHead to clarify what it's doing