### PR TITLE
r11s-driver: expose minBlobSize config via driver policies

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -69,6 +69,7 @@ export class DocumentService implements api.IDocumentService {
             caching: this.driverPolicies.enablePrefetch
                 ? api.LoaderCachingPolicy.Prefetch
                 : api.LoaderCachingPolicy.NoCaching,
+            minBlobSize: this.driverPolicies.aggregateBlobsSmallerThanBytes,
         };
 
         this.documentStorageService = new DocumentStorageService(

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -28,6 +28,7 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
     maxConcurrentStorageRequests: 100,
     maxConcurrentOrdererRequests: 100,
+    aggregateBlobsSmallerThanBytes: 2048,
 };
 
 /**

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -28,7 +28,7 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
     maxConcurrentStorageRequests: 100,
     maxConcurrentOrdererRequests: 100,
-    aggregateBlobsSmallerThanBytes: 2048,
+    aggregateBlobsSmallerThanBytes: undefined,
 };
 
 /**

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -19,4 +19,12 @@ export interface IRouterliciousDriverPolicies {
      * Default: 100
      */
     maxConcurrentOrdererRequests: number;
+    /**
+     * Give hosts the option to change blob aggregation behavior to suit their needs.
+     * Larger number means fewer blob individual requests, but less blob-deduping.
+     * Smaller number means more blob individual requests, but more blob-deduping.
+     * Setting to `undefined` disables blob aggregration.
+     * Default: 2048
+     */
+    aggregateBlobsSmallerThanBytes: number | undefined;
 }

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -24,7 +24,7 @@ export interface IRouterliciousDriverPolicies {
      * Larger number means fewer blob individual requests, but less blob-deduping.
      * Smaller number means more blob individual requests, but more blob-deduping.
      * Setting to `undefined` disables blob aggregration.
-     * Default: 2048
+     * Default: undefined
      */
     aggregateBlobsSmallerThanBytes: number | undefined;
 }


### PR DESCRIPTION
Allow the use of blob aggregation by exposing minBlobSize via a driver policy called `aggregateBlobsSmallerThanBytes`, with the default being 2048, similar to ODSP