### PR TITLE
Fix tsconfig exclude in frs-client and tinylicious-client

### DIFF
--- a/experimental/framework/frs-client/package.json
+++ b/experimental/framework/frs-client/package.json
@@ -42,6 +42,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
+    "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^8.2.2",
     "concurrently": "^5.2.0",

--- a/experimental/framework/frs-client/tsconfig.json
+++ b/experimental/framework/frs-client/tsconfig.json
@@ -12,7 +12,6 @@
         "src/**/*"
     ],
     "exclude": [
-        "dist",
-        "node_modules",
+        "src/test/**/*"
     ]
 }

--- a/experimental/framework/tinylicious-client/tsconfig.json
+++ b/experimental/framework/tinylicious-client/tsconfig.json
@@ -12,8 +12,6 @@
         "src/**/*"
     ],
     "exclude": [
-        "dist",
-        "node_modules",
         "src/test/**/*"
     ]
 }


### PR DESCRIPTION
The main tsconfig for a package should exclude the test source, which has it's only tsconfig and separate build step.
Also add missing dependency to build-common in frs-client.