### PR TITLE
[main > 0.42]: Put redeem fallback behind a feature flag (#6650)

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -16,6 +16,8 @@ export interface HostStoragePolicy {
     concurrentOpsBatches?: number;
     concurrentSnapshotFetch?: boolean;
     // (undocumented)
+    enableRedeemFallback?: boolean;
+    // (undocumented)
     opsBatchSize?: number;
     opsCaching?: IOpsCachingPolicy;
     sessionOptions?: ICollabSessionOptions;

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -129,7 +129,7 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
 }
 
 // @public
-export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined): Promise<boolean>;
+export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean): Promise<boolean>;
 
 // @public
 export interface ShareLinkFetcherProps {

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -85,4 +85,8 @@ export interface HostStoragePolicy {
      * Policy controlling how collaboration session is established
      */
     sessionOptions?: ICollabSessionOptions;
+
+    // True to have the sharing link redeem fallback in case the Trees Latest/Redeem 1RT call fails with redeem error.
+    // During fallback it will first redeem the sharing link and then make the Trees latest call.
+    enableRedeemFallback?: boolean;
 }

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -74,6 +74,7 @@ export async function fetchSnapshotWithRedeem(
     snapshotDownloader: (url: string, fetchOptions: {[index: string]: any}) => Promise<IOdspResponse<IOdspSnapshot>>,
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
     removeEntries: () => Promise<void>,
+    enableRedeemFallback?: boolean,
 ): Promise<ISnapshotCacheValue> {
     return fetchLatestSnapshotCore(
         odspResolvedUrl,
@@ -83,7 +84,7 @@ export async function fetchSnapshotWithRedeem(
         snapshotDownloader,
         putInCache,
     ).catch(async (error) => {
-        if (isRedeemSharingLinkError(odspResolvedUrl, error)) {
+        if (enableRedeemFallback && isRedeemSharingLinkError(odspResolvedUrl, error)) {
             // Execute the redeem fallback
             logger.sendErrorEvent({
                 eventName: "RedeemFallback",

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -613,7 +613,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 this.logger,
                 snapshotDownloader,
                 putInCache,
-                removeEntries);
+                removeEntries,
+                this.hostPolicy.enableRedeemFallback);
             return odspSnapshot;
         } catch (error) {
             const errorType = error.errorType;
@@ -635,7 +636,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     this.logger,
                     snapshotDownloader,
                     putInCache,
-                    removeEntries);
+                    removeEntries,
+                    this.hostPolicy.enableRedeemFallback);
                 return odspSnapshot;
             }
             throw error;

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -32,6 +32,9 @@ import { IOdspSnapshot, IVersionedValueWithEpoch } from "./contracts";
  * @param persistedCache - Cache to store the fetched snapshot.
  * @param logger - Logger to have telemetry events.
  * @param hostSnapshotFetchOptions - Options to fetch the snapshot if any. Otherwise default will be used.
+ * @param enableRedeemFallback - True to have the sharing link redeem fallback in case the Trees Latest/Redeem
+ *  1RT call fails with redeem error. During fallback it will first redeem the sharing link and then make
+ *  the Trees latest call.
  * @returns - True if the snapshot is cached, false otherwise.
  */
 export async function prefetchLatestSnapshot(
@@ -40,6 +43,7 @@ export async function prefetchLatestSnapshot(
     persistedCache: IPersistedCache,
     logger: ITelemetryBaseLogger,
     hostSnapshotFetchOptions: ISnapshotOptions | undefined,
+    enableRedeemFallback?: boolean,
 ): Promise<boolean> {
     const odspLogger = createOdspLogger(ChildLogger.create(logger, "PrefetchSnapshot"));
     const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
@@ -79,6 +83,7 @@ export async function prefetchLatestSnapshot(
                     snapshotDownloader,
                     putInCache,
                     removeEntries,
+                    enableRedeemFallback,
                 );
             assert(cacheP !== undefined, 0x1e7 /* "caching was not performed!" */);
             await cacheP;

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -59,6 +59,7 @@ export const generateOdspHostStoragePolicy = (seed: number)=> {
         snapshotOptions:[undefined, ...generatePairwiseOptions(odspSnapshotOptions, seed)],
         opsCaching: [undefined, ...generatePairwiseOptions(odspOpsCaching, seed)],
         sessionOptions: [undefined, ...generatePairwiseOptions(odspSessionOptions, seed)],
+        enableRedeemFallback: booleanCases,
     };
     return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };


### PR DESCRIPTION
We are facing some issues in single redeem call also. While we wait to get to the root cause at server side we need to put it behind a feature flag.