### PR TITLE
Add error codes for new dataStoreContext assertions

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -726,7 +726,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
                 tree = tree.trees[channelsTreeName];
                 assert(
                     tree !== undefined,
-                    0x1f8 /* "isolated channels subtree should exist inremote datastore snapshot" */,
+                    0x1f8 /* "isolated channels subtree should exist in remote datastore snapshot" */,
                 );
             }
         }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -724,7 +724,10 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
 
             if (hasIsolatedChannels(attributes)) {
                 tree = tree.trees[channelsTreeName];
-                assert(tree !== undefined, "isolated channels subtree should exist in remote datastore snapshot");
+                assert(
+                    tree !== undefined,
+                    0x1f8 /* "isolated channels subtree should exist inremote datastore snapshot" */,
+                );
             }
         }
 
@@ -862,7 +865,10 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 
             if (hasIsolatedChannels(attributes)) {
                 snapshot = snapshot.trees[channelsTreeName];
-                assert(snapshot !== undefined, "isolated channels subtree should exist in local datastore snapshot");
+                assert(
+                    snapshot !== undefined,
+                    0x1f9 /* "isolated channels subtree should exist in local datastore snapshot" */,
+                );
             }
         }
 


### PR DESCRIPTION
Add two additional error codes for the new assertions introduced to check for if the isolated channels subtree is present in the snapshot