### PR TITLE
Draft for removing blob contents from ISnapshotTree.blobs

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;
@@ -281,11 +281,6 @@ export class Queue<T> implements IStream<T> {
 
 // @public
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
-
-// @public
-export function readAndParseFromBlobs<T>(blobs: {
-    [index: string]: string;
-}, id: string): T;
 
 // @public (undocumented)
 export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal): IStream<ISequencedDocumentMessage[]>;

--- a/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
+++ b/packages/loader/container-loader/src/test/snapshotConversionTest.spec.ts
@@ -51,7 +51,7 @@ describe("Dehydrate Container", () => {
                 },
             },
         };
-        const { snapshotTree } = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
+        const snapshotTree = convertProtocolAndAppSummaryToSnapshotTree(protocolSummary, appSummary);
 
         assert.strictEqual(Object.keys(snapshotTree.trees).length, 2, "2 trees should be there");
         assert.strictEqual(Object.keys(snapshotTree.trees[".protocol"].blobs).length, 4,

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -6,7 +6,13 @@
 import { parse } from "url";
 import { v4 as uuid } from "uuid";
 import { assert, bufferToString, stringToBuffer } from "@fluidframework/common-utils";
-import { ISummaryTree, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { ISnapshotTree, ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+
+// This will got in common place to loader and runtime as it used by both.
+export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
+    blobsContents: {[path: string]: ArrayBufferLike},
+    trees: {[path: string]: ISnapshotTreeWithBlobContents},
+}
 
 export interface IParsedUrl {
     id: string;
@@ -45,13 +51,12 @@ export function parseUrl(url: string): IParsedUrl | undefined {
  */
 function convertSummaryToSnapshotWithEmbeddedBlobContents(
     summary: ISummaryTree,
-    blobs: Map<string, ArrayBufferLike>,
-): ISnapshotTree {
-    const treeNode: ISnapshotTree = {
+): ISnapshotTreeWithBlobContents {
+    const treeNode: ISnapshotTreeWithBlobContents = {
         blobs: {},
         trees: {},
         commits: {},
-        id: uuid(),
+        blobsContents: {},
         unreferenced: summary.unreferenced,
     };
     const keys = Object.keys(summary.tree);
@@ -60,7 +65,7 @@ function convertSummaryToSnapshotWithEmbeddedBlobContents(
 
         switch (summaryObject.type) {
             case SummaryType.Tree: {
-                treeNode.trees[key] = convertSummaryToSnapshotWithEmbeddedBlobContents(summaryObject, blobs);
+                treeNode.trees[key] = convertSummaryToSnapshotWithEmbeddedBlobContents(summaryObject);
                 break;
             }
             case SummaryType.Blob: {
@@ -68,7 +73,9 @@ function convertSummaryToSnapshotWithEmbeddedBlobContents(
                 treeNode.blobs[key] = blobId;
                 const contentBuffer = typeof summaryObject.content === "string" ?
                     stringToBuffer(summaryObject.content, "utf8") : summaryObject.content;
-                blobs.set(blobId, contentBuffer);
+                treeNode.blobsContents[blobId] = contentBuffer;
+                // 0.42 back-compat old runtime will still expect content in the blobs only.
+                // So need to put in blobs for now.
                 treeNode.blobs[blobId] = bufferToString(contentBuffer, "base64");
                 break;
             }
@@ -91,7 +98,7 @@ function convertSummaryToSnapshotWithEmbeddedBlobContents(
 export function convertProtocolAndAppSummaryToSnapshotTree(
     protocolSummaryTree: ISummaryTree,
     appSummaryTree: ISummaryTree,
-) {
+): ISnapshotTreeWithBlobContents {
     // Shallow copy is fine, since we are doing a deep clone below.
     const combinedSummary: ISummaryTree = {
         type: SummaryType.Tree,
@@ -99,9 +106,9 @@ export function convertProtocolAndAppSummaryToSnapshotTree(
     };
 
     combinedSummary.tree[".protocol"] = protocolSummaryTree;
-    const blobs = new Map<string, ArrayBufferLike>();
-    const snapshotTree = convertSummaryToSnapshotWithEmbeddedBlobContents(combinedSummary, blobs);
-    return { snapshotTree, blobs };
+    const snapshotTreeWithBlobContents =
+        convertSummaryToSnapshotWithEmbeddedBlobContents(combinedSummary);
+    return snapshotTreeWithBlobContents;
 }
 
 // This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
@@ -111,9 +118,9 @@ export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot
     const appSummaryTree = detachedContainerSnapshot.tree[".app"] as ISummaryTree;
     assert(protocolSummaryTree !== undefined && appSummaryTree !== undefined,
         0x1e0 /* "Protocol and App summary trees should be present" */);
-    const { snapshotTree, blobs } = convertProtocolAndAppSummaryToSnapshotTree(
+    const snapshotTreeWithBlobContents = convertProtocolAndAppSummaryToSnapshotTree(
         protocolSummaryTree,
         appSummaryTree,
     );
-    return { snapshotTree, blobs };
+    return snapshotTreeWithBlobContents;
 };

--- a/packages/loader/driver-utils/src/readAndParse.ts
+++ b/packages/loader/driver-utils/src/readAndParse.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { bufferToString, fromBase64ToUtf8 } from "@fluidframework/common-utils";
+import { bufferToString } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 
 /**
@@ -16,18 +16,5 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 export async function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T> {
     const blob = await storage.readBlob(id);
     const decoded = bufferToString(blob, "utf8");
-    return JSON.parse(decoded) as T;
-}
-
-/**
- * Read a blob from map, decode it (from "base64") and JSON.parse it into object of type T
- *
- * @param blobs - the blob map to read from
- * @param id - the id of the blob to read and parse
- * @returns the object that we decoded and JSON.parse
- */
-export function readAndParseFromBlobs<T>(blobs: {[index: string]: string}, id: string): T {
-    const encoded = blobs[id];
-    const decoded = fromBase64ToUtf8(encoded);
     return JSON.parse(decoded) as T;
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -49,7 +49,6 @@ import {
 import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
 import {
     readAndParse,
-    readAndParseFromBlobs,
     BlobAggregationStorage,
 } from "@fluidframework/driver-utils";
 import { CreateContainerError } from "@fluidframework/container-utils";
@@ -594,13 +593,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const tryFetchBlob = async <T>(blobName: string): Promise<T | undefined> => {
             const blobId = context.baseSnapshot?.blobs[blobName];
             if (context.baseSnapshot && blobId) {
-                if (context.attachState === AttachState.Attached) {
-                    // IContainerContext storage api return type still has undefined in 0.39 package version.
-                    // So once we release 0.40 container-defn package we can remove this check.
-                    assert(storage !== undefined, 0x1f5 /* "Attached state should have storage" */);
-                    return readAndParse<T>(storage, blobId);
-                }
-                return readAndParseFromBlobs<T>(context.baseSnapshot.blobs, blobId);
+                assert(storage !== undefined, 0x1f5 /* "Should always have storage" */);
+                return readAndParse<T>(storage, blobId);
             }
         };
         const chunks = await tryFetchBlob<[string, string[]][]>(chunksBlobName) ?? [];

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -26,7 +26,7 @@ import {
     TypedEventEmitter,
 } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { readAndParse, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { readAndParse } from "@fluidframework/driver-utils";
 import { BlobTreeEntry } from "@fluidframework/protocol-base";
 import {
     IClientDetails,
@@ -766,14 +766,14 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
 export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
     constructor(
         id: string,
-        pkg: Readonly<string[]>,
+        pkg: Readonly<string[]> | undefined,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
         scope: IFluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         private readonly snapshotTree: ISnapshotTree | undefined,
-        protected readonly isRootDataStore: boolean,
+        protected isRootDataStore: boolean | undefined,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */
@@ -845,24 +845,35 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
     }
 
     protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
-        assert(this.pkg !== undefined, 0x152 /* "pkg should be available in local data store" */);
-        assert(this.isRootDataStore !== undefined,
-            0x153 /* "isRootDataStore should be available in local data store" */);
-
         let snapshot = this.snapshotTree;
+        let attributes;
         if (snapshot !== undefined) {
-            // Note: storage can be undefined in special case while detached.
-            const attributes = this.storage !== undefined
-                ? await readAndParse<ReadFluidDataStoreAttributes>(
-                    this.storage, snapshot.blobs[dataStoreAttributesBlobName])
-                : readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
-                    snapshot.blobs, snapshot.blobs[dataStoreAttributesBlobName]);
-
+            // Need to rip through snapshot.
+            attributes = await readAndParse<ReadFluidDataStoreAttributes>(
+                this.storage,
+                snapshot.blobs[dataStoreAttributesBlobName]);
+            // Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
+            // For snapshotFormatVersion = "0.1" (1) or above, pkg is jsonified, otherwise it is just a string.
+            // However the feature of loading a detached container from snapshot, is added when the
+            // snapshotFormatVersion is at least "0.1" (1), so we don't expect it to be anything else.
+            const formatVersion = getAttributesFormatVersion(attributes);
+            assert(formatVersion > 0,
+                0x1d5 /* `Invalid snapshot format version ${attributes.snapshotFormatVersion}` */);
             if (hasIsolatedChannels(attributes)) {
                 snapshot = snapshot.trees[channelsTreeName];
                 assert(snapshot !== undefined, "isolated channels subtree should exist in local datastore snapshot");
             }
+            if (this.pkg === undefined) {
+                this.pkg = JSON.parse(attributes.pkg) as string[];
+                // If there is no isRootDataStore in the attributes blob, set it to true. This ensures that data
+                // stores in older documents are not garbage collected incorrectly. This may lead to additional
+                // roots in the document but they won't break.
+                this.isRootDataStore = attributes.isRootDataStore ?? true;
+            }
         }
+        assert(this.pkg !== undefined, 0x152 /* "pkg should be available in local data store" */);
+        assert(this.isRootDataStore !== undefined,
+            0x153 /* "isRootDataStore should be available in local data store" */);
 
         return {
             pkg: this.pkg,
@@ -886,14 +897,14 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
     constructor(
         id: string,
-        pkg: string[],
+        pkg: string[] | undefined,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
         scope: IFluidObject & IFluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         snapshotTree: ISnapshotTree | undefined,
-        isRootDataStore: boolean,
+        isRootDataStore: boolean | undefined,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -37,7 +37,7 @@ import {
 } from "@fluidframework/runtime-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { BlobCacheStorageService, buildSnapshotTree, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { BlobCacheStorageService, buildSnapshotTree } from "@fluidframework/driver-utils";
 import { assert, Lazy } from "@fluidframework/common-utils";
 import { v4 as uuid } from "uuid";
 import { TreeTreeEntry } from "@fluidframework/protocol-base";
@@ -52,12 +52,9 @@ import {
     LocalDetachedFluidDataStoreContext,
 } from "./dataStoreContext";
 import {
-    dataStoreAttributesBlobName,
     IContainerRuntimeMetadata,
     nonDataStorePaths,
     rootHasIsolatedChannels,
-    ReadFluidDataStoreAttributes,
-    getAttributesFormatVersion,
 } from "./summaryFormat";
 
  /**
@@ -111,32 +108,16 @@ export class DataStores implements IDisposable {
                     throw new Error("Snapshot should be there to load from!!");
                 }
                 const snapshotTree = value;
-                // Need to rip through snapshot.
-                const attributes = readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
-                        snapshotTree.blobs,
-                        snapshotTree.blobs[dataStoreAttributesBlobName]);
-                // Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
-                // For snapshotFormatVersion = "0.1" (1) or above, pkg is jsonified, otherwise it is just a string.
-                // However the feature of loading a detached container from snapshot, is added when the
-                // snapshotFormatVersion is at least "0.1" (1), so we don't expect it to be anything else.
-                const formatVersion = getAttributesFormatVersion(attributes);
-                assert(formatVersion > 0,
-                    0x1d5 /* `Invalid snapshot format version ${attributes.snapshotFormatVersion}` */);
-                const pkgFromSnapshot = JSON.parse(attributes.pkg) as string[];
-
                 dataStoreContext = new LocalFluidDataStoreContext(
                     key,
-                    pkgFromSnapshot,
+                    undefined,
                     this.runtime,
                     this.runtime.storage,
                     this.runtime.scope,
                     this.getCreateChildSummarizerNodeFn(key, { type: CreateSummarizerNodeSource.FromSummary }),
                     (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
                     snapshotTree,
-                    // If there is no isRootDataStore in the attributes blob, set it to true. This ensures that data
-                    // stores in older documents are not garbage collected incorrectly. This may lead to additional
-                    // roots in the document but they won't break.
-                    attributes.isRootDataStore ?? true,
+                    undefined,
                 );
             }
             this.contexts.addBoundOrRemoted(dataStoreContext);

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -31,7 +31,7 @@ import {
     ChildLogger,
     raiseConnectedEvent,
 } from "@fluidframework/telemetry-utils";
-import { buildSnapshotTree, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { buildSnapshotTree } from "@fluidframework/driver-utils";
 import {
     IClientDetails,
     IDocumentMessage,
@@ -69,7 +69,6 @@ import {
     IFluidDataStoreRuntime,
     IFluidDataStoreRuntimeEvents,
     IChannelFactory,
-    IChannelAttributes,
 } from "@fluidframework/datastore-definitions";
 import {
     cloneGCData,
@@ -250,12 +249,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                 // container from snapshot where we load detached container from a snapshot, isLocalDataStore would be
                 // true. In this case create a LocalChannelContext.
                 if (dataStoreContext.isLocalDataStore) {
-                    const channelAttributes = readAndParseFromBlobs<IChannelAttributes>(
-                        tree.trees[path].blobs, tree.trees[path].blobs[".attributes"]);
                     channelContext = new LocalChannelContext(
                         path,
                         this.sharedObjectRegistry,
-                        channelAttributes.type,
+                        undefined,
                         this,
                         this.dataStoreContext,
                         this.dataStoreContext.storage,

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -269,23 +269,17 @@ export function convertSnapshotTreeToSummaryTree(
         0x19e /* "There should not be commit tree entries in snapshot" */);
 
     const builder = new SummaryTreeBuilder();
-    if ((snapshot as any).blobsContents !== undefined) {
-        for (const [path, id] of Object.entries(snapshot.blobs)) {
-            // 0.42 back-compat We still put contents in same blob for back-compat so need to add blob
-            // only for blobPath -> blobId mapping and not for blobId -> blob value contents.
-            if (snapshot.blobs[id] !== undefined) {
-                const decoded = bufferToString((snapshot as any).blobsContents[id], "utf8");
-                builder.addBlob(path, decoded);
+    for (const [path, id] of Object.entries(snapshot.blobs)) {
+        // 0.42 back-compat We still put contents in same blob for back-compat so need to add blob
+        // only for blobPath -> blobId mapping and not for blobId -> blob value contents.
+        if (snapshot.blobs[id] !== undefined) {
+            let decoded;
+            if ((snapshot as ISnapshotTreeWithBlobContents).blobsContents !== undefined) {
+                decoded = bufferToString((snapshot as any).blobsContents[id], "utf8");
+            } else {
+                decoded = fromBase64ToUtf8(snapshot.blobs[id]);
             }
-        }
-    } else {
-        for (const [key, value] of Object.entries(snapshot.blobs)) {
-            // The entries in blobs are supposed to be blobPath -> blobId and blobId -> blobValue
-            // and we want to push blobPath to blobValue in tree entries.
-            if (snapshot.blobs[value] !== undefined) {
-                const decoded = fromBase64ToUtf8(snapshot.blobs[value]);
-                builder.addBlob(key, decoded);
-            }
+            builder.addBlob(path, decoded);
         }
     }
 

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -15,7 +15,6 @@ import {
     ISummaryBlob,
     ISummaryHandle,
     SummaryType,
-    ISnapshotTree,
     ITree,
 } from "@fluidframework/protocol-definitions";
 import { BlobTreeEntry, TreeTreeEntry } from "@fluidframework/protocol-base";
@@ -23,6 +22,7 @@ import {
     convertSnapshotTreeToSummaryTree,
     convertSummaryTreeToITree,
     convertToSummaryTree,
+    ISnapshotTreeWithBlobContents,
     utf8ByteLength,
 } from "../summaryUtils";
 
@@ -173,24 +173,30 @@ describe("Summary Utils", () => {
     });
 
     describe("ISnapshotTree -> ISummaryTree", () => {
-        let snapshotTree: ISnapshotTree;
+        let snapshotTree: ISnapshotTreeWithBlobContents;
 
         beforeEach(() => {
             snapshotTree = {
+                blobsContents: {
+                    "blob-b": IsoBuffer.from("test-blob"),
+                },
                 blobs: {
-                    "b": "blob-b",
-                    "blob-b": IsoBuffer.from("test-blob").toString("base64"),
+                    b: "blob-b",
                 },
                 trees: {
                     t: {
+                        blobsContents: {
+                            "blob-bu8": IsoBuffer.from("test-u8"),
+                            "blob-b64": IsoBuffer.from("test-b64"),
+                        },
                         blobs: {
-                            "bu8": "blob-bu8",
-                            "blob-bu8": IsoBuffer.from("test-u8").toString("base64"),
-                            "b64": "blob-b64",
-                            "blob-b64": IsoBuffer.from("test-b64").toString("base64"),
+                            bu8: "blob-bu8",
+                            b64: "blob-b64",
                         },
                         trees: {
                             tu: {
+                                blobsContents: {
+                                },
                                 blobs: {
                                 },
                                 trees: {
@@ -204,6 +210,8 @@ describe("Summary Utils", () => {
                         },
                     },
                     unref: {
+                        blobsContents: {
+                        },
                         blobs: {
                         },
                         trees: {

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -181,7 +181,8 @@ describe("Summary Utils", () => {
                     "blob-b": IsoBuffer.from("test-blob"),
                 },
                 blobs: {
-                    b: "blob-b",
+                    "b": "blob-b",
+                    "blob-b": IsoBuffer.from("test-blob").toString("base64"),
                 },
                 trees: {
                     t: {
@@ -190,8 +191,10 @@ describe("Summary Utils", () => {
                             "blob-b64": IsoBuffer.from("test-b64"),
                         },
                         blobs: {
-                            bu8: "blob-bu8",
-                            b64: "blob-b64",
+                            "bu8": "blob-bu8",
+                            "blob-bu8": IsoBuffer.from("test-u8").toString("base64"),
+                            "b64": "blob-b64",
+                            "blob-b64": IsoBuffer.from("test-b64").toString("base64"),
                         },
                         trees: {
                             tu: {

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -141,12 +141,9 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
     const getSnapshotTreeFromSerializedSnapshot = (
         container: Container,
     ) => {
-        const { snapshotTree, blobs } =
+        const snapshotTree =
             getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
-        return {
-            snapshotTree,
-            blobs,
-        };
+        return snapshotTree;
     };
 
     beforeEach(async () => {
@@ -164,7 +161,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
         it("Dehydrated container snapshot", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();
-            const { snapshotTree, blobs } = getSnapshotTreeFromSerializedSnapshot(container);
+            const snapshotTree = getSnapshotTreeFromSerializedSnapshot(container);
 
             // Check for protocol attributes
             const protocolTree = assertProtocolTree(snapshotTree);
@@ -179,7 +176,8 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
 
             // Check blobs contents for protocolAttributes
             const protocolAttributesBlobId = snapshotTree.trees[".protocol"].blobs.attributes;
-            assert(blobs.get(protocolAttributesBlobId) !== undefined, "Blobs should contain attributes blob");
+            assert(snapshotTree.trees[".protocol"].blobsContents[protocolAttributesBlobId] !== undefined,
+                "Blobs should contain attributes blob");
             // Check for default dataStore
             const { datastoreTree: defaultDatastore } = assertDatastoreTree(snapshotTree, "default");
             const datastoreAttributes = assertBlobContents<{ pkg: string }>(defaultDatastore, ".component");
@@ -189,14 +187,12 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
         it("Dehydrated container snapshot 2 times with changes in between", async () => {
             const { container, defaultDataStore } =
                 await createDetachedContainerAndGetRootDataStore();
-            const res1 = getSnapshotTreeFromSerializedSnapshot(container);
-            const snapshotTree1 = res1.snapshotTree;
+            const snapshotTree1 = getSnapshotTreeFromSerializedSnapshot(container);
             // Create a channel
             const channel = defaultDataStore.runtime.createChannel("test1",
                 "https://graph.microsoft.com/types/map") as SharedMap;
             channel.bindToContext();
-            const res2 = getSnapshotTreeFromSerializedSnapshot(container);
-            const snapshotTree2: ISnapshotTree = res2.snapshotTree;
+            const snapshotTree2 = getSnapshotTreeFromSerializedSnapshot(container);
 
             assert.strictEqual(JSON.stringify(Object.keys(snapshotTree1.trees)),
                 JSON.stringify(Object.keys(snapshotTree2.trees)),
@@ -229,7 +225,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const rootOfDataStore1 = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
             rootOfDataStore1.set("dataStore2", dataStore2.handle);
 
-            const { snapshotTree } = getSnapshotTreeFromSerializedSnapshot(container);
+            const snapshotTree = getSnapshotTreeFromSerializedSnapshot(container);
 
             assertProtocolTree(snapshotTree);
             assertDatastoreTree(snapshotTree, "default");
@@ -600,7 +596,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             // Create another not bounded dataStore
             await createPeerDataStore(defaultDataStore.context.containerRuntime);
 
-            const { snapshotTree } = getSnapshotTreeFromSerializedSnapshot(container);
+            const snapshotTree = getSnapshotTreeFromSerializedSnapshot(container);
 
             assertProtocolTree(snapshotTree);
             assertDatastoreTree(snapshotTree, "default");


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/4746
This is just a draft and want to take some hints/suggestions on the problem as @vladsud suggested.
1.) This Pr achieves removing blobId -> blob Contents mapping from the snapshot taken in detached container
(serialize) for draft mode.
2.) Lower layers like datastores/dds can use storage to read blob contents from cached blobs.
3.) One main problem is that we do need to read blob contents synchronously while de-serializing the container. So I had to supply the blob contents but for that I added blobContents in a separate property in ISnapshotTreeWithBlobContents and read from that.