### PR TITLE
Make endIntervalTree preserve nodes with different start positions

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -93,6 +93,17 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
     }
     assert.strictEqual(i, tempArray.length, "Interval omitted from backward iteration with start position");
 
+    iterator = intervalCollection.CreateForwardIteratorWithEndPosition(2);
+    tempArray = [];
+    tempArray[0] = intervalArray[2];
+    tempArray[1] = intervalArray[5];
+    tempArray[2] = intervalArray[8];
+    for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
+        const interval = result.value;
+        assert.strictEqual(interval, tempArray[i], "Mismatch in backward iteration with end position");
+    }
+    assert.strictEqual(i, tempArray.length, "Interval omitted from backward iteration with end position");
+
     iterator = intervalCollection.CreateBackwardIteratorWithEndPosition(1);
     tempArray = [];
     tempArray[0] = intervalArray[7];


### PR DESCRIPTION
This makes the contents of endIntervalTree match intervalTree.intervals, so we can use endIntervalTree to optimize iteration over intervals that match a given end position.