### PR TITLE
Remove branch property from ContainerContext

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1216,7 +1216,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const codeDetails = this.getCodeDetailsFromQuorum();
         await this.instantiateContext(
             existing,
-            attributes,
             codeDetails,
             snapshot,
             pendingLocalState,
@@ -1305,7 +1304,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // The load context - given we seeded the quorum - will be great
         await this.instantiateContextDetached(
             false, // existing
-            attributes,
         );
 
         this.propagateConnectionState();
@@ -1329,7 +1327,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         await this.instantiateContextDetached(
             true, // existing
-            attributes,
             snapshotTree,
         );
 
@@ -1827,7 +1824,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     private async instantiateContextDetached(
         existing: boolean,
-        attributes: IDocumentAttributes,
         snapshot?: ISnapshotTree,
         pendingLocalState?: unknown,
     ) {
@@ -1838,7 +1834,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         await this.instantiateContext(
             existing,
-            attributes,
             codeDetails,
             snapshot,
             pendingLocalState,
@@ -1847,7 +1842,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     private async instantiateContext(
         existing: boolean,
-        attributes: IDocumentAttributes,
         codeDetails: IFluidCodeDetails,
         snapshot?: ISnapshotTree,
         pendingLocalState?: unknown,
@@ -1867,7 +1861,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.codeLoader,
             codeDetails,
             snapshot,
-            attributes,
             new DeltaManagerProxy(this._deltaManager),
             new QuorumProxy(this.protocolHandler.quorum),
             loader,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -29,7 +29,6 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
     IClientConfiguration,
     IClientDetails,
-    IDocumentAttributes,
     IDocumentMessage,
     IQuorum,
     ISequencedDocumentMessage,
@@ -54,7 +53,6 @@ export class ContainerContext implements IContainerContext {
         codeLoader: ICodeDetailsLoader | ICodeLoader,
         codeDetails: IFluidCodeDetails,
         baseSnapshot: ISnapshotTree | undefined,
-        attributes: IDocumentAttributes,
         deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         quorum: IQuorum,
         loader: ILoader,
@@ -73,7 +71,6 @@ export class ContainerContext implements IContainerContext {
             codeLoader,
             codeDetails,
             baseSnapshot,
-            attributes,
             deltaManager,
             quorum,
             loader,
@@ -101,10 +98,6 @@ export class ContainerContext implements IContainerContext {
 
     public get clientDetails(): IClientDetails {
         return this.container.clientDetails;
-    }
-
-    public get branch(): string {
-        return this.attributes.branch;
     }
 
     public get connected(): boolean {
@@ -166,7 +159,6 @@ export class ContainerContext implements IContainerContext {
         private readonly codeLoader: ICodeDetailsLoader | ICodeLoader,
         private readonly _codeDetails: IFluidCodeDetails,
         private readonly _baseSnapshot: ISnapshotTree | undefined,
-        private readonly attributes: IDocumentAttributes,
         public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         public readonly quorum: IQuorum,
         public readonly loader: ILoader,

--- a/packages/loader/container-loader/src/test/containerContext.spec.ts
+++ b/packages/loader/container-loader/src/test/containerContext.spec.ts
@@ -15,7 +15,6 @@ import {
     IFluidObject,
 } from "@fluidframework/core-interfaces";
 import {
-    IDocumentAttributes,
     IQuorum,
 } from "@fluidframework/protocol-definitions";
 import {
@@ -63,7 +62,6 @@ describe("ContainerContext Tests", () => {
             codeLoader as ICodeDetailsLoader,
             quorumCodeDetails,
             undefined,
-            (sandbox.stub() as unknown) as IDocumentAttributes,
             sandbox.stub() as any,
             (sandbox.stub() as unknown) as IQuorum,
             (sandbox.stub() as unknown) as ILoader,


### PR DESCRIPTION
Branching was removed in 0.30, so this can be safely removed.  Also allows us to stop passing document attributes through to the context.