### PR TITLE
Remove duplicate package from @fluidframework/sequence

### DIFF
--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -76,7 +76,6 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/gitresources": "^0.1027.0-0",
     "@fluidframework/mocha-test-setup": "^0.42.0",
-    "@fluidframework/runtime-definitions": "^0.41.0",
     "@fluidframework/server-services-client": "^0.1027.0-0",
     "@fluidframework/test-runtime-utils": "^0.42.0",
     "@microsoft/api-extractor": "^7.16.1",


### PR DESCRIPTION
`@fluidframework/runtime-definitions` was referenced twice in both dependencies and devDependencies. The latter looks like it was missing the last version bump. Removing the duplicate