### PR TITLE
Making property inspector app resizable using AutoSizer

### DIFF
--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -67,7 +67,8 @@
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.21",
     "react": "^16.10.2",
-    "react-dom": "^16.10.2"
+    "react-dom": "^16.10.2",
+    "react-virtualized-auto-sizer": "^1.0.2"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^3.0.0",

--- a/experimental/PropertyDDS/examples/property-inspector/src/index.html
+++ b/experimental/PropertyDDS/examples/property-inspector/src/index.html
@@ -10,6 +10,6 @@
     <title>Property Inspector</title>
 </head>
 <body>
-    <div style="height: 100%" id="root"></div>
+    <div style="height: 100vh" id="root"></div>
 </body>
 </html>

--- a/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
@@ -25,6 +25,8 @@ import { PropertyProxy } from "@fluid-experimental/property-proxy";
 
 import { FluidBinder } from "@fluid-experimental/property-binder";
 import { SharedPropertyTree } from "@fluid-experimental/property-dds";
+import AutoSizer from "react-virtualized-auto-sizer";
+
 import { theme } from "./theme";
 
 const useStyles = makeStyles({
@@ -60,6 +62,8 @@ const useStyles = makeStyles({
     },
     tableContainer: {
         display: "flex",
+        height: '100%',
+        width: '100%',
     },
 }, { name: "InspectorApp" });
 
@@ -90,9 +94,16 @@ export const InspectorApp = (props: any) => {
                 <div className={classes.root}>
                     <div className={classes.horizontalContainer}>
                         <div className={classes.tableContainer}>
-                            <InspectorTable
-                                {...tableProps}
-                                {...props} />
+                        <AutoSizer>
+                                {
+                                ({ width, height }) =>
+                                            <InspectorTable
+                                                {...tableProps}
+                                                width={width}
+                                                height={height}
+                                                {...props} />
+                                }
+                        </AutoSizer>
                         </div>
                     </div>
                 </div>

--- a/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/inspector.tsx
@@ -62,8 +62,8 @@ const useStyles = makeStyles({
     },
     tableContainer: {
         display: "flex",
-        height: '100%',
-        width: '100%',
+        height: "100%",
+        width: "100%",
     },
 }, { name: "InspectorApp" });
 


### PR DESCRIPTION
Using **[AutoSizer]( (https://github.com/bvaughn/react-virtualized/blob/master/docs/usingAutoSizer.md))**  to adapt to window size when resizing the window instead of defining fixed **width** & **height**.