### PR TITLE
Removed some apis from export in container loader package

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,6 +1,7 @@
 ## 0.42 Breaking changes
 
 - [Package renames](#0.42-package-renames)
+- [Removed IParsedUrl interface, parseUrl, getSnapshotTreeFromSerializedContainer and convertProtocolAndAppSummaryToSnapshotTree api from export](#Removed-IParsedUrl-interface,-parseUrl,-getSnapshotTreeFromSerializedContainer-and-convertProtocolAndAppSummaryToSnapshotTree-api-from-export)
 
 ### 0.42 package renames
 
@@ -10,6 +11,9 @@ the npm scopes.
 
 - `@fluidframework/react-inputs` is renamed to `@fluid-experimental/react-inputs`
 - `@fluidframework/react` is renamed to `@fluid-experimental/react`
+
+### Removed IParsedUrl interface, parseUrl, getSnapshotTreeFromSerializedContainer and convertProtocolAndAppSummaryToSnapshotTree api from export
+These interface and apis are not supposed to be used outside the fluid framework repo. So stop exposing them.
 
 ## 0.41 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -13,7 +13,7 @@ the npm scopes.
 - `@fluidframework/react` is renamed to `@fluid-experimental/react`
 
 ### Removed IParsedUrl interface, parseUrl, getSnapshotTreeFromSerializedContainer and convertProtocolAndAppSummaryToSnapshotTree api from export
-These interface and apis are not supposed to be used outside the fluid framework repo. So stop exposing them.
+These interface and apis are not supposed to be used outside the package. So stop exposing them.
 
 ## 0.41 Breaking changes
 

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -168,12 +168,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 }
 
 // @public
-export function convertProtocolAndAppSummaryToSnapshotTree(protocolSummaryTree: ISummaryTree, appSummaryTree: ISummaryTree): {
-    snapshotTree: ISnapshotTree;
-    blobs: Map<string, ArrayBufferLike>;
-};
-
-// @public
 export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, IEventProvider<IDeltaManagerInternalEvents> {
     constructor(serviceProvider: () => IDocumentService | undefined, client: IClient, logger: ITelemetryLogger, reconnectAllowed: boolean, _active: () => boolean);
     // (undocumented)
@@ -243,12 +237,6 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     // (undocumented)
     get version(): string;
 }
-
-// @public (undocumented)
-export const getSnapshotTreeFromSerializedContainer: (detachedContainerSnapshot: ISummaryTree) => {
-    snapshotTree: ISnapshotTree;
-    blobs: Map<string, ArrayBufferLike>;
-};
 
 // @public
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
@@ -326,17 +314,6 @@ export interface ILoaderServices {
     readonly urlResolver: IUrlResolver;
 }
 
-// @public (undocumented)
-export interface IParsedUrl {
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    path: string;
-    // (undocumented)
-    query: string;
-    version: string | null | undefined;
-}
-
 // @public
 export class Loader implements IHostLoader {
     constructor(loaderProps: ILoaderProps);
@@ -355,9 +332,6 @@ export class Loader implements IHostLoader {
     // (undocumented)
     readonly services: ILoaderServices;
 }
-
-// @public (undocumented)
-export function parseUrl(url: string): IParsedUrl | undefined;
 
 // @public (undocumented)
 export enum ReconnectMode {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -100,11 +100,11 @@ import { IConnectionArgs, DeltaManager, ReconnectMode } from "./deltaManager";
 import { DeltaManagerProxy } from "./deltaManagerProxy";
 import { ILoaderOptions, Loader, RelativeLoader } from "./loader";
 import { pkgVersion } from "./packageVersion";
-import { convertProtocolAndAppSummaryToSnapshotTree } from "./utils";
 import { ConnectionStateHandler, ILocalSequencedClient } from "./connectionStateHandler";
 import { RetriableDocumentStorageService } from "./retriableDocumentStorageService";
 import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService";
 import { ContainerStorageAdapter } from "./containerStorageAdapter";
+import { getSnapshotTreeFromSerializedContainer } from "./utils";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -156,20 +156,6 @@ export enum ConnectionState {
      */
     Connected,
 }
-
-// This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
-// a detached container can be rehydrated.
-export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot: ISummaryTree) => {
-    const protocolSummaryTree = detachedContainerSnapshot.tree[".protocol"] as ISummaryTree;
-    const appSummaryTree = detachedContainerSnapshot.tree[".app"] as ISummaryTree;
-    assert(protocolSummaryTree !== undefined && appSummaryTree !== undefined,
-        0x1e0 /* "Protocol and App summary trees should be present" */);
-    const { snapshotTree, blobs } = convertProtocolAndAppSummaryToSnapshotTree(
-        protocolSummaryTree,
-        appSummaryTree,
-    );
-    return { snapshotTree, blobs };
-};
 
 /**
  * Waits until container connects to delta storage and gets up-to-date

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -7,5 +7,4 @@ export * from "./audience";
 export * from "./container";
 export * from "./deltaManager";
 export * from "./loader";
-export * from "./utils";
 export * from "./retriableDocumentStorageService";

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -5,7 +5,7 @@
 
 import { parse } from "url";
 import { v4 as uuid } from "uuid";
-import { bufferToString, stringToBuffer } from "@fluidframework/common-utils";
+import { assert, bufferToString, stringToBuffer } from "@fluidframework/common-utils";
 import { ISummaryTree, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 
 export interface IParsedUrl {
@@ -102,3 +102,17 @@ export function convertProtocolAndAppSummaryToSnapshotTree(
     const snapshotTree = convertSummaryToSnapshotWithEmbeddedBlobContents(combinedSummary, blobs);
     return { snapshotTree, blobs };
 }
+
+// This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
+// a detached container can be rehydrated.
+export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot: ISummaryTree) => {
+    const protocolSummaryTree = detachedContainerSnapshot.tree[".protocol"] as ISummaryTree;
+    const appSummaryTree = detachedContainerSnapshot.tree[".app"] as ISummaryTree;
+    assert(protocolSummaryTree !== undefined && appSummaryTree !== undefined,
+        0x1e0 /* "Protocol and App summary trees should be present" */);
+    const { snapshotTree, blobs } = convertProtocolAndAppSummaryToSnapshotTree(
+        protocolSummaryTree,
+        appSummaryTree,
+    );
+    return { snapshotTree, blobs };
+};

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -5,11 +5,7 @@
 
 import { strict as assert } from "assert";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
-import {
-    Container,
-    getSnapshotTreeFromSerializedContainer,
-    Loader,
-} from "@fluidframework/container-loader";
+import { Container, Loader } from "@fluidframework/container-loader";
 import {
     LocalCodeLoader,
     TestFluidObjectFactory,
@@ -33,6 +29,8 @@ import { IRequest, IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
+// eslint-disable-next-line import/no-internal-modules
+import { getSnapshotTreeFromSerializedContainer } from "@fluidframework/container-loader/dist/utils";
 
 const detachedContainerRefSeqNumber = 0;
 


### PR DESCRIPTION
Removed IParsedUrl interface, parseUrl, getSnapshotTreeFromSerializedContainer and convertProtocolAndAppSummaryToSnapshotTree api from export. These interface and apis are not supposed to be used outside the package. So stop exposing them.