### PR TITLE
Refresh latest ack from server before generating summary tree and catch up to it before pausing

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2064,9 +2064,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
  * or reject if closed.
  */
 const waitForSeq = async (
-    deltaManager: IDeltaManager<Pick<ISequencedDocumentMessage, "sequenceNumber">, any>,
+    deltaManager: IDeltaManager<Pick<ISequencedDocumentMessage, "sequenceNumber">, unknown>,
     targetSeq: number,
 ): Promise<void> => new Promise<void>((accept, reject) => {
+    // TODO: remove cast to any when actual event is determined
     deltaManager.on("closed" as any, reject);
 
     const handleOp = (message: Pick<ISequencedDocumentMessage, "sequenceNumber">) => {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1640,10 +1640,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     summaryLogger,
                     {
                         eventName: "WaitingForSeq",
-                        startSequenceNumber: this.deltaManager.lastSequenceNumber,
+                        lastSequenceNumber: this.deltaManager.lastSequenceNumber,
                         targetSequenceNumber: latestSummaryRefSeq,
+                        lastKnownSeqNumber: this.deltaManager.lastKnownSeqNumber,
                     },
                     async () => waitForSeq(this.deltaManager, latestSummaryRefSeq),
+                    { start: true, end: true, cancel: "error" }, // definitely want start event
                 );
             }
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from "events";
 import {
     AgentSchedulerFactory,
 } from "@fluidframework/agent-scheduler";
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { ITelemetryGenericEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IFluidObject,
     IFluidRouter,
@@ -70,7 +70,6 @@ import {
     ISummaryTree,
     ITree,
     MessageType,
-    IVersion,
     SummaryType,
 } from "@fluidframework/protocol-definitions";
 import {
@@ -106,6 +105,7 @@ import {
     create404Response,
     exceptionToResponse,
     responseToException,
+    seqFromTree,
 } from "@fluidframework/runtime-utils";
 import { v4 as uuid } from "uuid";
 import { ContainerFluidHandleContext } from "./containerHandleContext";
@@ -1630,6 +1630,24 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     public async generateSummary(options: IGenerateSummaryOptions): Promise<GenerateSummaryData | undefined> {
         const { fullTree, refreshLatestAck, summaryLogger } = options;
 
+        if (refreshLatestAck) {
+            const latestSummaryRefSeq = await this.refreshLatestSummaryAckFromServer(
+                ChildLogger.create(summaryLogger, undefined, { all: { safeSummary: true } }));
+
+            if (latestSummaryRefSeq > this.deltaManager.lastSequenceNumber) {
+                // We need to catch up to the latest summary's reference sequence number before pausing.
+                await PerformanceEvent.timedExecAsync(
+                    summaryLogger,
+                    {
+                        eventName: "WaitingForSeq",
+                        startSequenceNumber: this.deltaManager.lastSequenceNumber,
+                        targetSequenceNumber: latestSummaryRefSeq,
+                    },
+                    async () => waitForSeq(this.deltaManager, latestSummaryRefSeq),
+                );
+            }
+        }
+
         const summaryRefSeqNum = this.deltaManager.lastSequenceNumber;
         const message =
             `Summary @${summaryRefSeqNum}:${this.deltaManager.minimumSequenceNumber}`;
@@ -1689,16 +1707,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const handle = await this.storage.uploadSummaryWithContext(
                 summarizeResult.summary,
                 summaryContext);
-
-            if (refreshLatestAck) {
-                const version = await this.getVersionFromStorage(this.id);
-                await this.refreshLatestSummaryAck(
-                    undefined,
-                    version.id,
-                    ChildLogger.create(summaryLogger, undefined, {all: { safeSummary: true }}),
-                    version,
-                );
-            }
 
             const parent = summaryContext.ackHandle;
             const summaryMessage: ISummaryContent = {
@@ -1983,49 +1991,66 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         proposalHandle: string | undefined,
         ackHandle: string,
         summaryLogger: ITelemetryLogger,
-        version?: IVersion,
     ) {
-        const getSnapshot = async () => {
-            const perfEvent = PerformanceEvent.start(summaryLogger, {
-                eventName: "RefreshLatestSummaryGetSnapshot",
-                hasVersion: !!version, // expected in this case
-            });
-            const stats: { getVersionDuration?: number; getSnapshotDuration?: number } = {};
-            let snapshot: ISnapshotTree | undefined;
-            try {
-                const trace = Trace.start();
-
-                const versionToUse = version ?? await this.getVersionFromStorage(ackHandle);
-                stats.getVersionDuration = trace.trace().duration;
-
-                snapshot = await this.getSnapshotFromStorage(versionToUse);
-                stats.getSnapshotDuration = trace.trace().duration;
-            } catch (error) {
-                perfEvent.cancel(stats, error);
-                throw error;
-            }
-
-            perfEvent.end(stats);
-            return snapshot;
-        };
-
+        const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
         await this.summarizerNode.refreshLatestSummary(
-                proposalHandle,
-                getSnapshot,
-                async <T>(id: string) => readAndParse<T>(this.storage, id),
-                summaryLogger,
-            );
-        }
-
-    private async getVersionFromStorage(versionId: string): Promise<IVersion> {
-        const versions = await this.storage.getVersions(versionId, 1);
-        assert(!!versions && !!versions[0], 0x137 /* "Failed to get version from storage" */);
-        return versions[0];
+            proposalHandle,
+            async () => this.fetchSnapshotFromStorage(ackHandle, summaryLogger, {
+                eventName: "RefreshLatestSummaryGetSnapshot",
+                fetchLatest: false,
+            }),
+            readAndParseBlob,
+            summaryLogger,
+        );
     }
 
-    private async getSnapshotFromStorage(version: IVersion): Promise<ISnapshotTree> {
-        const snapshot = await this.storage.getSnapshotTree(version);
-        assert(!!snapshot, 0x138 /* "Failed to get snapshot from storage" */);
+    /**
+     * Fetches the latest snapshot from storage and uses it to refresh SummarizerNode's
+     * internal state as it should be considered the latest summary ack.
+     * @param summaryLogger - logger to use when fetching snapshot from storage
+     * @returns downloaded snapshot's reference sequence number
+     */
+    private async refreshLatestSummaryAckFromServer(summaryLogger: ITelemetryLogger): Promise<number> {
+        const snapshot = await this.fetchSnapshotFromStorage(this.id, summaryLogger, {
+            eventName: "RefreshLatestSummaryGetSnapshot",
+            fetchLatest: true,
+        });
+
+        const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
+        const snapshotRefSeq = await seqFromTree(snapshot, readAndParseBlob);
+
+        await this.summarizerNode.refreshLatestSummary(
+            undefined,
+            async () => snapshot,
+            readAndParseBlob,
+            summaryLogger,
+        );
+
+        return snapshotRefSeq;
+    }
+
+    private async fetchSnapshotFromStorage(versionId: string, logger: ITelemetryLogger, event: ITelemetryGenericEvent) {
+        const perfEvent = PerformanceEvent.start(logger, event);
+        const stats: { getVersionDuration?: number; getSnapshotDuration?: number } = {};
+        let snapshot: ISnapshotTree;
+        try {
+            const trace = Trace.start();
+
+            const versions = await this.storage.getVersions(versionId, 1);
+            assert(!!versions && !!versions[0], 0x137 /* "Failed to get version from storage" */);
+            stats.getVersionDuration = trace.trace().duration;
+
+            const maybeSnapshot = await this.storage.getSnapshotTree(versions[0]);
+            assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
+            stats.getSnapshotDuration = trace.trace().duration;
+
+            snapshot = maybeSnapshot;
+        } catch (error) {
+            perfEvent.cancel(stats, error);
+            throw error;
+        }
+
+        perfEvent.end(stats);
         return snapshot;
     }
 
@@ -2033,3 +2058,22 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this.pendingStateManager.getLocalState();
     }
 }
+
+/**
+ * Wait for a specific sequence number. Promise should resolve when we reach that number,
+ * or reject if closed.
+ */
+const waitForSeq = async (
+    deltaManager: IDeltaManager<Pick<ISequencedDocumentMessage, "sequenceNumber">, any>,
+    targetSeq: number,
+): Promise<void> => new Promise<void>((accept, reject) => {
+    deltaManager.on("closed" as any, reject);
+
+    const handleOp = (message: Pick<ISequencedDocumentMessage, "sequenceNumber">) => {
+        if (message.sequenceNumber >= targetSeq) {
+            accept();
+            deltaManager.off("op", handleOp);
+        }
+    };
+    deltaManager.on("op", handleOp);
+});

--- a/packages/runtime/runtime-utils/src/summarizerNode/index.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export { ReadAndParseBlob, ISummarizerNodeRootContract } from "./summarizerNodeUtils";
+export { ISummarizerNodeRootContract } from "./summarizerNodeUtils";
 export { IRootSummarizerNode, createRootSummarizerNode } from "./summarizerNode";
 export { IRootSummarizerNodeWithGC, createRootSummarizerNodeWithGC } from "./summarizerNodeWithGc";

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -21,6 +21,7 @@ import {
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { mergeStats, convertToSummaryTree, calculateStats } from "../summaryUtils";
+import { ReadAndParseBlob, seqFromTree } from "../utils";
 import {
     decodeSummary,
     encodeSummary,
@@ -31,8 +32,6 @@ import {
     ISummarizerNodeRootContract,
     parseSummaryForSubtrees,
     parseSummaryTreeForSubtrees,
-    ReadAndParseBlob,
-    seqFromTree,
     SummaryNode,
 } from "./summarizerNodeUtils";
 

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -7,7 +7,6 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert } from "@fluidframework/common-utils";
 import {
     ISnapshotTree,
-    IDocumentAttributes,
     ISequencedDocumentMessage,
     SummaryType,
     ISummaryTree,
@@ -15,13 +14,11 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { SummaryTreeBuilder } from "../summaryUtils";
+import { ReadAndParseBlob } from "../utils";
 
 const baseSummaryTreeKey = "_baseSummary";
 const outstandingOpsBlobKey = "_outstandingOps";
 const maxDecodeDepth = 100;
-
-/** Reads a blob from storage and parses it from JSON. */
-export type ReadAndParseBlob = <T>(id: string) => Promise<T>;
 
 export interface ISummarizerNodeRootContract {
     startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
@@ -33,21 +30,6 @@ export interface ISummarizerNodeRootContract {
         readAndParseBlob: ReadAndParseBlob,
         correlatedSummaryLogger: ITelemetryLogger,
     ): Promise<void>;
-}
-
-/**
- * Fetches the sequence number of the snapshot tree by examining the protocol.
- * @param tree - snapshot tree to examine
- * @param readAndParseBlob - function to read blob contents from storage
- * and parse the result from JSON.
- */
-export async function seqFromTree(
-    tree: ISnapshotTree,
-    readAndParseBlob: ReadAndParseBlob,
-): Promise<number> {
-    const attributesHash = tree.trees[".protocol"].blobs.attributes;
-    const attrib = await readAndParseBlob<IDocumentAttributes>(attributesHash);
-    return attrib.sequenceNumber;
 }
 
 /** Path for nodes in a tree with escaped special characters */

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -17,13 +17,13 @@ import {
     ISummarizerNodeConfigWithGC,
     ISummarizerNodeWithGC,
 } from "@fluidframework/runtime-definitions";
+import { ReadAndParseBlob } from "../utils";
 import { SummarizerNode } from "./summarizerNode";
 import {
     EscapedPath,
     ICreateChildDetails,
     IInitialSummary,
     ISummarizerNodeRootContract,
-    ReadAndParseBlob,
     SummaryNode,
 } from "./summarizerNodeUtils";
 

--- a/packages/runtime/runtime-utils/src/utils.ts
+++ b/packages/runtime/runtime-utils/src/utils.ts
@@ -4,6 +4,25 @@
  */
 
 import { ISerializedHandle } from "@fluidframework/core-interfaces";
+import { IDocumentAttributes, ISnapshotTree } from "@fluidframework/protocol-definitions";
 
 export const isSerializedHandle = (value: any): value is ISerializedHandle =>
     value?.type === "__fluid_handle__";
+
+/** Reads a blob from storage and parses it from JSON. */
+export type ReadAndParseBlob = <T>(id: string) => Promise<T>;
+
+/**
+ * Fetches the sequence number of the snapshot tree by examining the protocol.
+ * @param tree - snapshot tree to examine
+ * @param readAndParseBlob - function to read blob contents from storage
+ * and parse the result from JSON.
+ */
+ export async function seqFromTree(
+    tree: ISnapshotTree,
+    readAndParseBlob: ReadAndParseBlob,
+): Promise<number> {
+    const attributesHash = tree.trees[".protocol"].blobs.attributes;
+    const attrib = await readAndParseBlob<IDocumentAttributes>(attributesHash);
+    return attrib.sequenceNumber;
+}


### PR DESCRIPTION
This does 2 things:
1. Fix bug which makes refreshLatestAck option not work during generateSummary (regression introduced in #5739)
2. If refreshing the latest ack, we will wait until we are "caught up" to its seq number before pausing and summarizing
