### PR TITLE
Strip query string from error response object

### DIFF
--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -88,10 +88,12 @@ export const create404Response = (request: IRequest) => createResponseError(404,
 
 export function createResponseError(status: number, value: string, request: IRequest): IResponse {
     assert(status !== 200, 0x19b /* "Cannot not create response error on 200 status" */);
+    // Omit query string which could contain personal data (aka "PII")
+    const urlNoQuery = request.url?.split("?")[0];
     return {
         mimeType: "text/plain",
         status,
-        value: request.url === undefined ? value : `${value}: ${request.url}`,
+        value: urlNoQuery === undefined ? value : `${value}: ${urlNoQuery}`,
         stack: getStack(),
     };
 }

--- a/packages/runtime/runtime-utils/src/test/dataStoreHelpers.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/dataStoreHelpers.spec.ts
@@ -8,7 +8,7 @@ import { createResponseError } from "../dataStoreHelpers";
 
 describe("createResponseError", () => {
     it("Strip URL query param ", () => {
-        const response = createResponseError(400, "", { url: "http://foo.com?a=b"});
-        assert.strictEqual(response.value, "http://foo.com");
+        const response = createResponseError(400, "SomeValue", { url: "http://foo.com?a=b"});
+        assert.strictEqual(response.value, "SomeValue: http://foo.com");
     });
 });

--- a/packages/runtime/runtime-utils/src/test/dataStoreHelpers.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/dataStoreHelpers.spec.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { createResponseError } from "../dataStoreHelpers";
+
+describe("createResponseError", () => {
+    it("Strip URL query param ", () => {
+        const response = createResponseError(400, "", { url: "http://foo.com?a=b"});
+        assert.strictEqual(response.value, "http://foo.com");
+    });
+});


### PR DESCRIPTION
Doesn't fully fix #5326 but does ameliorate the more concerning user personal data case.  We can wait for more clarity on 3P-in-1P scenarios before fully addressing that issue.