### PR TITLE
Set @fluid-experimental/property-query to 0.42.0

### DIFF
--- a/experimental/PropertyDDS/services/property-query/package.json
+++ b/experimental/PropertyDDS/services/property-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-experimental/property-query",
-  "version": "0.1.0",
+  "version": "0.42.0",
   "private": true,
   "description": "",
   "homepage": "https://fluidframework.com",


### PR DESCRIPTION
Looks like this is a new package that got introduced since the 0.41 release and had its version set to 0.1.0
Bumping to 0.42.0 to match other client packages in the repo