### PR TITLE
Remove duplicate strict declaration to avoid build warning

### DIFF
--- a/packages/test/test-service-load/tsconfig.json
+++ b/packages/test/test-service-load/tsconfig.json
@@ -4,7 +4,6 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
-        "strict": true,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [


### PR DESCRIPTION
In #6370 I enabled strict mode in test-service-load but did not notice that explicitly setting strict was giving a build warning

```bash
@fluid-internal/test-service-load: warning: duplicate compilerOptions strict: true
```