### PR TITLE
Add additional properties to ISummaryNack

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -474,10 +474,10 @@ export interface ISummaryHandle {
 
 // @public
 export interface ISummaryNack {
-    code: number;
+    code?: number;
     // @deprecated
     errorMessage: string;
-    message: string;
+    message?: string;
     retryAfter?: number;
     summaryProposal: ISummaryProposal;
 }

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -202,10 +202,7 @@ export interface INack {
 }
 
 // @public
-export interface INackContent {
-    code: number;
-    message: string;
-    retryAfter?: number;
+export interface INackContent extends IServerError {
     type: NackErrorType;
 }
 
@@ -345,7 +342,11 @@ export type ISequencedProposal = {
 
 // @public
 export interface IServerError {
-    errorMessage: string;
+    code: number;
+    // @deprecated
+    errorMessage?: string;
+    message: string;
+    retryAfter?: number;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -343,8 +343,6 @@ export type ISequencedProposal = {
 // @public
 export interface IServerError {
     code: number;
-    // @deprecated
-    errorMessage?: string;
     message: string;
     retryAfter?: number;
 }
@@ -475,6 +473,8 @@ export interface ISummaryHandle {
 
 // @public
 export interface ISummaryNack extends IServerError {
+    // @deprecated
+    errorMessage?: string;
     summaryProposal: ISummaryProposal;
 }
 

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -472,9 +472,9 @@ export interface ISummaryHandle {
 }
 
 // @public
-export interface ISummaryNack extends IServerError {
+export interface ISummaryNack extends Partial<IServerError> {
     // @deprecated
-    errorMessage?: string;
+    errorMessage: string;
     summaryProposal: ISummaryProposal;
 }
 

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -202,7 +202,10 @@ export interface INack {
 }
 
 // @public
-export interface INackContent extends IServerError {
+export interface INackContent {
+    code: number;
+    message: string;
+    retryAfter?: number;
     type: NackErrorType;
 }
 
@@ -342,9 +345,7 @@ export type ISequencedProposal = {
 
 // @public
 export interface IServerError {
-    code: number;
-    message: string;
-    retryAfter?: number;
+    errorMessage: string;
 }
 
 // @public (undocumented)
@@ -472,9 +473,12 @@ export interface ISummaryHandle {
 }
 
 // @public
-export interface ISummaryNack extends Partial<IServerError> {
+export interface ISummaryNack {
+    code: number;
     // @deprecated
     errorMessage: string;
+    message: string;
+    retryAfter?: number;
     summaryProposal: ISummaryProposal;
 }
 

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -207,13 +207,32 @@ export interface ISummaryContent {
 
 /**
  * General errors returned from the server.
- * May want to add error code or something similar in the future.
  */
 export interface IServerError {
     /**
-     * Message describing the server error.
+     * An error code number that represents the error. It will be a valid HTTP error code.
+     * 403 errors are non retryable.
+     * 400 errors are always immediately retriable.
+     * 429 errors are retriable or non retriable (depends on type field).
      */
-    errorMessage: string;
+    code: number;
+
+    /**
+     * A message about the error for debugging/logging/telemetry purposes
+     */
+    message: string;
+
+    /**
+     * Optional Retry-After time in seconds.
+     * If specified, the client should wait this many seconds before retrying.8
+     */
+    retryAfter?: number;
+
+    /**
+     * Message describing the error.
+     * @deprecated - Use "message" instead.
+     */
+    errorMessage?: string;
 }
 
 /**
@@ -279,30 +298,11 @@ export interface IQueueMessage {
 /**
  * Interface for nack content.
  */
-export interface INackContent {
-    /**
-     * An error code number that represents the error. It will be a valid HTTP error code.
-     * 403 errors are non retryable and client should acquire a new identity before reconnection.
-     * 400 errors are always immediately retriable
-     * 429 errors are retriable or non retriable (depends on type field).
-     */
-    code: number;
-
+export interface INackContent extends IServerError {
     /**
      * Type of the Nack.
      */
     type: NackErrorType;
-
-    /**
-     * A message about the nack for debugging/logging/telemetry purposes
-     */
-    message: string;
-
-    /**
-     * Optional Retry-After time in seconds
-     * If specified, the client should wait this many seconds before retrying
-     */
-    retryAfter?: number;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -257,7 +257,7 @@ export interface ISummaryAck {
 /**
  * Contents of summary nack expected from the server.
  */
-export interface ISummaryNack extends IServerError {
+export interface ISummaryNack extends Partial<IServerError> {
     /**
      * Information about the proposed summary op.
      */
@@ -268,7 +268,7 @@ export interface ISummaryNack extends IServerError {
      * @deprecated - Use "message" instead. Clients should check for errorMessage ?? message.
      * Once all servers & clients are all updated, we can remove that errorMessage property
      */
-    errorMessage?: string;
+    errorMessage: string;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -262,12 +262,12 @@ export interface ISummaryNack {
      * 400 errors are always immediately retriable.
      * 429 errors are retriable or non retriable (depends on type field).
      */
-    code: number;
+    code?: number;
 
     /**
      * A message about the error for debugging/logging/telemetry purposes
      */
-    message: string;
+    message?: string;
 
     /**
      * Optional Retry-After time in seconds.

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -207,6 +207,7 @@ export interface ISummaryContent {
 
 /**
  * General errors returned from the server.
+ * May want to add error code or something similar in the future.
  */
 export interface IServerError {
     /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -227,13 +227,6 @@ export interface IServerError {
      * If specified, the client should wait this many seconds before retrying.8
      */
     retryAfter?: number;
-
-    /**
-     * Message describing the error.
-     * @deprecated - Use "message" instead. Clients should check for errorMessage ?? message.
-     * Once all servers & clients are all updated, we can remove that errorMessage property
-     */
-    errorMessage?: string;
 }
 
 /**
@@ -269,6 +262,13 @@ export interface ISummaryNack extends IServerError {
      * Information about the proposed summary op.
      */
     summaryProposal: ISummaryProposal;
+
+    /**
+     * Message describing the error.
+     * @deprecated - Use "message" instead. Clients should check for errorMessage ?? message.
+     * Once all servers & clients are all updated, we can remove that errorMessage property
+     */
+    errorMessage?: string;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -210,23 +210,9 @@ export interface ISummaryContent {
  */
 export interface IServerError {
     /**
-     * An error code number that represents the error. It will be a valid HTTP error code.
-     * 403 errors are non retryable.
-     * 400 errors are always immediately retriable.
-     * 429 errors are retriable or non retriable (depends on type field).
+     * Message describing the server error.
      */
-    code: number;
-
-    /**
-     * A message about the error for debugging/logging/telemetry purposes
-     */
-    message: string;
-
-    /**
-     * Optional Retry-After time in seconds.
-     * If specified, the client should wait this many seconds before retrying.8
-     */
-    retryAfter?: number;
+    errorMessage: string;
 }
 
 /**
@@ -257,7 +243,7 @@ export interface ISummaryAck {
 /**
  * Contents of summary nack expected from the server.
  */
-export interface ISummaryNack extends Partial<IServerError> {
+export interface ISummaryNack {
     /**
      * Information about the proposed summary op.
      */
@@ -265,10 +251,29 @@ export interface ISummaryNack extends Partial<IServerError> {
 
     /**
      * Message describing the error.
-     * @deprecated - Use "message" instead. Clients should check for errorMessage ?? message.
+     * @deprecated - Use "message" instead. Clients should check for message ?? errorMessage.
      * Once all servers & clients are all updated, we can remove that errorMessage property
      */
     errorMessage: string;
+
+    /**
+     * An error code number that represents the error. It will be a valid HTTP error code.
+     * 403 errors are non retryable.
+     * 400 errors are always immediately retriable.
+     * 429 errors are retriable or non retriable (depends on type field).
+     */
+    code: number;
+
+    /**
+     * A message about the error for debugging/logging/telemetry purposes
+     */
+    message: string;
+
+    /**
+     * Optional Retry-After time in seconds.
+     * If specified, the client should wait this many seconds before retrying.8
+     */
+    retryAfter?: number;
 }
 
 /**
@@ -299,11 +304,30 @@ export interface IQueueMessage {
 /**
  * Interface for nack content.
  */
-export interface INackContent extends IServerError {
+export interface INackContent {
+    /**
+     * An error code number that represents the error. It will be a valid HTTP error code.
+     * 403 errors are non retryable and client should acquire a new identity before reconnection.
+     * 400 errors are always immediately retriable
+     * 429 errors are retriable or non retriable (depends on type field).
+     */
+    code: number;
+
     /**
      * Type of the Nack.
      */
     type: NackErrorType;
+
+    /**
+     * A message about the nack for debugging/logging/telemetry purposes
+     */
+    message: string;
+
+    /**
+     * Optional Retry-After time in seconds
+     * If specified, the client should wait this many seconds before retrying
+     */
+    retryAfter?: number;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -230,7 +230,8 @@ export interface IServerError {
 
     /**
      * Message describing the error.
-     * @deprecated - Use "message" instead.
+     * @deprecated - Use "message" instead. Clients should check for errorMessage ?? message.
+     * Once all servers & clients are all updated, we can remove that errorMessage property
      */
     errorMessage?: string;
 }


### PR DESCRIPTION
Add additional properties to ISummaryNack

We should switch it to just `message`, since that's what `INackContent` uses. Client should check for `errorMessage ?? message`. Once all servers & clients are all updated, we can remove that `errorMessage` property