### PR TITLE
Allow multiple intervals with the same (start, end) in a collection

### DIFF
--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -669,16 +669,20 @@ export class RedBlackTree<TKey, TData> implements Base.SortedDictionary<TKey, TD
                 return;
             }
 
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            if ((!this.isRed(this.root!.left)) && (!this.isRed(this.root!.right))) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this.root!.color = RBColor.RED;
-            }
-
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this.root = this.nodeRemove(this.root!, key);
+            this.removeExisting(key);
         }
         // TODO: error on undefined key
+    }
+
+    removeExisting(key: TKey) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        if ((!this.isRed(this.root!.left)) && (!this.isRed(this.root!.right))) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.root!.color = RBColor.RED;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.root = this.nodeRemove(this.root!, key);
     }
 
     nodeRemove(node: RBNode<TKey, TData>, key: TKey) {
@@ -1176,6 +1180,10 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
         this.intervals.remove(x);
     }
 
+    removeExisting(x: T) {
+        this.intervals.removeExisting(x);
+    }
+
     put(x: T, conflict?: IntervalConflictResolver<T>) {
         let rbConflict: Base.ConflictAction<T, AugmentedIntervalNode> | undefined;
         if (conflict) {
@@ -1201,6 +1209,16 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
             infix: (node) => {
                 fn(node.key);
                 return true;
+            },
+            showStructure: true,
+        };
+        this.intervals.walk(actions);
+    }
+
+    mapUntil(fn: (X: T) => boolean) {
+        const actions = <RBNodeActions<T, AugmentedIntervalNode>>{
+            infix: (node) => {
+                return fn(node.key);
             },
             showStructure: true,
         };

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -90,7 +90,21 @@ export class Interval implements ISerializableInterval {
     public compare(b: Interval) {
         const startResult = this.compareStart(b);
         if (startResult === 0) {
-            return this.compareEnd(b);
+            const endResult = this.compareEnd(b);
+            if (endResult === 0) {
+                const thisId = this.getIntervalId();
+                if (thisId) {
+                    const bId = b.getIntervalId();
+                    if (bId) {
+                        return thisId > bId ? 1 : thisId < bId ? -1 : 0;
+                    }
+                    return 0;
+                }
+                return 0;
+            }
+            else {
+                return endResult;
+            }
         } else {
             return startResult;
         }
@@ -160,7 +174,21 @@ export class SequenceInterval implements ISerializableInterval {
     public compare(b: SequenceInterval) {
         const startResult = this.compareStart(b);
         if (startResult === 0) {
-            return this.compareEnd(b);
+            const endResult = this.compareEnd(b);
+            if (endResult === 0) {
+                const thisId = this.getIntervalId();
+                if (thisId) {
+                    const bId = b.getIntervalId();
+                    if (bId) {
+                        return thisId > bId ? 1 : thisId < bId ? -1 : 0;
+                    }
+                    return 0;
+                }
+                return 0;
+            }
+            else {
+                return endResult;
+            }
         } else {
             return startResult;
         }
@@ -483,7 +511,6 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
         return this.helpers.create(this.label, start, end, this.client, intervalType);
     }
 
-    // TODO: remove interval, handle duplicate intervals
     public addInterval(
         start: number,
         end: number,
@@ -727,7 +754,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     private client: MergeTree.Client;
 
     public get attached(): boolean {
-        // return !!this.view;
         return !!this.localCollection;
     }
 
@@ -849,10 +875,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     }
 
     public attachDeserializer(onDeserialize: DeserializeCallback): void {
-        this.attachDeserializerCore(onDeserialize);
-    }
-
-    private attachDeserializerCore(onDeserialize?: DeserializeCallback): void {
         // If no deserializer is specified can skip all processing work
         if (!onDeserialize) {
             return;
@@ -978,18 +1000,34 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     }
 
     public findOverlappingIntervals(startPosition: number, endPosition: number): TInterval[] {
+        if (!this.attached) {
+            throw new Error("attachSequence must be called");
+        }
+
         return this.localCollection.findOverlappingIntervals(startPosition, endPosition);
     }
 
     public map(fn: (interval: TInterval) => void) {
+        if (!this.attached) {
+            throw new Error("attachSequence must be called");
+        }
+
         this.localCollection.map(fn);
     }
 
     public previousInterval(pos: number): TInterval {
+        if (!this.attached) {
+            throw new Error("attachSequence must be called");
+        }
+
         return this.localCollection.previousInterval(pos);
     }
 
     public nextInterval(pos: number): TInterval {
+        if (!this.attached) {
+            throw new Error("attachSequence must be called");
+        }
+
         return this.localCollection.nextInterval(pos);
     }
 

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -51,13 +51,41 @@ const assertIntervalsHelper = (
     }
 };
 
-function testIntervalCollection(intervalCollection: IntervalCollection<SequenceInterval>) {
+function testIntervalOperations(intervalCollection: IntervalCollection<SequenceInterval>) {
     if (!intervalCollection[Symbol.iterator]) {
         // Check for prior version that doesn't support iteration
         return;
     }
 
     const intervalArray: SequenceInterval[] = [];
+    let interval: SequenceInterval;
+    let id;
+
+    intervalArray[0] = intervalCollection.add(0, 0, IntervalType.SlideOnRemove);
+    if (typeof(intervalArray[0]?.getIntervalId) !== "function") {
+        intervalCollection.delete(0, 0);
+        return;
+    }
+
+    intervalArray[1] = intervalCollection.add(0, 0, IntervalType.SlideOnRemove);
+    assert.notStrictEqual(intervalArray[0], intervalArray[1], "Unique intervals not added");
+
+    id = intervalArray[0].getIntervalId();
+    assert.notStrictEqual(id, undefined, "ID not created");
+
+    intervalCollection.removeIntervalById(id);
+    interval = intervalCollection.getIntervalById(id);
+    assert.strictEqual(interval, undefined, "Interval not removed");
+
+    id = intervalArray[1].getIntervalId();
+    assert.notStrictEqual(id, undefined, "ID not created");
+    interval = intervalCollection.getIntervalById(id);
+    assert.notStrictEqual(interval, undefined, "Wrong interval removed?");
+
+    intervalCollection.removeIntervalById(id);
+    interval = intervalCollection.getIntervalById(id);
+    assert.strictEqual(interval, undefined, "Interval not removed");
+
     intervalArray[0] = intervalCollection.add(0, 0, IntervalType.SlideOnRemove);
     intervalArray[1] = intervalCollection.add(0, 1, IntervalType.SlideOnRemove);
     intervalArray[2] = intervalCollection.add(0, 2, IntervalType.SlideOnRemove);
@@ -76,7 +104,7 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
     tempArray[1] = intervalArray[4];
     tempArray[2] = intervalArray[5];
     for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
-        const interval = result.value;
+        interval = result.value;
         assert.strictEqual(interval, tempArray[i], "Mismatch in forward iteration with start position");
     }
     assert.strictEqual(i, tempArray.length, "Interval omitted from forward iteration with start position");
@@ -87,10 +115,21 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
     tempArray[1] = intervalArray[1];
     tempArray[2] = intervalArray[0];
     for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
-        const interval = result.value;
+        interval = result.value;
         assert.strictEqual(interval, tempArray[i], "Mismatch in backward iteration with start position");
     }
     assert.strictEqual(i, tempArray.length, "Interval omitted from backward iteration with start position");
+
+    iterator = intervalCollection.CreateForwardIteratorWithEndPosition(2);
+    tempArray = [];
+    tempArray[0] = intervalArray[2];
+    tempArray[1] = intervalArray[5];
+    tempArray[2] = intervalArray[8];
+    for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
+        interval = result.value;
+        assert.strictEqual(interval, tempArray[i], "Mismatch in forward iteration with end position");
+    }
+    assert.strictEqual(i, tempArray.length, "Interval omitted from forward iteration with end position");
 
     iterator = intervalCollection.CreateBackwardIteratorWithEndPosition(1);
     tempArray = [];
@@ -98,7 +137,7 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
     tempArray[1] = intervalArray[4];
     tempArray[2] = intervalArray[1];
     for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
-        const interval = result.value;
+        interval = result.value;
         assert.strictEqual(interval, tempArray[i], "Mismatch in backward iteration with end position");
     }
     assert.strictEqual(i, tempArray.length, "Interval omitted from backward iteration with end position");
@@ -123,16 +162,15 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
         assert(false, "Iterator with OOB position should not produce a result");
     }
 
-    for (const interval of intervalCollection) {
+    i = 0;
+    for (interval of intervalCollection) {
         assert.strictEqual(interval, intervalArray[i], "Mismatch in for...of iteration of collection");
         i++;
     }
     assert.strictEqual(i, intervalArray.length, "Interval omitted from for...of iteration");
 
     if (typeof(intervalArray[0]?.getIntervalId) === "function") {
-        let interval: SequenceInterval;
-
-        let id = intervalArray[0].getIntervalId();
+        id = intervalArray[0].getIntervalId();
         assert.notStrictEqual(id, undefined, "Unique Id should have been assigned");
         if (id !== undefined) {
             interval = intervalCollection.getIntervalById(id);
@@ -159,8 +197,8 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
         }
     }
 
-    for (const interval of intervalArray) {
-        const id = typeof(interval.getIntervalId) === "function" ? interval.getIntervalId() : undefined;
+    for (interval of intervalArray) {
+        id = typeof(interval.getIntervalId) === "function" ? interval.getIntervalId() : undefined;
         if (id !== undefined) {
             intervalCollection.removeIntervalById(id);
         }
@@ -199,7 +237,7 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
 
             intervals = sharedString.getIntervalCollection("intervals");
             intervalView = await intervals.getView();
-            testIntervalCollection(intervals);
+            testIntervalOperations(intervals);
         });
 
         it("replace all is included", async () => {
@@ -339,6 +377,218 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
 
             await provider.ensureSynchronized();
             assertIntervalsHelper(sharedString1, intervalView1, [{ start: 1, end: 7 }]);
+        });
+
+        it("multi-client interval ops", async () => {
+            const stringId = "stringKey";
+            const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+            const testContainerConfig: ITestContainerConfig = {
+                fluidDataObjectType: DataObjectFactoryType.Test,
+                registry,
+            };
+
+            // Create a Container for the first client.
+            const container1 = await provider.makeTestContainer(testContainerConfig);
+            const dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+            const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+
+            sharedString1.insertText(0, "012");
+            const intervals1 = sharedString1.getIntervalCollection("intervals");
+            const intervalArray: SequenceInterval[] = [];
+            let interval: SequenceInterval;
+
+            intervalArray[0] = intervals1.add(0, 0, IntervalType.SlideOnRemove);
+            intervalArray[1] = intervals1.add(0, 1, IntervalType.SlideOnRemove);
+            intervalArray[2] = intervals1.add(0, 2, IntervalType.SlideOnRemove);
+            intervalArray[3] = intervals1.add(1, 0, IntervalType.SlideOnRemove);
+            intervalArray[4] = intervals1.add(1, 1, IntervalType.SlideOnRemove);
+            intervalArray[5] = intervals1.add(1, 2, IntervalType.SlideOnRemove);
+            intervalArray[6] = intervals1.add(2, 0, IntervalType.SlideOnRemove);
+            intervalArray[7] = intervals1.add(2, 1, IntervalType.SlideOnRemove);
+            intervalArray[8] = intervals1.add(2, 2, IntervalType.SlideOnRemove);
+
+            // Load the Container that was created by the first client.
+            const container2 = await provider.loadTestContainer(testContainerConfig);
+            const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+
+            await provider.ensureSynchronized();
+
+            const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+            const intervals2 = sharedString2.getIntervalCollection("intervals");
+
+            if (intervals2[Symbol.iterator]) {
+                const checkIdEquals = (a: SequenceInterval, b: SequenceInterval, s: string) => {
+                    if (typeof(a.getIntervalId) === "function") {
+                        assert.strictEqual(a.getIntervalId(), b.getIntervalId(), s);
+                    }
+                };
+                let i: number;
+                let result;
+                let tempArray: SequenceInterval[] = [];
+                let iterator = intervals2.CreateForwardIteratorWithStartPosition(1);
+                tempArray[0] = intervalArray[3];
+                tempArray[1] = intervalArray[4];
+                tempArray[2] = intervalArray[5];
+                for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
+                    checkIdEquals(result.value, tempArray[i], "Mismatch in forward iteration with start position");
+                }
+                assert.strictEqual(i, tempArray.length, "Interval omitted from forward iteration with start position");
+
+                iterator = intervals2.CreateBackwardIteratorWithStartPosition(0);
+                tempArray = [];
+                tempArray[0] = intervalArray[2];
+                tempArray[1] = intervalArray[1];
+                tempArray[2] = intervalArray[0];
+                for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
+                    checkIdEquals(result.value, tempArray[i], "Mismatch in backward iteration with start position");
+                }
+                assert.strictEqual(i, tempArray.length, "Interval omitted from backward iteration with start position");
+
+                iterator = intervals2.CreateBackwardIteratorWithEndPosition(1);
+                tempArray = [];
+                tempArray[0] = intervalArray[7];
+                tempArray[1] = intervalArray[4];
+                tempArray[2] = intervalArray[1];
+                for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
+                    checkIdEquals(result.value, tempArray[i], "Mismatch in backward iteration with end position");
+                }
+                assert.strictEqual(i, tempArray.length, "Interval omitted from backward iteration with end position");
+
+                i = 0;
+                for (interval of intervals2) {
+                    checkIdEquals(interval, intervalArray[i], "Mismatch in for...of iteration of collection");
+                    i++;
+                }
+                assert.strictEqual(i, intervalArray.length, "Interval omitted from for...of iteration");
+            }
+
+            if (typeof(intervalArray[0]?.getIntervalId) === "function") {
+                for (interval of intervalArray) {
+                    const id = interval.getIntervalId();
+                    if (id !== undefined) {
+                        intervals2.removeIntervalById(id);
+                    }
+                }
+            }
+            else {
+                intervals2.delete(0,0);
+                intervals2.delete(0,1);
+                intervals2.delete(0,2);
+                intervals2.delete(1,0);
+                intervals2.delete(1,1);
+                intervals2.delete(1,2);
+                intervals2.delete(2,0);
+                intervals2.delete(2,1);
+                intervals2.delete(2,2);
+            }
+
+            await provider.ensureSynchronized();
+
+            if (intervals1[Symbol.iterator]) {
+                for (interval of intervals1) {
+                    assert(false, "intervals1 should be empty after emptying invervals2");
+                }
+            }
+        });
+
+        it("Conflicting ops", async () => {
+            const stringId = "stringKey";
+            const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+            const testContainerConfig: ITestContainerConfig = {
+                fluidDataObjectType: DataObjectFactoryType.Test,
+                registry,
+            };
+
+            // Create a Container for the first client.
+            const container1 = await provider.makeTestContainer(testContainerConfig);
+            const dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+            const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+
+            sharedString1.insertText(0, "012");
+            const intervals1 = sharedString1.getIntervalCollection("intervals");
+            let interval1: SequenceInterval;
+            let interval2: SequenceInterval;
+            let id1;
+            let id2;
+
+            await provider.ensureSynchronized();
+
+            // Load the Container that was created by the first client.
+            const container2 = await provider.loadTestContainer(testContainerConfig);
+            const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+            const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+            const intervals2 = sharedString2.getIntervalCollection("intervals");
+
+            // Conflicting adds
+            interval1 = intervals1.add(0, 0, IntervalType.SlideOnRemove);
+            if (typeof(interval1?.getIntervalId) !== "function") {
+                intervals1.delete(0, 0);
+            }
+            else {
+                id1 = interval1.getIntervalId();
+                interval2 = intervals2.add(0, 0, IntervalType.SlideOnRemove);
+                id2 = interval2.getIntervalId();
+
+                await provider.ensureSynchronized();
+
+                assert.notStrictEqual(intervals1.getIntervalById(id2), undefined, "Interval not added to collection 1");
+                assert.notStrictEqual(intervals1.getIntervalById(id2), interval1, "Unique interval not added");
+                assert.notStrictEqual(intervals2.getIntervalById(id1), undefined, "Interval not added to collection 2");
+                assert.notStrictEqual(intervals2.getIntervalById(id1), interval2, "Unique interval not added");
+
+                // Conflicting removes
+                interval1 = intervals1.removeIntervalById(id2);
+                assert.notStrictEqual(interval1, undefined, "Interval not removed by id");
+                interval2 = intervals2.removeIntervalById(id1);
+                assert.notStrictEqual(interval2, undefined, "Interval not removed by id");
+
+                await provider.ensureSynchronized();
+
+                assert.strictEqual(
+                    intervals1.getIntervalById(id1), undefined, "Interval not removed from other client");
+                assert.strictEqual(
+                    intervals2.getIntervalById(id2), undefined, "Interval not removed from other client");
+
+                // Conflicting removes + add
+                interval1 = intervals1.add(1, 1, IntervalType.SlideOnRemove);
+                id1 = interval1.getIntervalId();
+                interval2 = intervals2.add(1, 1, IntervalType.SlideOnRemove);
+                id2 = interval2.getIntervalId();
+
+                await provider.ensureSynchronized();
+
+                intervals2.removeIntervalById(id1);
+                intervals1.removeIntervalById(id2);
+                interval1 = intervals1.add(1, 1, IntervalType.SlideOnRemove);
+                id1 = interval1.getIntervalId();
+
+                await provider.ensureSynchronized();
+
+                assert.strictEqual(interval1, intervals1.getIntervalById(id1), "Interval missing from collection 1");
+                for (const interval of intervals1) {
+                    assert.strictEqual(interval, interval1, "Oddball interval found in client 1");
+                }
+
+                interval2 = intervals2.getIntervalById(id1);
+                assert.notStrictEqual(interval2, undefined, "Interval missing from collection 2");
+                for (const interval of intervals2) {
+                    assert.strictEqual(interval, interval2, "Oddball interval found in client 2");
+                }
+
+                // Conflicting removes
+                intervals1.removeIntervalById(id1);
+                intervals2.removeIntervalById(id1);
+
+                await provider.ensureSynchronized();
+
+                for (interval1 of intervals1) {
+                    assert.fail("Interval not removed from collection 1");
+                }
+
+                for (interval2 of intervals2) {
+                    assert.fail("Interval not removed from collection 2");
+                }
+            }
         });
     });
 

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -129,15 +129,45 @@ function testIntervalCollection(intervalCollection: IntervalCollection<SequenceI
     }
     assert.strictEqual(i, intervalArray.length, "Interval omitted from for...of iteration");
 
-    intervalCollection.delete(0, 0);
-    intervalCollection.delete(0, 1);
-    intervalCollection.delete(0, 2);
-    intervalCollection.delete(1, 0);
-    intervalCollection.delete(1, 1);
-    intervalCollection.delete(1, 2);
-    intervalCollection.delete(2, 0);
-    intervalCollection.delete(2, 1);
-    intervalCollection.delete(2, 2);
+    if (typeof(intervalArray[0]?.getIntervalId) === "function") {
+        let interval: SequenceInterval;
+
+        let id = intervalArray[0].getIntervalId();
+        assert.notStrictEqual(id, undefined, "Unique Id should have been assigned");
+        if (id !== undefined) {
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, intervalArray[0]);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, intervalArray[0]);
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, undefined);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, undefined);
+        }
+
+        id = intervalArray[intervalArray.length - 1].getIntervalId();
+        assert.notStrictEqual(id, undefined, "Unique Id should have been assigned");
+        if (id !== undefined) {
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, intervalArray[intervalArray.length - 1]);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, intervalArray[intervalArray.length - 1]);
+            interval = intervalCollection.getIntervalById(id);
+            assert.strictEqual(interval, undefined);
+            interval = intervalCollection.removeIntervalById(id);
+            assert.strictEqual(interval, undefined);
+        }
+    }
+
+    for (const interval of intervalArray) {
+        const id = typeof(interval.getIntervalId) === "function" ? interval.getIntervalId() : undefined;
+        if (id !== undefined) {
+            intervalCollection.removeIntervalById(id);
+        }
+        else {
+            intervalCollection.delete(interval.start.getOffset(), interval.end.getOffset());
+        }
+    }
 }
 
 describeFullCompat("SharedInterval", (getTestObjectProvider) => {


### PR DESCRIPTION
Use the interval ID as a third key for sorting. Fix an issue in serialization of add ops that was causing the original ID not to be sent over the wire.