### PR TITLE
wrap doc and tenant id as metadata for scribe log

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -363,8 +363,10 @@ export class ScribeLambda implements IPartitionLambda {
             } catch (error) {
                 this.context.log?.error(`Protocol error ${error}`,
                     {
-                        documentId: this.documentId,
-                        tenantId: this.tenantId,
+                        messageMetaData: {
+                            documentId: this.documentId,
+                            tenantId: this.tenantId,
+                        },
                     });
             }
         }


### PR DESCRIPTION
wrap document and tenant IDs as message meta data.