### PR TITLE
Assert: Optionally log telemetry error event on assertion failure

### DIFF
--- a/common/lib/common-utils/src/assert.ts
+++ b/common/lib/common-utils/src/assert.ts
@@ -3,15 +3,40 @@
  * Licensed under the MIT License.
  */
 
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
+
 /**
  * A browser friendly version of the node assert library. Use this instead of the 'assert' package, which has a big
  * impact on bundle sizes.
+ *
  * @param condition - The condition that should be true, if the condition is false an error will be thrown.
- * @param message - The message to include in the error when the condition does not hold.
- *  A number should not be specificed manually. Run policy-check to get shortcode number assigned.
+ * @param message - The message to include in the error when the condition does not hold.  A number should
+ *                  not be specificed manually. Run policy-check to get shortcode number assigned.
+ * @param logger - If provided, assertion failures will be logged as error events on the given logger.
+ * @param eventName - Used to specify the name of the telemetry event logged on failure.  Default is
+ *                    "InvariantViolation".
  */
- export function assert(condition: boolean, message: string | number): asserts condition {
-     if (!condition) {
-         throw new Error(typeof message === "number" ? `0x${message.toString(16).padStart(3,"0")}` : message);
-     }
- }
+export function assert(
+    condition: boolean,
+    message: string | number,
+    logger?: ITelemetryLogger,
+    eventName?: string,
+): asserts condition {
+    if (!condition) { fail(message, logger, eventName); }
+}
+
+export function fail(
+    message: string | number,
+    logger?: ITelemetryLogger,
+    eventName = "InvariantViolation",
+): never {
+    try {
+        throw new Error(
+            typeof message === "number"
+                ? `0x${message.toString(16).padStart(3, "0")}`
+                : message);
+    } catch (error) {
+        logger?.sendErrorEvent({ eventName }, error);
+        throw error;
+    }
+}

--- a/tools/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
@@ -32,7 +32,7 @@ function getAssertMessageParams(sourceFile: SourceFile): (StringLiteral | Numeri
     const calls = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
     const messageArgs:(StringLiteral | NumericLiteral | TemplateLiteral)[] = []
     for(const call of calls){
-        if(call.getExpression().getText() === "assert"){
+        if(["assert", "fail"].includes(call.getExpression().getText())) {
             const args = call.getArguments();
             if(args.length >=1 && args[1] !== undefined){
                 const kind = args[1].getKind();


### PR DESCRIPTION
@anthony-murphy - Curious what you think about expanding assert() to optionally log a telemetry error event?  (Vlad and I were recently looking at a PR that was throwing an unreachable code error and logging telemetry back-to-back in several places.)

@vladsud - Inspired by your feedback on Wes's PR.

(You won't hurt my feelings if you feel this has low value.)