### PR TITLE
Preserve unreferenced flag across conversions between summary formats

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -143,10 +143,15 @@ export function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree):
         const summaryObject = summary.tree[key];
 
         let value: OdspSummaryTreeValue;
+        // Tracks if an entry is unreferenced. Currently, only tree entries can be marked as unreferenced. If the
+        // property is not present, the tree entry is considered referenced. If the property is present and is true,
+        // the tree entry is considered unreferenced.
+        let unreferenced: true | undefined;
 
         switch (summaryObject.type) {
             case SummaryType.Tree: {
                 value = convertSummaryToSnapshotTreeForCreateNew(summaryObject);
+                unreferenced = summaryObject.unreferenced;
                 break;
             }
             case SummaryType.Blob: {
@@ -173,6 +178,7 @@ export function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree):
             path: encodeURIComponent(key),
             type: getGitType(summaryObject),
             value,
+            unreferenced,
         };
         snapshotTree.entries?.push(entry);
     }

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -46,6 +46,7 @@ function convertSummaryTreeToIOdspSnapshotCore(
                 trees.push({
                     type: "tree",
                     path: currentPath,
+                    unreferenced: summaryObject.unreferenced,
                 });
                 convertSummaryTreeToIOdspSnapshotCore(summaryObject, trees, blobs, currentPath);
                 break;

--- a/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
+++ b/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
@@ -42,6 +42,11 @@ describe("Dehydrate Container", () => {
                                 },
                             },
                         },
+                        "unref": {
+                            type: SummaryType.Tree,
+                            tree: {},
+                            unreferenced: true,
+                        },
                     },
                 },
             },
@@ -51,12 +56,33 @@ describe("Dehydrate Container", () => {
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 2, "2 trees should be there");
         assert.strictEqual(Object.keys(snapshotTree.trees[".protocol"].blobs).length, 4,
             "2 protocol blobs should be there(4 mappings)");
+
+        // Validate the ".component" blob.
         const defaultDataStoreBlobId = snapshotTree.trees.default.blobs[".component"];
-        assert.strictEqual(JSON.parse(fromBase64ToUtf8(snapshotTree.trees.default.blobs[defaultDataStoreBlobId])),
-           "defaultDataStore", "Default data store should be there");
+        assert.strictEqual(
+            JSON.parse(fromBase64ToUtf8(snapshotTree.trees.default.blobs[defaultDataStoreBlobId])),
+           "defaultDataStore",
+           "The .component blob's content is incorrect",
+        );
+
+        // Validate "root" sub-tree.
         const rootAttributesBlobId = snapshotTree.trees.default.trees.root.blobs.attributes;
         assert.strictEqual(
             JSON.parse(fromBase64ToUtf8(snapshotTree.trees.default.trees.root.blobs[rootAttributesBlobId])),
-            "rootattributes", "Default data store root attributes should be there");
+            "rootattributes",
+            "The root sub-tree's content is incorrect",
+        );
+        assert.strictEqual(
+            snapshotTree.trees.default.trees.root.unreferenced,
+            undefined,
+            "The root sub-tree should not be marked as unreferenced",
+        );
+
+        // Validate "unref" sub-tree.
+        assert.strictEqual(
+            snapshotTree.trees.default.trees.unref.unreferenced,
+            true,
+            "The unref sub-tree should be marked as unreferenced",
+        );
     });
 });

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -46,11 +46,12 @@ export function parseUrl(url: string): IParsedUrl | undefined {
 function convertSummaryToSnapshotWithEmbeddedBlobContents(
     summary: ISummaryTree,
 ): ISnapshotTree {
-    const treeNode = {
+    const treeNode: ISnapshotTree = {
         blobs: {},
         trees: {},
         commits: {},
         id: uuid(),
+        unreferenced: summary.unreferenced,
     };
     const keys = Object.keys(summary.tree);
     for (const key of keys) {

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -220,7 +220,9 @@ export function convertToSummaryTreeWithStats(
         }
     }
 
-    return builder.getSummaryTree();
+    const summaryTree = builder.getSummaryTree();
+    summaryTree.summary.unreferenced = snapshot.unreferenced;
+    return summaryTree;
 }
 
 /**
@@ -274,7 +276,10 @@ export function convertSnapshotTreeToSummaryTree(
         const subtree = convertSnapshotTreeToSummaryTree(tree);
         builder.addWithStats(key, subtree);
     }
-    return builder.getSummaryTree();
+
+    const summaryTree = builder.getSummaryTree();
+    summaryTree.summary.unreferenced = snapshot.unreferenced;
+    return summaryTree;
 }
 
 /**
@@ -318,5 +323,6 @@ export function convertSummaryTreeToITree(summaryTree: ISummaryTree): ITree {
     }
     return {
         entries,
+        unreferenced: summaryTree.unreferenced,
     };
 }

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -4,52 +4,60 @@
  */
 
 import { strict as assert } from "assert";
-import { IsoBuffer, stringToBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
+import {
+    IsoBuffer,
+    stringToBuffer,
+    Uint8ArrayToString,
+} from "@fluidframework/common-utils";
 import {
     SummaryObject,
     ISummaryTree,
     ISummaryBlob,
     ISummaryHandle,
     SummaryType,
+    ISnapshotTree,
     ITree,
 } from "@fluidframework/protocol-definitions";
 import { BlobTreeEntry, TreeTreeEntry } from "@fluidframework/protocol-base";
-import { convertToSummaryTree, utf8ByteLength } from "../summaryUtils";
+import {
+    convertSnapshotTreeToSummaryTree,
+    convertSummaryTreeToITree,
+    convertToSummaryTree,
+    utf8ByteLength,
+} from "../summaryUtils";
 
 describe("Summary Utils", () => {
-    describe("Convert to Summary Tree", () => {
-        function assertSummaryTree(obj: SummaryObject): ISummaryTree {
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            if (obj && obj.type === SummaryType.Tree) {
-                return obj;
-            } else {
-                assert.fail("Object should be summary tree");
-            }
+    function assertSummaryTree(obj: SummaryObject): ISummaryTree {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (obj && obj.type === SummaryType.Tree) {
+            return obj;
+        } else {
+            assert.fail("Object should be summary tree");
         }
-        function assertSummaryBlob(obj: SummaryObject): ISummaryBlob {
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            if (obj && obj.type === SummaryType.Blob) {
-                return obj;
-            } else {
-                assert.fail("Object should be summary blob");
-            }
+    }
+    function assertSummaryBlob(obj: SummaryObject): ISummaryBlob {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (obj && obj.type === SummaryType.Blob) {
+            return obj;
+        } else {
+            assert.fail("Object should be summary blob");
         }
-        function assertSummaryHandle(obj: SummaryObject): ISummaryHandle {
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            if (obj && obj.type === SummaryType.Handle) {
-                return obj;
-            } else {
-                assert.fail("Object should be summary handle");
-            }
+    }
+    function assertSummaryHandle(obj: SummaryObject): ISummaryHandle {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (obj && obj.type === SummaryType.Handle) {
+            return obj;
+        } else {
+            assert.fail("Object should be summary handle");
         }
+    }
 
-        let bufferLength: number;
-        let inputTree: ITree;
+    describe("ITree <-> ISummaryTree", () => {
+        let tree: ITree;
 
         beforeEach(() => {
             const base64Content = IsoBuffer.from("test-b64").toString("base64");
-            bufferLength = IsoBuffer.from(base64Content, "base64").byteLength;
-            inputTree = {
+            tree = {
                 entries: [
                     new TreeTreeEntry("t", {
                         entries: [
@@ -57,6 +65,7 @@ describe("Summary Utils", () => {
                             new BlobTreeEntry("b64", base64Content, "base64"),
                             new TreeTreeEntry("tu", { entries: [], unreferenced: true}),
                         ],
+                        unreferenced: undefined,
                     }),
                     new BlobTreeEntry("b", "test-blob"),
                     new TreeTreeEntry("h", {
@@ -69,11 +78,12 @@ describe("Summary Utils", () => {
                         unreferenced: true,
                     }),
                 ],
+                unreferenced: undefined,
             };
         });
 
-        it("Should convert correctly", () => {
-            const summaryResults = convertToSummaryTree(inputTree);
+        it("Should convert ITree to ISummaryTree correctly", () => {
+            const summaryResults = convertToSummaryTree(tree);
             const summaryTree = assertSummaryTree(summaryResults.summary);
 
             // blobs should parse
@@ -95,8 +105,8 @@ describe("Summary Utils", () => {
             assert.strictEqual(Object.keys(subTreeUnref.tree).length, 0, "There should be no entries in tu subtree");
         });
 
-        it("Should convert correctly with fullTree enabled", () => {
-            const summaryResults = convertToSummaryTree(inputTree, true);
+        it("Should convert ITree to ISummaryTree correctly with fullTree enabled", () => {
+            const summaryResults = convertToSummaryTree(tree, true);
             const summaryTree = assertSummaryTree(summaryResults.summary);
 
             // blobs should parse
@@ -119,17 +129,127 @@ describe("Summary Utils", () => {
         });
 
         it("Should calculate summary data correctly", () => {
-            const summaryResults = convertToSummaryTree(inputTree);
+            const summaryResults = convertToSummaryTree(tree);
             // nodes should count
             assert.strictEqual(summaryResults.stats.blobNodeCount, 3);
             assert.strictEqual(summaryResults.stats.handleNodeCount, 1);
             assert.strictEqual(summaryResults.stats.treeNodeCount, 4);
-            assert.strictEqual(summaryResults.stats.totalBlobSize,
-                bufferLength + IsoBuffer.from("test-blob").byteLength + IsoBuffer.from("test-u8").byteLength);
+
+            const bufferLength = IsoBuffer.from("test-b64").byteLength
+                + IsoBuffer.from("test-blob").byteLength
+                + IsoBuffer.from("test-u8").byteLength;
+            assert.strictEqual(summaryResults.stats.totalBlobSize, bufferLength);
         });
 
         it("should convert unreferenced state correctly", () => {
-            const summaryResults = convertToSummaryTree(inputTree);
+            const summaryResults = convertToSummaryTree(tree);
+            const summaryTree = assertSummaryTree(summaryResults.summary);
+            assert.strictEqual(summaryTree.unreferenced, undefined, "The root summary tree should be referenced");
+
+            const subTreeT = assertSummaryTree(summaryTree.tree.t);
+            assert.strictEqual(subTreeT.unreferenced, undefined, "The t subtree should be referenced");
+            const subTreeTUnrefTree = assertSummaryTree(subTreeT.tree.tu);
+            assert.strictEqual(subTreeTUnrefTree.unreferenced, true, "The tu subtree of t should be referenced");
+
+            const subTreeUnref = assertSummaryTree(summaryTree.tree.unref);
+            assert.strictEqual(subTreeUnref.unreferenced, true, "The unref subtree should be unreferenced");
+        });
+
+        it("should convert ISummaryTree to ITree correctly", () => {
+            // convertSummaryTreeToITree API does not accept a tree with handles. So, remove handles from the ITree.
+            const treeWithoutHandles: ITree = {
+                entries: tree.entries.filter((treeEntry) => {
+                    return treeEntry.path !== "h";
+                }),
+                unreferenced: undefined,
+            };
+            const summaryResults = convertToSummaryTree(treeWithoutHandles);
+            const summaryTree = assertSummaryTree(summaryResults.summary);
+
+            // Covert the ISummaryTree back to ITree and validate that it matches with the original tree.
+            const iTree = convertSummaryTreeToITree(summaryTree);
+            assert.deepStrictEqual(treeWithoutHandles, iTree, "Could not covert back to ITree correctly");
+        });
+    });
+
+    describe("ISnapshotTree -> ISummaryTree", () => {
+        let snapshotTree: ISnapshotTree;
+
+        beforeEach(() => {
+            snapshotTree = {
+                blobs: {
+                    "b": "blob-b",
+                    "blob-b": IsoBuffer.from("test-blob").toString("base64"),
+                },
+                trees: {
+                    t: {
+                        blobs: {
+                            "bu8": "blob-bu8",
+                            "blob-bu8": IsoBuffer.from("test-u8").toString("base64"),
+                            "b64": "blob-b64",
+                            "blob-b64": IsoBuffer.from("test-b64").toString("base64"),
+                        },
+                        trees: {
+                            tu: {
+                                blobs: {
+                                },
+                                trees: {
+                                },
+                                commits: {
+                                },
+                                unreferenced: true,
+                            },
+                        },
+                        commits: {
+                        },
+                    },
+                    unref: {
+                        blobs: {
+                        },
+                        trees: {
+                        },
+                        commits: {
+                        },
+                        unreferenced: true,
+                    },
+                },
+                commits: {
+                },
+            };
+        });
+        it("Should convert correctly", () => {
+            const summaryResults = convertSnapshotTreeToSummaryTree(snapshotTree);
+            const summaryTree = assertSummaryTree(summaryResults.summary);
+
+            // blobs should parse
+            const blob = assertSummaryBlob(summaryTree.tree.b);
+            assert.strictEqual(blob.content, "test-blob");
+
+            // subtrees should recurse
+            const subTree = assertSummaryTree(summaryTree.tree.t);
+            const subBlobUtf8 = assertSummaryBlob(subTree.tree.bu8);
+            assert.strictEqual(subBlobUtf8.content, "test-u8");
+            const subBlobBase64 = assertSummaryBlob(subTree.tree.b64);
+            assert.strictEqual(Uint8ArrayToString(subBlobBase64.content as Uint8Array), "test-b64");
+            const subTreeUnref = assertSummaryTree(subTree.tree.tu);
+            assert.strictEqual(Object.keys(subTreeUnref.tree).length, 0, "There should be no entries in tu subtree");
+        });
+
+        it("Should calculate summary data correctly", () => {
+            const summaryResults = convertSnapshotTreeToSummaryTree(snapshotTree);
+            // nodes should count
+            assert.strictEqual(summaryResults.stats.blobNodeCount, 3);
+            assert.strictEqual(summaryResults.stats.handleNodeCount, 0);
+            assert.strictEqual(summaryResults.stats.treeNodeCount, 4);
+
+            const bufferLength = IsoBuffer.from("test-b64").byteLength
+                + IsoBuffer.from("test-blob").byteLength
+                + IsoBuffer.from("test-u8").byteLength;
+            assert.strictEqual(summaryResults.stats.totalBlobSize, bufferLength);
+        });
+
+        it("should convert unreferenced state correctly", () => {
+            const summaryResults = convertSnapshotTreeToSummaryTree(snapshotTree);
             const summaryTree = assertSummaryTree(summaryResults.summary);
             assert.strictEqual(summaryTree.unreferenced, undefined, "The root summary tree should be referenced");
 


### PR DESCRIPTION
Fixes #5956.

We convert summaries across multiple different formats. This change preserves the `unreferenced` flag across the APIs that do these conversions.