### PR TITLE
Fix isolated channels detached

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -801,8 +801,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             && !this.runtimeOptions.gcOptions.disableGC
         );
 
-        // Default to false (enabled).
-        this.disableIsolatedChannels = this.runtimeOptions.summaryOptions.disableIsolatedChannels ?? false;
+        // Default to true (disabled) until 0.42.
+        this.disableIsolatedChannels = this.runtimeOptions.summaryOptions.disableIsolatedChannels ?? true;
 
         this._connected = this.context.connected;
         this.chunkMap = new Map<string, string[]>(chunks);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -724,6 +724,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
 
             if (hasIsolatedChannels(attributes)) {
                 tree = tree.trees[channelsTreeName];
+                assert(tree !== undefined, "isolated channels subtree should exist in remote datastore snapshot");
             }
         }
 
@@ -850,9 +851,18 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         assert(this.isRootDataStore !== undefined,
             0x153 /* "isRootDataStore should be available in local data store" */);
 
-        const snapshot = this.disableIsolatedChannels
-            ? this.snapshotTree
-            : this.snapshotTree?.trees[channelsTreeName];
+        let snapshot = this.snapshotTree;
+        if (snapshot !== undefined) {
+            const attributes = await readAndParse<ReadFluidDataStoreAttributes>(
+                this.storage,
+                snapshot.blobs[dataStoreAttributesBlobName]);
+
+            if (hasIsolatedChannels(attributes)) {
+                snapshot = snapshot.trees[channelsTreeName];
+                assert(snapshot !== undefined, "isolated channels subtree should exist in local datastore snapshot");
+            }
+        }
+
         return {
             pkg: this.pkg,
             snapshot,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -26,7 +26,7 @@ import {
     TypedEventEmitter,
 } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { readAndParse } from "@fluidframework/driver-utils";
+import { readAndParse, readAndParseFromBlobs } from "@fluidframework/driver-utils";
 import { BlobTreeEntry } from "@fluidframework/protocol-base";
 import {
     IClientDetails,
@@ -853,9 +853,12 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 
         let snapshot = this.snapshotTree;
         if (snapshot !== undefined) {
-            const attributes = await readAndParse<ReadFluidDataStoreAttributes>(
-                this.storage,
-                snapshot.blobs[dataStoreAttributesBlobName]);
+            // Note: storage can be undefined in special case while detached.
+            const attributes = this.storage !== undefined
+                ? await readAndParse<ReadFluidDataStoreAttributes>(
+                    this.storage, snapshot.blobs[dataStoreAttributesBlobName])
+                : readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
+                    snapshot.blobs, snapshot.blobs[dataStoreAttributesBlobName]);
 
             if (hasIsolatedChannels(attributes)) {
                 snapshot = snapshot.trees[channelsTreeName];

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -24,6 +24,7 @@ import {
     SummarizeInternalFn,
     CreateChildSummarizerNodeFn,
     CreateSummarizerNodeSource,
+    channelsTreeName,
 } from "@fluidframework/runtime-definitions";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { createRootSummarizerNodeWithGC, IRootSummarizerNodeWithGC } from "@fluidframework/runtime-utils";
@@ -362,7 +363,11 @@ describe("Data Store Context Tests", () => {
                     const snapshotTree: ISnapshotTree = {
                         blobs: { [dataStoreAttributesBlobName]: "fluidDataStoreAttributes" },
                         commits: {},
-                        trees: {},
+                        trees: { [channelsTreeName]: {
+                            blobs: {},
+                            commits: {},
+                            trees: {},
+                        } },
                     };
 
                     remotedDataStoreContext = new RemotedFluidDataStoreContext(

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -53,7 +53,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
 
             // Check for default data store
             const response = await container.request({ url: "/" });
-            assert.strictEqual(response.status, 200, "Component should exist!!");
+            assert.strictEqual(response.status, 200, `Component should exist!! ${response.value}`);
             const defaultDataStore = response.value as TestFluidObject;
             assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
 


### PR DESCRIPTION
Bug that causes detached containers between 0.40.x and 0.41.x (or with different disableIsolatedChannels runtimeOptions) to have an error. Specifically: loading a snapshot with isolated channels while detached and having disableIsolatedChannels true (or reverse: loading a snapshot without isolated channels while detached and having disabledIsolatedChannels false).

Also disable isolated channels by default until next version (0.42), because even though this is a narrow scenario, it is causing test failures.