### PR TITLE
Add a unique ID to Interval properties on addition to a collection

### DIFF
--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -68,7 +68,8 @@
     "@fluidframework/shared-object-base": "^0.43.0",
     "@fluidframework/telemetry-utils": "^0.43.0",
     "assert": "^2.0.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.43.0",


### PR DESCRIPTION
Create a non-unique ID based on start/end when an interval comes over the wire or from a snapshot without an ID