### PR TITLE
Also log the original error when logging Container Warnings

### DIFF
--- a/api-report/container-utils.api.md
+++ b/api-report/container-utils.api.md
@@ -58,12 +58,15 @@ export class GenericError extends LoggingError implements IGenericError {
 
 // @public
 export class ThrottlingWarning extends LoggingError implements IThrottlingWarning {
-    constructor(message: string, retryAfterSeconds: number, props?: ITelemetryProperties);
+    constructor(message: string, retryAfterSeconds: number, originalError: unknown, // for logging
+    props?: ITelemetryProperties);
     // (undocumented)
     readonly errorType = ContainerErrorType.throttlingError;
     // (undocumented)
+    readonly originalError: unknown;
+    // (undocumented)
     readonly retryAfterSeconds: number;
-    static wrap(error: any, messagePrefix: string, retryAfterSeconds: number): IThrottlingWarning;
+    static wrap(error: unknown, messagePrefix: string, retryAfterSeconds: number): IThrottlingWarning;
 }
 
 // @public

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1885,16 +1885,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // And expose a different errorType to consumers of the warning event.
         // Let's log the original error "as-is" here if present
         if (warning.originalError !== undefined) {
-            const warningProps = isILoggingError(warning) ? warning.getTelemetryProperties() : {};
             this.logger.sendErrorEvent({
-                    eventName: "ContainerWarning",
+                    eventName: "ContainerWarning-OriginalError",
                     warningErrorType: warning.errorType,
                     warningErrorMessage: warning.message,
-                    warningProps: JSON.stringify(warningProps),
                 },
                 warning.originalError);
-        } else {
-            this.logger.sendErrorEvent({ eventName: "ContainerWarning" }, warning);
         }
+        // Also log the wrapped warning directly
+        this.logger.sendErrorEvent({ eventName: "ContainerWarning" }, warning);
     }
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -92,7 +92,6 @@ import {
     TelemetryLogger,
     connectedEventName,
     disconnectedEventName,
-    isILoggingError,
 } from "@fluidframework/telemetry-utils";
 import { Audience } from "./audience";
 import { ContainerContext } from "./containerContext";

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -87,6 +87,7 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
     constructor(
         message: string,
         readonly retryAfterSeconds: number,
+        public readonly originalError: unknown, // for logging
         props?: ITelemetryProperties,
     ) {
         super(message, props);
@@ -96,10 +97,10 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
      * Wrap the given error as a ThrottlingWarning, preserving any safe properties for logging
      * and prefixing the wrapped error message with messagePrefix.
      */
-    static wrap(error: any, messagePrefix: string, retryAfterSeconds: number): IThrottlingWarning {
+    static wrap(error: unknown, messagePrefix: string, retryAfterSeconds: number): IThrottlingWarning {
         const newErrorFn =
             (errMsg: string) =>
-                new ThrottlingWarning(`${messagePrefix}: ${errMsg}`, retryAfterSeconds);
+                new ThrottlingWarning(`${messagePrefix}: ${errMsg}`, retryAfterSeconds, error);
         return wrapError(error, newErrorFn);
     }
 }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -77,12 +77,16 @@ export class SummarizingWarning extends LoggingError implements ISummarizingWarn
     readonly errorType = summarizingError;
     readonly canRetry = true;
 
-    constructor(errorMessage: string, readonly logged: boolean = false) {
+    constructor(
+        errorMessage: string,
+        readonly logged: boolean = false,
+        public readonly originalError?: unknown, // for logging
+    ) {
         super(errorMessage);
     }
 
     static wrap(error: any, logged: boolean = false) {
-        const newErrorFn = (errMsg: string) => new SummarizingWarning(errMsg, logged);
+        const newErrorFn = (errMsg: string) => new SummarizingWarning(errMsg, logged, error);
         return wrapError<SummarizingWarning>(error, newErrorFn);
     }
 }


### PR DESCRIPTION
When we wrap an error, we lose the shape of the original error in favor of the wrapping error.  In the work I'm doing along the lines of #6676 most places where we wrap will become `annotateError`, to keep the original error instead of wrapping.

But ContainerWarning is a case where we are intentionally introducing a layer of abstraction to hide the original error and present a new shape, so that will remain a case for wrapping.  In light of this, let's log the intact original error if present.