### PR TITLE
r11s-driver: retry at lower level in uploadSummaryWithContext

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -26,6 +26,7 @@ import {
 import { GitManager, ISummaryUploadManager, SummaryTreeUploadManager } from "@fluidframework/server-services-client";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { DocumentStorageServiceProxy, PrefetchDocumentStorageService } from "@fluidframework/driver-utils";
+import { RetriableGitManager } from "./retriableGitManager";
 
 /**
  * Document access to underlying storage for routerlicious driver.
@@ -46,7 +47,7 @@ class DocumentStorageServiceCore implements IDocumentStorageService {
         private readonly logger: ITelemetryLogger,
         public readonly policies: IDocumentStorageServicePolicies = {}) {
         this.summaryUploadManager = new SummaryTreeUploadManager(
-            this.manager,
+            new RetriableGitManager(this.manager, this.logger),
             this.blobsShaCache,
             this.getPreviousFullSnapshot.bind(this),
         );

--- a/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
@@ -1,0 +1,150 @@
+import type * as git from "@fluidframework/gitresources";
+import type * as protocol from "@fluidframework/protocol-definitions";
+import { IGitManager, IWholeSummaryPayload, IWriteSummaryResponse } from "@fluidframework/server-services-client";
+import { runWithRetry } from "@fluidframework/driver-utils";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
+
+export class RetriableGitManager implements IGitManager {
+    constructor(
+        private readonly internalGitManager: IGitManager,
+        private readonly logger: ITelemetryLogger,
+    ) {
+    }
+
+    public async getHeader(id: string, sha: string): Promise<protocol.ISnapshotTree> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getHeader(id, sha),
+            "gitManager_getHeader",
+        );
+    }
+
+    public async getFullTree(sha: string): Promise<any> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getFullTree(sha),
+            "gitManager_getFullTree",
+        );
+    }
+
+    public async getCommit(sha: string): Promise<git.ICommit> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getCommit(sha),
+            "gitManager_getCommit",
+        );
+    }
+
+    public async getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getCommits(sha, count),
+            "gitManager_getCommits",
+        );
+    }
+
+    public async getTree(root: string, recursive: boolean): Promise<git.ITree> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getTree(root, recursive),
+            "gitManager_getTree",
+        );
+    }
+
+    public async getBlob(sha: string): Promise<git.IBlob> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getBlob(sha),
+            "gitManager_getBlob",
+        );
+    }
+
+    public getRawUrl(sha: string): string {
+        return this.internalGitManager.getRawUrl(sha);
+    }
+
+    public async getContent(commit: string, path: string): Promise<git.IBlob> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getContent(commit, path),
+            "gitManager_getContent",
+        );
+    }
+
+    public async createBlob(content: string, encoding: string): Promise<git.ICreateBlobResponse> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.createBlob(content, encoding),
+            "gitManager_createBlob",
+        );
+    }
+
+    public async createGitTree(params: git.ICreateTreeParams): Promise<git.ITree> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.createGitTree(params),
+            "gitManager_createGitTree",
+        );
+    }
+
+    public async createTree(files: protocol.ITree): Promise<git.ITree> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.createTree(files),
+            "gitManager_createTree",
+        );
+    }
+
+    public async createCommit(commit: git.ICreateCommitParams): Promise<git.ICommit> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.createCommit(commit),
+            "gitManager_createCommit",
+        );
+    }
+
+    public async getRef(ref: string): Promise<git.IRef> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.getRef(ref),
+            "gitManager_getRef",
+        );
+    }
+
+    public async createRef(branch: string, sha: string): Promise<git.IRef> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.createRef(branch, sha),
+            "gitManager_createRef",
+        );
+    }
+
+    public async upsertRef(branch: string, commitSha: string): Promise<git.IRef> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.upsertRef(branch, commitSha),
+            "gitManager_upsertRef",
+        );
+    }
+
+    public async write(branch: string,
+        inputTree: protocol.ITree,
+        parents: string[],
+        message: string): Promise<git.ICommit> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.write(branch, inputTree, parents, message),
+            "gitManager_write",
+        );
+    }
+
+    public async createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
+        return this.runWithRetry(
+            async () => this.internalGitManager.createSummary(summary),
+            "gitManager_createSummary",
+        );
+    }
+
+    private async runWithRetry<T>(api: () => Promise<T>, callName: string): Promise<T> {
+        return runWithRetry(
+            api,
+            callName,
+            (id: string) => this.refreshDelayInfo(id),
+            (id: string, retryInMs: number, err: any) => this.emitDelayInfo(id, retryInMs, err),
+            this.logger,
+        );
+    }
+
+    private refreshDelayInfo(id: string): void {
+        return;
+    }
+
+    private emitDelayInfo(id: string, retryInMs: number, err: any): void {
+        return;
+    }
+}

--- a/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import type * as git from "@fluidframework/gitresources";
 import type * as protocol from "@fluidframework/protocol-definitions";
 import { IGitManager, IWholeSummaryPayload, IWriteSummaryResponse } from "@fluidframework/server-services-client";


### PR DESCRIPTION
Currently, when any internal network calls fail in `uploadSummaryWithContext`, the entire operation is retried. Theoretically, this would be OK because blobShaCache in DocumentStorageService keeps track of what's been uploaded and won't try again. However, when the HTTP/2 limit failure count gets high enough per request, it never recovers (or maybe it does eventually but I've seen it go for 10+ min).

Instead, retrying individual failed network requests instead of the entire call results in a quick recovery from HTTP/2 limit failures on summary upload.

This PR adds a RetriableGitManager that is only used in `uploadSummaryWithContext` flow. It is not needed in other operations, such as read blob, because there are not multiple calls per operation. It is possible that this could be used in the `DocumentStorageService.write` API, since it performs a similar recursive tree upload, but I have not tested that method's use cases.