### PR TITLE
Remove unused 'ICreateBlobResponse.url'

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -149,8 +149,6 @@ export interface IConnected {
 export interface ICreateBlobResponse {
     // (undocumented)
     id: string;
-    // (undocumented)
-    url: string;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -50,7 +50,6 @@ export interface IAttachment {
 
 export interface ICreateBlobResponse {
     id: string;
-    url: string;
 }
 
 /**

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@microsoft/api-extractor": "^7.13.1",
     "@types/isomorphic-fetch": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "~4.14.0",


### PR DESCRIPTION
I believe this was exposing the 'url' returned from the GIT REST service [here](https://docs.github.com/en/rest/reference/git#create-a-blob), isn't used, and probably not generally applicable to other drivers.