### PR TITLE
driver-definitions change to allow createContainer() with undefined s…

### DIFF
--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -135,8 +135,7 @@ export interface IDocumentService {
 
 // @public (undocumented)
 export interface IDocumentServiceFactory {
-    // (undocumented)
-    createContainer(createNewSummary: ISummaryTree, createNewResolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
+    createContainer(createNewSummary: ISummaryTree | undefined, createNewResolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
     protocolName: string;
 }

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -291,9 +291,13 @@ export interface IDocumentServiceFactory {
      */
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
 
-    // Creates a new document on the host with the provided options. Returns the document service.
+    /**
+     * Creates a new document with the provided options. Returns the document service.
+     * @param createNewSummary - Summary used to create file. If undefined, an empty file will be created and a summary
+     * should be posted later, before connecting to ordering service.
+     */
     createContainer(
-        createNewSummary: ISummaryTree,
+        createNewSummary: ISummaryTree | undefined,
         createNewResolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService>;


### PR DESCRIPTION
…ummary (cherry-pick #6655 from 0.39)

Change `createContainer()` definition to allow passing undefined for `createNewSummary` to create an empty file. Used in `Container.attach()` when attachment blobs have been uploaded to a detached container (an empty file is created, then the blobs are uploaded before the summary is posted).