### PR TITLE
Add more helpful info to layer-check error

### DIFF
--- a/tools/build-tools/src/layerCheck/layerGraph.ts
+++ b/tools/build-tools/src/layerCheck/layerGraph.ts
@@ -335,7 +335,7 @@ export class LayerGraph {
                 }
             }
             if (!matched) {
-                throw new Error(`${pkg.nameColored}: ERROR: Package doesn't match any directories. Unable to do dependency check`);
+                throw new Error(`${pkg.nameColored}: ERROR: Package doesn't match any directories. Unable to do dependency check. Check that the package is listed in data/layerInfo.json.`);
             }
         }
     }


### PR DESCRIPTION
For those unfamiliar with layer-check, the current error message doesn't help them find the remedy, which is to add the package to layerInfo.json.