### PR TITLE
Remove delay() implementations from around the repository

### DIFF
--- a/experimental/dds/tree/src/test/SharedTree.tests.ts
+++ b/experimental/dds/tree/src/test/SharedTree.tests.ts
@@ -7,6 +7,7 @@ import { assert, expect } from 'chai';
 import { v4 as uuidv4 } from 'uuid';
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { MockFluidDataStoreRuntime } from '@fluidframework/test-runtime-utils';
+import { delay } from '@fluidframework/common-utils';
 import { assertArrayOfOne, assertNotUndefined, isSharedTreeEvent } from '../Common';
 import { Definition, DetachedSequenceId, EditId, NodeId, TraitLabel } from '../Identifiers';
 import {
@@ -628,7 +629,7 @@ describe('SharedTree', () => {
 
 			// Just waiting for the ChunksEmitted event here isn't sufficient, as the SharedTree error
 			// will propagate in a separate promise chain.
-			await new Promise((resolve) => setTimeout(resolve, 0));
+			await delay(0);
 			expect(treeErrorEventWasInvoked).to.equal(true, 'SharedTree error was never raised');
 		});
 	});

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { PromiseCache } from "@fluidframework/common-utils";
+import { delay, PromiseCache } from "@fluidframework/common-utils";
 import { canRetryOnError, getRetryDelayFromError } from "@fluidframework/driver-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
@@ -16,13 +16,6 @@ import {
 } from "@fluidframework/odsp-driver-definitions";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { fetchHelper, getWithRetryForTokenRefresh } from "./odspUtils";
-
-/**
- * returns a promise that resolves after timeMs
- */
-async function delay(timeMs: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(() => resolve(), timeMs));
-}
 
 // Store cached responses for the lifetime of web session as file link remains the same for given file item
 const fileLinkCache = new PromiseCache<string, string | undefined>();

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -6,14 +6,11 @@ import { strict as assert } from "assert";
 import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IStream } from "@fluidframework/driver-definitions";
+import { delay } from "@fluidframework/common-utils";
 import { OdspDeltaStorageWithCache } from "../odspDeltaStorageService";
 import { OpsCache, ICache, IMessage, CacheEntry } from "../opsCaching";
 
 export type MyDataInput = IMessage & { data: string; };
-
-async function delay(timeMs: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(() => resolve(), timeMs));
-}
 
 class MockCache implements ICache {
     public writeCount = 0;

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -21,7 +21,7 @@ import {
     IVersion,
     ScopeType,
 } from "@fluidframework/protocol-definitions";
-import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { delay, TypedEventEmitter } from "@fluidframework/common-utils";
 import { debug } from "./debug";
 import { ReplayController } from "./replayController";
 
@@ -301,7 +301,6 @@ export class ReplayDocumentDeltaConnection
         documentStorageService: IDocumentDeltaStorageService,
         controller: ReplayController,
     ): Promise<void> {
-        const delay = async (ms?: number) => new Promise((res) => setTimeout(res, ms));
         let done;
         let replayPromiseChain = Promise.resolve();
 

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -5,11 +5,8 @@
 
 import { v4 as uuid } from "uuid";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { performance } from "@fluidframework/common-utils";
+import { delay, performance } from "@fluidframework/common-utils";
 import { canRetryOnError, getRetryDelayFromError } from "./network";
-
-const delay = async (timeMs: number): Promise<void> =>
-    new Promise((resolve) => setTimeout(() => resolve(), timeMs));
 
 export async function runWithRetry<T>(
     api: () => Promise<T>,

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -9,6 +9,7 @@ import {
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
 import {
+    delay,
     IPromiseTimerResult,
     PromiseTimer,
 } from "@fluidframework/common-utils";
@@ -355,7 +356,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         if (shouldDelay || shouldInitialDelay) {
             await Promise.all([
                 shouldInitialDelay ? this.initialDelayP : Promise.resolve(),
-                shouldDelay ? new Promise((resolve) => setTimeout(resolve, delayMs)) : Promise.resolve(),
+                shouldDelay ? delay(delayMs) : Promise.resolve(),
             ]);
         }
 

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -16,6 +16,7 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import random from "random-js";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { delay } from "@fluidframework/common-utils";
 import { ILoadTestConfig } from "./testConfigFile";
 
 export interface IRunConfig {
@@ -28,7 +29,6 @@ export interface IRunConfig {
 export interface ILoadTest {
     run(config: IRunConfig, reset: boolean): Promise<boolean>;
 }
-const wait = async (timeMs: number) => new Promise((resolve) => setTimeout(resolve, timeMs));
 
 const taskManagerKey = "taskManager";
 const counterKey = "counter";
@@ -342,10 +342,10 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
                     if (dataModel.counter.value % opsPerCycle === 0) {
                         dataModel.abandonTask();
                         // give our partner a half cycle to get the task
-                        await wait(cycleMs / 2);
+                        await delay(cycleMs / 2);
                     }else{
                         // Random jitter of +- 50% of opWaitMs
-                        await wait(opsGapMs + opsGapMs * random.real(0,.5,true)(config.randEng));
+                        await delay(opsGapMs + opsGapMs * random.real(0,.5,true)(config.randEng));
                     }
                 }else{
                     await dataModel.lockTask();


### PR DESCRIPTION
See #6212 

Replaced with a call to the function in `common-utils`