### PR TITLE
Add new internal team names to labelmaker config

### DIFF
--- a/.github/labelmaker.yml
+++ b/.github/labelmaker.yml
@@ -1,5 +1,5 @@
 teams:
-  internal: ['Prague', 'PragueAdmin', 'FRS-Admin']
+  internal: ['Prague', 'PragueAdmin', 'FRS-Admin', 'FluidFramework-Admin', 'FluidFramework-Contributors']
 
 labels:
   externalPRs: ['community-contribution']


### PR DESCRIPTION
We're about to rename some of the old GitHub teams, so this PR updates the labelmaker config to include the new names. The old names will be removed in a future PR.