### PR TITLE
Add error codes for 0.42 release

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -98,7 +98,7 @@ export class BlobManager {
     }
 
     public processBlobAttachOp(blobId: string, local: boolean) {
-        assert(!local || this.pendingBlobIds.has(blobId), "local BlobAttach op with no pending blob");
+        assert(!local || this.pendingBlobIds.has(blobId), 0x1f8 /* "local BlobAttach op with no pending blob" */);
         this.pendingBlobIds.get(blobId)?.resolve();
         this.pendingBlobIds.delete(blobId);
         this.blobIds.add(blobId);


### PR DESCRIPTION
Adds in an additional error code for the new assertion added in `processBlobAttachOp` in container-runtime's blobManager.ts