### PR TITLE
Fix crash in server tests on windows

### DIFF
--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -9,90 +9,90 @@ import type * as kafkaTypes from "node-rdkafka";
 import { tryImportNodeRdkafka } from "./tryImport";
 
 export interface IKafkaBaseOptions {
-	numberOfPartitions: number;
-	replicationFactor: number;
+    numberOfPartitions: number;
+    replicationFactor: number;
 }
 
 export interface IKafkaEndpoints {
-	kafka: string[];
-	zooKeeper?: string[];
+    kafka: string[];
+    zooKeeper?: string[];
 }
 
 export abstract class RdkafkaBase extends EventEmitter {
     protected readonly kafka: typeof kafkaTypes;
-	private readonly options: IKafkaBaseOptions;
+    private readonly options: IKafkaBaseOptions;
 
-	constructor(
-		protected readonly endpoints: IKafkaEndpoints,
-		public readonly clientId: string,
-		public readonly topic: string,
-		options?: Partial<IKafkaBaseOptions>,
-	) {
-		super();
+    constructor(
+        protected readonly endpoints: IKafkaEndpoints,
+        public readonly clientId: string,
+        public readonly topic: string,
+        options?: Partial<IKafkaBaseOptions>,
+    ) {
+        super();
 
         const kafka = tryImportNodeRdkafka();
-		if (!kafka) {
-			throw new Error("Invalid node-rdkafka package");
-		}
+        if (!kafka) {
+            throw new Error("Invalid node-rdkafka package");
+        }
 
         this.kafka = kafka;
-		this.options = {
-			...options,
-			numberOfPartitions: options?.numberOfPartitions ?? 32,
-			replicationFactor: options?.replicationFactor ?? 3,
-		};
+        this.options = {
+            ...options,
+            numberOfPartitions: options?.numberOfPartitions ?? 32,
+            replicationFactor: options?.replicationFactor ?? 3,
+        };
 
-		// eslint-disable-next-line @typescript-eslint/no-floating-promises
-		this.initialize();
-	}
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.initialize();
+    }
 
-	protected abstract connect(): void;
+    protected abstract connect(): void;
 
-	private async initialize() {
-		try {
-			await this.ensureTopics();
-		} catch (ex) {
-			this.emit("error", ex);
+    private async initialize() {
+        try {
+            await this.ensureTopics();
+        } catch (ex) {
+            this.emit("error", ex);
 
-			// eslint-disable-next-line @typescript-eslint/no-floating-promises
-			this.initialize();
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.initialize();
 
-			return;
-		}
+            return;
+        }
 
-		this.connect();
-	}
+        this.connect();
+    }
 
-	protected async ensureTopics() {
-		const adminClient = this.kafka.AdminClient.create({
-			"client.id": `${this.clientId}-admin`,
-			"metadata.broker.list": this.endpoints.kafka.join(","),
-		});
+    protected async ensureTopics() {
+        const adminClient = this.kafka.AdminClient.create({
+            "client.id": `${this.clientId}-admin`,
+            "metadata.broker.list": this.endpoints.kafka.join(","),
+        });
 
-		const newTopic: kafkaTypes.NewTopic = {
-			topic: this.topic,
-			num_partitions: this.options.numberOfPartitions,
-			replication_factor: this.options.replicationFactor,
-		};
+        const newTopic: kafkaTypes.NewTopic = {
+            topic: this.topic,
+            num_partitions: this.options.numberOfPartitions,
+            replication_factor: this.options.replicationFactor,
+        };
 
-		return new Promise<void>((resolve, reject) => {
-			adminClient.createTopic(newTopic, 10000, (err) => {
-				adminClient.disconnect();
+        return new Promise<void>((resolve, reject) => {
+            adminClient.createTopic(newTopic, 10000, (err) => {
+                adminClient.disconnect();
 
-				if (err && err.code !== this.kafka.CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS) {
-					reject(err);
-				} else {
-					resolve();
-				}
-			});
-		});
-	}
+                if (err && err.code !== this.kafka.CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
 
-	protected error(error: any, restartOnError: boolean = false) {
-		const errorData: IContextErrorData = {
-			restart: restartOnError,
-		};
+    protected error(error: any, restartOnError: boolean = false) {
+        const errorData: IContextErrorData = {
+            restart: restartOnError,
+        };
 
-		this.emit("error", error, errorData);
-	}
+        this.emit("error", error, errorData);
+    }
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -14,9 +14,6 @@ import {
 } from "@fluidframework/server-services-core";
 
 import { IKafkaBaseOptions, IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
-import { tryImportNodeRdkafka } from "./tryImport";
-
-const kafka = tryImportNodeRdkafka();
 
 export interface IKafkaProducerOptions extends Partial<IKafkaBaseOptions> {
 	enableIdempotence: boolean;
@@ -82,7 +79,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 		};
 
 		const producer: kafkaTypes.Producer = this.producer =
-			new kafka.HighLevelProducer(options, this.producerOptions.topicConfig);
+			new this.kafka.HighLevelProducer(options, this.producerOptions.topicConfig);
 
 		producer.on("ready", () => {
 			this.connected = true;

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/tryImport.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/tryImport.ts
@@ -16,10 +16,10 @@ let nodeRdkafkaModule: typeof kafkaTypes | undefined;
 // Because of this limitation, currently we cannot use node-rdkafka in local dev flow. So locally kafka config should
 // always point to kafka-node library. Production code can use either one of those.
 //
-// node-rdkafka set up an AtExit callback to call RdKafka::wait_destroyed to cleanup
-// However, on windows it AVs if we never create and rdkafka instance.
-// librdkafka lazy initialize the global mutex, and it wouldn't be initialize it if no rdkafka is created,
-// and the clean would try to access the mutex and crash.
+// node-rdkafka sets up an AtExit callback to call RdKafka::wait_destroyed to cleanup.
+// However, on windows it AVs if we never create an rdkafka instance.
+// librdkafka lazy initializes the global mutex, and it wouldn't be initialized if no rdkafka is created,
+// so then the cleanup callback tries to access the mutex and crashes.
 //
 // So we will also lazy import node-rdkafka only if we intent to use it.
 export function tryImportNodeRdkafka() {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/tryImport.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/tryImport.ts
@@ -3,14 +3,33 @@
  * Licensed under the MIT License.
  */
 
+import type * as kafkaTypes from "node-rdkafka";
+
+let tryImport = false;
+let nodeRdkafkaModule: typeof kafkaTypes | undefined;
+
 // Imports a module inside a try-catch block and swallows the error if import fails.
+//
+// The native dependency of node-rdkafka throws an error when installing in one environment (e.g., macOS) and running
+// inside another (e.g., docker ubuntu). The issue only occurs because we volume mount code directly into docker
+// for local dev flow. Using a pre-built image works fine (https://github.com/Blizzard/node-rdkafka/issues/315).
+// Because of this limitation, currently we cannot use node-rdkafka in local dev flow. So locally kafka config should
+// always point to kafka-node library. Production code can use either one of those.
+//
+// node-rdkafka set up an AtExit callback to call RdKafka::wait_destroyed to cleanup
+// However, on windows it AVs if we never create and rdkafka instance.
+// librdkafka lazy initialize the global mutex, and it wouldn't be initialize it if no rdkafka is created,
+// and the clean would try to access the mutex and crash.
+//
+// So we will also lazy import node-rdkafka only if we intent to use it.
 export function tryImportNodeRdkafka() {
-    let module;
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        module = require("node-rdkafka");
-    } catch (e) {
+    if (!tryImport) {
+        tryImport = true;
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            nodeRdkafkaModule = require("node-rdkafka");
+        } catch (e) {
+        }
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return module;
+    return nodeRdkafkaModule;
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/tryImport.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/tryImport.ts
@@ -21,7 +21,7 @@ let nodeRdkafkaModule: typeof kafkaTypes | undefined;
 // librdkafka lazy initializes the global mutex, and it wouldn't be initialized if no rdkafka is created,
 // so then the cleanup callback tries to access the mutex and crashes.
 //
-// So we will also lazy import node-rdkafka only if we intent to use it.
+// So we will also lazy import node-rdkafka only if we intend to use it.
 export function tryImportNodeRdkafka() {
     if (!tryImport) {
         tryImport = true;


### PR DESCRIPTION
Loading the `node-rdkafka` module without create an instance of RdKafka would cause the node process to AV when exiting (observed in windows).  This causes our `npm run test` command to fail even though all the test passed.

The solution is to only load the module if we are using RdKafka.