### PR TITLE
r11s: properly read riddler 401s in alfred

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -213,7 +213,11 @@ export function configureWebSocketServices(
                 await tenantManager.verifyToken(claims.tenantId, token);
             } catch (err) {
                 // eslint-disable-next-line prefer-promise-reject-errors
-                return Promise.reject({ code: err?.code ?? 403, message: err?.message ?? "Invalid token" });
+                return Promise.reject({
+                    // if we don't understand the error, be lenient and allow retry
+                    code: err?.response?.status ?? 401,
+                    message: err?.response?.data ?? "Invalid token",
+                });
             }
 
             const clientId = generateClientId();


### PR DESCRIPTION
#6390 did not actually resolve the issue, because Axios does not return the status code in `AxiosError.code`. Instead, `AxiosError.code` returns messages like "ECONNREFUSED". `AxiosError.message` also does not return useful information, and instead only returns messages like "Request failed with status code 404".

This PR swaps to the correct AxiosError properties (`AxiosError.response.status` and `AxiosError.response.data`), but it also adds a bit of leniency by defaulting to 401, which is retriable, if we are unable to accurately parse the Riddler response.