### PR TITLE
Decouple reconnect/delay errors from ICriticalContainerError

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -6,7 +6,6 @@
 - [Property removed from the Container class](#Property-removed-from-the-Container-class)
 - [Creating new containers with Container.load has been deprecated](#Creating-new-containers-with-Containerload-has-been-deprecated)
 - [Changes to client-api](#changes-to-client-api)
-- [DeltaManager.emitDelayInfo signature change](#DeltaManager.emitDelayInfo-signature-change)
 
 ### TinyliciousClient no longer static
 `TinyliciousClient` global static property is removed. Instead, object instantiation is now required.
@@ -28,9 +27,6 @@ See [AgentScheduler-related deprecations](#AgentScheduler-related-deprecations) 
 
 ### Changes to client-api
 - The `load` function from `document.ts` will fail the container does not exist. Going forward, please use the `create` function to handle this scenario.
-
-### DeltaManager.emitDelayInfo signature change
-The `error` parameter is now of type `any`, whereas it was previously constrained to be `ICriticalContainerError`.
 
 ## 0.42 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -6,6 +6,7 @@
 - [Property removed from the Container class](#Property-removed-from-the-Container-class)
 - [Creating new containers with Container.load has been deprecated](#Creating-new-containers-with-Containerload-has-been-deprecated)
 - [Changes to client-api](#changes-to-client-api)
+- [DeltaManager.emitDelayInfo signature change](#DeltaManager.emitDelayInfo-signature-change)
 
 ### TinyliciousClient no longer static
 `TinyliciousClient` global static property is removed. Instead, object instantiation is now required.
@@ -27,6 +28,9 @@ See [AgentScheduler-related deprecations](#AgentScheduler-related-deprecations) 
 
 ### Changes to client-api
 - The `load` function from `document.ts` will fail the container does not exist. Going forward, please use the `create` function to handle this scenario.
+
+### DeltaManager.emitDelayInfo signature change
+The `error` parameter is now of type `any`, whereas it was previously constrained to be `ICriticalContainerError`.
 
 ## 0.42 Breaking changes
 

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -183,7 +183,7 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     // (undocumented)
     get disposed(): boolean;
     // (undocumented)
-    emitDelayInfo(id: string, delayMs: number, error: ICriticalContainerError): void;
+    emitDelayInfo(id: string, delayMs: number, error: any): void;
     // (undocumented)
     flush(): void;
     forceReadonly(readonly: boolean): void;

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -182,8 +182,7 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     dispose(): void;
     // (undocumented)
     get disposed(): boolean;
-    // (undocumented)
-    emitDelayInfo(id: string, delayMs: number, error: any): void;
+    emitDelayInfo(id: string, delayMs: number, error: unknown): void;
     // (undocumented)
     flush(): void;
     forceReadonly(readonly: boolean): void;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -831,7 +831,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     "containerAttach",
                     (id: string) => this._deltaManager.refreshDelayInfo(id),
                     (id: string, delayMs: number, error: any) =>
-                        this._deltaManager.emitDelayInfo(id, delayMs, CreateContainerError(error)),
+                        this._deltaManager.emitDelayInfo(id, delayMs, error),
                     this.logger,
                 );
             }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -917,9 +917,9 @@ export class DeltaManager
      * Emit info about a delay in service communication on account of throttling.
      * @param id - Id of the connection that is delayed
      * @param delayMs - Duration of the delay
-     * @param error - error objecct indicating the throttled
+     * @param error - error objecct indicating the throttling
      */
-    public emitDelayInfo(id: string, delayMs: number, error: any) {
+    public emitDelayInfo(id: string, delayMs: number, error: unknown) {
         const timeNow = Date.now();
         this.throttlingIdSet.add(id);
         if (delayMs > 0 && (timeNow + delayMs > this.timeTillThrottling)) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -913,11 +913,13 @@ export class DeltaManager
         }
     }
 
-    public emitDelayInfo(
-        id: string,
-        delayMs: number,
-        error: any,
-    ) {
+    /**
+     * Emit info about a delay in service communication on account of throttling.
+     * @param id - Id of the connection that is delayed
+     * @param delayMs - Duration of the delay
+     * @param error - error objecct indicating the throttled
+     */
+    public emitDelayInfo(id: string, delayMs: number, error: any) {
         const timeNow = Date.now();
         this.throttlingIdSet.add(id);
         if (delayMs > 0 && (timeNow + delayMs > this.timeTillThrottling)) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1165,11 +1165,12 @@ export class DeltaManager
         this.disconnectFromDeltaStream(error.message);
 
         // If reconnection is not an option, close the DeltaManager
-        if (this.reconnectMode === ReconnectMode.Never || !error.canRetry) {
+        const canRetry = canRetryOnError(error);
+        if (this.reconnectMode === ReconnectMode.Never || !canRetry) {
             // Do not raise container error if we are closing just because we lost connection.
             // Those errors (like IdleDisconnect) would show up in telemetry dashboards and
             // are very misleading, as first initial reaction - some logic is broken.
-            this.close(error.canRetry ? undefined : error);
+            this.close(canRetry ? undefined : error);
         }
 
         // If closed then we can't reconnect

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -58,6 +58,7 @@ import {
     CreateContainerError,
     CreateProcessingError,
     DataCorruptionError,
+    wrapError,
 } from "@fluidframework/container-utils";
 import { DeltaQueue } from "./deltaQueue";
 
@@ -72,12 +73,11 @@ function getNackReconnectInfo(nackContent: INackContent) {
     return createGenericNetworkError(reason, canRetry, retryAfterMs, { statusCode: nackContent.code });
 }
 
-function createReconnectError(prefix: string, err: any) {
-    // use CreateContainerError to get a safe message, but we will ignore errorType if found on err
-    const errorMessage = CreateContainerError(err).message;
-    const error = createGenericNetworkError(`${prefix}: ${errorMessage}`, true);
-    return error;
-}
+const createReconnectError = (prefix: string, err: any) =>
+    wrapError(
+        err,
+        (errorMessage: string) => createGenericNetworkError(`${prefix}: ${errorMessage}`, true /* canRetry */),
+    );
 
 export interface IConnectionArgs {
     mode?: ConnectionMode;

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -107,7 +107,7 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
             callName,
             (id: string) => this.deltaManager.refreshDelayInfo(id),
             (id: string, delayMs: number, error: any) =>
-                this.deltaManager.emitDelayInfo(id, delayMs, CreateContainerError(error)),
+                this.deltaManager.emitDelayInfo(id, delayMs, error),
             this.logger,
             () => this.checkStorageDisposed(),
         );

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -194,7 +194,6 @@ export function throwOdspNetworkError(
         response,
         responseText);
 
-    // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw networkError;
 }
 


### PR DESCRIPTION
* `emitDelayInfo` already wraps via `ThrottingWarning.wrap`, so that can take `any`
* `createReconnectError` was just using `CreateContainerError` to safely parse `message` and `stack` (I checked telemetry that there are no different `errorType`s coming through here that would have runtime impact, since `errorType` will now be one of the driver error types). Better to use `wrapError`.
* `reconnectOnError` typing was relying on incidental overlap between `IDriverErrorBase` and `ErrorBase`.  Now its typing is more correct (IMO).