### PR TITLE
Fix wrong handling of brackets in absolute paths passed as options

### DIFF
--- a/experimental/PropertyDDS/packages/property-binder/index.d.ts
+++ b/experimental/PropertyDDS/packages/property-binder/index.d.ts
@@ -1206,6 +1206,8 @@ declare module "@fluid-experimental/property-binder" {
              */
             _clone(): RemovalContext;
 
+            getAbsolutePath(): string;
+
         }
 
         /**

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
@@ -545,18 +545,19 @@ const recursivelyVisitHierarchy = function(
         const ids = in_propertyElement.getChildIds();
         if (ids) {
           _.each(ids, function(id) {
-            const child = in_propertyElement.getChild(id, RESOLVE_NEVER);
+            const skippedId = PathHelper.quotePathSegmentIfNeeded(id);
+            const child = in_propertyElement.getChild(skippedId, RESOLVE_NEVER);
             in_tokenizedPath.push(id);
             const oldDataBindingTreeNode = in_dataBindingTreeNode;
             if (in_dataBindingTreeNode) {
-              in_dataBindingTreeNode = in_dataBindingTreeNode.getNodeForTokenizedPath([id]);
+              in_dataBindingTreeNode = in_dataBindingTreeNode.getNodeForTokenizedPath([skippedId]);
             }
             const typeidSplit = TypeIdHelper.extractContext(in_propertyElement.getProperty().getFullTypeid());
             const subpath = (in_path === '/')
-              ? '/' + id
+              ? '/' + skippedId
               : typeidSplit.context !== 'single'
-                ? in_path + `[${PathHelper.quotePathSegmentIfNeeded(id)}]`
-                : in_path + '.' + PathHelper.quotePathSegmentIfNeeded(id);
+                ? in_path + `[${skippedId}]`
+                : in_path + '.' + skippedId;
             _recursiveStep(child, subpath, in_tokenizedPath, in_dataBindingTreeNode);
             in_tokenizedPath.pop();
             in_dataBindingTreeNode = oldDataBindingTreeNode;

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
@@ -552,11 +552,11 @@ const recursivelyVisitHierarchy = function(
               in_dataBindingTreeNode = in_dataBindingTreeNode.getNodeForTokenizedPath([id]);
             }
             const typeidSplit = TypeIdHelper.extractContext(in_propertyElement.getProperty().getFullTypeid());
-            const subpath = (in_path === '/') 
-              ? '/' + id 
-              : typeidSplit.context !== 'single' 
-                ? in_path + `[${id}]` 
-                : in_path + '.' + id;
+            const subpath = (in_path === '/')
+              ? '/' + id
+              : typeidSplit.context !== 'single'
+                ? in_path + `[${PathHelper.quotePathSegmentIfNeeded(id)}]`
+                : in_path + '.' + PathHelper.quotePathSegmentIfNeeded(id);
             _recursiveStep(child, subpath, in_tokenizedPath, in_dataBindingTreeNode);
             in_tokenizedPath.pop();
             in_dataBindingTreeNode = oldDataBindingTreeNode;

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
@@ -551,7 +551,8 @@ const recursivelyVisitHierarchy = function(
             if (in_dataBindingTreeNode) {
               in_dataBindingTreeNode = in_dataBindingTreeNode.getNodeForTokenizedPath([id]);
             }
-            const subpath = (in_path === '/') ? '/' + id : in_path + '.' + id;
+            const typeidSplit = TypeIdHelper.extractContext(in_propertyElement.getProperty().getFullTypeid());
+            const subpath = (in_path === '/') ? '/' + id : typeidSplit.context !== 'single' ? in_path + `[${id}]` : in_path + '.' + id;
             _recursiveStep(child, subpath, in_tokenizedPath, in_dataBindingTreeNode);
             in_tokenizedPath.pop();
             in_dataBindingTreeNode = oldDataBindingTreeNode;

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/internal_utils.js
@@ -552,7 +552,11 @@ const recursivelyVisitHierarchy = function(
               in_dataBindingTreeNode = in_dataBindingTreeNode.getNodeForTokenizedPath([id]);
             }
             const typeidSplit = TypeIdHelper.extractContext(in_propertyElement.getProperty().getFullTypeid());
-            const subpath = (in_path === '/') ? '/' + id : typeidSplit.context !== 'single' ? in_path + `[${id}]` : in_path + '.' + id;
+            const subpath = (in_path === '/') 
+              ? '/' + id 
+              : typeidSplit.context !== 'single' 
+                ? in_path + `[${id}]` 
+                : in_path + '.' + id;
             _recursiveStep(child, subpath, in_tokenizedPath, in_dataBindingTreeNode);
             in_tokenizedPath.pop();
             in_dataBindingTreeNode = oldDataBindingTreeNode;

--- a/experimental/PropertyDDS/packages/property-binder/src/internal/property_element.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/internal/property_element.js
@@ -334,9 +334,15 @@ class PropertyElement {
       return this;
     }
 
-    if (typeof in_child === 'string' || typeof in_child === 'number') {
+    let isPathString = false;
+    if (typeof in_child === 'string') {
+      isPathString = true;
+    }
+
+    if (isPathString || typeof in_child === 'number') {
       in_child = [in_child];
     }
+
     const resolutionMode = in_options.referenceResolutionMode;
     // Determine how to resolve references before the last one
     const isAlways = (resolutionMode === undefined || resolutionMode === BaseProperty.REFERENCE_RESOLUTION.ALWAYS);
@@ -370,7 +376,7 @@ class PropertyElement {
             this.becomeDereference();
           }
         }
-        const key = PathHelper.unquotePathSegment(token);
+        const key = !isPathString ? token : PathHelper.unquotePathSegment(token);
         if (this._property && this._property.has(key)) {
           if (this.isPrimitiveCollection()) {
             if (this._childToken !== undefined) {

--- a/experimental/PropertyDDS/packages/property-binder/src/internal/property_element.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/internal/property_element.js
@@ -370,7 +370,7 @@ class PropertyElement {
             this.becomeDereference();
           }
         }
-        const key = PathHelper.tokenizePathString(token)[0];
+        const key = PathHelper.unquotePathSegment(token);
         if (this._property && this._property.has(key)) {
           if (this.isPrimitiveCollection()) {
             if (this._childToken !== undefined) {

--- a/experimental/PropertyDDS/packages/property-binder/src/internal/property_element.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/internal/property_element.js
@@ -370,7 +370,8 @@ class PropertyElement {
             this.becomeDereference();
           }
         }
-        if (this._property && this._property.has(token)) {
+        const key = PathHelper.tokenizePathString(token)[0];
+        if (this._property && this._property.has(key)) {
           if (this.isPrimitiveCollection()) {
             if (this._childToken !== undefined) {
               // We're currently representing an element of a string or number array, why
@@ -378,15 +379,15 @@ class PropertyElement {
               console.assert(!this.isReference());
               this.invalidate();
             } else if (this._property.getContext() === 'array') {
-              this._childToken = Number(token);
+              this._childToken = Number(key);
             } else {
-              this._childToken = String(token);
+              this._childToken = String(key);
             }
           } else {
             // We pass RESOLVE_NEVER so that we just get the child, without following
             // any references if the child is another reference.
             // Below, we will decide whether to dereference
-            this._property = this._property.get(token, RESOLVE_NEVER);
+            this._property = this._property.get(key, RESOLVE_NEVER);
           }
           if (this._property && options === RESOLVE_ALWAYS && nextToken !== '*' && this.isReference()) {
             this.becomeDereference();

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binder.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binder.spec.js
@@ -3776,6 +3776,64 @@ describe('DataBinder', function() {
       expect(childDataBinding.getProperty()).toEqual(childPset2);
       expect(childDataBinding.onPostCreate).toHaveBeenCalledTimes(1);
     });
+    it('excludePrefix with absolute paths using brackets', function() {
+      dataBinder.attachTo(workspace);
+
+      //   Register the base (Child) typeid
+      dataBinder.defineDataBinding('BINDING',
+        ChildTemplate.typeid,
+        ChildDataBinding);
+      const namedPropertyMap = PropertyFactory.create(ChildTemplate.typeid, 'map');
+      workspace.root.insert('map', namedPropertyMap);
+      const namedProperty = PropertyFactory.create(ChildTemplate.typeid);
+      namedPropertyMap.insert(namedProperty.getId(), namedProperty);
+      dataBinder.activateDataBinding('BINDING', ChildTemplate.typeid, {
+        excludePrefix: namedProperty.getAbsolutePath()
+      });
+      expect(dataBinder._dataBindingCreatedCounter).toEqual(0);
+    });
+
+    it('exactPath with absolute paths using brackets', function() {
+      dataBinder.attachTo(workspace);
+  
+      //   Register the base (Child) typeid
+      dataBinder.defineDataBinding('BINDING',
+        ChildTemplate.typeid,
+        ChildDataBinding);
+
+      const namedPropertyMap = PropertyFactory.create(ChildTemplate.typeid, 'map');
+      workspace.root.insert('map', namedPropertyMap);
+      const namedProperty1 = PropertyFactory.create(ChildTemplate.typeid);
+      const namedProperty2 = PropertyFactory.create(ChildTemplate.typeid);
+      namedPropertyMap.insert(namedProperty1.getId(), namedProperty1);
+      namedPropertyMap.insert(namedProperty2.getId(), namedProperty2);
+
+      dataBinder.activateDataBinding('BINDING', ChildTemplate.typeid, {
+        exactPath: namedProperty1.getAbsolutePath()
+      });
+      expect(dataBinder._dataBindingCreatedCounter).toEqual(1);
+    });
+
+    it('includePrefix with absolute paths using brackets', function() {
+      dataBinder.attachTo(workspace);
+    
+      //   Register the base (Child) typeid
+      dataBinder.defineDataBinding('BINDING',
+        ChildTemplate.typeid,
+        ChildDataBinding);
+  
+      const namedPropertyMap = PropertyFactory.create(ChildTemplate.typeid, 'map');
+      workspace.root.insert('map', namedPropertyMap);
+      const namedProperty1 = PropertyFactory.create(ChildTemplate.typeid);
+      const namedProperty2 = PropertyFactory.create(ChildTemplate.typeid);
+      namedPropertyMap.insert(namedProperty1.getId(), namedProperty1);
+      namedPropertyMap.insert(namedProperty2.getId(), namedProperty2);
+  
+      dataBinder.activateDataBinding('BINDING', ChildTemplate.typeid, {
+        includePrefix: namedProperty1.getAbsolutePath()
+      });
+      expect(dataBinder._dataBindingCreatedCounter).toEqual(1);
+    });
 
     it('should only create an DataBinding when allowed by includePrefix', function() {
       // Register the base (Child) typeid

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binder.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binder.spec.js
@@ -133,6 +133,44 @@ describe('DataBinder', function() {
       handle.destroy();
     });
 
+    it('Should be possible to listen to paths with special characters that need to be escaped/quoted.', function() {
+      const dataBinder = new DataBinder(workspace);
+      const handle = dataBinder.register('BINDING', ParentTemplate.typeid, ParentDataBinding);
+
+      let property = PropertyFactory.create(ParentTemplate.typeid, 'single');
+      workspace.root.insert('/', property);
+      let dataBinding = dataBinder.resolve(property, 'BINDING');
+      expect(dataBinding.onPostCreate).toHaveBeenCalledTimes(1);
+
+      // Test a child modification on that path with special characters
+      expect(property.getValue('text')).toEqual('');
+      property.get('text').setValue('test');
+      expect(property.getValue('text')).toEqual('test');
+      expect(dataBinding.onModify).toHaveBeenCalledTimes(1);
+
+      property = PropertyFactory.create(ParentTemplate.typeid, 'single');
+      workspace.root.insert('//', property);
+      dataBinding = dataBinder.resolve(property, 'BINDING');
+      expect(dataBinding.onPostCreate).toHaveBeenCalledTimes(1);
+
+      property = PropertyFactory.create(ParentTemplate.typeid, 'single');
+      workspace.root.insert('./', property);
+      dataBinding = dataBinder.resolve(property, 'BINDING');
+      expect(dataBinding.onPostCreate).toHaveBeenCalledTimes(1);
+
+      property = PropertyFactory.create(ParentTemplate.typeid, 'single');
+      workspace.root.insert('.//', property);
+      dataBinding = dataBinder.resolve(property, 'BINDING');
+      expect(dataBinding.onPostCreate).toHaveBeenCalledTimes(1);
+
+      property = PropertyFactory.create(ParentTemplate.typeid, 'single');
+      workspace.root.insert('./filename.extension', property);
+      dataBinding = dataBinder.resolve(property, 'BINDING');
+      expect(dataBinding.onPostCreate).toHaveBeenCalledTimes(1);
+
+      handle.destroy();
+    });
+
     it('it should not be possible to register multiple DataBindings for a single typeid and bindingType', function() {
       var dataBinder = new DataBinder();
       var bindingType = 'BINDING';
@@ -3795,7 +3833,7 @@ describe('DataBinder', function() {
 
     it('exactPath with absolute paths using brackets', function() {
       dataBinder.attachTo(workspace);
-  
+
       //   Register the base (Child) typeid
       dataBinder.defineDataBinding('BINDING',
         ChildTemplate.typeid,
@@ -3816,19 +3854,19 @@ describe('DataBinder', function() {
 
     it('includePrefix with absolute paths using brackets', function() {
       dataBinder.attachTo(workspace);
-    
+
       //   Register the base (Child) typeid
       dataBinder.defineDataBinding('BINDING',
         ChildTemplate.typeid,
         ChildDataBinding);
-  
+
       const namedPropertyMap = PropertyFactory.create(ChildTemplate.typeid, 'map');
       workspace.root.insert('map', namedPropertyMap);
       const namedProperty1 = PropertyFactory.create(ChildTemplate.typeid);
       const namedProperty2 = PropertyFactory.create(ChildTemplate.typeid);
       namedPropertyMap.insert(namedProperty1.getId(), namedProperty1);
       namedPropertyMap.insert(namedProperty2.getId(), namedProperty2);
-  
+
       dataBinder.activateDataBinding('BINDING', ChildTemplate.typeid, {
         includePrefix: namedProperty1.getAbsolutePath()
       });

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/onDemandDataBinding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/onDemandDataBinding.spec.js
@@ -877,7 +877,7 @@ describe('on demand DataBindings', function() {
       { includePrefix: 'root.child1' });
     // matches root.child1.map.key3
     const h3 = dataBinder.register('BINDING3', PrimitiveChildrenTemplate.typeid, ParentDataBinding,
-      { exactPath: 'root.child1.map.key3' });
+      { exactPath: 'root.child1.map[key3]' });
 
     // Nothing should be created yet
     expect(dataBinder._dataBindingCreatedCounter).toEqual(0);
@@ -916,13 +916,13 @@ describe('on demand DataBindings', function() {
 
     // matches myArray.{1,2,3} and data
     const h1 = dataBinder.register('BINDING', PrimitiveChildrenTemplate.typeid, ParentDataBinding,
-      { excludePrefix: 'myArray.0' });
+      { excludePrefix: 'myArray[0]' });
     // matches myArray.{0,1,2,3}
     const h2 = dataBinder.register('BINDING2', PrimitiveChildrenTemplate.typeid, ParentDataBinding,
       { includePrefix: 'myArray' });
     // matches myArray.2
     const h3 = dataBinder.register('BINDING3', PrimitiveChildrenTemplate.typeid, ParentDataBinding,
-      { exactPath: 'myArray.2' });
+      { exactPath: 'myArray[2]' });
 
     // Nothing should be created yet
     expect(dataBinder._dataBindingCreatedCounter).toEqual(0);

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/property_element.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/property_element.spec.js
@@ -655,7 +655,7 @@ describe('Property element', function() {
 
     const propElem = new PropertyElement(workspace.root);
     expect(propElem.getChild(['"/"', 'aString']).isValid()).toEqual(true);
-    expect(propElem.getChild(['"/"', 'aString', '/']).getProperty()).toEqual(workspace.root);
+    expect(propElem.getChild(['"/"', 'aString', '/']).isValid()).toEqual(false);
   });
 
 });

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/property_element.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/property_element.spec.js
@@ -270,7 +270,8 @@ describe('Property element', function() {
 
     mymap.insert('"my.child.path"', 42);
     const propElem = new PropertyElement(mymap);
-    propElem.becomeChild('"my.child.path"');
+    // Now becomeChild expect a quoted/escaped paths instead of ids.
+    propElem.becomeChild('""my.child.path""');
     expect(propElem.isValid()).toEqual(true);
 
     expect(propElem.getValue()).toEqual(42);

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/property_element.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/property_element.spec.js
@@ -649,4 +649,13 @@ describe('Property element', function() {
     expect(propElem.getChild(['myReference2', 'aNumber'], RESOLVE_NO_LEAFS).getValue()).toEqual(42);
   });
 
+  it('getChild with special characters in tokenized path', function() {
+    const myData = PropertyFactory.create(PrimitiveChildrenTemplate.typeid);
+    workspace.root.insert('"/"', myData);
+
+    const propElem = new PropertyElement(workspace.root);
+    expect(propElem.getChild(['"/"', 'aString']).isValid()).toEqual(true);
+    expect(propElem.getChild(['"/"', 'aString', '/']).getProperty()).toEqual(workspace.root);
+  });
+
 });

--- a/experimental/PropertyDDS/packages/property-changeset/src/path_helper.js
+++ b/experimental/PropertyDDS/packages/property-changeset/src/path_helper.js
@@ -340,20 +340,21 @@ PathHelper.quotePathSegment = function(in_pathSegment) {
  * @return {string} unquoted path string
  */
  PathHelper.unquotePathSegment = function(in_quotedPathSegment) {
-    if (!in_quotedPathSegment || typeof in_quotedPathSegment !== 'string') {
-        return in_quotedPathSegment;
+    if (typeof in_quotedPathSegment !== 'string') {
+        throw new Error(`Expecting a string as a path: ${in_quotedPathSegment}`);
     }
 
-    // We remove double quotes: ;
     if (in_quotedPathSegment[0] === '"' && in_quotedPathSegment[in_quotedPathSegment.length - 1] === '"') {
-        in_quotedPathSegment = in_quotedPathSegment.substr(1, in_quotedPathSegment.length - 2);
+
+          // We remove double quotes
+          in_quotedPathSegment = in_quotedPathSegment.substr(1, in_quotedPathSegment.length - 2);
+
+          // Then we unescape escape symbols
+          in_quotedPathSegment = in_quotedPathSegment.replace(/\\\\/g, '\\');
+
+          // Then we unescape quotes
+          in_quotedPathSegment = in_quotedPathSegment.replace(/\\"/g, '"');
     }
-
-    // Then we unescape escape symbols
-    in_quotedPathSegment = in_quotedPathSegment.replace(/\\\\/g, '\\');
-
-    // Then we unescape quotes
-    in_quotedPathSegment = in_quotedPathSegment.replace(/\\"/g, '"');
 
     return in_quotedPathSegment;
   };

--- a/experimental/PropertyDDS/packages/property-changeset/src/path_helper.js
+++ b/experimental/PropertyDDS/packages/property-changeset/src/path_helper.js
@@ -333,6 +333,33 @@ PathHelper.quotePathSegment = function(in_pathSegment) {
 };
 
 /**
+ * Reverse a quoted/escaped string for a path seqment
+ *
+ * @param {string} in_quotedPathSegment   - The quoted/escaped path string to put in quotes
+ *
+ * @return {string} unquoted path string
+ */
+ PathHelper.unquotePathSegment = function(in_quotedPathSegment) {
+    if (!in_quotedPathSegment || typeof in_quotedPathSegment !== 'string') {
+        return in_quotedPathSegment;
+    }
+
+    // We remove double quotes: ;
+    if (in_quotedPathSegment[0] === '"' && in_quotedPathSegment[in_quotedPathSegment.length - 1] === '"') {
+        in_quotedPathSegment = in_quotedPathSegment.substr(1, in_quotedPathSegment.length - 2);
+    }
+
+    // Then we unescape escape symbols
+    in_quotedPathSegment = in_quotedPathSegment.replace(/\\\\/g, '\\');
+
+    // Then we unescape quotes
+    in_quotedPathSegment = in_quotedPathSegment.replace(/\\"/g, '"');
+
+    return in_quotedPathSegment;
+  };
+
+
+/**
  * Adds quotation marks to a path string if they are needed
  *
  * @param {string} in_pathSegment   - The path string to put in quotes

--- a/experimental/PropertyDDS/packages/property-changeset/test/path_helper.spec.js
+++ b/experimental/PropertyDDS/packages/property-changeset/test/path_helper.spec.js
@@ -238,6 +238,34 @@ describe('PathHelper', function() {
   });
 
 
+  describe('unquotePathSegment', function() {
+    it('should unquote simple strings', function() {
+      expect(PathHelper.unquotePathSegment('"test"')).to.equal('test');
+    });
+    
+    it('should correctly unquote strings with a quotation mark', function() {
+      expect(PathHelper.unquotePathSegment('"\\""')).to.equal('"');
+    });
+
+    it('should correctly unquote strings with a backslash', function() {
+      expect(PathHelper.unquotePathSegment('"\\\\"')).to.equal('\\');
+    });
+
+    it('should work with empty strings', function() {
+        expect(PathHelper.unquotePathSegment('')).to.equal('');
+    });
+
+    it('should ignore non strings', function() {
+        expect(PathHelper.unquotePathSegment(5)).to.equal(5);
+    });
+
+    it('should work for paths with multiple occurrences of the test string', function() {
+      expect(PathHelper.unquotePathSegment('"test\\"property\\""')).to.equal('test"property"');
+      expect(PathHelper.unquotePathSegment('"test\\\\property\\\\"')).to.equal('test\\property\\');
+      expect(PathHelper.unquotePathSegment('"test\\"\\\\property\\\\\\""')).to.equal('test"\\property\\"');
+    });
+  });
+
   describe('convertAbsolutePathToCanonical', function() {
     it('should remove leading /', function() {
       expect(PathHelper.convertAbsolutePathToCanonical('/a.b.c')).to.equal('a.b.c');

--- a/experimental/PropertyDDS/packages/property-changeset/test/path_helper.spec.js
+++ b/experimental/PropertyDDS/packages/property-changeset/test/path_helper.spec.js
@@ -242,7 +242,7 @@ describe('PathHelper', function() {
     it('should unquote simple strings', function() {
       expect(PathHelper.unquotePathSegment('"test"')).to.equal('test');
     });
-    
+
     it('should correctly unquote strings with a quotation mark', function() {
       expect(PathHelper.unquotePathSegment('"\\""')).to.equal('"');
     });
@@ -255,8 +255,8 @@ describe('PathHelper', function() {
         expect(PathHelper.unquotePathSegment('')).to.equal('');
     });
 
-    it('should ignore non strings', function() {
-        expect(PathHelper.unquotePathSegment(5)).to.equal(5);
+    it('should throw on non strings', function() {
+        expect(() => PathHelper.unquotePathSegment(5)).to.throw();
     });
 
     it('should work for paths with multiple occurrences of the test string', function() {


### PR DESCRIPTION
Inconsistent handling/constructing absolute paths causes inconsistent behaviour when passing the options `includePrefix`, `excludePrefix`, `exactPath` with different paths strings.
It used to assume while building the paths, that path tokens are separated only by `.`s, and ignore the use case when one of the tokens points to a collection such as `map` or `array`, then it should be separated by brackets (e.g. `map['test']` // and not `map.test`) 
This PR , calculates the paths in consistent similar to how the property-tree calculates it when calling `property_example.getAbsolutePath()`. 