### PR TITLE
remove tree array from QS in post

### DIFF
--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -126,7 +126,7 @@ export class Historian implements IHistorian {
     }
 
     public createTree(tree: git.ICreateTreeParams): Promise<git.ITree> {
-        return this.restWrapper.post<git.ITree>(`/git/trees`, tree, this.getQueryString(tree));
+        return this.restWrapper.post<git.ITree>(`/git/trees`, tree, this.getQueryString());
     }
 
     public getTree(sha: string, recursive: boolean): Promise<git.ITree> {


### PR DESCRIPTION
Missed a spot in #5735 which causes the query string to be ridiculously long.