### PR TITLE
Add instanceOf functions to common-utils

### DIFF
--- a/common/lib/common-utils/src/buffer.ts
+++ b/common/lib/common-utils/src/buffer.ts
@@ -1,0 +1,13 @@
+import { bindInstanceOfBuiltin } from "./instanceOf";
+
+/**
+ * Determines if an object is an array buffer
+ * Will detect and reject TypedArrays, like Uint8Array.
+ * Reason - they can be viewport into Array, they can be accepted, but caller has to deal with
+ * math properly (i.e. take into account byteOffset at minimum).
+ * For example, construction of new TypedArray can be in the form of new TypedArray(typedArray) or
+ * new TypedArray(buffer, byteOffset, length), but passing TypedArray will result in fist path (and
+ * ignoring byteOffice, length)
+ * @param obj - The object to determine if it is an ArrayBuffer
+ */
+export const isArrayBuffer: (obj: any) => obj is ArrayBuffer = bindInstanceOfBuiltin(new ArrayBuffer(0));

--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -4,6 +4,7 @@
  */
 
 import * as base64js from "base64-js";
+import { instanceOf } from "./instanceOf";
 import { assert } from "./assert";
 
 /**
@@ -59,7 +60,7 @@ export const bufferToString = (blob: ArrayBufferLike, encoding: string): string 
  */
 export function isArrayBuffer(obj: any): obj is ArrayBuffer {
     const maybe = obj as (Partial<ArrayBuffer> & Partial<Uint8Array>) | undefined;
-    return obj instanceof ArrayBuffer
+    return instanceOf.ArrayBuffer(obj)
     || (typeof maybe === "object"
         && maybe !== null
         && typeof maybe.byteLength === "number"

--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -4,8 +4,10 @@
  */
 
 import * as base64js from "base64-js";
-import { instanceOf } from "./instanceOf";
+import { instanceOf$ } from "./instanceOf";
 import { assert } from "./assert";
+
+const is = { ...instanceOf$ }; // amortize possible performance costs of property reads on frozen objects
 
 /**
  * Converts a Uint8Array to a string of the provided encoding
@@ -60,7 +62,7 @@ export const bufferToString = (blob: ArrayBufferLike, encoding: string): string 
  */
 export function isArrayBuffer(obj: any): obj is ArrayBuffer {
     const maybe = obj as (Partial<ArrayBuffer> & Partial<Uint8Array>) | undefined;
-    return instanceOf.ArrayBuffer(obj)
+    return is.ArrayBuffer(obj)
     || (typeof maybe === "object"
         && maybe !== null
         && typeof maybe.byteLength === "number"

--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -4,10 +4,10 @@
  */
 
 import * as base64js from "base64-js";
-import { instanceOf$ } from "./instanceOf";
+import { bindInstanceOfBuiltin } from "./instanceOf";
 import { assert } from "./assert";
 
-const is = { ...instanceOf$ }; // amortize possible performance costs of property reads on frozen objects
+const instanceOfArrayBuffer = bindInstanceOfBuiltin(new ArrayBuffer(0));
 
 /**
  * Converts a Uint8Array to a string of the provided encoding
@@ -62,7 +62,7 @@ export const bufferToString = (blob: ArrayBufferLike, encoding: string): string 
  */
 export function isArrayBuffer(obj: any): obj is ArrayBuffer {
     const maybe = obj as (Partial<ArrayBuffer> & Partial<Uint8Array>) | undefined;
-    return is.ArrayBuffer(obj)
+    return instanceOfArrayBuffer(obj)
     || (typeof maybe === "object"
         && maybe !== null
         && typeof maybe.byteLength === "number"

--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -4,10 +4,8 @@
  */
 
 import * as base64js from "base64-js";
-import { bindInstanceOfBuiltin } from "./instanceOf";
 import { assert } from "./assert";
-
-const instanceOfArrayBuffer = bindInstanceOfBuiltin(new ArrayBuffer(0));
+import { isArrayBuffer } from "./buffer";
 
 /**
  * Converts a Uint8Array to a string of the provided encoding
@@ -49,27 +47,6 @@ export const stringToBuffer = (input: string, encoding: string): ArrayBufferLike
  */
 export const bufferToString = (blob: ArrayBufferLike, encoding: string): string =>
      IsoBuffer.from(blob).toString(encoding);
-
-/**
- * Determines if an object is an array buffer
- * Will detect and reject TypedArrays, like Uint8Array.
- * Reason - they can be viewport into Array, they can be accepted, but caller has to deal with
- * math properly (i.e. take into account byteOffset at minimum).
- * For example, construction of new TypedArray can be in the form of new TypedArray(typedArray) or
- * new TypedArray(buffer, byteOffset, length), but passing TypedArray will result in fist path (and
- * ignoring byteOffice, length)
- * @param obj - The object to determine if it is an ArrayBuffer
- */
-export function isArrayBuffer(obj: any): obj is ArrayBuffer {
-    const maybe = obj as (Partial<ArrayBuffer> & Partial<Uint8Array>) | undefined;
-    return instanceOfArrayBuffer(obj)
-    || (typeof maybe === "object"
-        && maybe !== null
-        && typeof maybe.byteLength === "number"
-        && typeof maybe.slice === "function"
-        && maybe.byteOffset === undefined
-        && maybe.buffer === undefined);
-}
 
 /**
  * Minimal implementation of Buffer for our usages in the browser environment.

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./assert";
 export * from "./indexNode";
+export * from "./buffer";
 export * from "./base64Encoding";
 export * from "./batchManager";
 export * from "./disposal";

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -23,3 +23,4 @@ export * from "./unreachable";
 export * from "./lazy";
 export * from "./performanceIsomorphic";
 export * from "./delay";
+export * from "./instanceOf";

--- a/common/lib/common-utils/src/instanceOf.ts
+++ b/common/lib/common-utils/src/instanceOf.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const toString: (value: any) => string = (value) => Object.prototype.toString.call(value);
+const objectString = toString(Object.prototype);
+
+/**
+ * Plain-Old-JavaScript-Object -- as recommended by TypeScript
+ */
+export type POJO = Record<string, unknown>;
+
+/**
+ * Tests if the passed value is a plain-old-javascript-object
+ * @param value - the value to check
+ * @returns true if the value is an object, otherwise false
+ */
+export function instanceOfObject(value: any): value is POJO {
+    return value !== null && typeof value === "object";
+}
+
+/**
+ * Produces partially applied functions that test if passed values match the provided builtin instance type
+ * @param match - an instance of the builtin to match subsequent values with
+ * @returns the partially applied test function -- (value: any): value is typeof match
+ */
+export function bindInstanceOfBuiltin<T>(match: T) {
+    const compareString = toString(match);
+
+    if (compareString === objectString) {
+        throw new Error("bindInstanceOfBuiltin cannot classify '[object Object]' instances");
+    }
+
+    return (value: any): value is T => compareString === toString(value);
+}
+
+// RFC:
+// Object.freeze?  Non-configurable getters?  Individual exports?
+// How "hostile" should the environment be treated?
+export const instanceOf = {
+    Object: instanceOfObject,
+
+    ArrayBuffer: bindInstanceOfBuiltin(ArrayBuffer.prototype),
+    Error: bindInstanceOfBuiltin(new Error("N/A")),
+    Map: bindInstanceOfBuiltin(Map.prototype),
+    Set: bindInstanceOfBuiltin(Set.prototype),
+    Uint8Array: bindInstanceOfBuiltin(new Uint8Array()),
+};

--- a/common/lib/common-utils/src/instanceOf.ts
+++ b/common/lib/common-utils/src/instanceOf.ts
@@ -11,9 +11,9 @@ const pinnedObjectToString: (value: any) => string = Function.prototype.call.bin
     Object.prototype.toString, // eslint-disable-line @typescript-eslint/unbound-method
 );
 
-const toString: (value: any) => string = (value) => pinnedObjectToString(value);
+const prototypeToString: (value: any) => string = (value) => pinnedObjectToString(value);
 
-const objectString = toString(Object.prototype);
+const objectString = prototypeToString(Object.prototype);
 
 /**
  * Plain-Old-JavaScript-Object -- as recommended by TypeScript
@@ -35,11 +35,11 @@ export function instanceOfObject(value: any): value is POJO {
  * @returns the partially applied test function -- (value: any): value is typeof match
  */
 export function bindInstanceOfBuiltin<T>(match: T) {
-    const compareString = toString(match);
+    const compareString = prototypeToString(match);
 
     if (compareString === objectString) {
         throw new Error(`bindInstanceOfBuiltin cannot classify '${objectString}' instances`);
     }
 
-    return (value: any): value is T => compareString === toString(value);
+    return (value: any): value is T => compareString === prototypeToString(value);
 }

--- a/common/lib/common-utils/src/instanceOf.ts
+++ b/common/lib/common-utils/src/instanceOf.ts
@@ -29,7 +29,7 @@ export function bindInstanceOfBuiltin<T>(match: T) {
     const compareString = toString(match);
 
     if (compareString === objectString) {
-        throw new Error("bindInstanceOfBuiltin cannot classify '[object Object]' instances");
+        throw new Error(`bindInstanceOfBuiltin cannot classify '${objectString}' instances`);
     }
 
     return (value: any): value is T => compareString === toString(value);

--- a/common/lib/common-utils/src/instanceOf.ts
+++ b/common/lib/common-utils/src/instanceOf.ts
@@ -43,14 +43,3 @@ export function bindInstanceOfBuiltin<T>(match: T) {
 
     return (value: any): value is T => compareString === toString(value);
 }
-
-export const instanceOf$ = Object.freeze({
-    Object: instanceOfObject,
-
-    ArrayBuffer: bindInstanceOfBuiltin(ArrayBuffer.prototype),
-    Error: bindInstanceOfBuiltin(new Error("N/A")),
-    Map: bindInstanceOfBuiltin(Map.prototype),
-    Set: bindInstanceOfBuiltin(Set.prototype),
-    Uint8Array: bindInstanceOfBuiltin(new Uint8Array()),
-});
-export const instanceOf = { ...instanceOf$ } as const;

--- a/common/lib/common-utils/src/instanceOf.ts
+++ b/common/lib/common-utils/src/instanceOf.ts
@@ -53,4 +53,4 @@ export const instanceOf$ = Object.freeze({
     Set: bindInstanceOfBuiltin(Set.prototype),
     Uint8Array: bindInstanceOfBuiltin(new Uint8Array()),
 });
-export const instanceOf = { ...instanceOf$ };
+export const instanceOf = { ...instanceOf$ } as const;

--- a/common/lib/common-utils/src/test/jest/instanceOf.spec.ts
+++ b/common/lib/common-utils/src/test/jest/instanceOf.spec.ts
@@ -1,0 +1,150 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import fs from "fs";
+import path from "path";
+import http from "http";
+import { instanceOfObject, bindInstanceOfBuiltin } from "../../instanceOf";
+
+const instanceOfJsFilePath = path.join(__dirname, "../../../dist/instanceOf.js");
+
+const PORT = 8081;
+
+describe("instanceOf", () => {
+    describe("Object", () => {
+        test("matches various types of window.Object", () => {
+            expect(instanceOfObject({})).toEqual(true);
+            expect(instanceOfObject(new Object())).toEqual(true);
+            expect(instanceOfObject(Object("string"))).toEqual(true);
+            expect(instanceOfObject(Object.create({}))).toEqual(true);
+            expect(instanceOfObject([])).toEqual(true);
+
+            expect(instanceOfObject(null)).toEqual(false);
+            expect(instanceOfObject(undefined)).toEqual(false);
+            expect(instanceOfObject(() => {})).toEqual(false);
+        });
+    });
+
+    describe("Bind-Builtin", () => {
+        test("throws for '[object Object]' instances", () => {
+            const unthrown = new Set();
+            let label = "";
+
+            try {
+                unthrown.add(label = "new Object()");
+                bindInstanceOfBuiltin(new Object());
+            } catch (err) {
+                unthrown.delete(label);
+            }
+
+            try {
+                unthrown.add(label = "new class NonBuiltin {}()");
+                // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+                bindInstanceOfBuiltin(new class NonBuiltin {}());
+            } catch (err) {
+                unthrown.delete(label);
+            }
+
+            try {
+                unthrown.add(label = "Date.prototype");
+                bindInstanceOfBuiltin(Date.prototype);
+            } catch (err) {
+                unthrown.delete(label);
+            }
+
+            expect([]).toMatchObject([...unthrown]);
+        });
+
+        test("yields instance checking functions", () => {
+            const instanceOfMap = bindInstanceOfBuiltin(new Map());
+            const instanceOfError = bindInstanceOfBuiltin(new Error("..."));
+
+            expect(instanceOfMap(new Map())).toEqual(true);
+            expect(instanceOfMap({})).toEqual(false);
+
+            expect(instanceOfError(new Error("!?"))).toEqual(true);
+            expect(instanceOfError([])).toEqual(false);
+        });
+    });
+
+    describe("IFrame Compatibility", () => {
+        let server: http.Server;
+
+        beforeAll(() => {
+            const scriptSrc = new Promise((resolve, reject) => {
+                fs.readFile(instanceOfJsFilePath, { encoding: "utf8" }, (err, source) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(source);
+                    }
+                });
+            });
+
+            server = http.createServer((req, res) => {
+                scriptSrc
+                    .then((js) => {
+                        const html = `
+                        <!DOCTYPE html>
+                        <html>
+                            <body>
+                                <script>
+                                    (function iife (exports) {
+                                        ${js} // tolerate trailing comments
+                                    })(window);
+                                </script>
+                                <script>
+                                    document.body.appendChild(document.createElement("iframe"));
+                                    window.ctx = window.frames[window.frames.length - 1];
+                                </script>
+                            </body>
+                        </html>
+                        `;
+
+                        res.statusCode = 200;
+                        res.setHeader("Content-Type", "text/html");
+                        res.end(html);
+                    })
+                    .catch(() => {
+                        res.statusCode = 404;
+                        res.setHeader("Content-Type", "text/plain");
+                        res.end("not found");
+                    });
+            });
+            server.listen(PORT, "localhost");
+        });
+
+        beforeEach(async () => {
+            await page.goto(`http://localhost:${PORT}`, { waitUntil: "load", timeout: 0 });
+        });
+
+        afterAll(() => {
+            server?.close();
+        });
+
+        test("checks properly across IFrame boundaries", async () => {
+            const allClaims = await page.evaluate(async () => {
+                const { ctx, instanceOf } = window as any;
+
+                return {
+                    "A1: $0: new Object() instanceof Object": new Object() instanceof Object,
+                    "A2: !(new ctx.Object() instanceof Object)": !(new ctx.Object() instanceof Object),
+                    "A3: instanceOf.Object(new Object())": instanceOf.Object(new Object()),
+                    "A4: instanceOf.Object(new ctx.Object())": instanceOf.Object(new ctx.Object()),
+
+                    "B1: new Set() instanceof Set": new Set() instanceof Set,
+                    "B2: !(new ctx.Set() instanceof Set)": !(new ctx.Set() instanceof Set),
+                    "B3: instanceOf.Set(new Set())": instanceOf.Set(new Set()),
+                    "B4: instanceOf.Set(new ctx.Set())": instanceOf.Set(new ctx.Set()),
+                };
+            });
+
+            // Array<string> (one for each falsey claim -- should be empty)
+            const falsyClaims = Object.entries(allClaims).filter(([_, ok]) => !ok).map(([label]) => label);
+
+            expect([]).toMatchObject(falsyClaims);
+        });
+    });
+});

--- a/common/lib/common-utils/src/test/jest/instanceOf.spec.ts
+++ b/common/lib/common-utils/src/test/jest/instanceOf.spec.ts
@@ -128,6 +128,9 @@ describe("instanceOf", () => {
             const allClaims = await page.evaluate(async () => {
                 const { ctx, instanceOf } = window as any;
 
+                Function.prototype.call = () => "foo bar";
+                Object.prototype.toString = () => "resilient to prototype manipulation";
+
                 return {
                     "A1: $0: new Object() instanceof Object": new Object() instanceof Object,
                     "A2: !(new ctx.Object() instanceof Object)": !(new ctx.Object() instanceof Object),
@@ -144,7 +147,7 @@ describe("instanceOf", () => {
             // Array<string> (one for each falsey claim -- should be empty)
             const falsyClaims = Object.entries(allClaims).filter(([_, ok]) => !ok).map(([label]) => label);
 
-            expect([]).toMatchObject(falsyClaims);
+            expect({ falsyClaims: [] }).toMatchObject({ falsyClaims });
         });
     });
 });

--- a/common/lib/common-utils/src/test/mocha/assert.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/assert.spec.ts
@@ -5,7 +5,9 @@
 
 import { strict } from "assert";
 import { assert } from "../../assert";
-import { instanceOf } from "../../instanceOf";
+import { bindInstanceOfBuiltin } from "../../instanceOf";
+
+const instanceOfError = bindInstanceOfBuiltin(new Error("N/A"));
 
 describe("Assert", () => {
     it("Validate Shortcode Format", async () => {
@@ -14,7 +16,7 @@ describe("Assert", () => {
             try {
                 assert(false, Number.parseInt(shortCode, 16));
             } catch (e) {
-                strict(instanceOf.Error(e), "not an error");
+                strict(instanceOfError(e), "not an error");
                 strict.strictEqual(
                     e.message,
                     shortCode,

--- a/common/lib/common-utils/src/test/mocha/assert.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/assert.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict } from "assert";
 import { assert } from "../../assert";
+import { instanceOf } from "../../instanceOf";
 
 describe("Assert", () => {
     it("Validate Shortcode Format", async () => {
@@ -13,7 +14,7 @@ describe("Assert", () => {
             try {
                 assert(false, Number.parseInt(shortCode, 16));
             } catch (e) {
-                strict(e instanceof Error, "not an error");
+                strict(instanceOf.Error(e), "not an error");
                 strict.strictEqual(
                     e.message,
                     shortCode,


### PR DESCRIPTION
Incremental WIP towards #6351 -- the proposed utility functions should be sufficient to replace all `instanceof` BinaryExpressions checking against built-in types (custom classes will require a different approach).

If the proposal here is generally acceptable, please comment specifically on [export conventions and mutation considerations here](https://github.com/microsoft/FluidFramework/compare/main...jcmoore:instanceof-common-util?expand=1#diff-9d8334829a7f3f5e58ab34d00d5605ac50eaf4cc9bc088c6d2677374b6950796R38-R40).

---

References:
- http://perfectionkills.com/instanceof-considered-harmful-or-how-to-write-a-robust-isarray/
- http://web.mit.edu/jwalden/www/isArray.html
> One test in this style is Object.prototype.toString.call(o) === "[object Array]", but that relies on Object.prototype.toString and Function.prototype.call not being changed (probably a good assumption but still fragile). It's also a bit more of an obvious hack than any of the other ideas.