### PR TITLE
Stop generating an empty tree when there are no blobs in the blob manager

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1150,7 +1150,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             addBlobToSummary(summaryTree, chunksBlobName, content);
         }
         const snapshot = this.blobManager.snapshot();
-        if (snapshot.entries.length) {
+
+        // Some storage (like git) doesn't allow empty tree, so we can omit it.
+        // and the blob manager can handle the tree not existing when loading
+        if (snapshot.entries.length !== 0) {
             const blobsTree = convertToSummaryTree(snapshot, false);
             addTreeToSummary(summaryTree, blobsTreeName, blobsTree);
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1149,8 +1149,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const content = JSON.stringify([...this.chunkMap]);
             addBlobToSummary(summaryTree, chunksBlobName, content);
         }
-        const blobsTree = convertToSummaryTree(this.blobManager.snapshot(), false);
-        addTreeToSummary(summaryTree, blobsTreeName, blobsTree);
+        const snapshot = this.blobManager.snapshot();
+        if (snapshot.entries.length) {
+            const blobsTree = convertToSummaryTree(snapshot, false);
+            addTreeToSummary(summaryTree, blobsTreeName, blobsTree);
+        }
     }
 
     public async stop() {

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -69,11 +69,11 @@
             },
             {
                 "id": "github",
-                "key": "0bea3f87c186991a69245a29dc3f61d2"
+                "key": "create-new-tenants-if-going-to-production"
             },
             {
                 "id": "local",
-                "key": "43cfc3fbf04a97c0921fd23ff10f9e4b"
+                "key": "create-new-tenants-if-going-to-production"
             }
         ],
         "socketIoAdapter" : {
@@ -203,22 +203,22 @@
         },
         {
             "_id": "github",
-            "key": "0bea3f87c186991a69245a29dc3f61d2",
+            "key": "create-new-tenants-if-going-to-production",
             "storage": {
                 "historianUrl": "http://localhost:3001",
                 "internalHistorianUrl": "http://historian:3000",
                 "url": "https://api.github.com",
-                "owner": "kurtb",
-                "repository": "praguedocs",
+                "owner": "gitrepoowner",
+                "repository": "gitrepo",
                 "credentials": {
-                    "user": "praguegit",
-                    "password": "8d043006d0a2704d4dd9972f848f1982026672a1"
+                    "user": "gituser",
+                    "password": "invalid"
                 }
             }
         },
         {
             "_id": "local",
-            "key": "43cfc3fbf04a97c0921fd23ff10f9e4b",
+            "key": "create-new-tenants-if-going-to-production",
             "storage": {
                 "historianUrl": "http://localhost:3001",
                 "internalHistorianUrl": "http://historian:3000",


### PR DESCRIPTION
Some server storage (`git` specifically) don't allow empty trees.  

Also:
- Clean up the routerlicious config to allow other tenants (github/local) to be used as well.
- Remove old invalid github cred and put in placeholders.   Filling those in for the github repo will allow a github repo to be used as storage from the docker image.


