### PR TITLE
Deprecate IErrorBase.sequenceNumber

### DIFF
--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -1,8 +1,14 @@
 ## 0.21 Breaking changes
 
 - [supportsTags deprecated](#supportstags-deprecated)
+- [IErrorBase.sequenceNumber deprecated](#IErrorBase.sequenceNumber-deprecated)
 
 ### supportsTags deprecated
 We are deprecating use of supportsTags and instead going to handle tags directly at the loader/runtime boundary
-via `IContainerContext`. Other than this boundary, all loggers can assume full support for tags on all telemetry events. 
+via `IContainerContext`. Other than this boundary, all loggers can assume full support for tags on all telemetry events.
 This will involve a change in `container-definitions`, which is packaged as part of the `build-common` release.
+
+### IErrorBase.sequenceNumber deprecated
+This field was used for logging and this was probably not the right abstraction for it to live in.
+But practically speaking, the only places it was set have been updated to log not just sequenceNumber
+but a large number of useful properties off the offending message, via `CreateProcessingError`.

--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -1,14 +1,8 @@
 ## 0.21 Breaking changes
 
-- [supportsTags deprecated](#supportstags-deprecated)
-- [IErrorBase.sequenceNumber deprecated](#IErrorBase.sequenceNumber-deprecated)
+- [ITelemetryBaseLogger.supportsTags deprecated](#ITelemetryBaseLogger.supportstags-deprecated)
 
-### supportsTags deprecated
+### ITelemetryBaseLogger.supportsTags deprecated
 We are deprecating use of supportsTags and instead going to handle tags directly at the loader/runtime boundary
 via `IContainerContext`. Other than this boundary, all loggers can assume full support for tags on all telemetry events.
 This will involve a change in `container-definitions`, which is packaged as part of the `build-common` release.
-
-### IErrorBase.sequenceNumber deprecated
-This field was used for logging and this was probably not the right abstraction for it to live in.
-But practically speaking, the only places it was set have been updated to log not just sequenceNumber
-but a large number of useful properties off the offending message, via `CreateProcessingError`.

--- a/common/lib/container-definitions/BREAKING.md
+++ b/common/lib/container-definitions/BREAKING.md
@@ -1,8 +1,8 @@
 ## 0.40 Breaking changes
 
-- [IErrorBase.sequenceNumber deprecated](#IErrorBase.sequenceNumber-deprecated)
+- [IErrorBase.sequenceNumber removed](#IErrorBase.sequenceNumber-removed)
 
-### IErrorBase.sequenceNumber deprecated
+### IErrorBase.sequenceNumber removed
 This field was used for logging and this was probably not the right abstraction for it to live in.
 But practically speaking, the only places it was set have been updated to log not just sequenceNumber
 but a large number of useful properties off the offending message, via `CreateProcessingError`.

--- a/common/lib/container-definitions/BREAKING.md
+++ b/common/lib/container-definitions/BREAKING.md
@@ -1,0 +1,8 @@
+## 0.40 Breaking changes
+
+- [IErrorBase.sequenceNumber deprecated](#IErrorBase.sequenceNumber-deprecated)
+
+### IErrorBase.sequenceNumber deprecated
+This field was used for logging and this was probably not the right abstraction for it to live in.
+But practically speaking, the only places it was set have been updated to log not just sequenceNumber
+but a large number of useful properties off the offending message, via `CreateProcessingError`.

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -299,6 +299,7 @@ export interface IErrorBase {
     readonly errorType: string;
     // (undocumented)
     readonly message: string;
+    // @deprecated
     sequenceNumber?: number;
 }
 

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -299,8 +299,6 @@ export interface IErrorBase {
     readonly errorType: string;
     // (undocumented)
     readonly message: string;
-    // @deprecated
-    sequenceNumber?: number;
 }
 
 // @public

--- a/common/lib/container-definitions/src/error.ts
+++ b/common/lib/container-definitions/src/error.ts
@@ -39,7 +39,10 @@ export interface IErrorBase {
      */
     readonly errorType: string;
     readonly message: string;
-    /** Sequence number when error happened */
+    /**
+     * Sequence number when error happened
+     * @deprecated - Was used for logging and is no longer needed due to DataProcessingError/DataCorruptionError
+     * */
     sequenceNumber?: number;
 }
 

--- a/common/lib/container-definitions/src/error.ts
+++ b/common/lib/container-definitions/src/error.ts
@@ -39,11 +39,6 @@ export interface IErrorBase {
      */
     readonly errorType: string;
     readonly message: string;
-    /**
-     * Sequence number when error happened
-     * @deprecated - Was used for logging and is no longer needed due to DataProcessingError/DataCorruptionError
-     * */
-    sequenceNumber?: number;
 }
 
 /**

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -733,14 +733,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         this.service?.dispose(error);
 
         if (error !== undefined) {
-            // Log current sequence number - useful if we have access to a file to understand better
-            // what op caused trouble (if it's related to op processing).
-            // Runtime may provide sequence number as part of error object - this may not match DeltaManager
-            // knowledge as old ops are processed when data stores / DDS are re-hydrated when delay-loaded
             this.logger.sendErrorEvent(
                 {
                     eventName: "ContainerClose",
-                    sequenceNumber: error.sequenceNumber ?? this._deltaManager.lastSequenceNumber,
+                    lastSequenceNumber: this._deltaManager.lastSequenceNumber,
                 },
                 error,
             );

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -165,15 +165,7 @@ export class LocalChannelContext implements IChannelContext {
 
         // Send all pending messages to the channel
         for (const message of this.pending) {
-            try {
-                this.services.value.deltaConnection.process(message, false, undefined /* localOpMetadata */);
-            } catch (err) {
-                // record sequence number for easier debugging
-                const error = CreateContainerError(err);
-                error.sequenceNumber = message.sequenceNumber;
-                // eslint-disable-next-line @typescript-eslint/no-throw-literal
-                throw error;
-            }
+            this.services.value.deltaConnection.process(message, false, undefined /* localOpMetadata */);
         }
         return this.channel;
     }

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -19,7 +19,7 @@ import {
     IGarbageCollectionData,
 } from "@fluidframework/runtime-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
-import { CreateContainerError, CreateProcessingError } from "@fluidframework/container-utils";
+import { CreateProcessingError } from "@fluidframework/container-utils";
 import { assert, Lazy, stringToBuffer } from "@fluidframework/common-utils";
 import {
     createServiceEndpoints,

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { CreateContainerError, DataCorruptionError } from "@fluidframework/container-utils";
+import { DataCorruptionError } from "@fluidframework/container-utils";
 import {
     IChannel,
     IChannelAttributes,

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -204,15 +204,7 @@ export class RemoteChannelContext implements IChannelContext {
         // Send all pending messages to the channel
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         for (const message of this.pending!) {
-            try {
-                this.services.deltaConnection.process(message, false, undefined /* localOpMetadata */);
-            } catch (err) {
-                // record sequence number for easier debugging
-                const error = CreateContainerError(err);
-                error.sequenceNumber = message.sequenceNumber;
-                // eslint-disable-next-line @typescript-eslint/no-throw-literal
-                throw error;
-            }
+            this.services.deltaConnection.process(message, false, undefined /* localOpMetadata */);
         }
 
         // Commit changes.


### PR DESCRIPTION
This field was used for logging and this was probably not the right abstraction for it to live in.

We can stop using it because the only places it was set have been updated to log not just sequenceNumber
but a large number of useful properties off the offending message, via `CreateProcessingError`.

Note that `ContainerClose` event will now have a field `lastSequenceNumber` which will be from `DeltaManager`, and in cases where an op processing error occurred, `messageSequenceNumber` will have the same value `sequenceNumber` used to.  See [here](https://github.com/microsoft/FluidFramework/blob/c32fff7c6214a8562bb6cf416eed94a6eb502a4f/packages/loader/container-utils/src/error.ts#L151) for the full list of op properties logged.