### PR TITLE
Deprecate supportsTags.

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,15 +1,9 @@
 ## 0.43 Breaking changes
 
 - [TinyliciousClient no longer static](#TinyliciousClient-no-longer-static)
-- [supportsTags deprecated](#supports-Tags-deprecated)
 
 ### TinyliciousClient no longer static
 `TinyliciousClient` global static property is removed. Instead, object instantiation is now required.
-
-### supportsTags deprecated
-We are deprecating use of supportsTags and instead going to handle tags directly at the interface of the runtime and
-`IContainerContext`. This will allow loggers downstream to be agnostic about whether messages have tags. However, note
-that this change will occur via a new release of `common-definitions` (not the client).
 
 ## 0.42 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,9 +1,15 @@
 ## 0.43 Breaking changes
 
 - [TinyliciousClient no longer static](#TinyliciousClient-no-longer-static)
+- [supportsTags deprecated](#supports-Tags-deprecated)
 
 ### TinyliciousClient no longer static
 `TinyliciousClient` global static property is removed. Instead, object instantiation is now required.
+
+### supportsTags deprecated
+We are deprecating use of supportsTags and instead going to handle tags directly at the interface of the runtime and
+`IContainerContext`. This will allow loggers downstream to be agnostic about whether messages have tags. However, note
+that this change will occur via a new release of `common-definitions` (not the client).
 
 ## 0.42 Breaking changes
 

--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -1,0 +1,7 @@
+## 0.21 Breaking changes
+
+- [supportsTags deprecated](#supportstags-deprecated)
+
+### supportsTags deprecated
+We are deprecating use of supportsTags and instead going to handle tags directly at the interface of the runtime and
+`IContainerContext`. This will allow loggers downstream to be agnostic about whether messages have tags. This will involve a change in `container-definitions`, which is packaged as part of the `build-common` release.

--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -3,5 +3,6 @@
 - [supportsTags deprecated](#supportstags-deprecated)
 
 ### supportsTags deprecated
-We are deprecating use of supportsTags and instead going to handle tags directly at the interface of the runtime and
-`IContainerContext`. This will allow loggers downstream to be agnostic about whether messages have tags. This will involve a change in `container-definitions`, which is packaged as part of the `build-common` release.
+We are deprecating use of supportsTags and instead going to handle tags directly at the loader/runtime boundary
+via `IContainerContext`. Other than this boundary, all loggers can assume full support for tags on all telemetry events. 
+This will involve a change in `container-definitions`, which is packaged as part of the `build-common` release.

--- a/common/lib/common-definitions/api-report/common-definitions.api.md
+++ b/common/lib/common-definitions/api-report/common-definitions.api.md
@@ -220,7 +220,7 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
 export interface ITelemetryBaseLogger {
     // (undocumented)
     send(event: ITelemetryBaseEvent): void;
-    // @deprecated
+    // @deprecated (undocumented)
     supportsTags?: true;
 }
 

--- a/common/lib/common-definitions/api-report/common-definitions.api.md
+++ b/common/lib/common-definitions/api-report/common-definitions.api.md
@@ -220,6 +220,7 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
 export interface ITelemetryBaseLogger {
     // (undocumented)
     send(event: ITelemetryBaseEvent): void;
+    // @deprecated
     supportsTags?: true;
 }
 

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -41,7 +41,7 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
  */
 export interface ITelemetryBaseLogger {
     /**
-     * @deprecated
+     * @deprecated deprecated
      */
     supportsTags?: true;
     send(event: ITelemetryBaseEvent): void;

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -41,11 +41,7 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
  */
 export interface ITelemetryBaseLogger {
     /**
-     * @deprecated An optional boolean which indicates to the user of this interface that tags
-     * (i.e. `ITaggedTelemetryPropertyType` objects) are in use. Eventually this will be a required property, but this
-     * is a stopgap that allows older hosts to continue to pass through telemetry without trouble (this property will
-     * simply show up undefined), while our current logger implementation in `telmetry-utils` handles tags in a
-     * separate manner.
+     * @deprecated
      */
     supportsTags?: true;
     send(event: ITelemetryBaseEvent): void;

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -41,10 +41,11 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
  */
 export interface ITelemetryBaseLogger {
     /**
-     * An optional boolean which indicates to the user of this interface that tags (i.e. `ITaggedTelemetryPropertyType`
-     * objects) are in use. Eventually this will be a required property, but this is a stopgap that allows older hosts
-     * to continue to pass through telemetry without trouble (this property will simply show up undefined), while our
-     * current logger implementation in `telmetry-utils` handles tags in a separate manner.
+     * @deprecated An optional boolean which indicates to the user of this interface that tags
+     * (i.e. `ITaggedTelemetryPropertyType` objects) are in use. Eventually this will be a required property, but this
+     * is a stopgap that allows older hosts to continue to pass through telemetry without trouble (this property will
+     * simply show up undefined), while our current logger implementation in `telmetry-utils` handles tags in a
+     * separate manner.
      */
     supportsTags?: true;
     send(event: ITelemetryBaseEvent): void;


### PR DESCRIPTION
Mark `supportsTags` deprecated and update breaking.md(s). Step 1 of plan (https://github.com/microsoft/FluidFramework/issues/5560#issuecomment-867843015) to change how tags are handled in repo.