### PR TITLE
Remove an old (and ineffectual) perf workaround

### DIFF
--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -168,16 +168,5 @@ export function extendIfUndefined<T>(base: MapLike<T>, extension: MapLike<T> | u
 
 // Create a MapLike with good performance.
 export function createMap<T>(): MapLike<T> {
-    const map = Object.create(null);
-
-    // Using 'delete' on an object causes V8 to put the object in dictionary mode.
-    // This disables creation of hidden classes, which are expensive when an object is
-    // constantly changing shape.
-    // eslint-disable-next-line @typescript-eslint/dot-notation
-    map["__"] = undefined;
-    // eslint-disable-next-line @typescript-eslint/dot-notation, @typescript-eslint/no-dynamic-delete
-    delete map["__"];
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return map;
+    return Object.create(null) as MapLike<T>;
 }


### PR DESCRIPTION
When we construct one of our basic data structures, we create and delete a dummy property on it to make the JS engine stop trying to use a shareable type/map. Using a shared type/map adds a certain amount of overhead, and we expect the object to be given a unique shape, so we won't get any sharing benefit. But the code isn't actually doing what we want, because V8 and Chakra will both continue to use a shareable type/map if the deleted property is the last one that was added. And it isn't really needed, because V8 already takes Object.create(null) as a signal to use a non-shared map.