### PR TITLE
Real Svc Test Pipeline: Split Stress and E2E

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -1,0 +1,49 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# test-real-service-stress pipeline
+
+name: $(Build.BuildId)
+
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+  - pipeline: client   # Name of the pipeline resource
+    source: Build - client packages
+    trigger:
+      branches:
+      - releases/*
+      - main
+
+variables:
+- group: prague-key-vault
+- name: testWorkspace
+  value: $(Pipeline.Workspace)/test
+
+stages:
+    # Run Stress Tests
+  - stage:
+    displayName:  Stress tests
+    dependsOn: []
+    jobs:
+    - template: templates/include-test-real-service.yml
+      parameters:
+        poolBuild: Main
+        testPackage: "@fluid-internal/test-service-load"
+        testWorkspace: ${{ variables.testWorkspace }}
+        testSteps:
+        - task: Npm@1
+          displayName: '[stress tests] npm run start'
+          continueOnError: true
+          timeoutInMinutes: 60
+          env:
+            login__microsoft__clientId: $(login-microsoft-clientId)
+            login__microsoft__secret: $(login-microsoft-secret)
+            login__odsp__test__accounts: $(automation-stress-login-odsp-test-accounts)
+            FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+          inputs:
+            command: 'custom'
+            workingDir: ${{ variables.testWorkspace }}/node_modules/@fluid-internal/test-service-load
+            customCommand: 'run start'

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -36,7 +36,6 @@ stages:
         testSteps:
         - task: Npm@1
           displayName: '[stress tests] npm run start'
-          continueOnError: true
           timeoutInMinutes: 60
           env:
             login__microsoft__clientId: $(login-microsoft-clientId)

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-# test-real-service pipeline
+# test-real-service-e2e pipeline
 
 name: $(Build.BuildId)
 
@@ -65,34 +65,9 @@ stages:
           env:
             login__microsoft__clientId: $(login-microsoft-clientId)
             login__microsoft__secret: $(login-microsoft-secret)
-            login__odsp__test__accounts: $(login-odsp-test-accounts)
+            login__odsp__test__accounts: $(automation-e2e-login-odsp-test-accounts)
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           inputs:
             command: 'custom'
             workingDir: ${{ variables.testWorkspace }}/node_modules/@fluidframework/test-end-to-end-tests
             customCommand: 'run test:realsvc:odsp:report'
-
-    # Run Stress Tests
-  - stage:
-    displayName:  Stress tests
-    dependsOn: []
-    jobs:
-    - template: templates/include-test-real-service.yml
-      parameters:
-        poolBuild: Main
-        testPackage: "@fluid-internal/test-service-load"
-        testWorkspace: ${{ variables.testWorkspace }}
-        testSteps:
-        - task: Npm@1
-          displayName: '[stress tests] npm run start'
-          continueOnError: true
-          timeoutInMinutes: 60
-          env:
-            login__microsoft__clientId: $(login-microsoft-clientId)
-            login__microsoft__secret: $(login-microsoft-secret)
-            login__odsp__test__accounts: $(login-odsp-test-accounts)
-            FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-          inputs:
-            command: 'custom'
-            workingDir: ${{ variables.testWorkspace }}/node_modules/@fluid-internal/test-service-load
-            customCommand: 'run start'


### PR DESCRIPTION
Split the real service test stress and e2e pipeline, and use unique secrets for each. This allows them to run in parallel, and more easily track the health of each test type.