### PR TITLE
Fix registerOnValues/registerOnProperty for primitive collections

### DIFF
--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/data_binding.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/data_binding.js
@@ -1740,7 +1740,8 @@ class DataBinding {
       // then it value represent the index/key of the entry involved in the registered event.
       if (propertyOrKey instanceof BaseProperty ) {
         const property = propertyOrKey;
-        const values = propertyOrKey.isPrimitiveType() ? propertyOrKey.getValue() : propertyOrKey.getValues();
+        const values = (propertyOrKey.isPrimitiveType() &&
+                        propertyOrKey.getContext() === 'single') ? propertyOrKey.getValue() : propertyOrKey.getValues();
         in_callback.call(this, values);
       } else {
         const key = propertyOrKey;

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/data_binding.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/data_binding.js
@@ -1740,8 +1740,9 @@ class DataBinding {
       // then it value represent the index/key of the entry involved in the registered event.
       if (propertyOrKey instanceof BaseProperty ) {
         const property = propertyOrKey;
-        const values = (propertyOrKey.isPrimitiveType() &&
-                        propertyOrKey.getContext() === 'single') ? propertyOrKey.getValue() : propertyOrKey.getValues();
+        const values = (property.isPrimitiveType() && property.getContext() === 'single') ?
+          property.getValue():
+          property.getValues();
         in_callback.call(this, values);
       } else {
         const key = propertyOrKey;

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binding.spec.js
@@ -2453,7 +2453,6 @@ describe('DataBinding.registerOnValues() should work for', function() {
     workspace.popNotificationDelayScope();
 
     expect(mapInsertSpy).toHaveBeenCalledTimes(2);
-    expect(mapInsertSpy).toHaveBeenCalledTimes(2);
     // Test first parameter (index or key)
     expect(mapInsertSpy.mock.calls[0][0]).toEqual('one');
     expect(mapInsertSpy.mock.calls[1][0]).toEqual('two');
@@ -2556,7 +2555,7 @@ describe('DataBinding.registerOnValues() should work for', function() {
     // Expect the insertion of map values to trigger onInsert messages
     workspace.root.insert('ArrayContainerTemplate', arrayPropertyParent);
 
-    ParentDataBinding.registerOnValues('arrayPrimitive', ['insert'], wholeArraySpy);
+    ParentDataBinding.registerOnValues('arrayPrimitive', ['insert', 'modify'], wholeArraySpy);
 
     // Register the base (Child) typeid
     dataBinder.register('BINDING', ArrayContainerTemplate.typeid, ParentDataBinding);
@@ -2564,8 +2563,16 @@ describe('DataBinding.registerOnValues() should work for', function() {
 
     expect(wholeArraySpy).toHaveBeenCalledTimes(1);
 
+    const arrayProperty = workspace.root.get(['ArrayContainerTemplate', 'arrayPrimitive']);
+
     // Test first parameter (collection values)
     expect(wholeArraySpy.mock.calls[0][0]).toEqual(['initial']);
+
+    arrayProperty.push('one');
+
+    // Test modify event
+    expect(wholeArraySpy).toHaveBeenCalledTimes(2);
+    expect(wholeArraySpy.mock.calls[1][0]).toEqual(['initial', 'one']);
 
     wholeArraySpy.mockClear();
   });

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binding.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/data_binding.spec.js
@@ -2453,6 +2453,7 @@ describe('DataBinding.registerOnValues() should work for', function() {
     workspace.popNotificationDelayScope();
 
     expect(mapInsertSpy).toHaveBeenCalledTimes(2);
+    expect(mapInsertSpy).toHaveBeenCalledTimes(2);
     // Test first parameter (index or key)
     expect(mapInsertSpy.mock.calls[0][0]).toEqual('one');
     expect(mapInsertSpy.mock.calls[1][0]).toEqual('two');
@@ -2487,4 +2488,85 @@ describe('DataBinding.registerOnValues() should work for', function() {
     mapRemoveSpy.mockClear();
   });
 
+  it('Array of primitives', function() {
+    var arrayInsertSpy = jest.fn();
+    var arrayModifySpy = jest.fn();
+    var arrayRemoveSpy = jest.fn();
+
+    // Add the container pset
+    var arrayPropertyParent = PropertyFactory.create(ArrayContainerTemplate.typeid, 'single');
+
+    // Expect the insertion of map values to trigger onInsert messages
+    workspace.root.insert('ArrayContainerTemplate', arrayPropertyParent);
+
+    ParentDataBinding.registerOnValues('arrayPrimitive', ['collectionInsert'], arrayInsertSpy);
+    ParentDataBinding.registerOnValues('arrayPrimitive', ['collectionModify'], arrayModifySpy);
+    ParentDataBinding.registerOnValues('arrayPrimitive', ['collectionRemove'], arrayRemoveSpy);
+
+    // Register the base (Child) typeid
+    dataBinder.register('BINDING', ArrayContainerTemplate.typeid, ParentDataBinding);
+    dataBinder.attachTo(workspace);
+
+    const arrayProperty = workspace.root.get(['ArrayContainerTemplate', 'arrayPrimitive']);
+    workspace.pushNotificationDelayScope();
+    arrayProperty.push('one');
+    arrayProperty.push('two');
+    workspace.popNotificationDelayScope();
+
+    expect(arrayInsertSpy).toHaveBeenCalledTimes(2);
+    // Test first parameter (index or key)
+    expect(arrayInsertSpy.mock.calls[0][0]).toEqual(0);
+    expect(arrayInsertSpy.mock.calls[1][0]).toEqual(1);
+
+    // Test second parameter
+    expect(arrayInsertSpy.mock.calls[0][1]).toEqual('one');
+    expect(arrayInsertSpy.mock.calls[1][1]).toEqual('two');
+
+    arrayInsertSpy.mockClear();
+
+    // modify array
+    workspace.pushNotificationDelayScope();
+    arrayProperty.setValues(['10', '20']);
+    workspace.popNotificationDelayScope();
+    expect(arrayModifySpy).toHaveBeenCalledTimes(2);
+    expect(arrayModifySpy.mock.calls[0][0]).toEqual(0);
+    expect(arrayModifySpy.mock.calls[1][0]).toEqual(1);
+
+    expect(arrayModifySpy.mock.calls[0][1]).toEqual('10');
+    expect(arrayModifySpy.mock.calls[1][1]).toEqual('20');
+    arrayModifySpy.mockClear();
+
+    // remove from array
+    workspace.pushNotificationDelayScope();
+    arrayProperty.removeRange(0, 2);
+    workspace.popNotificationDelayScope();
+    expect(arrayRemoveSpy).toHaveBeenCalledTimes(2);
+    // TODO: Not sure if these are the correct remove keys (Expectation is to have the values 0 and 1, since its a batched opertation)
+    expect(arrayRemoveSpy.mock.calls[0][0]).toEqual(0);
+    expect(arrayRemoveSpy.mock.calls[1][0]).toEqual(0);
+    arrayRemoveSpy.mockClear();
+  });
+
+  it('Register on the whole primitives array changes', function() {
+    var wholeArraySpy = jest.fn();
+
+    // Add the container pset
+    var arrayPropertyParent = PropertyFactory.create(ArrayContainerTemplate.typeid, 'single', {arrayPrimitive: ['initial']});
+
+    // Expect the insertion of map values to trigger onInsert messages
+    workspace.root.insert('ArrayContainerTemplate', arrayPropertyParent);
+
+    ParentDataBinding.registerOnValues('arrayPrimitive', ['insert'], wholeArraySpy);
+
+    // Register the base (Child) typeid
+    dataBinder.register('BINDING', ArrayContainerTemplate.typeid, ParentDataBinding);
+    dataBinder.attachTo(workspace);
+
+    expect(wholeArraySpy).toHaveBeenCalledTimes(1);
+
+    // Test first parameter (collection values)
+    expect(wholeArraySpy.mock.calls[0][0]).toEqual(['initial']);
+
+    wholeArraySpy.mockClear();
+  });
 });

--- a/experimental/PropertyDDS/packages/property-binder/test/data_binder/testTemplates.js
+++ b/experimental/PropertyDDS/packages/property-binder/test/data_binder/testTemplates.js
@@ -118,6 +118,11 @@ const ArrayContainerTemplate = {
       context: 'array'
     },
     {
+      id: 'arrayPrimitive',
+      typeid: 'String',
+      context: 'array'
+    },
+    {
       id: 'nested',
       properties: [
         {


### PR DESCRIPTION
Fix a bug in `registerOnValues` and `registerOnProperty` which caused the callback to fail when listening to changes from primitive collections with the combination of the flag `insert`.  