### PR TITLE
Move Throttler to separate file

### DIFF
--- a/packages/runtime/container-runtime/src/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/orderedClientElection.ts
@@ -229,35 +229,3 @@ export class OrderedClientElection extends TypedEventEmitter<IOrderedClientElect
         return result;
     }
 }
-
-/**
- * Used to give increasing delay times for throttling a single functionality.
- * Delay is based on previous attempts within specified time window, ignoring actual delay time.
- */
- export class Throttler {
-    private startTimes: number[] = [];
-    constructor(
-        private readonly delayWindowMs: number,
-        private readonly maxDelayMs: number,
-        private readonly delayFunction: (n: number) => number,
-    ) { }
-
-    public get attempts() {
-        return this.startTimes.length;
-    }
-
-    public getDelay() {
-        const now = Date.now();
-        this.startTimes = this.startTimes.filter((t) => now - t < this.delayWindowMs);
-        const delayMs = Math.min(this.delayFunction(this.startTimes.length), this.maxDelayMs);
-        this.startTimes.push(now);
-        this.startTimes = this.startTimes.map((t) => t + delayMs); // account for delay time
-        if (delayMs === this.maxDelayMs) {
-            // we hit max delay so adding more won't affect anything
-            // shift off oldest time to stop this array from growing forever
-            this.startTimes.shift();
-        }
-
-        return delayMs;
-    }
-}

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -23,7 +23,8 @@ import { ISequencedClient, MessageType } from "@fluidframework/protocol-definiti
 import { DriverHeader } from "@fluidframework/driver-definitions";
 import { ISummarizer, createSummarizingWarning, ISummarizingWarning, SummarizerStopReason } from "./summarizer";
 import { SummaryCollection } from "./summaryCollection";
-import { ITrackedClient, OrderedClientElection, summarizerClientType, Throttler } from "./orderedClientElection";
+import { ITrackedClient, OrderedClientElection, summarizerClientType } from "./orderedClientElection";
+import { Throttler } from "./throttler";
 
 const defaultInitialDelayMs = 5000;
 const opsToBypassInitialDelay = 4000;

--- a/packages/runtime/container-runtime/src/throttler.ts
+++ b/packages/runtime/container-runtime/src/throttler.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Used to give increasing delay times for throttling a single functionality.
+ * Delay is based on previous attempts within specified time window, ignoring actual delay time.
+ */
+ export class Throttler {
+    private startTimes: number[] = [];
+    constructor(
+        private readonly delayWindowMs: number,
+        private readonly maxDelayMs: number,
+        private readonly delayFunction: (n: number) => number,
+    ) { }
+
+    public get attempts() {
+        return this.startTimes.length;
+    }
+
+    public getDelay() {
+        const now = Date.now();
+        this.startTimes = this.startTimes.filter((t) => now - t < this.delayWindowMs);
+        const delayMs = Math.min(this.delayFunction(this.startTimes.length), this.maxDelayMs);
+        this.startTimes.push(now);
+        this.startTimes = this.startTimes.map((t) => t + delayMs); // account for delay time
+        if (delayMs === this.maxDelayMs) {
+            // we hit max delay so adding more won't affect anything
+            // shift off oldest time to stop this array from growing forever
+            this.startTimes.shift();
+        }
+
+        return delayMs;
+    }
+}


### PR DESCRIPTION
As requested by #6335 to split into separate PRs.
This helper class doesn't belong in orderedClientElection.ts; so moved it to its own file.