### PR TITLE
Add blob data in rehydrating container to read from

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -168,7 +168,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 }
 
 // @public
-export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree, blobs: Map<string, ArrayBufferLike>): ISnapshotTree;
+export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree): {
+    snapshotTree: ISnapshotTree;
+    blobs: Map<string, ArrayBufferLike>;
+};
 
 // @public
 export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, IEventProvider<IDeltaManagerInternalEvents> {
@@ -242,7 +245,10 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
 }
 
 // @public (undocumented)
-export const getSnapshotTreeFromSerializedContainer: (detachedContainerSnapshot: ISummaryTree, blobs: Map<string, ArrayBufferLike>) => ISnapshotTree;
+export const getSnapshotTreeFromSerializedContainer: (detachedContainerSnapshot: ISummaryTree) => {
+    snapshotTree: ISnapshotTree;
+    blobs: Map<string, ArrayBufferLike>;
+};
 
 // @public
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -168,7 +168,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 }
 
 // @public
-export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree): ISnapshotTree;
+export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree, blobs: Map<string, ArrayBufferLike>): ISnapshotTree;
 
 // @public
 export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, IEventProvider<IDeltaManagerInternalEvents> {
@@ -242,7 +242,7 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
 }
 
 // @public (undocumented)
-export const getSnapshotTreeFromSerializedContainer: (detachedContainerSnapshot: ISummaryTree) => ISnapshotTree;
+export const getSnapshotTreeFromSerializedContainer: (detachedContainerSnapshot: ISummaryTree, blobs: Map<string, ArrayBufferLike>) => ISnapshotTree;
 
 // @public
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -23,7 +23,7 @@ import {
  */
 export class ContainerStorageAdapter implements IDocumentStorageService {
     constructor(
-        private readonly storageGetter: () => IDocumentStorageService,
+        private readonly storageGetter: (callName: string) => IDocumentStorageService,
         private readonly blobs: Map<string, ArrayBufferLike>,
     ) {
     }
@@ -32,17 +32,17 @@ export class ContainerStorageAdapter implements IDocumentStorageService {
         // back-compat 0.40 containerRuntime requests policies even in detached container if storage is present
         // and storage is always present in >=0.41.
         try {
-            return this.storageGetter().policies;
+            return this.storageGetter("policies").policies;
         } catch(e) {}
         return undefined;
     }
 
     public get repositoryUrl(): string {
-        return this.storageGetter().repositoryUrl;
+        return this.storageGetter("repositoryUrl").repositoryUrl;
     }
 
     public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null> {
-        return this.storageGetter().getSnapshotTree(version);
+        return this.storageGetter("getSnapshotTree").getSnapshotTree(version);
     }
 
     public async readBlob(id: string): Promise<ArrayBufferLike> {
@@ -50,26 +50,26 @@ export class ContainerStorageAdapter implements IDocumentStorageService {
         if (blob !== undefined) {
             return blob;
         }
-        return this.storageGetter().readBlob(id);
+        return this.storageGetter(("readBlob")).readBlob(id);
     }
 
     public async getVersions(versionId: string, count: number): Promise<IVersion[]> {
-        return this.storageGetter().getVersions(versionId, count);
+        return this.storageGetter("getVersions").getVersions(versionId, count);
     }
 
     public async write(tree: ITree, parents: string[], message: string, ref: string): Promise<IVersion> {
-        return this.storageGetter().write(tree, parents, message, ref);
+        return this.storageGetter("write").write(tree, parents, message, ref);
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
-        return this.storageGetter().uploadSummaryWithContext(summary, context);
+        return this.storageGetter("uploadSummaryWithContext").uploadSummaryWithContext(summary, context);
     }
 
     public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
-        return this.storageGetter().downloadSummary(handle);
+        return this.storageGetter("downloadSummary").downloadSummary(handle);
     }
 
     public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
-        return this.storageGetter().createBlob(file);
+        return this.storageGetter("createBlob").createBlob(file);
     }
 }

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -23,7 +23,7 @@ import {
  */
 export class ContainerStorageAdapter implements IDocumentStorageService {
     constructor(
-        private readonly storageGetter: (callName: string) => IDocumentStorageService,
+        private readonly storageGetter: () => IDocumentStorageService,
         private readonly blobs: Map<string, ArrayBufferLike>,
     ) {
     }
@@ -32,17 +32,17 @@ export class ContainerStorageAdapter implements IDocumentStorageService {
         // back-compat 0.40 containerRuntime requests policies even in detached container if storage is present
         // and storage is always present in >=0.41.
         try {
-            return this.storageGetter("policies").policies;
+            return this.storageGetter().policies;
         } catch(e) {}
         return undefined;
     }
 
     public get repositoryUrl(): string {
-        return this.storageGetter("repositoryUrl").repositoryUrl;
+        return this.storageGetter().repositoryUrl;
     }
 
     public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null> {
-        return this.storageGetter("getSnapshotTree").getSnapshotTree(version);
+        return this.storageGetter().getSnapshotTree(version);
     }
 
     public async readBlob(id: string): Promise<ArrayBufferLike> {
@@ -50,26 +50,26 @@ export class ContainerStorageAdapter implements IDocumentStorageService {
         if (blob !== undefined) {
             return blob;
         }
-        return this.storageGetter(("readBlob")).readBlob(id);
+        return this.storageGetter().readBlob(id);
     }
 
     public async getVersions(versionId: string, count: number): Promise<IVersion[]> {
-        return this.storageGetter("getVersions").getVersions(versionId, count);
+        return this.storageGetter().getVersions(versionId, count);
     }
 
     public async write(tree: ITree, parents: string[], message: string, ref: string): Promise<IVersion> {
-        return this.storageGetter("write").write(tree, parents, message, ref);
+        return this.storageGetter().write(tree, parents, message, ref);
     }
 
     public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
-        return this.storageGetter("uploadSummaryWithContext").uploadSummaryWithContext(summary, context);
+        return this.storageGetter().uploadSummaryWithContext(summary, context);
     }
 
     public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
-        return this.storageGetter("downloadSummary").downloadSummary(handle);
+        return this.storageGetter().downloadSummary(handle);
     }
 
     public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
-        return this.storageGetter("createBlob").createBlob(file);
+        return this.storageGetter().createBlob(file);
     }
 }

--- a/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
+++ b/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
@@ -51,7 +51,7 @@ describe("Dehydrate Container", () => {
                 },
             },
         };
-        const snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
+        const snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary, new Map());
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 2, "2 trees should be there");
         assert.strictEqual(Object.keys(snapshotTree.trees[".protocol"].blobs).length, 4,

--- a/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
+++ b/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
@@ -51,7 +51,7 @@ describe("Dehydrate Container", () => {
                 },
             },
         };
-        const snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary, new Map());
+        const { snapshotTree } = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 2, "2 trees should be there");
         assert.strictEqual(Object.keys(snapshotTree.trees[".protocol"].blobs).length, 4,

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -154,8 +154,8 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
         it("Dehydrated container snapshot", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();
-            const snapshotTree: ISnapshotTree =
-                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
+            const snapshotTree =
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()), new Map());
 
             // Check for protocol attributes
             const protocolTree = assertProtocolTree(snapshotTree);
@@ -178,13 +178,13 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             const { container, defaultDataStore } =
                 await createDetachedContainerAndGetRootDataStore();
             const snapshotTree1: ISnapshotTree =
-                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()), new Map());
             // Create a channel
             const channel = defaultDataStore.runtime.createChannel("test1",
                 "https://graph.microsoft.com/types/map") as SharedMap;
             channel.bindToContext();
             const snapshotTree2: ISnapshotTree =
-                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()), new Map());
 
             assert.strictEqual(JSON.stringify(Object.keys(snapshotTree1.trees)),
                 JSON.stringify(Object.keys(snapshotTree2.trees)),
@@ -218,7 +218,7 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
             const snapshotTree: ISnapshotTree =
-                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
+                getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()), new Map());
 
             assertProtocolTree(snapshotTree);
             assertDatastoreTree(snapshotTree, "default");
@@ -589,7 +589,7 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
             // Create another not bounded dataStore
             await createPeerDataStore(defaultDataStore.context.containerRuntime);
 
-            const snapshotTree = getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
+            const snapshotTree = getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()), new Map());
 
             assertProtocolTree(snapshotTree);
             assertDatastoreTree(snapshotTree, "default");

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -31,11 +31,11 @@ import { SharedCounter } from "@fluidframework/counter";
 import { IRequest, IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 
 const detachedContainerRefSeqNumber = 0;
 
-describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) => {
+describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) => {
     let disableIsolatedChannels = false;
 
     function assertSubtree(tree: ISnapshotTree, key: string, msg?: string): ISnapshotTree {
@@ -600,6 +600,11 @@ describeNoCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) =
     tests();
 
     // Run again with isolated channels disabled
-    disableIsolatedChannels = true;
-    describe("With isolated channels disabled", tests);
+    describe("With isolated channels disabled", () => {
+        before(() => {
+            disableIsolatedChannels = true;
+        });
+
+        tests();
+    });
 });

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -166,7 +166,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
         it("Dehydrated container snapshot", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();
-            const { snapshotTree } = getSnapshotTreeFromSerializedSnapshot(container);
+            const { snapshotTree, blobs } = getSnapshotTreeFromSerializedSnapshot(container);
 
             // Check for protocol attributes
             const protocolTree = assertProtocolTree(snapshotTree);
@@ -179,6 +179,9 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
                 protocolAttributes.minimumSequenceNumber <= protocolAttributes.sequenceNumber,
                 "Min Seq # <= seq #");
 
+            // Check blobs contents for protocolAttributes
+            const protocolAttributesBlobId = snapshotTree.trees[".protocol"].blobs.attributes;
+            assert(blobs[protocolAttributesBlobId] !== undefined, "Blobs should contain attributes blob");
             // Check for default dataStore
             const { datastoreTree: defaultDatastore } = assertDatastoreTree(snapshotTree, "default");
             const datastoreAttributes = assertBlobContents<{ pkg: string }>(defaultDatastore, ".component");


### PR DESCRIPTION
Add blob data while rehydrating container in cache to read from. In latest runtime we don't make readBlobs call in detached container yet, however in older runtime we do make readblob call is storage is present. So for that add blob data in cache.

For now keeping it to just blob calls. Later would add other functionality too to pass full snapshot in storage adapter.