### PR TITLE
Refactor IntervalCollection to eliminate IntervalCollectionView

### DIFF
--- a/examples/data-objects/client-ui-lib/src/controls/flowView.ts
+++ b/examples/data-objects/client-ui-lib/src/controls/flowView.ts
@@ -1089,7 +1089,7 @@ function showBookmarks(
     if (flowView.bookmarks || flowView.comments || sel || havePresenceSel) {
         const computedEnd = lineEnd;
         const bookmarks = flowView.bookmarks.findOverlappingIntervals(lineStart, computedEnd);
-        const comments = flowView.commentsView.findOverlappingIntervals(lineStart, computedEnd);
+        const comments = flowView.comments.findOverlappingIntervals(lineStart, computedEnd);
         const lineText = flowView.sharedString.getText(lineStart, computedEnd);
         if (sel && ((sel.start < lineEnd) && (sel.end > lineStart))) {
             showBookmark(flowView, undefined, lineText, sel.start, sel.end, lineStart, endPGMarker,
@@ -3007,10 +3007,9 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public wheelTicking = false;
     public topChar = -1;
     public cursor: FlowCursor;
-    public bookmarks: Sequence.IntervalCollectionView<Sequence.SequenceInterval>;
+    public bookmarks: Sequence.IntervalCollection<Sequence.SequenceInterval>;
     public tempBookmarks: Sequence.SequenceInterval[];
     public comments: Sequence.IntervalCollection<Sequence.SequenceInterval>;
-    public commentsView: Sequence.IntervalCollectionView<Sequence.SequenceInterval>;
     public sequenceTest: Sequence.SharedNumberSequence;
     public persistentComponents: Map<IFluidObject, PersistentComponent>;
     public sequenceObjTest: Sequence.SharedObjectSequence<ISeqTestItem>;
@@ -3188,7 +3187,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
         childFlow.parentFlow = this;
         childFlow.setEdit(this.docRoot);
         childFlow.comments = this.comments;
-        childFlow.commentsView = this.commentsView;
         childFlow.presenceSignal = this.presenceSignal;
         childFlow.presenceVector = this.presenceVector;
         childFlow.bookmarks = this.bookmarks;
@@ -4433,7 +4431,7 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     }
 
     public showCommentText() {
-        const overlappingComments = this.commentsView.findOverlappingIntervals(
+        const overlappingComments = this.comments.findOverlappingIntervals(
             this.cursor.pos,
             this.cursor.pos + 1);
 
@@ -5011,13 +5009,10 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
             ]);
         }
 
-        const bookmarksCollection = this.sharedString.getIntervalCollection("bookmarks");
-        this.bookmarks = await bookmarksCollection.getView();
+        this.bookmarks = this.sharedString.getIntervalCollection("bookmarks");
 
-        // For examples of showing the API we do interval adds on the collection with comments. But use
-        // the view when doing bookmarks.
+        // For examples of showing the API we do interval adds on the collection with comments.
         this.comments = this.sharedString.getIntervalCollection("comments");
-        this.commentsView = await this.comments.getView();
 
         this.sequenceTest = await this.docRoot
             .get<IFluidHandle<Sequence.SharedNumberSequence>>("sequence-test")

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -70,7 +70,7 @@ export class TableDocument extends DataObject<{}, {}, ITableDocumentEvents> impl
 
     public async getRange(label: string) {
         const intervals = this.matrix.getIntervalCollection(label);
-        const interval = (await intervals.getView()).nextInterval(0);
+        const interval = intervals.nextInterval(0);
         return new CellRange(interval, this.localRefToRowCol);
     }
 

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -11,7 +11,6 @@ export {
     ISerializedInterval,
     IntervalCollection,
     IntervalCollectionIterator,
-    IntervalCollectionView,
     SequenceInterval,
 } from "./intervalCollection";
 export {

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -608,173 +608,6 @@ export class IntervalCollectionValueType
 
 export type DeserializeCallback = (properties: MergeTree.PropertySet) => void;
 
-export class IntervalCollectionView<TInterval extends ISerializableInterval> extends EventEmitter {
-    private readonly localCollection: LocalIntervalCollection<TInterval>;
-    private onDeserialize: DeserializeCallback;
-
-    constructor(
-        private readonly client: MergeTree.Client,
-        savedSerializedIntervals: ISerializedInterval[],
-        label: string,
-        helpers: IIntervalHelpers<TInterval>,
-        private readonly emitter: IValueOpEmitter) {
-        super();
-
-        // Instantiate the local interval collection based on the saved intervals
-        this.localCollection = new LocalIntervalCollection<TInterval>(client, label, helpers);
-        if (savedSerializedIntervals) {
-            for (const serializedInterval of savedSerializedIntervals) {
-                this.localCollection.addInterval(
-                    serializedInterval.start,
-                    serializedInterval.end,
-                    serializedInterval.intervalType,
-                    serializedInterval.properties);
-            }
-        }
-    }
-
-    public attachDeserializer(onDeserialize: DeserializeCallback): void {
-        this.attachDeserializerCore(onDeserialize);
-    }
-
-    public addConflictResolver(conflictResolver: MergeTree.IntervalConflictResolver<TInterval>): void {
-        this.localCollection.addConflictResolver(conflictResolver);
-    }
-
-    public findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[] {
-        return this.localCollection.findOverlappingIntervals(startPosition, endPosition);
-    }
-
-    public map(fn: (interval: TInterval) => void) {
-        this.localCollection.map(fn);
-    }
-
-    public gatherIterationResults(
-        results: TInterval[],
-        iteratesForward: boolean,
-        start?: number,
-        end?: number) {
-        this.localCollection.gatherIterationResults(results, iteratesForward, start, end);
-    }
-
-    public previousInterval(pos: number): TInterval {
-        return this.localCollection.previousInterval(pos);
-    }
-
-    public nextInterval(pos: number): TInterval {
-        return this.localCollection.nextInterval(pos);
-    }
-
-    public on(
-        event: "addInterval" | "deleteInterval",
-        listener: (interval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) => void): this {
-        return super.on(event, listener);
-    }
-
-    public add(
-        start: number,
-        end: number,
-        intervalType: MergeTree.IntervalType,
-        props?: MergeTree.PropertySet,
-    ) {
-        let seq = 0;
-        if (this.client) {
-            seq = this.client.getCurrentSeq();
-        }
-
-        const serializedInterval: ISerializedInterval = {
-            end,
-            intervalType,
-            properties: props,
-            sequenceNumber: seq,
-            start,
-        };
-
-        return this.addInternal(serializedInterval, true, undefined);
-    }
-
-    public delete(
-        start: number,
-        end: number) {
-        let sequenceNumber = 0;
-        if (this.client) {
-            sequenceNumber = this.client.getCurrentSeq();
-        }
-
-        const serializedInterval: ISerializedInterval = {
-            start,
-            end,
-            sequenceNumber,
-            intervalType: MergeTree.IntervalType.Transient,
-        };
-
-        this.deleteInterval(serializedInterval, true, undefined);
-    }
-
-    // TODO: error cases
-    public addInternal(serializedInterval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) {
-        const interval = this.localCollection.addInterval(
-            serializedInterval.start,
-            serializedInterval.end,
-            serializedInterval.intervalType,
-            serializedInterval.properties);
-
-        if (interval) {
-            // Local ops get submitted to the server. Remote ops have the deserializer run.
-            if (local) {
-                this.emitter.emit("add", undefined, serializedInterval);
-            } else {
-                if (this.onDeserialize) {
-                    this.onDeserialize(interval);
-                }
-            }
-        }
-
-        this.emit("addInterval", interval, local, op);
-
-        return interval;
-    }
-
-    public deleteInterval(serializedInterval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) {
-        const interval = this.localCollection.removeInterval(serializedInterval.start, serializedInterval.end);
-
-        if (interval) {
-            // Local ops get submitted to the server. Remote ops have the deserializer run.
-            if (local) {
-                this.emitter.emit("delete", undefined, serializedInterval);
-            } else {
-                if (this.onDeserialize) {
-                    this.onDeserialize(interval);
-                }
-            }
-        }
-
-        this.emit("deleteInterval", interval, local, op);
-
-        return this;
-    }
-
-    public serializeInternal() {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return this.localCollection.serialize();
-    }
-
-    private attachDeserializerCore(onDeserialize?: DeserializeCallback): void {
-        // If no deserializer is specified can skip all processing work
-        if (!onDeserialize) {
-            return;
-        }
-
-        // Start by storing the callbacks so that any subsequent modifications make use of them
-        this.onDeserialize = onDeserialize;
-
-        // Trigger the async prepare work across all values in the collection
-        this.localCollection.map((interval) => {
-            this.onDeserialize(interval);
-        });
-    }
-}
-
 export class IntervalCollectionIterator<TInterval extends ISerializableInterval> {
     private readonly results: TInterval[];
     private index: number;
@@ -806,22 +639,27 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
     }
 }
 
-export class IntervalCollection<TInterval extends ISerializableInterval> {
+export class IntervalCollection<TInterval extends ISerializableInterval> extends EventEmitter {
     private savedSerializedIntervals?: ISerializedInterval[];
-    private view: IntervalCollectionView<TInterval>;
+    // private view: IntervalCollectionView<TInterval>;
+    private localCollection: LocalIntervalCollection<TInterval>;
+    private onDeserialize: DeserializeCallback;
+    private client: MergeTree.Client;
 
     public get attached(): boolean {
-        return !!this.view;
+        // return !!this.view;
+        return !!this.localCollection;
     }
 
     constructor(private readonly helpers: IIntervalHelpers<TInterval>, private readonly requiresClient: boolean,
         private readonly emitter: IValueOpEmitter,
         serializedIntervals: ISerializedInterval[]) {
+        super();
         this.savedSerializedIntervals = serializedIntervals;
     }
 
     public attachGraph(client: MergeTree.Client, label: string) {
-        if (this.view) {
+        if (this.attached) {
             throw new Error("Only supports one Sequence attach");
         }
 
@@ -829,80 +667,173 @@ export class IntervalCollection<TInterval extends ISerializableInterval> {
             throw new Error("Client required for this collection");
         }
 
-        this.view = new IntervalCollectionView<TInterval>(client,
-            this.savedSerializedIntervals, label, this.helpers, this.emitter);
+        // Instantiate the local interval collection based on the saved intervals
+        this.client = client;
+        this.localCollection = new LocalIntervalCollection<TInterval>(client, label, this.helpers);
+        if (this.savedSerializedIntervals) {
+            for (const serializedInterval of this.savedSerializedIntervals) {
+                this.localCollection.addInterval(
+                    serializedInterval.start,
+                    serializedInterval.end,
+                    serializedInterval.intervalType,
+                    serializedInterval.properties);
+            }
+        }
         this.savedSerializedIntervals = undefined;
     }
 
     public add(
-        startPosition: number,
-        endPosition: number,
+        start: number,
+        end: number,
         intervalType: MergeTree.IntervalType,
         props?: MergeTree.PropertySet,
     ) {
-        if (!this.view) {
+        if (!this.attached) {
             throw new Error("attach must be called prior to adding intervals");
         }
 
-        return this.view.add(startPosition, endPosition, intervalType, props);
+        let seq = 0;
+        if (this.client) {
+            seq = this.client.getCurrentSeq();
+        }
+
+        const serializedInterval: ISerializedInterval = {
+            end,
+            intervalType,
+            properties: props,
+            sequenceNumber: seq,
+            start,
+        };
+
+        return this.addInternal(serializedInterval, true, undefined);
     }
 
     public delete(
-        startPosition: number,
-        endPosition: number,
+        start: number,
+        end: number,
     ) {
-        if (!this.view) {
+        let sequenceNumber = 0;
+        if (!this.attached) {
             throw new Error("attach must be called prior to deleting intervals");
         }
 
-        this.view.delete(startPosition, endPosition);
+        if (this.client) {
+            sequenceNumber = this.client.getCurrentSeq();
+        }
+
+        const serializedInterval: ISerializedInterval = {
+            start,
+            end,
+            sequenceNumber,
+            intervalType: MergeTree.IntervalType.Transient,
+        };
+
+        this.deleteInterval(serializedInterval, true, undefined);
     }
 
     public addConflictResolver(conflictResolver: MergeTree.IntervalConflictResolver<TInterval>): void {
-        this.view.addConflictResolver(conflictResolver);
+        if (!this.attached) {
+            throw new Error("attachSequence must be called");
+        }
+        this.localCollection.addConflictResolver(conflictResolver);
     }
 
-    public async getView(onDeserialize?: DeserializeCallback): Promise<IntervalCollectionView<TInterval>> {
-        if (!this.view) {
-            return Promise.reject(new Error("attachSequence must be called prior to retrieving the view"));
+    public attachDeserializer(onDeserialize: DeserializeCallback): void {
+        this.attachDeserializerCore(onDeserialize);
+    }
+
+    private attachDeserializerCore(onDeserialize?: DeserializeCallback): void {
+        // If no deserializer is specified can skip all processing work
+        if (!onDeserialize) {
+            return;
+        }
+
+        // Start by storing the callbacks so that any subsequent modifications make use of them
+        this.onDeserialize = onDeserialize;
+
+        // Trigger the async prepare work across all values in the collection
+        this.localCollection.map((interval) => {
+            this.onDeserialize(interval);
+        });
+    }
+
+    /**
+     * @deprecated - IntervalCollectionView has been removed. Please refer to IntervalCollection directly.
+     */
+    public getView(onDeserialize?: DeserializeCallback): IntervalCollection<TInterval> {
+        if (!this.attached) {
+            throw new Error("attachSequence must be called prior to retrieving the view");
         }
 
         // Attach custom deserializers if specified
         if (onDeserialize) {
-            this.view.attachDeserializer(onDeserialize);
+            this.attachDeserializer(onDeserialize);
         }
 
-        return this.view;
+        return this;
     }
 
     public addInternal(
         serializedInterval: ISerializedInterval,
         local: boolean,
         op: ISequencedDocumentMessage) {
-        if (!this.view) {
+        if (!this.attached) {
             throw new Error("attachSequence must be called");
         }
 
-        return this.view.addInternal(serializedInterval, local, op);
+        const interval = this.localCollection.addInterval(
+            serializedInterval.start,
+            serializedInterval.end,
+            serializedInterval.intervalType,
+            serializedInterval.properties);
+
+        if (interval) {
+            // Local ops get submitted to the server. Remote ops have the deserializer run.
+            if (local) {
+                this.emitter.emit("add", undefined, serializedInterval);
+            } else {
+                if (this.onDeserialize) {
+                    this.onDeserialize(interval);
+                }
+            }
+        }
+
+        this.emit("addInterval", interval, local, op);
+
+        return interval;
     }
 
     public deleteInterval(
         serializedInterval: ISerializedInterval,
         local: boolean,
         op: ISequencedDocumentMessage): void {
-        if (!this.view) {
+        if (!this.attached) {
             throw new Error("attach must be called prior to deleting intervals");
         }
-        this.view.deleteInterval(serializedInterval, local, op);
+
+        const interval = this.localCollection.removeInterval(serializedInterval.start, serializedInterval.end);
+
+        if (interval) {
+            // Local ops get submitted to the server. Remote ops have the deserializer run.
+            if (local) {
+                this.emitter.emit("delete", undefined, serializedInterval);
+            } else {
+                if (this.onDeserialize) {
+                    this.onDeserialize(interval);
+                }
+            }
+        }
+
+        this.emit("deleteInterval", interval, local, op);
     }
 
     public serializeInternal() {
-        if (!this.view) {
+        if (!this.attached) {
             throw new Error("attachSequence must be called");
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return this.view.serializeInternal();
+        return this.localCollection.serialize();
     }
 
     public [Symbol.iterator](): IntervalCollectionIterator<TInterval> {
@@ -935,10 +866,32 @@ export class IntervalCollection<TInterval extends ISerializableInterval> {
         iteratesForward: boolean,
         start?: number,
         end?: number) {
-        if (!this.view) {
+        if (!this.attached) {
             return;
         }
 
-        this.view.gatherIterationResults(results, iteratesForward, start, end);
+        this.localCollection.gatherIterationResults(results, iteratesForward, start, end);
+    }
+
+    public findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[] {
+        return this.localCollection.findOverlappingIntervals(startPosition, endPosition);
+    }
+
+    public map(fn: (interval: TInterval) => void) {
+        this.localCollection.map(fn);
+    }
+
+    public previousInterval(pos: number): TInterval {
+        return this.localCollection.previousInterval(pos);
+    }
+
+    public nextInterval(pos: number): TInterval {
+        return this.localCollection.nextInterval(pos);
+    }
+
+    public on(
+        event: "addInterval" | "deleteInterval",
+        listener: (interval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) => void): this {
+        return super.on(event, listener);
     }
 }

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -641,7 +641,6 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
 
 export class IntervalCollection<TInterval extends ISerializableInterval> extends EventEmitter {
     private savedSerializedIntervals?: ISerializedInterval[];
-    // private view: IntervalCollectionView<TInterval>;
     private localCollection: LocalIntervalCollection<TInterval>;
     private onDeserialize: DeserializeCallback;
     private client: MergeTree.Client;
@@ -760,9 +759,9 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     /**
      * @deprecated - IntervalCollectionView has been removed. Please refer to IntervalCollection directly.
      */
-    public getView(onDeserialize?: DeserializeCallback): IntervalCollection<TInterval> {
+    public async getView(onDeserialize?: DeserializeCallback): Promise<IntervalCollection<TInterval>> {
         if (!this.attached) {
-            throw new Error("attachSequence must be called prior to retrieving the view");
+            return Promise.reject(new Error("attachSequence must be called prior to retrieving the view"));
         }
 
         // Attach custom deserializers if specified

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -11,7 +11,6 @@ import { ISummaryBlob } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     IntervalCollection,
-    IntervalCollectionView,
     ISerializedInterval,
     SequenceInterval,
     SharedString,
@@ -27,10 +26,10 @@ import { describeFullCompat } from "@fluidframework/test-version-utils";
 
 const assertIntervalsHelper = (
     sharedString: SharedString,
-    intervals: IntervalCollectionView<SequenceInterval>,
+    intervalView,
     expected: readonly { start: number; end: number }[],
 ) => {
-    const actual = intervals.findOverlappingIntervals(0, sharedString.getLength() - 1);
+    const actual = intervalView.findOverlappingIntervals(0, sharedString.getLength() - 1);
     assert.strictEqual(actual.length, expected.length,
         `findOverlappingIntervals() must return the expected number of intervals`);
 
@@ -150,11 +149,11 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
         const stringId = "stringKey";
 
         let sharedString: SharedString;
-        let intervalCollection: IntervalCollection<SequenceInterval>;
-        let intervals: IntervalCollectionView<SequenceInterval>;
+        let intervals: IntervalCollection<SequenceInterval>;
+        let intervalView;
 
         const assertIntervals = (expected: readonly { start: number; end: number }[]) => {
-            assertIntervalsHelper(sharedString, intervals, expected);
+            assertIntervalsHelper(sharedString, intervalView, expected);
         };
 
         beforeEach(async () => {
@@ -168,10 +167,9 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
             sharedString = await dataObject.getSharedObject<SharedString>(stringId);
             sharedString.insertText(0, "012");
 
-            intervalCollection = sharedString.getIntervalCollection("intervals");
-            intervals = await intervalCollection.getView();
-
-            testIntervalCollection(intervalCollection);
+            intervals = sharedString.getIntervalCollection("intervals");
+            intervalView = await intervals.getView();
+            testIntervalCollection(intervals);
         });
 
         it("replace all is included", async () => {
@@ -287,9 +285,10 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
             const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
 
             sharedString1.insertText(0, "0123456789");
-            const intervals1 = await sharedString1.getIntervalCollection("intervals").getView();
+            const intervals1 = sharedString1.getIntervalCollection("intervals");
+            const intervalView1 = await intervals1.getView();
             intervals1.add(1, 7, IntervalType.SlideOnRemove);
-            assertIntervalsHelper(sharedString1, intervals1, [{ start: 1, end: 7 }]);
+            assertIntervalsHelper(sharedString1, intervalView1, [{ start: 1, end: 7 }]);
 
             // Load the Container that was created by the first client.
             const container2 = await provider.loadTestContainer(testContainerConfig);
@@ -298,17 +297,18 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
             await provider.ensureSynchronized();
 
             const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-            const intervals2 = await sharedString2.getIntervalCollection("intervals").getView();
-            assertIntervalsHelper(sharedString2, intervals2, [{ start: 1, end: 7 }]);
+            const intervals2 = sharedString2.getIntervalCollection("intervals");
+            const intervalView2 = await intervals2.getView();
+            assertIntervalsHelper(sharedString2, intervalView2, [{ start: 1, end: 7 }]);
 
             sharedString2.removeRange(4, 5);
-            assertIntervalsHelper(sharedString2, intervals2, [{ start: 1, end: 6 }]);
+            assertIntervalsHelper(sharedString2, intervalView2, [{ start: 1, end: 6 }]);
 
             sharedString2.insertText(4, "x");
-            assertIntervalsHelper(sharedString2, intervals2, [{ start: 1, end: 7 }]);
+            assertIntervalsHelper(sharedString2, intervalView2, [{ start: 1, end: 7 }]);
 
             await provider.ensureSynchronized();
-            assertIntervalsHelper(sharedString1, intervals1, [{ start: 1, end: 7 }]);
+            assertIntervalsHelper(sharedString1, intervalView1, [{ start: 1, end: 7 }]);
         });
     });
 


### PR DESCRIPTION
IntervalCollectionView functionality can be accessed through IntervalCollection. (Most of it already could.) IntervalCollection.getView() remains as a deprecated method that will return a reference to the IntervalCollection itself. Sorry that the merge is hard to read.