### PR TITLE
r11s-driver: stop calling token provider on every delta retrieval

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,9 +1,14 @@
 ## 0.43 Breaking changes
 
 - [TinyliciousClient no longer static](#TinyliciousClient-no-longer-static)
+- [Routerlicious Driver DeltaStorageService constructor changed](#Routerlicious-Driver-DeltaStorageService-constructor-changed)
 
 ### TinyliciousClient no longer static
 `TinyliciousClient` global static property is removed. Instead, object instantiation is now required.
+
+### Routerlicious Driver DeltaStorageService constructor changed
+
+`DeltaStorageService` from `@fluidframework/routerlicious-driver` now takes a `RestWrapper` as the second constructor parameter, rather than a TokenProvider.
 
 ## 0.42 Breaking changes
 

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -14,9 +14,8 @@ import { readAndParse, requestOps, emptyMessageStream } from "@fluidframework/dr
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { ITokenProvider } from "./tokens";
+import { RestWrapper } from "@fluidframework/server-services-client";
 import { DocumentStorageService } from "./documentStorageService";
-import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 
 const MaxBatchDeltas = 2000; // Maximum number of ops we can fetch at a time
 
@@ -79,7 +78,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 export class DeltaStorageService implements IDeltaStorageService {
     constructor(
         private readonly url: string,
-        private readonly tokenProvider: ITokenProvider,
+        private readonly restWrapper: RestWrapper,
         private readonly logger: ITelemetryLogger) {
     }
 
@@ -90,8 +89,6 @@ export class DeltaStorageService implements IDeltaStorageService {
         to: number, // exclusive
         ): Promise<IDeltasFetchResult>
     {
-        const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
-            tenantId, id, this.tokenProvider, this.logger);
         const ops = await PerformanceEvent.timedExecAsync(
             this.logger,
             {
@@ -100,7 +97,7 @@ export class DeltaStorageService implements IDeltaStorageService {
                 to,
             },
             async (event) => {
-                const response = await ordererRestWrapper.get<ISequencedDocumentMessage[]>(
+                const response = await this.restWrapper.get<ISequencedDocumentMessage[]>(
                     this.url,
                     { from: from - 1, to });
                 event.end({

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -14,7 +14,7 @@ import { DocumentStorageService } from "./documentStorageService";
 import { R11sDocumentDeltaConnection } from "./documentDeltaConnection";
 import { NullBlobStorageService } from "./nullBlobStorageService";
 import { ITokenProvider } from "./tokens";
-import { RouterliciousStorageRestWrapper } from "./restWrapper";
+import { RouterliciousOrdererRestWrapper, RouterliciousStorageRestWrapper } from "./restWrapper";
 import { IRouterliciousDriverPolicies } from "./policies";
 
 /**
@@ -84,7 +84,9 @@ export class DocumentService implements api.IDocumentService {
     public async connectToDeltaStorage(): Promise<api.IDocumentDeltaStorageService> {
         assert(!!this.documentStorageService, 0x0b1 /* "Storage service not initialized" */);
 
-        const deltaStorage = new DeltaStorageService(this.deltaStorageUrl, this.tokenProvider, this.logger);
+        const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
+            this.tenantId, this.documentId, this.tokenProvider, this.logger);
+        const deltaStorage = new DeltaStorageService(this.deltaStorageUrl, ordererRestWrapper, this.logger);
         return new DocumentDeltaStorageService(this.tenantId, this.documentId,
             deltaStorage, this.documentStorageService);
     }


### PR DESCRIPTION
Currently, every call to DeltaStorageService.get() triggers a call to TokenProvider.fetchOrdererToken(). This is unnecessary and slow. `RouterliciousOrdererRestWrapper` handles token retrieval and refreshing, so we can initialize the rest wrapper once, then use it for as many delta retrievals as we want.