### PR TITLE
Pipeline: Publish @fluid-tools npm namespace

### DIFF
--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -25,10 +25,6 @@ This can have significant overhead (the child process reruns mocha test discover
 The `benchmark` function tags its tests with `@Benchmark` as well as the benchmark type (for example `@Measurement`). These can be used to filter to just benchmarks using the mocha `--fgrep` option.
 See `BenchmarkType` for more information.
 
-## Artifacts
-
-[@fluid-experimental/benchmark](https://dev.azure.com/intentional/intent/_packaging?_a=package&feed=intentional-npm&package=%40intentional%2Fbenchmark&protocolType=Npm)
-
 ## Trademark
 
 This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services. Use of these trademarks

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -65,6 +65,7 @@ jobs:
                       echo "@fluid-example:registry=${{ parameters.feedName }}" >> ./.npmrc
                       echo "@fluid-internal:registry=${{ parameters.feedName }}" >> ./.npmrc
                       echo "@fluid-experimental:registry=${{ parameters.feedName }}" >> ./.npmrc
+                      echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
                       echo "always-auth=true" >> ./.npmrc
                       cat .npmrc
                   ${{ if eq(parameters.official, true) }}:
@@ -72,6 +73,7 @@ jobs:
                       echo Generating .npmrc for ${{ parameters.feedName }}
                       echo "@fluidframework:registry=${{ parameters.feedName }}" >> ./.npmrc
                       echo "@fluid-experimental:registry=${{ parameters.feedName }}" >> ./.npmrc
+                      echo "@fluid-tools:registry=${{ parameters.feedName }}" >> ./.npmrc
                       echo "always-auth=true" >> ./.npmrc
                       cat .npmrc
 


### PR DESCRIPTION
Make the `@fluid-tools\benchmark` package accessible to others wanting to use the same benchmarking harness/reporter in their repo.