### PR TITLE
add mongo connection options

### DIFF
--- a/server/routerlicious/packages/services-core/src/mongo.ts
+++ b/server/routerlicious/packages/services-core/src/mongo.ts
@@ -66,6 +66,14 @@ export class MongoManager {
                     this.reconnect(this.reconnectDelayMs);
                 });
 
+                db.on("reconnect", (value) => {
+                    debug("DB Reconnect");
+                });
+
+                db.on("reconnectFailed", (value) => {
+                    debug("DB Reconnect failed");
+                });
+
                 return db;
             });
 

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -126,8 +126,13 @@ export class MongoDbFactory implements core.IDbFactory {
     public async connect(): Promise<core.IDb> {
         // Need to cast to any before MongoClientOptions due to missing properties in d.ts
         const options: MongoClientOptions = {
-            autoReconnect: false,
+            autoReconnect: true,
             bufferMaxEntries: 0,
+            keepAlive: true,
+            keepAliveInitialDelay: 180000,
+            reconnectInterval: 1000,
+            reconnectTries: 100,
+            socketTimeoutMS: 120000,
             useNewUrlParser: true,
         };
 


### PR DESCRIPTION
Adding some additional fields to the MongoClientOptions. This is recommended by CosmosDB team to avoid connection issues, and it will apply for native MongoDB as well, hence making the changes directly instead of putting behind a cosmos-specific config.

Set autoreconnect to true so the mongo driver will try to reconnect on connection close/error. To check if autoreconnect works or not, added logs for reconnect and reconnectFailed events. The reconnectFailed event is only documented in one place for Nodejs, so adding the log here to test if it occurs or not. Reconnect interval is the milliseconds to wait between retries. Set the number of retries to a finite number (100) to give a chance for reconnect failed to be logged if all the retries fail. If reconnectFailed event occurs, then we can implement logic to close the connection and establish a new one.

Also set tcp keepalive to true so that it will periodically send pings to the mongo server and fail the connection if the pings fail. socketTimeoutMS is the amount of time the driver waits for an inactive socket before closing it - set it to the value recommended by CosmosDB. The default value is to never time out the socket.

