### PR TITLE
Fix assert in redeem fallback logic

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -126,7 +126,7 @@ async function redeemSharingLink(
             eventName: "RedeemShareLink",
         },
         async () => getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
-                assert(odspResolvedUrl.sharingLinkToRedeem !== undefined, 0x1ed /* "Share link should be present" */);
+                assert(!!odspResolvedUrl.sharingLinkToRedeem, 0x1ed /* "Share link should be present" */);
                 const storageToken = await storageTokenFetcher(tokenFetchOptions, "RedeemShareLink");
                 const encodedShareUrl = getEncodedShareUrl(odspResolvedUrl.sharingLinkToRedeem);
                 const redeemUrl = `${odspResolvedUrl.siteUrl}/_api/v2.0/shares/${encodedShareUrl}`;
@@ -365,8 +365,6 @@ function isRedeemSharingLinkError(odspResolvedUrl: IOdspResolvedUrl, error: any)
 }
 
 function getEncodedShareUrl(url: string): string {
-    assert(!url, 0x1ee /* "Url should not be empty" */);
-
     /**
      * Encode the url to accepted format by Sharepoint
      * https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/shares_get


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/6430
The sharing link in case of redeem fallback should not be empty or undefined. So now "0x1ed " assert check both instead of checking both separately. This fallback happens when we receive 401/403/404 from server and server was not able to redeem sharing link in 1 network call along with trees/latest. So we execute redeem separately and then execute trees latest. 
