### PR TITLE
Better socket error object if canRetry is false

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -433,10 +433,6 @@ export class DocumentDeltaConnection
      * Error raising for socket.io issues
      */
     protected createErrorObject(handler: string, error?: any, canRetry = true): DriverError {
-        // Note: we suspect the incoming error object is either:
-        // - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
-        // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
-        //   over it.
         const errorObj = createGenericNetworkError(
             `socket.io:${handler}`,
             canRetry,

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -248,13 +248,13 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection impleme
     /**
      * Error raising for socket.io issues
      */
-    protected createErrorObject(handler: string, error?: any, canRetry = true): DriverError {
+    protected createErrorObject(handler: string, error?: unknown, canRetry = true): DriverError {
         // Note: we suspect the incoming error object is either:
         // - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
         // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
         //   over it.
-        if (canRetry && typeof error === "object" && error !== null) {
-            return errorObjectFromSocketError(error, handler) as DriverError;
+        if (typeof error === "object" && error !== null) {
+            return errorObjectFromSocketError(error as IOdspSocketError, handler, canRetry) as DriverError;
         } else {
             return super.createErrorObject(handler, error, canRetry);
         }

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -10,12 +10,15 @@ import { IOdspSocketError } from "./contracts";
 /**
  * Returns network error based on error object from ODSP socket (IOdspSocketError)
  */
-export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string): OdspError {
-    const message = `socket.io:${handler}`;
+export function errorObjectFromSocketError(
+    socketError: IOdspSocketError,
+    handler: string,
+    canRetry: boolean,
+): OdspError {
     return createOdspNetworkError(
-        message,
+        `socket.io:${handler}`,
         socketError.code,
-        socketError.retryAfter,
+        canRetry ? socketError.retryAfter : undefined,
         undefined /* response */,
         undefined /* responseText */,
         { socketError: socketError.message } /* props */,

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -154,7 +154,7 @@ export function createOdspNetworkError(
             break;
         default:
             const retryAfterMs = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : undefined;
-            error = createGenericNetworkError(errorMessage, true, retryAfterMs, { statusCode });
+            error = createGenericNetworkError(errorMessage, retryAfterMs !== undefined, retryAfterMs, { statusCode });
     }
 
     error.online = OnlineStatus[isOnline()];


### PR DESCRIPTION
This is a follow-on to #6557 that I noticed when reviewing that change.  `canRetry` being true or false yields pretty different results in the logs.