### PR TITLE
Policy-Check: Require NPM v6

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
@@ -9,34 +9,49 @@ import {
     readFile
 } from "../common";
 
+const filePattern = /^.*?[^_]package-lock\.json$/i; // Ignore _package-lock.json
 const urlPattern = /(https?[^"@]+)(\/@.+|\/[^/]+\/-\/.+tgz)/g;
+const versionPattern = /"lockfileVersion"\s*:\s*1\s*,/g;
 
-export const handler: Handler = {
-    name: "package-lockfiles",
-    match: /^.*?[^_]package-lock\.json$/i, // Ignore _package-lock.json
-    handler: file => {
-        let content = readFile(file);
-        const matches = content.match(urlPattern);
-        if (matches !== null) {
-            const results: string[] = [];
-            const containsBadUrl = matches.some((value) => {
-                if (value.startsWith(`https://registry.npmjs.org`)) {
-                    return false;
+export const handlers: Handler[] = [
+    {
+        name: "package-lockfiles-no-private-url",
+        match: filePattern,
+        handler: file => {
+            const content = readFile(file);
+            const matches = content.match(urlPattern);
+            if (matches !== null) {
+                const results: string[] = [];
+                const containsBadUrl = matches.some((value) => {
+                    if (value.startsWith(`https://registry.npmjs.org`)) {
+                        return false;
+                    }
+                    results.push(value)
+                    return true;
+                });
+                if (containsBadUrl) {
+                    return `A private registry URL is in lock file: ${file}:\n${results.join("\n")}`;
                 }
-                results.push(value)
-                return true;
-            });
-            if (containsBadUrl) {
-                return `A private registry URL is in lock file: ${file}:\n${results.join("\n")}`;
             }
+            return;
+        },
+        resolver: file => {
+            const command = `package-lock-sanitizer -l ${file}`;
+            if (shell.exec(command).code !== 0) {
+                return { resolved: false, message: "Error: package-lock sanitize" };
+            }
+            return { resolved: true };
         }
-        return;
     },
-    resolver: file => {
-        const command = `package-lock-sanitizer -l ${file}`;
-        if (shell.exec(command).code !== 0) {
-            return { resolved: false, message: "Error: package-lock sanitize" };
-        }
-        return { resolved: true };
+    {
+        name: "package-lockfiles-npm-version",
+        match: filePattern,
+        handler: file => {
+            const content = readFile(file);
+            if (content.match(versionPattern) === null) {
+                return `Unexpected 'lockFileVersion' (Please use NPM v6: 'npm i -g npm@latest-6'): ${file}`;
+            }
+            return;
+        },
     }
-};
+];

--- a/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
+++ b/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
@@ -15,7 +15,7 @@ import { handlers as copyrightFileHeaderHandlers } from "./handlers/copyrightFil
 import { handlers as npmPackageContentsHandlers } from "./handlers/npmPackages";
 import { handler as dockerfilePackageHandler } from "./handlers/dockerfilePackages";
 import { handler as fluidCaseHandler } from "./handlers/fluidCase";
-import { handler as lockfilesHandler } from "./handlers/lockfiles";
+import { handlers as lockfilesHandlers } from "./handlers/lockfiles";
 
 const exclusions: RegExp[] = require('../../data/exclusions.json').map((e: string) => new RegExp(e, "i"));
 
@@ -59,7 +59,7 @@ const handlers: Handler[] = [
     ...npmPackageContentsHandlers,
     dockerfilePackageHandler,
     fluidCaseHandler,
-    lockfilesHandler,
+    ...lockfilesHandlers,
     assertShortCodeHandler,
 ];
 


### PR DESCRIPTION
NPM v7 introduces a new lockfile version that adds a lot of additional information to the '-lock.json'.

Because the new lockfile format is backwards compatible it passes our CI, leading to churn and conflicts as the format ping-pongs between the two versions.

This change adds a new rule to policheck to restrict lockfiles to version 1, which is what is produced by NPM v6.

(Also happy for all of us to switch to NPM v7.  I just picked 6 because it's the default for Node 12.)