### PR TITLE
Remove duplicate dep and devDep in tinylicious-client

### DIFF
--- a/experimental/framework/tinylicious-client/package.json
+++ b/experimental/framework/tinylicious-client/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@fluid-example/diceroller": "^0.43.0",
-    "@fluid-experimental/fluid-framework": "^0.42.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/assert": "^1.5.2",
     "@types/mocha": "^8.2.2",


### PR DESCRIPTION
I don't think there is a reason why there needs to be two different versions required here.