### PR TITLE
Event improvements and refactoring for ServiceAudience

### DIFF
--- a/examples/data-objects/focus-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/focus-tracker/src/FocusTracker.ts
@@ -62,10 +62,14 @@ export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents>
         this._audience.on("addMember", (clientId: string, member: IMember) => {
             this.emit("focusChanged");
         });
-        this._audience.on("removeMember", (clientId: string, member?: IMember) => {
-            this.focusMap.forEach((clientIdMap, userId) => {
+        this._audience.on("removeMember", (clientId: string, member: IMember) => {
+            const clientIdMap = this.focusMap.get(member.userId);
+            if (clientIdMap !== undefined) {
                 clientIdMap.delete(clientId);
-            });
+                if (clientIdMap.size === 0) {
+                    this.focusMap.delete(member.userId);
+                }
+            }
             this.emit("focusChanged");
         });
     }

--- a/examples/data-objects/focus-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/focus-tracker/src/FocusTracker.ts
@@ -59,10 +59,10 @@ export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents>
         }
         this._audience = newAudience;
 
-        this._audience.on("addMember", (clientId: string, member: IMember) => {
+        this._audience.on("memberAdded", (clientId: string, member: IMember) => {
             this.emit("focusChanged");
         });
-        this._audience.on("removeMember", (clientId: string, member: IMember) => {
+        this._audience.on("memberRemoved", (clientId: string, member: IMember) => {
             const clientIdMap = this.focusMap.get(member.userId);
             if (clientIdMap !== undefined) {
                 clientIdMap.delete(clientId);

--- a/experimental/framework/fluid-static/src/serviceAudience.ts
+++ b/experimental/framework/fluid-static/src/serviceAudience.ts
@@ -43,14 +43,14 @@ export abstract class ServiceAudience<M extends IMember = IMember>
     this.audience.on("addMember", (clientId: string, details: IClient) => {
       if (this.shouldIncludeAsMember(details)) {
         const member = this.getMember(clientId);
-        this.emit("addMember", clientId, member);
+        this.emit("memberAdded", clientId, member);
         this.emit("membersChanged");
       }
     });
 
     this.audience.on("removeMember", (clientId: string) => {
       if (this.lastMembers.has(clientId)) {
-        this.emit("removeMember", clientId, this.lastMembers.get(clientId));
+        this.emit("memberRemoved", clientId, this.lastMembers.get(clientId));
         this.emit("membersChanged");
       }
     });

--- a/experimental/framework/fluid-static/src/types.ts
+++ b/experimental/framework/fluid-static/src/types.ts
@@ -74,12 +74,13 @@ export interface ContainerSchema {
 }
 
 /**
- * Events that trigger when the roster of members in the Fluid session change
+ * Events that trigger when the roster of members in the Fluid session change.
+ * Only changes that would be reflected in the returned map of IServiceAudience's getMembers method
+ * will emit events.
  */
 export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
     (event: "membersChanged", listener: () => void): void;
-    (event: "addMember", listener: (clientId: string, member: M) => void): void;
-    (event: "removeMember", listener: (clientId: string, member?: M) => void): void;
+    (event: "addMember" | "removeMember", listener: (clientId: string, member: M) => void): void;
 }
 
 /**
@@ -90,7 +91,7 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
 export interface IServiceAudience<M extends IMember> extends IEventProvider<IServiceAudienceEvents<M>> {
     /**
      * Returns an map of all users currently in the Fluid session where key is the userId and the value is the
-     * member object
+     * member object.  The implementation may choose to exclude certain connections from the returned map.
      */
     getMembers(): Map<string, M>;
 

--- a/experimental/framework/fluid-static/src/types.ts
+++ b/experimental/framework/fluid-static/src/types.ts
@@ -80,7 +80,7 @@ export interface ContainerSchema {
  */
 export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
     (event: "membersChanged", listener: () => void): void;
-    (event: "addMember" | "removeMember", listener: (clientId: string, member: M) => void): void;
+    (event: "memberAdded" | "memberRemoved", listener: (clientId: string, member: M) => void): void;
 }
 
 /**
@@ -92,6 +92,7 @@ export interface IServiceAudience<M extends IMember> extends IEventProvider<ISer
     /**
      * Returns an map of all users currently in the Fluid session where key is the userId and the value is the
      * member object.  The implementation may choose to exclude certain connections from the returned map.
+     * E.g. ServiceAudience excludes non-interactive connections to represent only the roster of live users.
      */
     getMembers(): Map<string, M>;
 

--- a/experimental/framework/fluid-static/src/types.ts
+++ b/experimental/framework/fluid-static/src/types.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { IChannelFactory } from "@fluidframework/datastore-definitions";
-import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { IFluidLoadable } from "@fluidframework/core-interfaces";
+import { IChannelFactory } from "@fluidframework/datastore-definitions";
+import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
@@ -74,10 +74,12 @@ export interface ContainerSchema {
 }
 
 /**
- * Event that triggers when the roster of members in the Fluid session change
+ * Events that trigger when the roster of members in the Fluid session change
  */
 export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
-    (event: "membersChanged", listener: (members: Map<string, M>) => void): void;
+    (event: "membersChanged", listener: () => void): void;
+    (event: "addMember", listener: (clientId: string, member: M) => void): void;
+    (event: "removeMember", listener: (clientId: string, member?: M) => void): void;
 }
 
 /**
@@ -96,12 +98,6 @@ export interface IServiceAudience<M extends IMember> extends IEventProvider<ISer
      * Returns the current active user on this client once they are connected. Otherwise, returns undefined.
      */
     getMyself(): M | undefined;
-
-    /**
-     * Gets the member matching the clientId if it is present
-     * @param clientId The clientId to match to a member
-     */
-    getMemberByClientId(clientId: string): M | undefined;
 }
 
 /**

--- a/experimental/framework/frs-client/src/FrsAudience.ts
+++ b/experimental/framework/frs-client/src/FrsAudience.ts
@@ -7,45 +7,12 @@ import { ServiceAudience } from "@fluid-experimental/fluid-framework";
 import { IClient } from "@fluidframework/protocol-definitions";
 import { IFrsAudience, FrsMember } from "./interfaces";
 
-export class FrsAudience extends ServiceAudience implements IFrsAudience {
-  /**
-   * @inheritdoc
-   */
-  public getMembers(): Map<string, FrsMember> {
-    const users = new Map<string, FrsMember>();
-    // Iterate through the members and get the user specifics.
-    this.audience.getMembers().forEach((member: IClient, clientId: string) => {
-      // Get all the current human members
-      if (member.details.capabilities.interactive) {
-        const userId = member.user.id;
-        // Ensure we're tracking the user
-        let user = users.get(userId);
-        if (user === undefined) {
-            user = {
-              userId,
-              userName: (member.user as any).name,
-              connections: [],
-            };
-            users.set(userId, user);
-        }
-        // Add this connection to their collection
-        user.connections.push({ id: clientId, mode: member.mode });
-      }
-    });
-    return users;
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public getMyself(): FrsMember | undefined {
-    return super.getMyself() as FrsMember;
-  }
-
-  /**
-   * @inheritdoc
-   */
-   public getMemberByClientId(clientId: string): FrsMember | undefined {
-    return super.getMemberByClientId(clientId) as FrsMember;
+export class FrsAudience extends ServiceAudience<FrsMember> implements IFrsAudience {
+  protected createServiceMember(audienceMember: IClient): FrsMember {
+    return {
+      userId: audienceMember.user.id,
+      userName: (audienceMember.user as any).name,
+      connections: [],
+    };
   }
 }

--- a/experimental/framework/tinylicious-client/src/TinyliciousAudience.ts
+++ b/experimental/framework/tinylicious-client/src/TinyliciousAudience.ts
@@ -7,45 +7,12 @@ import { ServiceAudience } from "@fluid-experimental/fluid-framework";
 import { IClient } from "@fluidframework/protocol-definitions";
 import { ITinyliciousAudience, TinyliciousMember } from "./interfaces";
 
-export class TinyliciousAudience extends ServiceAudience implements ITinyliciousAudience {
-  /**
-   * @inheritdoc
-   */
-  public getMembers(): Map<string, TinyliciousMember> {
-    const users = new Map<string, TinyliciousMember>();
-    // Iterate through the members and get the user specifics.
-    this.audience.getMembers().forEach((member: IClient, clientId: string) => {
-      // Get all the current human members
-      if (member.details.capabilities.interactive) {
-        const userId = member.user.id;
-        // Ensure we're tracking the user
-        let user = users.get(userId);
-        if (user === undefined) {
-            user = {
-              userId,
-              userName: (member.user as any).name,
-              connections: [],
-            };
-            users.set(userId, user);
-        }
-        // Add this connection to their collection
-        user.connections.push({ id: clientId, mode: member.mode });
-      }
-    });
-    return users;
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public getMyself(): TinyliciousMember | undefined {
-    return super.getMyself() as TinyliciousMember;
-  }
-
-  /**
-   * @inheritdoc
-   */
-   public getMemberByClientId(clientId: string): TinyliciousMember | undefined {
-    return super.getMemberByClientId(clientId) as TinyliciousMember;
+export class TinyliciousAudience extends ServiceAudience<TinyliciousMember> implements ITinyliciousAudience {
+  protected createServiceMember(audienceMember: IClient): TinyliciousMember {
+    return {
+      userId: audienceMember.user.id,
+      userName: (audienceMember.user as any).name,
+      connections: [],
+    };
   }
 }


### PR DESCRIPTION
Some QoL changes to ServiceAudience events to make them easier to work with.
- Split the `membersChanged` event back into `memberAdded` and `memberRemoved` and provide both the `clientId` and `IMember` object for the affected member in the event.  For consumers who track data about audience members in the `user -> connections -> data` format (which is the same way ServiceAudience formats its member information), this makes it easier to make incremental changes to that data instead of needing to compare all ServiceAudience members with all user-known members to determine the affected member as was needed before.
- Change event behavior to only emit for member changes that are reflected in the member list provided by the ServiceAudience.  This means a summarizer client leaving `IAudience` doesn't trigger ServiceAudience events because there is no externally visible change to ServiceAudience members.
- Do some generics stuff on ServiceAudience and make it abstract so child classes duplicate less code
- Update FocusTracker example to reflect changes to ServiceAudience