### PR TITLE
Remove existing property - Part 2, Container/ContainerContext

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1834,6 +1834,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.logger.sendErrorEvent({ eventName: "DirtyContainerReloadContainer" });
         }
 
+        // The relative loader will proxy requests to '/' to the loader itself assuming no non-cache flags
+        // are set. Global requests will still go directly to the loader
+        const loader = new RelativeLoader(this, this.loader);
         this._context = await ContainerContext.createOrLoad(
             this,
             this.scope,
@@ -1843,10 +1846,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             attributes,
             new DeltaManagerProxy(this._deltaManager),
             new QuorumProxy(this.protocolHandler.quorum),
-            // The relative loader will proxy requests to '/' to the loader itself
-            // assuming no non-cache flags are set.
-            // Global requests will still go directly to the loader
-            new RelativeLoader(this, this.loader),
+            loader,
             (warning: ContainerWarning) => this.raiseContainerWarning(warning),
             (type, contents, batch, metadata) => this.submitContainerMessage(type, contents, batch, metadata),
             (message) => this.submitSignal(message),

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1833,7 +1833,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             throw new Error("pkg should be provided in create flow!!");
         }
 
-        this.instantiateContext(
+        await this.instantiateContext(
             existing,
             attributes,
             codeDetails,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1203,9 +1203,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         this._protocolHandler = await protocolHandlerP;
 
+        const codeDetails = this.getCodeDetailsFromQuorum();
         await this.instantiateContext(
             this._existing === true,
             attributes,
+            codeDetails,
             snapshot,
             pendingLocalState,
         );
@@ -1295,7 +1297,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             values);
 
         // The load context - given we seeded the quorum - will be great
-        await this.instantiateContext(
+        await this.instantiateContextDetached(
             false, // existing
             attributes,
         );
@@ -1322,7 +1324,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this._protocolHandler =
             await this.loadAndInitializeProtocolState(attributes, undefined, snapshotTree);
 
-        await this.instantiateContext(
+        await this.instantiateContextDetached(
             true, // existing
             attributes,
             snapshotTree,
@@ -1820,7 +1822,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return { snapshot, versionId: version?.id };
     }
 
-    private async instantiateContext(
+    private async instantiateContextDetached(
         existing: boolean,
         attributes: IDocumentAttributes,
         snapshot?: ISnapshotTree,
@@ -1831,6 +1833,22 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             throw new Error("pkg should be provided in create flow!!");
         }
 
+        this.instantiateContext(
+            existing,
+            attributes,
+            codeDetails,
+            snapshot,
+            pendingLocalState,
+        );
+    }
+
+    private async instantiateContext(
+        existing: boolean,
+        attributes: IDocumentAttributes,
+        codeDetails: IFluidCodeDetails,
+        snapshot?: ISnapshotTree,
+        pendingLocalState?: unknown,
+    ) {
         assert(this._context?.disposed !== false, 0x0dd /* "Existing context not disposed" */);
         // If this assert fires, our state tracking is likely not synchronized between COntainer & runtime.
         if (this._dirtyContainer) {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -299,7 +299,7 @@ export class ContainerContext implements IContainerContext {
      */
     private async instantiateRuntime(_existing: boolean) {
         const runtimeFactory = await this.getRuntimeFactory();
-        this._runtime = runtimeFactory.instantiateRuntime(this);
+        this._runtime = await runtimeFactory.instantiateRuntime(this);
     }
 
     private attachListener() {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -85,7 +85,7 @@ export class ContainerContext implements IContainerContext {
             updateDirtyContainerState,
             existing,
             pendingLocalState);
-        await (existing ? context.initializeFromExisting() : context.initializeFirstTime());
+        await context.instantiateRuntime(existing);
         return context;
     }
 
@@ -283,25 +283,6 @@ export class ContainerContext implements IContainerContext {
 
     // #region private
 
-    // back compat: 0.40 (see #3429)
-    private isFactoryStateful(runtimeFactory: IRuntimeFactory): boolean {
-        return "getRuntime" in runtimeFactory;
-    }
-
-    private async initializeFromExisting() {
-        const runtimeFactory = await this.getRuntimeFactory();
-        this._runtime = await (this.isFactoryStateful(runtimeFactory) ?
-            runtimeFactory.getRuntime(this, true) :
-            runtimeFactory.instantiateRuntime(this));
-    }
-
-    private async initializeFirstTime() {
-        const runtimeFactory = await this.getRuntimeFactory();
-        this._runtime = await (this.isFactoryStateful(runtimeFactory) ?
-            runtimeFactory.getRuntime(this, false) :
-            runtimeFactory.instantiateRuntime(this));
-    }
-
     private async getRuntimeFactory(): Promise<IRuntimeFactory> {
         const runtimeFactory = (await this._fluidModuleP).module?.fluidExport?.IRuntimeFactory;
         if (runtimeFactory === undefined) {
@@ -309,6 +290,17 @@ export class ContainerContext implements IContainerContext {
         }
 
         return runtimeFactory;
+    }
+
+    /**
+     * TODO(andre4i):
+     * - Will be adjusted to branch on existing
+     *   and call the proper runtime factory initializer
+     * - See #3429
+     */
+    private async instantiateRuntime(_existing: boolean) {
+        const runtimeFactory = await this.getRuntimeFactory();
+        this._runtime = runtimeFactory.instantiateRuntime(this);
     }
 
     private attachListener() {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -293,7 +293,7 @@ export class ContainerContext implements IContainerContext {
     }
 
     /**
-     * TODO(andre4i) #3429
+     * #3429
      * Will be adjusted to branch on the `existing` parameter
      * and call the proper runtime factory initializer
      */

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -293,10 +293,9 @@ export class ContainerContext implements IContainerContext {
     }
 
     /**
-     * TODO(andre4i):
-     * - Will be adjusted to branch on existing
-     *   and call the proper runtime factory initializer
-     * - See #3429
+     * TODO(andre4i) #3429
+     * Will be adjusted to branch on the `existing` parameter
+     * and call the proper runtime factory initializer
      */
     private async instantiateRuntime(_existing: boolean) {
         const runtimeFactory = await this.getRuntimeFactory();

--- a/packages/loader/container-loader/src/test/containerContext.spec.ts
+++ b/packages/loader/container-loader/src/test/containerContext.spec.ts
@@ -55,6 +55,7 @@ describe("ContainerContext Tests", () => {
 
     const createTestContext = async (
         codeLoader: unknown, /* ICodeDetailsLoader */
+        existing: boolean = true,
     ) => {
         return ContainerContext.createOrLoad(
             (mockContainer as unknown) as Container,
@@ -72,6 +73,7 @@ describe("ContainerContext Tests", () => {
             Sinon.fake(),
             Container.version,
             Sinon.fake(),
+            existing,
         );
     };
 


### PR DESCRIPTION
See #6346

- The container context no longer holds the container's state wrt to the `existing` property
- the property is received via a parameter of `createOrLoad`

This is part of merging https://github.com/microsoft/FluidFramework/pull/6486

After merging the changes to the `IRuntimeFactory` interface and bumping `@fluidframework/container-definitions` , the changes to the context need to be revisited to branch on `existing`.