### PR TITLE
Isolate summarizer client election logic

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -128,6 +128,7 @@ import {
 } from "./summaryFormat";
 import { SummaryCollection } from "./summaryCollection";
 import { getLocalStorageFeatureGate } from "./localStorageFeatureGates";
+import { OrderedClientElection } from "./orderedClientElection";
 
 export enum ContainerMessageType {
     // An op to be delivered to store
@@ -948,6 +949,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.summaryManager = new SummaryManager(
             context,
             this.summaryCollection,
+            new OrderedClientElection(this.context.quorum),
             this.runtimeOptions.summaryOptions.generateSummaries !== false,
             this.logger,
             maxOpsSinceLastSummary,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -129,6 +129,7 @@ import {
 import { SummaryCollection } from "./summaryCollection";
 import { getLocalStorageFeatureGate } from "./localStorageFeatureGates";
 import { OrderedClientElection } from "./orderedClientElection";
+import { SummarizerClientElection } from "./summarizerClientElection";
 
 export enum ContainerMessageType {
     // An op to be delivered to store
@@ -949,7 +950,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.summaryManager = new SummaryManager(
             context,
             this.summaryCollection,
-            new OrderedClientElection(this.context.quorum),
+            new SummarizerClientElection(
+                this.logger,
+                this.summaryCollection,
+                new OrderedClientElection(this.context.quorum),
+                maxOpsSinceLastSummary,
+            ),
             this.runtimeOptions.summaryOptions.generateSummaries !== false,
             this.logger,
             maxOpsSinceLastSummary,

--- a/packages/runtime/container-runtime/src/summarizerClientElection.ts
+++ b/packages/runtime/container-runtime/src/summarizerClientElection.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IEventProvider, ITelemetryLogger } from "@fluidframework/common-definitions";
+import { MessageType } from "@fluidframework/protocol-definitions";
+import { OrderedClientElection, ITrackedClient } from "./orderedClientElection";
+import { ISummaryCollectionOpEvents } from "./summaryCollection";
+
+export const summarizerClientType = "summarizer";
+
+/**
+ * This class encapsulates logic around tracking the elected summarizer client.
+ * It will handle updated the elected client when a summary ack hasn't been seen
+ * for some configured number of ops.
+ */
+export class SummarizerClientElection {
+    /** Used to calculate number of ops since last summary ack for the current elected client */
+    private lastSummaryAckSeqForClient = 0;
+    private _hasSummarizersInQuorum: boolean;
+    private hasLoggedTelemetry = false;
+
+    public get electedClientId() {
+        return this.clientElection.getElectedClient()?.clientId;
+    }
+
+    public get hasSummarizersInQuorum() {
+        return this._hasSummarizersInQuorum;
+    }
+
+    constructor(
+        private readonly logger: ITelemetryLogger,
+        private readonly summaryCollection: IEventProvider<ISummaryCollectionOpEvents>,
+        public readonly clientElection: OrderedClientElection,
+        private readonly maxOpsSinceLastSummary: number,
+        private readonly refreshSummarizer: () => void,
+    ) {
+        this.summaryCollection.on("default", (op) => {
+            const opsSinceLastAckForClient = op.sequenceNumber - this.lastSummaryAckSeqForClient;
+            if (
+                opsSinceLastAckForClient > this.maxOpsSinceLastSummary
+                && !this.hasLoggedTelemetry
+                && this.electedClientId !== undefined
+            ) {
+                // Limit telemetry to only next client?
+                this.logger.sendErrorEvent({
+                    eventName: "ElectedClientNotSummarizing",
+                    electedClientId: this.electedClientId,
+                    sequenceNumber: op.sequenceNumber,
+                    lastSummaryAckSeqForClient: this.lastSummaryAckSeqForClient,
+                });
+
+                // In future we will change the elected client.
+                // this.orderedClients.incrementCurrentClient();
+
+                this.hasLoggedTelemetry = true;
+            }
+        });
+
+        this.summaryCollection.on(MessageType.SummaryAck, (op) => {
+            this.hasLoggedTelemetry = false;
+            this.lastSummaryAckSeqForClient = op.sequenceNumber;
+        });
+
+        this.clientElection.on("summarizerChange", (summarizerCount) => {
+            const prev = this._hasSummarizersInQuorum;
+            this._hasSummarizersInQuorum = summarizerCount > 0;
+            if (prev !== this._hasSummarizersInQuorum) {
+                this.refreshSummarizer();
+            }
+        });
+        this.clientElection.on("electedChange", (client: ITrackedClient | undefined) => {
+            this.hasLoggedTelemetry = false;
+            if (client !== undefined) {
+                // set to join seq
+                this.lastSummaryAckSeqForClient = client.sequenceNumber;
+            }
+            this.refreshSummarizer();
+        });
+        this._hasSummarizersInQuorum = this.clientElection.getSummarizerCount() > 0;
+    }
+}

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -19,11 +19,12 @@ import {
     IContainerContext,
     LoaderHeader,
 } from "@fluidframework/container-definitions";
-import { ISequencedClient, MessageType } from "@fluidframework/protocol-definitions";
+import { ISequencedClient } from "@fluidframework/protocol-definitions";
 import { DriverHeader } from "@fluidframework/driver-definitions";
 import { ISummarizer, createSummarizingWarning, ISummarizingWarning, SummarizerStopReason } from "./summarizer";
 import { SummaryCollection } from "./summaryCollection";
-import { ITrackedClient, OrderedClientElection, summarizerClientType, Throttler } from "./orderedClientElection";
+import { OrderedClientElection, Throttler } from "./orderedClientElection";
+import { SummarizerClientElection, summarizerClientType } from "./summarizerClientElection";
 
 const defaultInitialDelayMs = 5000;
 const opsToBypassInitialDelay = 4000;
@@ -51,7 +52,7 @@ type ShouldSummarizeState =
 
 export class SummaryManager extends EventEmitter implements IDisposable {
     private readonly logger: ITelemetryLogger;
-    private readonly orderedClients: OrderedClientElection;
+    public readonly clientElection: SummarizerClientElection;
     private readonly initialDelayP: Promise<IPromiseTimerResult | void>;
     private readonly initialDelayTimer?: PromiseTimer;
     private electedClientId?: string;
@@ -76,17 +77,13 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         return this._disposed;
     }
 
-    /** Used to calculate number of ops since last summary ack for the current elected client */
-    private lastSummaryAckSeqForClient = 0;
-    private hasSummarizersInQuorum: boolean;
-    private hasLoggedTelemetry = false;
-
     constructor(
         private readonly context: IContainerContext,
-        private readonly summaryCollection: SummaryCollection,
+        summaryCollection: SummaryCollection,
+        clientElection: OrderedClientElection,
         private readonly summariesEnabled: boolean,
         parentLogger: ITelemetryLogger,
-        private readonly maxOpsSinceLastSummary: number,
+        maxOpsSinceLastSummary: number,
         initialDelayMs: number = defaultInitialDelayMs,
     ) {
         super();
@@ -110,50 +107,13 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         };
         context.quorum.on("addMember", opsUntilFirstConnectHandler);
 
-        this.summaryCollection.on("default", (op) => {
-            const opsSinceLastAckForClient = op.sequenceNumber - this.lastSummaryAckSeqForClient;
-            if (
-                opsSinceLastAckForClient > this.maxOpsSinceLastSummary
-                && !this.hasLoggedTelemetry
-                && this.electedClientId !== undefined
-            ) {
-                // Limit telemetry to only next client?
-                this.logger.sendErrorEvent({
-                    eventName: "ElectedClientNotSummarizing",
-                    thisClientId: this.clientId,
-                    electedClientId: this.electedClientId,
-                    sequenceNumber: op.sequenceNumber,
-                    lastSummaryAckSeqForClient: this.lastSummaryAckSeqForClient,
-                });
-
-                // In future we will change the elected client.
-                // this.orderedClients.incrementCurrentClient();
-
-                this.hasLoggedTelemetry = true;
-            }
-        });
-        this.summaryCollection.on(MessageType.SummaryAck, (op) => {
-            this.hasLoggedTelemetry = false;
-            this.lastSummaryAckSeqForClient = op.sequenceNumber;
-        });
-
-        this.orderedClients = new OrderedClientElection(context.quorum);
-        this.orderedClients.on("summarizerChange", (summarizerCount) => {
-            const prev = this.hasSummarizersInQuorum;
-            this.hasSummarizersInQuorum = summarizerCount > 0;
-            if (prev !== this.hasSummarizersInQuorum) {
-                this.refreshSummarizer();
-            }
-        });
-        this.orderedClients.on("electedChange", (client: ITrackedClient | undefined) => {
-            this.hasLoggedTelemetry = false;
-            if (client !== undefined) {
-                // set to join seq
-                this.lastSummaryAckSeqForClient = client.sequenceNumber;
-            }
-            this.refreshSummarizer();
-        });
-        this.hasSummarizersInQuorum = this.orderedClients.getSummarizerCount() > 0;
+        this.clientElection = new SummarizerClientElection(
+            this.logger,
+            summaryCollection,
+            clientElection,
+            maxOpsSinceLastSummary,
+            () => this.refreshSummarizer(),
+        );
 
         this.initialDelayTimer = new PromiseTimer(initialDelayMs, () => { });
         this.initialDelayP = this.initialDelayTimer?.start() ?? Promise.resolve();
@@ -201,7 +161,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
             return { shouldSummarize: false, stopReason: "parentShouldNotSummarize" };
         } else if (this.disposed) {
             return { shouldSummarize: false, stopReason: "disposed" };
-        } else if (this.orderedClients.getSummarizerCount() > 0) {
+        } else if (this.clientElection.hasSummarizersInQuorum) {
             // Need to wait for any other existing summarizer clients to close,
             // because they can live longer than their parent container.
             // TODO: We will need to remove this check when we allow elected summarizer
@@ -213,8 +173,8 @@ export class SummaryManager extends EventEmitter implements IDisposable {
     }
 
     private refreshSummarizer() {
-        // Compute summarizer
-        const newSummarizerClientId = this.orderedClients.getElectedClient()?.clientId;
+        // Check which client is elected as summarizer, and propagate the event if changed.
+        const newSummarizerClientId = this.clientElection.electedClientId;
         if (newSummarizerClientId !== this.electedClientId) {
             this.electedClientId = newSummarizerClientId;
             this.emit("summarizer", newSummarizerClientId);

--- a/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
@@ -96,7 +96,7 @@ describe("Summarizer Client Election", () => {
             assertState("b", 8, "elected client leaving should reelect next oldest client");
         });
 
-        it("Should reelect when client not summarizing", () => {
+        it("Should not yet reelect when client not summarizing", () => {
             createElection([
                 ["s1", 1, false],
                 ["a", 2, true],
@@ -111,11 +111,11 @@ describe("Summarizer Client Election", () => {
 
             // Should elect next client at this point
             defaultOp();
-            assertState("b", maxOps + 8, "should reelect > max ops");
+            assertState("a", maxOps + 8, "should not yet reelect > max ops");
 
             // Next election should be undefined, which resets to first client
             defaultOp(maxOps);
-            assertState("b", maxOps + 8, "should not reelect <= max ops since baseline");
+            assertState("a", maxOps + 8, "should not reelect <= max ops since baseline");
             defaultOp();
             assertState("a", 2 * maxOps + 9, "should reelect back to oldest client");
         });
@@ -143,7 +143,7 @@ describe("Summarizer Client Election", () => {
 
             // Should elect next client at this point
             defaultOp();
-            assertState("b", 2 * maxOps + 9, "should reelect > max ops since summary ack");
+            assertState("a", 2 * maxOps + 9, "should not yet reelect > max ops since summary ack");
         });
     });
 });

--- a/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
@@ -45,8 +45,8 @@ describe("Summarizer Client Election", () => {
             summaryCollectionEmitter,
             new OrderedClientElection(testQuorum),
             maxOps,
-            () => refreshSummarizerCallCount++,
         );
+        election.on("shouldSummarizeStateChanged", () => refreshSummarizerCallCount++);
     }
     function defaultOp(opCount = 1) {
         currentSequenceNumber += opCount;

--- a/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
@@ -1,0 +1,149 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { MockLogger } from "@fluidframework/test-runtime-utils";
+import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { ISequencedClient, MessageType } from "@fluidframework/protocol-definitions";
+import { OrderedClientElection } from "../orderedClientElection";
+import { ISummaryCollectionOpEvents } from "../summaryCollection";
+import { SummarizerClientElection } from "../summarizerClientElection";
+import { TestQuorum } from "./testQuorum";
+
+describe("Summarizer Client Election", () => {
+    const maxOps = 1000;
+    const testQuorum = new TestQuorum();
+    let currentSequenceNumber: number = 0;
+    const mockLogger = new MockLogger();
+    let refreshSummarizerCallCount = 0;
+    const summaryCollectionEmitter = new TypedEventEmitter<ISummaryCollectionOpEvents>();
+    let election: SummarizerClientElection;
+
+    function addClient(clientId: string, sequenceNumber: number, interactive = true) {
+        if (sequenceNumber > currentSequenceNumber) {
+            currentSequenceNumber = sequenceNumber;
+        }
+        const details: ISequencedClient["client"]["details"] = { capabilities: { interactive } };
+        const c: Partial<ISequencedClient["client"]> = { details };
+        const client: ISequencedClient = { client: c as ISequencedClient["client"], sequenceNumber };
+        testQuorum.addClient(clientId, client);
+    }
+    function removeClient(clientId: string, opCount = 1) {
+        currentSequenceNumber += opCount;
+        testQuorum.removeClient(clientId);
+    }
+    function createElection(
+        initialClients: [id: string, seq: number, int: boolean][] = [],
+    ) {
+        for (const [id, seq, int] of initialClients) {
+            addClient(id, seq, int);
+        }
+        election = new SummarizerClientElection(
+            mockLogger,
+            summaryCollectionEmitter,
+            new OrderedClientElection(testQuorum),
+            maxOps,
+            () => refreshSummarizerCallCount++,
+        );
+    }
+    function defaultOp(opCount = 1) {
+        currentSequenceNumber += opCount;
+        summaryCollectionEmitter.emit("default", { sequenceNumber: currentSequenceNumber });
+    }
+    function summaryAck(opCount = 1) {
+        currentSequenceNumber += opCount;
+        summaryCollectionEmitter.emit(MessageType.SummaryAck, { sequenceNumber: currentSequenceNumber });
+    }
+
+    function assertState(
+        expectedId: string | undefined,
+        expectedSeq: number,
+        message: string,
+    ) {
+        // Do not use expectedSeq for now.
+        assert.strictEqual(election.electedClientId, expectedId, `Invalid clientId; ${message}`);
+    }
+
+    afterEach(() => {
+        mockLogger.events = [];
+        testQuorum.reset();
+        summaryCollectionEmitter.removeAllListeners();
+        currentSequenceNumber = 0;
+    });
+
+    describe("No initial state", () => {
+        it("Should reelect during add/remove clients", () => {
+            createElection();
+            assertState(undefined, 0, "no clients, should initially be undefined");
+
+            // Add non-interactive client, no effect
+            addClient("s1", 1, false);
+            assertState(undefined, 0, "only non-interactive client in quorum");
+
+            // Add interactive client, should elect
+            addClient("a", 2, true);
+            assertState("a", 2, "only one interactive client in quorum, should elect");
+
+            // Add more clients, no effect
+            addClient("s2", 3, false);
+            addClient("b", 4, true);
+            assertState("a", 2, "additional younger clients should have no effect");
+
+            // Remove elected client, should reelect
+            removeClient("a", 4);
+            assertState("b", 8, "elected client leaving should reelect next oldest client");
+        });
+
+        it("Should reelect when client not summarizing", () => {
+            createElection([
+                ["s1", 1, false],
+                ["a", 2, true],
+                ["s2", 4, false],
+                ["b", 7, true],
+            ]);
+            assertState("a", 7, "initially should be oldest interactive client");
+
+            // Should stay the same right up until max ops
+            defaultOp(maxOps);
+            assertState("a", 7, "should not reelect <= max ops");
+
+            // Should elect next client at this point
+            defaultOp();
+            assertState("b", maxOps + 8, "should reelect > max ops");
+
+            // Next election should be undefined, which resets to first client
+            defaultOp(maxOps);
+            assertState("b", maxOps + 8, "should not reelect <= max ops since baseline");
+            defaultOp();
+            assertState("a", 2 * maxOps + 9, "should reelect back to oldest client");
+        });
+
+        it("Should not reelect when summary ack is found", () => {
+            createElection([
+                ["s1", 1, false],
+                ["a", 2, true],
+                ["s2", 4, false],
+                ["b", 7, true],
+            ]);
+            assertState("a", 7, "initially should elect oldest interactive client");
+
+            // Should stay the same right up until max ops
+            defaultOp(maxOps);
+            assertState("a", 7, "should not reelect <= max ops");
+
+            // Summary ack should only increment election seq #
+            summaryAck();
+            assertState("a", maxOps + 8, "should not reelect after summary ack");
+
+            // Summary ack should prevent reelection
+            defaultOp(maxOps);
+            assertState("a", maxOps + 8, "should not reelect <= max ops since summary ack");
+
+            // Should elect next client at this point
+            defaultOp();
+            assertState("b", 2 * maxOps + 9, "should reelect > max ops since summary ack");
+        });
+    });
+});

--- a/packages/runtime/container-runtime/src/test/testQuorum.ts
+++ b/packages/runtime/container-runtime/src/test/testQuorum.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { ICommittedProposal, IQuorum, IQuorumEvents, ISequencedClient } from "@fluidframework/protocol-definitions";
+
+export class TestQuorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum {
+    public disposed = false;
+    public dispose() {
+        this.disposed = true;
+    }
+
+    private readonly members = new Map<string, ISequencedClient>();
+
+    public getMembers(): Map<string, ISequencedClient> {
+        return this.members;
+    }
+
+    public getMember(clientId: string): ISequencedClient | undefined {
+        return this.members.get(clientId);
+    }
+
+    private readonly values = new Map<string, any>();
+
+    public async propose(key: string, value: any): Promise<void> {
+        this.values.set(key, value);
+    }
+
+    public has(key: string): boolean {
+        return this.values.has(key);
+    }
+
+    public get(key: string): any {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return this.values.get(key);
+    }
+
+    public getApprovalData(key: string): ICommittedProposal | undefined {
+        const value = this.values.get(key);
+        if (value === undefined) {
+            return undefined;
+        }
+        return {
+            key,
+            value,
+            commitSequenceNumber: 0,
+            approvalSequenceNumber: 0,
+            sequenceNumber: 0,
+        };
+    }
+
+    public addClient(clientId: string, client: ISequencedClient) {
+        this.members.set(clientId, client);
+        this.emit("addMember", clientId, client);
+    }
+
+    public removeClient(clientId: string) {
+        this.members.delete(clientId);
+        this.emit("removeMember", clientId);
+    }
+
+    public reset() {
+        this.members.clear();
+        this.values.clear();
+        this.removeAllListeners();
+    }
+}


### PR DESCRIPTION
As requested by #6335 to split into separate PRs.

This change isolates the existing elected summarizer logic into its own class outside of SummaryManager. The new class is SummarizerClientElection, which depends on an OrderedClientElection.

The goal is to reduce code in SummaryManager and add tests for the summarizer client election logic.