### PR TITLE
Restore details to socket.io error message

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -437,11 +437,13 @@ export class DocumentDeltaConnection
         // - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
         // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
         //   over it.
+        let message = `socket.io: ${handler}`;
+        if (typeof error === "string") {
+            message = `${message}: ${error}`;
+        }
         const errorObj = createGenericNetworkError(
-            `socket.io:${handler}`,
+            message,
             canRetry,
-            undefined /* retryAfterMs */,
-            typeof error === "string" ? { socketError: error } : undefined /* props */,
         );
 
         return errorObj;

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -15,8 +15,5 @@ export function errorObjectFromSocketError(socketError: IOdspSocketError, handle
     return createOdspNetworkError(
         message,
         socketError.code,
-        socketError.retryAfter,
-        // TODO: When long lived token is supported for websocket then IOdspSocketError need to support
-        // passing "claims" value that is used to fetch new token
-        undefined /* claims */);
+        socketError.retryAfter);
 }

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -11,13 +11,12 @@ import { IOdspSocketError } from "./contracts";
  * Returns network error based on error object from ODSP socket (IOdspSocketError)
  */
 export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string): OdspError {
-    const message = `socket.io:${handler}`;
+    const message = `socket.io: ${handler}: ${socketError.message}`;
     return createOdspNetworkError(
         message,
         socketError.code,
         socketError.retryAfter,
-        undefined /* response */,
-        undefined /* responseText */,
-        { socketError: socketError.message } /* props */,
-    );
+        // TODO: When long lived token is supported for websocket then IOdspSocketError need to support
+        // passing "claims" value that is used to fetch new token
+        undefined /* claims */);
 }

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -14,7 +14,6 @@ import {
     throwOdspNetworkError,
 } from "@fluidframework/odsp-doclib-utils";
 import { OdspError } from "@fluidframework/odsp-driver-definitions";
-import { LoggingError } from "@fluidframework/telemetry-utils";
 import { IOdspSocketError } from "../contracts";
 import { getWithRetryForTokenRefresh } from "../odspUtils";
 import { errorObjectFromSocketError } from "../odspError";
@@ -86,8 +85,7 @@ describe("Odsp Error", () => {
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
         } else {
-            assert.equal(networkError.message, "socket.io:disconnect");
-            assert.equal((networkError as unknown as LoggingError).getTelemetryProperties().socketError, "testMessage");
+            assert.equal(networkError.message, "socket.io: disconnect: testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
         }
@@ -102,8 +100,7 @@ describe("Odsp Error", () => {
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
         } else {
-            assert.equal(networkError.message, "socket.io:error");
-            assert.equal((networkError as unknown as LoggingError).getTelemetryProperties().socketError, "testMessage");
+            assert.equal(networkError.message, "socket.io: error: testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
         }
@@ -119,8 +116,7 @@ describe("Odsp Error", () => {
         if (networkError.errorType !== DriverErrorType.throttlingError) {
             assert.fail("networkError should be a throttlingError");
         } else {
-            assert.equal(networkError.message, "socket.io:429");
-            assert.equal((networkError as unknown as LoggingError).getTelemetryProperties().socketError, "testMessage");
+            assert.equal(networkError.message, "socket.io: 429: testMessage");
             assert.equal(networkError.retryAfterSeconds, 10);
         }
     });

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -93,6 +93,7 @@ export function createOdspNetworkError(
     retryAfterSeconds?: number,
     response?: Response,
     responseText?: string,
+    props: ITelemetryProperties = {},
 ): OdspError & LoggingError & IFacetCodes {
     let error: OdspError & LoggingError & IFacetCodes;
     switch (statusCode) {
@@ -160,9 +161,9 @@ export function createOdspNetworkError(
 
     const facetCodes = responseText !== undefined ? parseFacetCodes(responseText) : undefined;
     error.facetCodes = facetCodes;
+    (error as any).response = responseText; // Issue #6139: This shouldn't be logged - will be fixed with #6485
 
-    const props: ITelemetryProperties = { response: responseText,
-        innerMostErrorCode: facetCodes !== undefined ? facetCodes[0] : undefined};
+    props.innerMostErrorCode = facetCodes !== undefined ? facetCodes[0] : undefined;
     if (response) {
         props.responseType = response.type;
         if (response.headers) {

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -93,7 +93,6 @@ export function createOdspNetworkError(
     retryAfterSeconds?: number,
     response?: Response,
     responseText?: string,
-    props: ITelemetryProperties = {},
 ): OdspError & LoggingError & IFacetCodes {
     let error: OdspError & LoggingError & IFacetCodes;
     switch (statusCode) {
@@ -161,9 +160,9 @@ export function createOdspNetworkError(
 
     const facetCodes = responseText !== undefined ? parseFacetCodes(responseText) : undefined;
     error.facetCodes = facetCodes;
-    (error as any).response = responseText; // Issue #6139: This shouldn't be logged - will be fixed with #6485
 
-    props.innerMostErrorCode = facetCodes !== undefined ? facetCodes[0] : undefined;
+    const props: ITelemetryProperties = { response: responseText,
+        innerMostErrorCode: facetCodes !== undefined ? facetCodes[0] : undefined};
     if (response) {
         props.responseType = response.type;
         if (response.headers) {


### PR DESCRIPTION
Reverts #6557 (except for a few unrelated cleanup changes in there).

When I made that change I thought my goal was going to be to make the `message` field more robust for aggregation, but since then I've realized it's best to leave `message` alone and find other strategies to help us aggregate errors.

@micahgodbolt I'm hoping to beat the 0.43 release (ironically, just like I was trying to beat 0.42 with the original PR... -_-)