### PR TITLE
Add api to allow read contents from snapshot synchronously in rehydrated container when required

### DIFF
--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -170,6 +170,7 @@ export interface IContainerContext extends IDisposable {
     readonly quorum: IQuorum;
     // (undocumented)
     raiseContainerWarning(warning: ContainerWarning): void;
+    readBlobContentsSync(blobId: string): ArrayBufferLike;
     readonly scope: IFluidObject;
     // (undocumented)
     readonly serviceConfiguration: IClientConfiguration | undefined;

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -148,6 +148,12 @@ export interface IContainerContext extends IDisposable {
     getLoadedFromVersion(): IVersion | undefined;
 
     updateDirtyContainerState(dirty: boolean): void;
+
+    /**
+     * This api is required whenever blob contents are to be read synchronously in detached container in rehydrate case
+     * @param blobId - Id of blob for which contents are fetched.
+     */
+    readBlobContentsSync(blobId: string): ArrayBufferLike;
 }
 
 export const IRuntimeFactory: keyof IProvideRuntimeFactory = "IRuntimeFactory";


### PR DESCRIPTION
We added storage even in detached container so that we can read blob contents from storage and not have different branches in code to either read from storage(async) or snapshot(sync). However at some place like while taking summary before attach we do need to read blob contents synchronously. We would still be able to resolve all problems mentioned in https://github.com/microsoft/FluidFramework/issues/4746 but this api is required to achieve that,