### PR TITLE
[Move telemetry tagging code - 3/3] Update telemetry-utils and client to use latest tagging definitions.

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -25,7 +25,6 @@ import { IStreamResult } from '@fluidframework/driver-definitions';
 import { ISummaryContext } from '@fluidframework/driver-definitions';
 import { ISummaryHandle } from '@fluidframework/protocol-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
-import { ITaggableTelemetryProperties } from '@fluidframework/telemetry-utils';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryErrorEvent } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
@@ -39,7 +38,7 @@ import { LoggingError } from '@fluidframework/telemetry-utils';
 
 // @public (undocumented)
 export class AuthorizationError extends LoggingError implements IAuthorizationError {
-    constructor(errorMessage: string, claims: string | undefined, tenantId: string | undefined, props?: ITaggableTelemetryProperties);
+    constructor(errorMessage: string, claims: string | undefined, tenantId: string | undefined, props?: ITelemetryProperties);
     // (undocumented)
     readonly canRetry = false;
     // (undocumented)
@@ -113,7 +112,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITaggableTelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType>;
@@ -160,7 +159,7 @@ export function ensureFluidResolvedUrl(resolved: IResolvedUrl | undefined): asse
 
 // @public
 export class GenericNetworkError extends LoggingError implements IDriverErrorBase {
-    constructor(errorMessage: string, canRetry: boolean, props?: ITaggableTelemetryProperties);
+    constructor(errorMessage: string, canRetry: boolean, props?: ITelemetryProperties);
     // (undocumented)
     readonly canRetry: boolean;
     // (undocumented)
@@ -210,7 +209,7 @@ export class MultiUrlResolver implements IUrlResolver {
 
 // @public (undocumented)
 export class NetworkErrorBasic<T> extends LoggingError {
-    constructor(errorMessage: string, errorType: T, canRetry: boolean, props?: ITaggableTelemetryProperties);
+    constructor(errorMessage: string, errorType: T, canRetry: boolean, props?: ITelemetryProperties);
     // (undocumented)
     readonly canRetry: boolean;
     // (undocumented)
@@ -219,7 +218,7 @@ export class NetworkErrorBasic<T> extends LoggingError {
 
 // @public (undocumented)
 export class NonRetryableError<T> extends NetworkErrorBasic<T> {
-    constructor(errorMessage: string, errorType: T, props?: ITaggableTelemetryProperties);
+    constructor(errorMessage: string, errorType: T, props?: ITelemetryProperties);
     // (undocumented)
     readonly errorType: T;
 }
@@ -274,7 +273,7 @@ export function requestOps(get: (from: number, to: number, telemetryProps: ITele
 
 // @public (undocumented)
 export class RetryableError<T> extends NetworkErrorBasic<T> {
-    constructor(errorMessage: string, errorType: T, props?: ITaggableTelemetryProperties);
+    constructor(errorMessage: string, errorType: T, props?: ITelemetryProperties);
     // (undocumented)
     readonly errorType: T;
 }
@@ -311,7 +310,7 @@ export function streamObserver<T>(stream: IStream<T>, handler: (value: IStreamRe
 
 // @public
 export class ThrottlingError extends LoggingError implements IThrottlingWarning {
-    constructor(errorMessage: string, retryAfterSeconds: number, props?: ITaggableTelemetryProperties);
+    constructor(errorMessage: string, retryAfterSeconds: number, props?: ITelemetryProperties);
     // (undocumented)
     readonly canRetry = true;
     // (undocumented)

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0"

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.1",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0"

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1025.0-0"
   },

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.1",
+    "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1025.0-0"
   },

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/react-inputs": "^0.41.0",
     "@fluidframework/sequence": "^0.41.0",

--- a/examples/apps/likes-and-comments/package.json
+++ b/examples/apps/likes-and-comments/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/counter": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.41.0",
     "@fluidframework/map": "^0.41.0",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -43,7 +43,7 @@
     "@fluid-example/prosemirror": "^0.41.0",
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",
     "@fluidframework/runtime-definitions": "^0.41.0",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "css-loader": "^1.0.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
     "@fluidframework/cell": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",
     "@fluidframework/map": "^0.41.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/ink": "^0.41.0",
     "@fluidframework/view-interfaces": "^0.41.0"

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/react": "^0.41.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/react": "^0.41.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/counter": "^0.41.0",
     "@fluidframework/react": "^0.41.0",
     "react": "^16.10.2",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/counter": "^0.41.0",
     "@fluidframework/react": "^0.41.0",
     "react": "^16.10.2",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/counter": "^0.41.0",
     "@fluidframework/react": "^0.41.0",
     "react": "^16.10.2",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-experimental/task-manager": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/counter": "^0.41.0",
     "@fluidframework/runtime-definitions": "^0.41.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/map": "^0.41.0",
     "@fluidframework/view-interfaces": "^0.41.0",
     "react": "^16.10.2",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/map": "^0.41.0",
     "@fluidframework/view-interfaces": "^0.41.0",
     "react": "^16.10.2",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -39,7 +39,7 @@
     "@fluid-example/multiview-coordinate-interface": "^0.41.0",
     "@fluid-example/multiview-coordinate-model": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/map": "^0.41.0"
   },

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@fluid-example/multiview-coordinate-interface": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/map": "^0.41.0"
   },
   "devDependencies": {

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/map": "^0.41.0",
     "@fluidframework/view-interfaces": "^0.41.0",
     "rc-slider": "^8.6.9",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime-definitions": "^0.41.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/counter": "^0.41.0",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/map": "^0.41.0",
     "@fluidframework/view-interfaces": "^0.41.0",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluid-example/clicker": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/view-interfaces": "^0.41.0"
   },
   "devDependencies": {

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/flow-util-lib": "^0.41.0",
     "@fluid-example/table-document": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/runtime-utils": "^0.41.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -36,7 +36,7 @@
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluid-experimental/task-manager": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.41.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/clicker": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
     "@fluidframework/cell": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/map": "^0.41.0",
     "@fluidframework/react-inputs": "^0.41.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -42,7 +42,7 @@
     "@fluid-example/spaces": "^0.41.0",
     "@fluid-experimental/last-edited": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.41.0",
     "@fluidframework/container-runtime-definitions": "^0.41.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@fluid-example/flow-util-lib": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/data-object-base": "^0.41.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -37,7 +37,7 @@
     "@fluid-experimental/fluid-framework": "^0.41.0",
     "@fluid-experimental/frs-client": "^0.41.0",
     "@fluid-experimental/tinylicious-client": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "css-loader": "^1.0.0",
     "react": "^16.10.2",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "css-loader": "^1.0.0",
     "style-loader": "^1.0.0"
   },

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -30,7 +30,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseEvent, ITelemetryProperties } from '@fluidframework/common-definitions';
+import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { ITelemetryLoggerPropertyBag } from '@fluidframework/telemetry-utils';
 
 const defaultFailMessage = 'Assertion failed';

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -4,6 +4,7 @@
  */
 
 import { ITelemetryBaseEvent, ITelemetryProperties } from '@fluidframework/common-definitions';
+import { ITelemetryLoggerPropertyBag } from '@fluidframework/telemetry-utils';
 
 const defaultFailMessage = 'Assertion failed';
 
@@ -21,7 +22,7 @@ export const sharedTreeAssertionErrorType = 'SharedTreeAssertion';
 /**
  * Telemetry properties decorated on all SharedTree events.
  */
-export interface SharedTreeTelemetryProperties extends ITelemetryProperties {
+export interface SharedTreeTelemetryProperties extends ITelemetryLoggerPropertyBag {
 	isSharedTreeEvent: true;
 }
 

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@fluid-experimental/bubblebench-common": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/bubblebench-common": "^0.41.0",
     "@fluid-experimental/sharejs-json1": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/bubblebench-common": "^0.41.0",
     "@fluid-experimental/tree": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/map": "^0.41.0"
   },
   "devDependencies": {

--- a/experimental/framework/fluid-static/package.json
+++ b/experimental/framework/fluid-static/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fluid-experimental/get-container": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",

--- a/experimental/framework/frs-client/package.json
+++ b/experimental/framework/frs-client/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluid-experimental/fluid-static": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-loader": "^0.41.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.41.0",
     "@fluidframework/container-runtime-definitions": "^0.41.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/experimental/framework/tinylicious-client/package.json
+++ b/experimental/framework/tinylicious-client/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluid-experimental/fluid-static": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3704,9 +3704,9 @@
             }
         },
         "@fluidframework/common-definitions": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0.tgz",
-            "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
+            "version": "0.20.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
+            "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
         },
         "@fluidframework/common-utils": {
             "version": "0.31.0-27017",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -53,7 +53,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -57,7 +57,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.41.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.41.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.41.0",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-base": "^0.41.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-base": "^0.41.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.41.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/driver-base": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -58,7 +58,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime": "^0.41.0",

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/counter": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -57,7 +57,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-utils": "^0.41.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -9,7 +9,8 @@ import {
     IAuthorizationError,
     DriverErrorType,
 } from "@fluidframework/driver-definitions";
-import { LoggingError, ITaggableTelemetryProperties } from "@fluidframework/telemetry-utils";
+import { ITelemetryProperties } from "@fluidframework/common-definitions";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 
 export enum OnlineStatus {
     Offline,
@@ -37,7 +38,7 @@ export class GenericNetworkError extends LoggingError implements IDriverErrorBas
     constructor(
         errorMessage: string,
         readonly canRetry: boolean,
-        props?: ITaggableTelemetryProperties,
+        props?: ITelemetryProperties,
     ) {
         super(errorMessage, props);
     }
@@ -68,7 +69,7 @@ export class AuthorizationError extends LoggingError implements IAuthorizationEr
         errorMessage: string,
         readonly claims: string | undefined,
         readonly tenantId: string | undefined,
-        props?: ITaggableTelemetryProperties,
+        props?: ITelemetryProperties,
     ) {
         super(errorMessage, props);
     }
@@ -79,7 +80,7 @@ export class NetworkErrorBasic<T> extends LoggingError {
         errorMessage: string,
         readonly errorType: T,
         readonly canRetry: boolean,
-        props?: ITaggableTelemetryProperties,
+        props?: ITelemetryProperties,
     ) {
         super(errorMessage, props);
     }
@@ -89,7 +90,7 @@ export class NonRetryableError<T> extends NetworkErrorBasic<T> {
     constructor(
         errorMessage: string,
         readonly errorType: T,
-        props?: ITaggableTelemetryProperties,
+        props?: ITelemetryProperties,
     ) {
         super(errorMessage, errorType, false, props);
     }
@@ -99,7 +100,7 @@ export class RetryableError<T> extends NetworkErrorBasic<T> {
     constructor(
         errorMessage: string,
         readonly errorType: T,
-        props?: ITaggableTelemetryProperties,
+        props?: ITelemetryProperties,
     ) {
         super(errorMessage, errorType, true, props);
     }
@@ -115,7 +116,7 @@ export class ThrottlingError extends LoggingError implements IThrottlingWarning 
     constructor(
         errorMessage: string,
         readonly retryAfterSeconds: number,
-        props?: ITaggableTelemetryProperties,
+        props?: ITelemetryProperties,
     ) {
         super(errorMessage, props);
     }
@@ -128,7 +129,7 @@ export function createGenericNetworkError(
     errorMessage: string,
     canRetry: boolean,
     retryAfterMs?: number,
-    props?: ITaggableTelemetryProperties) {
+    props?: ITelemetryProperties) {
     if (retryAfterMs !== undefined && canRetry) {
         return new ThrottlingError(errorMessage, retryAfterMs / 1000, props);
     }

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/agent-scheduler": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-runtime-definitions": "^0.41.0",

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -61,7 +61,7 @@ import {
     SummarizeInternalFn,
 } from "@fluidframework/runtime-definitions";
 import { addBlobToSummary, convertSummaryTreeToITree } from "@fluidframework/runtime-utils";
-import { LoggingError } from "@fluidframework/telemetry-utils";
+import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ContainerRuntime } from "./containerRuntime";
 import {
     dataStoreAttributesBlobName,
@@ -260,7 +260,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     }
 
     private rejectDeferredRealize(reason: string, packageName?: string): never {
-        throw new LoggingError(reason, { packageName: { value: packageName, tag: "PackageData" }});
+        throw new LoggingError(reason, { packageName: { value: packageName, tag: TelemetryDataTag.PackageData }});
     }
 
     public async realize(): Promise<IFluidDataStoreChannel> {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -61,7 +61,7 @@ import {
     SummarizeInternalFn,
 } from "@fluidframework/runtime-definitions";
 import { addBlobToSummary, convertSummaryTreeToITree } from "@fluidframework/runtime-utils";
-import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 import { ContainerRuntime } from "./containerRuntime";
 import {
     dataStoreAttributesBlobName,
@@ -260,7 +260,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     }
 
     private rejectDeferredRealize(reason: string, packageName?: string): never {
-        throw new LoggingError(reason, { packageName: { value: packageName, tag: TelemetryDataTag.PackageData }});
+        throw new LoggingError(reason, { packageName: { value: packageName, tag: "PackageData" }});
     }
 
     public async realize(): Promise<IFluidDataStoreChannel> {

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-utils": "^0.41.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -59,7 +59,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/runtime-definitions": "^0.41.0"
   },

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/datastore-definitions": "^0.41.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/core-interfaces": "^0.39.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/test-driver-definitions": "^0.41.0",
     "mocha": "^8.4.0"
   },

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/aqueduct": "^0.41.0",
     "@fluidframework/base-host": "^0.41.0",
     "@fluidframework/cell": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",
     "@fluidframework/container-runtime": "^0.41.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@fluid-experimental/task-manager": "^0.41.0",
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",
     "@fluidframework/container-runtime": "^0.41.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fluid-internal/client-api": "^0.41.0",
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/container-definitions": "^0.39.0",
     "@fluidframework/container-loader": "^0.41.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "@fluidframework/driver-definitions": "^0.39.0",
     "@fluidframework/driver-utils": "^0.41.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -59,7 +59,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.31.0-0",
     "debug": "^4.1.1",
     "events": "^3.1.0"

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -87,13 +87,13 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
                         // No tag means we can log plainly
                         event[key] = value;
                         break;
-                    case "PackageData":
+                    case TelemetryDataTag.PackageData:
                         // For Microsoft applications, PackageData is safe for now
                         // (we don't load 3P code in 1P apps)
                         // But this determination really belongs in the host layer
                         event[key] = value;
                         break;
-                    case "UserData":
+                    case TelemetryDataTag.UserData:
                         // Strip out anything tagged explicitly as PII.
                         // Alternate strategy would be to hash these props
                         event[key] = "REDACTED (UserData)";
@@ -491,13 +491,6 @@ export class PerformanceEvent {
 }
 
 /**
- * Property bag containing a mix of value literals and wrapped values along with a tag
- */
-export interface ITaggableTelemetryProperties {
-    [name: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
-}
-
-/**
  * Type guard to identify if a particular value (loosely) appears to be a tagged telemetry property
  */
 export function isTaggedTelemetryPropertyValue(x: any): x is ITaggedTelemetryPropertyType {
@@ -509,8 +502,8 @@ export const isILoggingError = (x: any): x is ILoggingError => typeof x?.getTele
 /**
  * Walk an object's enumerable properties to find those fit for telemetry.
  */
-function getValidTelemetryProps(obj: any): ITaggableTelemetryProperties {
-    const props: ITaggableTelemetryProperties = {};
+function getValidTelemetryProps(obj: any): ITelemetryProperties {
+    const props: ITelemetryProperties = {};
     for (const key of Object.keys(obj)) {
         const val = obj[key];
         switch (typeof val) {
@@ -554,7 +547,7 @@ export class LoggingError extends Error implements ILoggingError {
 
     constructor(
         message: string,
-        props?: ITaggableTelemetryProperties,
+        props?: ITelemetryProperties,
     ) {
         super(message);
         if (props) {
@@ -565,14 +558,14 @@ export class LoggingError extends Error implements ILoggingError {
     /**
      * Add additional properties to be logged
      */
-    public addTelemetryProperties(props: ITaggableTelemetryProperties) {
+    public addTelemetryProperties(props: ITelemetryProperties) {
         Object.assign(this, props);
     }
 
     /**
      * Get all properties fit to be logged to telemetry for this error
      */
-    public getTelemetryProperties(): ITaggableTelemetryProperties {
+    public getTelemetryProperties(): ITelemetryProperties {
         const taggableProps = getValidTelemetryProps(this);
         // Include non-enumerable props inherited from Error that would not be returned by getValidTelemetryProps
         // But if any were overwritten (e.g. with a tagged property), then use the result from getValidTelemetryProps.

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -483,7 +483,7 @@ export class PerformanceEvent {
  * Broad classifications to be applied to individual properties as they're prepared to be logged to telemetry.
  * Please do not modify existing entries for backwards compatibility.
  */
- export enum TelemetryDataTag {
+export enum TelemetryDataTag {
     /** Data containing terms from code packages that may have been dynamically loaded */
     PackageData = "PackageData",
     /** Personal data of a variety of classifications that pertains to the user */

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -100,7 +100,6 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
                         break;
                     default:
                         // If we encounter a tag we don't recognize
-                        // (e.g. due to interaction between different versions)
                         // then we must assume we should scrub.
                         event[key] = "REDACTED (unknown tag)";
                         break;

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -480,6 +480,17 @@ export class PerformanceEvent {
 }
 
 /**
+ * Broad classifications to be applied to individual properties as they're prepared to be logged to telemetry.
+ * Please do not modify existing entries for backwards compatibility.
+ */
+ export enum TelemetryDataTag {
+    /** Data containing terms from code packages that may have been dynamically loaded */
+    PackageData = "PackageData",
+    /** Personal data of a variety of classifications that pertains to the user */
+    UserData = "UserData",
+}
+
+/**
  * Property bag containing a mix of value literals and wrapped values along with a tag
  */
 export interface ITaggableTelemetryProperties {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -83,7 +83,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
                     ? taggableProp
                     : { value: taggableProp, tag: undefined };
                 switch (tag) {
-                    case "":
+                    case undefined:
                         // No tag means we can log plainly
                         event[key] = value;
                         break;

--- a/packages/utils/telemetry-utils/src/test/logger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/logger.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 // eslint-disable-next-line max-len
-import { LoggingError, TelemetryLogger, TelemetryDataTag, isTaggedTelemetryPropertyValue, ITaggableTelemetryProperties } from "../logger";
+import { LoggingError, TelemetryLogger, isTaggedTelemetryPropertyValue, ITaggableTelemetryProperties } from "../logger";
 
 describe("Logger", () => {
     describe("Error Logging", () => {
@@ -70,17 +70,17 @@ describe("Logger", () => {
                 TelemetryLogger.prepareErrorObject(event, error, false);
                 assert(event.foo === "foo" && event.bar === 2);
             });
-            it("getTelemetryProperties - tagged TelemetryDataTag.UserData is removed", () => {
+            it("getTelemetryProperties - tagged UserData is removed", () => {
                 const event = freshEvent();
                 const error = createILoggingError(
-                    { somePii: { value: "very personal", tag: TelemetryDataTag.UserData }});
+                    { somePii: { value: "very personal", tag: "UserData" }});
                 TelemetryLogger.prepareErrorObject(event, error, false);
                 assert.strictEqual(event.somePii, "REDACTED (UserData)", "somePii should be redacted");
             });
             it("getTelemetryProperties - tagged PackageData are preserved", () => {
                 const event = freshEvent();
                 const error = createILoggingError({
-                    packageName: { value: "myPkg", tag: TelemetryDataTag.PackageData },
+                    packageName: { value: "myPkg", tag: "PackageData" },
                 });
                 TelemetryLogger.prepareErrorObject(event, error, false);
                 assert.strictEqual(event.packageName, "myPkg");
@@ -88,20 +88,20 @@ describe("Logger", () => {
             it("getTelemetryProperties - tagged [unrecognized tag] are removed", () => {
                 const event = freshEvent();
                 const error = createILoggingError(
-                    { somePii: { value: "very personal", tag: "FutureTag" as TelemetryDataTag }});
+                    { somePii: { value: "very personal", tag: "FutureTag"}});
                 TelemetryLogger.prepareErrorObject(event, error, false);
                 assert.strictEqual(event.somePii, "REDACTED (unknown tag)", "somePii should be redacted");
             });
             it("getTelemetryProperties - tags on overwritten Error base props are NOT respected", () => {
                 const event = freshEvent();
                 const error = createILoggingError({
-                    message: { value: "Mark Fields", tag: TelemetryDataTag.UserData }, // hopefully no one does this!
-                    stack: { value: "tagged", tag: TelemetryDataTag.PackageData },
+                    message: { value: "Mark Fields", tag: "UserData" }, // hopefully no one does this!
+                    stack: { value: "tagged", tag: "PackageData" },
                 });
                 TelemetryLogger.prepareErrorObject(event, error, false);
                 assert.strictEqual(event.message, "REDACTED (UserData)");
-                assert.deepStrictEqual(event.error, { value: "Mark Fields", tag: TelemetryDataTag.UserData }); // Bug!
-                assert.deepStrictEqual(event.stack, { value: "tagged", tag: TelemetryDataTag.PackageData }); // Bug!
+                assert.deepStrictEqual(event.error, { value: "Mark Fields", tag: "UserData" }); // Bug!
+                assert.deepStrictEqual(event.stack, { value: "tagged", tag: "PackageData" }); // Bug!
             });
             it("fetchStack false - Don't add a stack if missing", () => {
                 const event = freshEvent();
@@ -121,13 +121,6 @@ describe("Logger", () => {
                 TelemetryLogger.prepareErrorObject(event, error, true);
                 assert.strictEqual(typeof (event.stack), "string");
                 assert(!(event.stack as string).includes("boom"));
-            });
-        });
-        describe("TaggedTelemetryData", () => {
-            it("Ensure backwards compatibility", () => {
-                // The values of the enum should never change (even if the keys are renamed)
-                assert(TelemetryDataTag.PackageData === "PackageData" as TelemetryDataTag);
-                assert(TelemetryDataTag.UserData === "UserData" as TelemetryDataTag);
             });
         });
         describe("isTaggedTelemetryPropertyValue", () => {
@@ -182,13 +175,13 @@ describe("Logger", () => {
             it("ctor props are assigned to the object", () => {
                 const loggingError = new LoggingError(
                     "myMessage",
-                    { p1: 1, p2: "two", p3: true, tagged: { value: 4, tag: TelemetryDataTag.PackageData }});
+                    { p1: 1, p2: "two", p3: true, tagged: { value: 4, tag: "PackageData" }});
                 const errorAsAny = loggingError as any;
                 assert.strictEqual(errorAsAny.message, "myMessage");
                 assert.strictEqual(errorAsAny.p1, 1);
                 assert.strictEqual(errorAsAny.p2, "two");
                 assert.strictEqual(errorAsAny.p3, true);
-                assert.deepStrictEqual(errorAsAny.tagged, { value: 4, tag: TelemetryDataTag.PackageData });
+                assert.deepStrictEqual(errorAsAny.tagged, { value: 4, tag: "PackageData" });
             });
             it("getTelemetryProperties extracts all untagged ctor props", () => {
                 const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true});
@@ -204,15 +197,15 @@ describe("Logger", () => {
                 const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true});
                 (loggingError as any).p1 = "should be overwritten";
                 loggingError.addTelemetryProperties(
-                    {p1: "one", p4: 4, p5: { value: 5, tag: TelemetryDataTag.PackageData }});
+                    {p1: "one", p4: 4, p5: { value: 5, tag: "PackageData" }});
                 const props = loggingError.getTelemetryProperties();
                 assert.strictEqual(props.p1, "one");
                 assert.strictEqual(props.p4, 4);
-                assert.deepStrictEqual(props.p5, { value: 5, tag: TelemetryDataTag.PackageData });
+                assert.deepStrictEqual(props.p5, { value: 5, tag: "PackageData" });
                 const errorAsAny = loggingError as any;
                 assert.strictEqual(errorAsAny.p1, "one");
                 assert.strictEqual(errorAsAny.p4, 4);
-                assert.deepStrictEqual(errorAsAny.p5, { value: 5, tag: TelemetryDataTag.PackageData });
+                assert.deepStrictEqual(errorAsAny.p5, { value: 5, tag: "PackageData" });
             });
             it("Set valid props via 'as any' - returned from getTelemetryProperties, overwrites", () => {
                 const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true});
@@ -220,13 +213,13 @@ describe("Logger", () => {
                 const errorAsAny = loggingError as any;
                 errorAsAny.p1 = "one";
                 errorAsAny.p4 = 4;
-                errorAsAny.p5 = { value: 5, tag: TelemetryDataTag.PackageData };
-                errorAsAny.pii6 = { value: 5, tag: TelemetryDataTag.UserData };
+                errorAsAny.p5 = { value: 5, tag: "PackageData" };
+                errorAsAny.pii6 = { value: 5, tag: "UserData" };
                 const props = loggingError.getTelemetryProperties();
                 assert.strictEqual(props.p1, "one");
                 assert.strictEqual(props.p4, 4);
-                assert.deepStrictEqual(props.p5, { value: 5, tag: TelemetryDataTag.PackageData });
-                assert.deepStrictEqual(props.pii6, { value: 5, tag: TelemetryDataTag.UserData });
+                assert.deepStrictEqual(props.p5, { value: 5, tag: "PackageData" });
+                assert.deepStrictEqual(props.pii6, { value: 5, tag: "UserData" });
             });
             it("Set invalid props via 'as any' - excluded from getTelemetryProperties, overwrites", () => {
                 const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true});
@@ -249,8 +242,8 @@ describe("Logger", () => {
             it("addTelemetryProperties - overwrites base class Error fields (tagged)", () => {
                 const overwritingProps = new LoggingError("myMessage");
                 const expectedProps = {
-                    message: { value: "Mark Fields", tag: TelemetryDataTag.UserData }, // hopefully no one does this!
-                    stack: { value: "surprise2", tag: TelemetryDataTag.PackageData },
+                    message: { value: "Mark Fields", tag: "UserData" }, // hopefully no one does this!
+                    stack: { value: "surprise2", tag: "PackageData" },
                 };
                 overwritingProps.addTelemetryProperties(expectedProps);
                 const props = overwritingProps.getTelemetryProperties();

--- a/packages/utils/telemetry-utils/src/test/logger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/logger.spec.ts
@@ -4,9 +4,9 @@
  */
 
 import { strict as assert } from "assert";
-import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
+import { ITelemetryBaseEvent, ITelemetryProperties } from "@fluidframework/common-definitions";
 // eslint-disable-next-line max-len
-import { LoggingError, TelemetryLogger, isTaggedTelemetryPropertyValue, ITaggableTelemetryProperties } from "../logger";
+import { LoggingError, TelemetryDataTag, TelemetryLogger, isTaggedTelemetryPropertyValue } from "../logger";
 
 describe("Logger", () => {
     describe("Error Logging", () => {
@@ -14,7 +14,7 @@ describe("Logger", () => {
             function freshEvent(): ITelemetryBaseEvent {
                 return { category: "cat1", eventName: "event1" };
             }
-            function createILoggingError(props: ITaggableTelemetryProperties) {
+            function createILoggingError(props: ITelemetryProperties) {
                 return {...props, getTelemetryProperties: () => props };
             }
 
@@ -121,6 +121,13 @@ describe("Logger", () => {
                 TelemetryLogger.prepareErrorObject(event, error, true);
                 assert.strictEqual(typeof (event.stack), "string");
                 assert(!(event.stack as string).includes("boom"));
+            });
+        });
+        describe("TaggedTelemetryData", () => {
+            it("Ensure backwards compatibility", () => {
+                // The values of the enum should never change (even if the keys are renamed)
+                assert(TelemetryDataTag.PackageData === "PackageData" as TelemetryDataTag);
+                assert(TelemetryDataTag.UserData === "UserData" as TelemetryDataTag);
             });
         });
         describe("isTaggedTelemetryPropertyValue", () => {


### PR DESCRIPTION
Remove extra code from logger in telemetry-utils and update client packages to use latest tagging changes in `common-definitions` 0.20.1.