### PR TITLE
Add methods to get and remove an interval from a collection by ID

### DIFF
--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -669,16 +669,20 @@ export class RedBlackTree<TKey, TData> implements Base.SortedDictionary<TKey, TD
                 return;
             }
 
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            if ((!this.isRed(this.root!.left)) && (!this.isRed(this.root!.right))) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this.root!.color = RBColor.RED;
-            }
-
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this.root = this.nodeRemove(this.root!, key);
+            this.removeExisting(key);
         }
         // TODO: error on undefined key
+    }
+
+    removeExisting(key: TKey) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        if ((!this.isRed(this.root!.left)) && (!this.isRed(this.root!.right))) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.root!.color = RBColor.RED;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.root = this.nodeRemove(this.root!, key);
     }
 
     nodeRemove(node: RBNode<TKey, TData>, key: TKey) {
@@ -1176,6 +1180,10 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
         this.intervals.remove(x);
     }
 
+    removeExisting(x: T) {
+        this.intervals.removeExisting(x);
+    }
+
     put(x: T, conflict?: IntervalConflictResolver<T>) {
         let rbConflict: Base.ConflictAction<T, AugmentedIntervalNode> | undefined;
         if (conflict) {
@@ -1201,6 +1209,16 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
             infix: (node) => {
                 fn(node.key);
                 return true;
+            },
+            showStructure: true,
+        };
+        this.intervals.walk(actions);
+    }
+
+    mapUntil(fn: (X: T) => boolean) {
+        const actions = <RBNodeActions<T, AugmentedIntervalNode>>{
+            infix: (node) => {
+                return fn(node.key);
             },
             showStructure: true,
         };

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -129,15 +129,45 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
     }
     assert.strictEqual(i, intervalArray.length, "Interval omitted from for...of iteration");
 
-    intervalCollection.delete(0, 0);
-    intervalCollection.delete(0, 1);
-    intervalCollection.delete(0, 2);
-    intervalCollection.delete(1, 0);
-    intervalCollection.delete(1, 1);
-    intervalCollection.delete(1, 2);
-    intervalCollection.delete(2, 0);
-    intervalCollection.delete(2, 1);
-    intervalCollection.delete(2, 2);
+    if (typeof(intervalArray[0]?.getIntervalId) === "function") {
+        let interval: SequenceInterval;
+
+        let id = intervalArray[0].getIntervalId();
+        assert.notStrictEqual(id, undefined, "Unique Id should have been assigned");
+        if (id !== undefined) {
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, intervalArray[0]);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, intervalArray[0]);
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, undefined);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, undefined);
+        }
+
+        id = intervalArray[intervalArray.length - 1].getIntervalId();
+        assert.notStrictEqual(id, undefined, "Unique Id should have been assigned");
+        if (id !== undefined) {
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, intervalArray[intervalArray.length - 1]);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, intervalArray[intervalArray.length - 1]);
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, undefined);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, undefined);
+        }
+    }
+
+    for (const interval of intervalArray) {
+        const id = typeof(interval.getIntervalId) === "function" ? interval.getIntervalId() : undefined;
+        if (id !== undefined) {
+            intervalCollection.removeIntervalById(id);
+        }
+        else {
+            intervalCollection.delete(interval.start.getOffset(), interval.end.getOffset());
+        }
+    }
 }
 
 describeFullCompat("SharedInterval", (getTestObjectProvider) => {


### PR DESCRIPTION
Add and delete ops will be supplied with ID's. delete(start, end) will be deprecated; for now it will delete the interval with a legacy ID based on start/end.