### PR TITLE
driver-definitions change to allow createContainer() with undefined summary

### DIFF
--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -292,9 +292,9 @@ export interface IDocumentServiceFactory {
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
 
     /**
-     * Creates a new document on the host with the provided options. Returns the document service.
+     * Creates a new document with the provided options. Returns the document service.
      * @param createNewSummary - Summary used to create file. If undefined, an empty file will be created and a summary
-     * should be posted before transitioning the container to "Attached" state.
+     * should be posted later, before connecting to ordering service.
      */
     createContainer(
         createNewSummary: ISummaryTree | undefined,

--- a/packages/loader/driver-definitions/src/storage.ts
+++ b/packages/loader/driver-definitions/src/storage.ts
@@ -291,9 +291,13 @@ export interface IDocumentServiceFactory {
      */
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
 
-    // Creates a new document on the host with the provided options. Returns the document service.
+    /**
+     * Creates a new document on the host with the provided options. Returns the document service.
+     * @param createNewSummary - Summary used to create file. If undefined, an empty file will be created and a summary
+     * should be posted before transitioning the container to "Attached" state.
+     */
     createContainer(
-        createNewSummary: ISummaryTree,
+        createNewSummary: ISummaryTree | undefined,
         createNewResolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService>;


### PR DESCRIPTION
required for #6630
Change `createContainer()` definition to allow passing undefined for `createNewSummary` to create an empty file. Used in `Container.attach()` when attachment blobs have been uploaded to a detached container (an empty file is created, then the blobs are uploaded before the summary is posted).