### PR TITLE
Safe error message stack

### DIFF
--- a/common/lib/common-utils/src/logger.ts
+++ b/common/lib/common-utils/src/logger.ts
@@ -41,3 +41,41 @@ export class TelemetryNullLogger implements ITelemetryLogger {
     public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {
     }
 }
+
+export function extractLogSafeErrorProperties(error: any) {
+    const isRegularObject = (value: any): boolean => {
+        return value !== null && !Array.isArray(value) && typeof value === "object";
+    };
+
+    const removeMessageFromStack = (stack: string, errorName?: string) => {
+        const stackFrames = stack.split("\n");
+        stackFrames.shift(); // Remove "[ErrorName]: [ErrorMessage]"
+        if (errorName !== undefined) {
+            stackFrames.unshift(errorName); // Add "[ErrorName]"
+        }
+        return stackFrames.join("\n");
+    };
+
+    const message = (typeof error?.message === "string")
+        ? error.message as string
+        : String(error);
+
+    const safeProps: { message: string; errorType?: string; stack?: string } = {
+        message,
+    };
+
+    if (isRegularObject(error)) {
+        const { errorType, stack, name } = error;
+
+        if (typeof errorType === "string") {
+            safeProps.errorType = errorType;
+        }
+
+        if (typeof stack === "string") {
+            const errorName = (typeof name === "string") ? name : undefined;
+            safeProps.stack = removeMessageFromStack(stack, errorName);
+        }
+    }
+
+    return safeProps;
+}

--- a/common/lib/common-utils/src/test/mocha/logger.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/logger.spec.ts
@@ -28,7 +28,7 @@ describe("extractLogSafeErrorProperties", () => {
             assert.strictEqual(extractLogSafeErrorProperties({ message: "hello"}).message, "hello");
             assert.strictEqual(extractLogSafeErrorProperties({ message: 42}).message, "[object Object]");
             assert.strictEqual(extractLogSafeErrorProperties({ foo: 42}).message, "[object Object]");
-            assert.strictEqual(extractLogSafeErrorProperties([1,2,3]).message, "[object Object]");
+            assert.strictEqual(extractLogSafeErrorProperties([1,2,3]).message, "1,2,3");
             assert.strictEqual(extractLogSafeErrorProperties(null).message, "null");
         });
         it("extract errorType", () => {

--- a/common/lib/common-utils/src/test/mocha/logger.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/logger.spec.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { extractLogSafeErrorProperties } from "../../logger";
+
+describe("extractLogSafeErrorProperties", () => {
+    describe("prepareErrorObject", () => {
+        function createSampleError(): Error {
+            try {
+                const error = new Error("asdf");
+                error.name = "FooError";
+                throw error;
+            } catch (e) {
+                return e as Error;
+            }
+        }
+
+        it("non-object error yields correct message", () => {
+            assert.strictEqual(extractLogSafeErrorProperties("hello").message, "hello");
+            assert.strictEqual(extractLogSafeErrorProperties(42).message, "42");
+            assert.strictEqual(extractLogSafeErrorProperties(true).message, "true");
+            assert.strictEqual(extractLogSafeErrorProperties(undefined).message, "undefined");
+        });
+        it("object error yields correct message", () => {
+            assert.strictEqual(extractLogSafeErrorProperties({ message: "hello"}).message, "hello");
+            assert.strictEqual(extractLogSafeErrorProperties({ message: 42}).message, "[Object] Object");
+            assert.strictEqual(extractLogSafeErrorProperties({ foo: 42}).message, "[Object] Object");
+            assert.strictEqual(extractLogSafeErrorProperties([1,2,3]).message, "[Object] Object");
+            assert.strictEqual(extractLogSafeErrorProperties(null).message, "null");
+        });
+        it("extract errorType", () => {
+            assert.strictEqual(extractLogSafeErrorProperties({ errorType: "hello"}).errorType, "hello");
+            assert.strictEqual(extractLogSafeErrorProperties({ foo: "hello"}).errorType, undefined);
+            assert.strictEqual(extractLogSafeErrorProperties({ errorType: 42}).errorType, undefined);
+            assert.strictEqual(extractLogSafeErrorProperties(42).errorType, undefined);
+        });
+        it("extract stack", () => {
+            const e1 = createSampleError();
+            const stack1 = extractLogSafeErrorProperties(e1).stack;
+            assert(typeof(stack1) === "string");
+            assert(!stack1?.includes("asdf"), "message should have been removed from stack");
+            assert(stack1?.includes("FooError"), "name should still be in the stack");
+        });
+        it("extract stack non-standard values", () => {
+            assert.strictEqual(extractLogSafeErrorProperties({ stack: "hello"}).stack, "");
+            assert.strictEqual(extractLogSafeErrorProperties({ stack: "hello", name: "name" }).stack, "name");
+            assert.strictEqual(extractLogSafeErrorProperties({ foo: "hello"}).stack, undefined);
+            assert.strictEqual(extractLogSafeErrorProperties({ stack: 42}).stack, undefined);
+            assert.strictEqual(extractLogSafeErrorProperties(42).stack, undefined);
+        });
+    });
+});

--- a/common/lib/common-utils/src/test/mocha/logger.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/logger.spec.ts
@@ -26,9 +26,9 @@ describe("extractLogSafeErrorProperties", () => {
         });
         it("object error yields correct message", () => {
             assert.strictEqual(extractLogSafeErrorProperties({ message: "hello"}).message, "hello");
-            assert.strictEqual(extractLogSafeErrorProperties({ message: 42}).message, "[Object] Object");
-            assert.strictEqual(extractLogSafeErrorProperties({ foo: 42}).message, "[Object] Object");
-            assert.strictEqual(extractLogSafeErrorProperties([1,2,3]).message, "[Object] Object");
+            assert.strictEqual(extractLogSafeErrorProperties({ message: 42}).message, "[object Object]");
+            assert.strictEqual(extractLogSafeErrorProperties({ foo: 42}).message, "[object Object]");
+            assert.strictEqual(extractLogSafeErrorProperties([1,2,3]).message, "[object Object]");
             assert.strictEqual(extractLogSafeErrorProperties(null).message, "null");
         });
         it("extract errorType", () => {

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -55,6 +55,41 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         return name.replace("@", "").replace("/", "-");
     }
 
+    private static extractLogSafeErrorProperties(error: any) {
+        const isRegularObject = (value: any): boolean => {
+            return value !== null && !Array.isArray(value) && typeof value === "object";
+        };
+
+        const removeMessageFromStack = (stack: string, errorName: string) => {
+            const stackFrames = stack.split("\n");
+            stackFrames.shift(); // Remove "ErrorName: ErrorMessage"
+            stackFrames.unshift(errorName); // Add "ErrorName"
+            return stackFrames.join("\n");
+        };
+
+        const message = (typeof error?.message === "string")
+            ? error.message as string
+            : String(error);
+
+        const safeProps: { message: string; errorType?: string; stack?: string } = {
+            message,
+        };
+
+        if (isRegularObject(error)) {
+            const { errorType, stack, name } = error;
+
+            if (typeof errorType === "string") {
+                safeProps.errorType = errorType;
+            }
+
+            if (typeof stack === "string") {
+                safeProps.stack = removeMessageFromStack(stack, name);
+            }
+        }
+
+        return safeProps;
+    }
+
     /**
      * Take an unknown error object and add the appropriate info from it to the event
      * NOTE - message and stack will be copied over from the error object,
@@ -64,15 +99,14 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param fetchStack - Whether to fetch the current callstack if error.stack is undefined
      */
     public static prepareErrorObject(event: ITelemetryBaseEvent, error: any, fetchStack: boolean) {
-        if (isILoggingError(error)) {
-            // First, copy over error message, stack, and errorType directly (overwrite if present on event)
-            // Warning: if these were overwritten with PII-tagged props, they will be logged as-is
-            // Note: For a safer implementation of this, see extractLogSafeErrorProperties in container-utils package
-            event.stack = error.stack;
-            event.error = error.message;
-            event.errorType = (error as any).errorType;
+        const { message, errorType, stack} = this.extractLogSafeErrorProperties(error);
+        // First, copy over error message, stack, and errorType directly (overwrite if present on event)
+        event.stack = { tag: TelemetryDataTag.PackageData, value: stack };
+        event.error = message;
+        event.errorType = errorType;
 
-            // Then add any other telemetry properties from the LoggingError
+        if (isILoggingError(error)) {
+            // Add any other telemetry properties from the LoggingError
             const taggableProps = error.getTelemetryProperties();
             for (const key of Object.keys(taggableProps)) {
                 if (event[key] !== undefined) {
@@ -106,14 +140,6 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
                         break;
                 }
             }
-        } else if (typeof error === "object" && error !== null) {
-            // Pull the message, stack and errorType off even if it's not an ILoggingError
-            // Note: For a safer implementation of this, see extractLogSafeErrorProperties in container-utils package
-            event.stack = error.stack;
-            event.error = error.message;
-            event.errorType = error.errorType;
-        } else {
-            event.error = error;
         }
 
         // Collect stack if we were not able to extract it from error


### PR DESCRIPTION
Fixes #5559 

Although I'm leaving out the tagging of the stack until the rest of tagging work is done (see #5560) because that's not urgently needed and would be kind of strange to tag it and then immediately remove the tag.

Also I triplicated `extractLogSafeErrorProperties` to get the same logic here and in container-utils, while jumpstarting moving it to common-utils.  Follow-up PRs will update the two usages to point to common-utils and remove the duplicates.