### PR TITLE
Port fix for isolated channels while rehydrating detached bug

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -26,7 +26,7 @@ import {
     TypedEventEmitter,
 } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { readAndParse } from "@fluidframework/driver-utils";
+import { readAndParse, readAndParseFromBlobs } from "@fluidframework/driver-utils";
 import { BlobTreeEntry } from "@fluidframework/protocol-base";
 import {
     IClientDetails,
@@ -722,6 +722,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
 
             if (hasIsolatedChannels(attributes)) {
                 tree = tree.trees[channelsTreeName];
+                assert(tree !== undefined, "isolated channels subtree should exist in remote datastore snapshot");
             }
         }
 
@@ -848,9 +849,21 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         assert(this.isRootDataStore !== undefined,
             0x153 /* "isRootDataStore should be available in local data store" */);
 
-        const snapshot = this.disableIsolatedChannels
-            ? this.snapshotTree
-            : this.snapshotTree?.trees[channelsTreeName];
+        let snapshot = this.snapshotTree;
+        if (snapshot !== undefined) {
+            // Note: storage can be undefined in special case while detached.
+            const attributes = this.storage !== undefined
+                ? await readAndParse<ReadFluidDataStoreAttributes>(
+                    this.storage, snapshot.blobs[dataStoreAttributesBlobName])
+                : readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
+                    snapshot.blobs, snapshot.blobs[dataStoreAttributesBlobName]);
+
+            if (hasIsolatedChannels(attributes)) {
+                snapshot = snapshot.trees[channelsTreeName];
+                assert(snapshot !== undefined, "isolated channels subtree should exist in local datastore snapshot");
+            }
+        }
+
         return {
             pkg: this.pkg,
             snapshot,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -24,6 +24,7 @@ import {
     SummarizeInternalFn,
     CreateChildSummarizerNodeFn,
     CreateSummarizerNodeSource,
+    channelsTreeName,
 } from "@fluidframework/runtime-definitions";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { createRootSummarizerNodeWithGC, IRootSummarizerNodeWithGC } from "@fluidframework/runtime-utils";
@@ -343,17 +344,21 @@ describe("Data Store Context Tests", () => {
              * and expectations.
              * This runs the same test with various summary write and read preferences. Specifically each call of this
              * function will run the test 4 times, one for each possible summary format we could be reading from.
-             * @param disableIsolatedChannels - whether or not to write summary with isolated channels disabled or not
+             * @param writeIsolatedChannels - whether to write summary with isolated channels disabled or not
              * @param expected - the expected datastore attributes to be generated given the write preference
              */
-            function testGenerateAttributes(disableIsolatedChannels: boolean, expected: WriteFluidDataStoreAttributes) {
+            function testGenerateAttributes(writeIsolatedChannels: boolean, expected: WriteFluidDataStoreAttributes) {
                 /**
                  * This function is called for each possible base snapshot format version. We want to cover all
                  * summary format read/write combinations. We only write in latest or -1 version, but we can
                  * need to be able to read old summary format versions forever.
+                 * @param hasIsolatedChannels - whether we expect to read a snapshot tree with isolated channels or not
                  * @param attributes - datastore attributes that are in the base snapshot we load from
                  */
-                async function testGenerateAttributesCore(attributes: ReadFluidDataStoreAttributes) {
+                async function testGenerateAttributesCore(
+                    hasIsolatedChannels: boolean,
+                    attributes: ReadFluidDataStoreAttributes,
+                ) {
                     const buffer = stringToBuffer(JSON.stringify(attributes), "utf8");
                     const blobCache = new Map<string, ArrayBufferLike>([["fluidDataStoreAttributes", buffer]]);
                     const snapshotTree: ISnapshotTree = {
@@ -361,11 +366,21 @@ describe("Data Store Context Tests", () => {
                         commits: {},
                         trees: {},
                     };
+                    if (hasIsolatedChannels) {
+                        // If we are expecting to read isolated channels as intended by the test, then make sure
+                        // it exists on the snapshot. Otherwise, make sure it doesn't to most closely resemble
+                        // real loading use cases.
+                        snapshotTree.trees[channelsTreeName] = {
+                            blobs: {},
+                            commits: {},
+                            trees: {},
+                        };
+                    }
 
                     remotedDataStoreContext = new RemotedFluidDataStoreContext(
                         dataStoreId,
                         snapshotTree,
-                        mockContainerRuntime(disableIsolatedChannels),
+                        mockContainerRuntime(!writeIsolatedChannels),
                         new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                         scope,
                         createSummarizerNodeFn,
@@ -385,30 +400,32 @@ describe("Data Store Context Tests", () => {
                     assert.deepStrictEqual(contents, expected, "Unexpected datastore attributes written");
                 }
 
-                it("can read from latest with isolated channels", async () => testGenerateAttributesCore({
+                it("can read from latest with isolated channels", async () => testGenerateAttributesCore(true, {
                     pkg: JSON.stringify([pkgName]),
                     summaryFormatVersion: 2,
                     isRootDataStore: true,
                 }));
 
-                it("can read from latest without isolated channels", async () => testGenerateAttributesCore({
+                it("can read from latest without isolated channels", async () => testGenerateAttributesCore(false, {
                     pkg: JSON.stringify([pkgName]),
                     summaryFormatVersion: 2,
                     isRootDataStore: true,
                     disableIsolatedChannels: true,
                 }));
 
-                it("can read from previous snapshot format", async () => testGenerateAttributesCore({
+                it("can read from previous snapshot format", async () => testGenerateAttributesCore(false, {
                     pkg: JSON.stringify([pkgName]),
                     snapshotFormatVersion: "0.1",
                     isRootDataStore: true,
                 }));
 
-                it("can read from oldest snapshot format", async () => testGenerateAttributesCore({ pkg: pkgName }));
+                it("can read from oldest snapshot format", async () => testGenerateAttributesCore(false, {
+                    pkg: pkgName,
+                }));
             }
 
             describe("writing with isolated channels disabled", () => testGenerateAttributes(
-                true, /* disableIsolatedChannels */
+                false, /* writeIsolatedChannels */
                 {
                     pkg: JSON.stringify([pkgName]),
                     snapshotFormatVersion: "0.1",
@@ -417,7 +434,7 @@ describe("Data Store Context Tests", () => {
             ));
 
             describe("writing with isolated channels enabled", () => testGenerateAttributes(
-                false, /* disableIsolatedChannels */
+                true, /* writeIsolatedChannels */
                 {
                     pkg: JSON.stringify([pkgName]),
                     summaryFormatVersion: 2,

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -53,7 +53,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
 
             // Check for default data store
             const response = await container.request({ url: "/" });
-            assert.strictEqual(response.status, 200, "Component should exist!!");
+            assert.strictEqual(response.status, 200, `Component should exist!! ${response.value}`);
             const defaultDataStore = response.value as TestFluidObject;
             assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
 


### PR DESCRIPTION
Port from #6536.

Leaving isolated channels enabled by default, since the gap for potential bug was very narrow.
Also attempted to better address the test bugs by clearly separating read from write isolated channels.