### PR TITLE
Remove unused 'sanitize-html' dependency

### DIFF
--- a/experimental/PropertyDDS/services/property-query/package.json
+++ b/experimental/PropertyDDS/services/property-query/package.json
@@ -62,7 +62,6 @@
     "qs": "6.7.0",
     "rmfr": "2.0.0",
     "sanitize": "2.1.0",
-    "sanitize-html": "1.18.2",
     "sleep-promise": "8.0.1"
   },
   "devDependencies": {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -34563,11 +34563,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
 			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
 		},
-		"lodash.escaperegexp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
-		},
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
@@ -34662,11 +34657,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-		},
-		"lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
 		},
 		"lodash.once": {
 			"version": "4.1.1",
@@ -47767,23 +47757,6 @@
 				}
 			}
 		},
-		"sanitize-html": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.18.2.tgz",
-			"integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
-			"requires": {
-				"chalk": "^2.3.0",
-				"htmlparser2": "^3.9.0",
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.escaperegexp": "^4.1.2",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.mergewith": "^4.6.0",
-				"postcss": "^6.0.14",
-				"srcset": "^1.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
 		"sanitize.css": {
 			"version": "10.0.0",
 			"resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
@@ -49258,15 +49231,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/spy-on-component/-/spy-on-component-1.1.3.tgz",
 			"integrity": "sha512-a7jgnoBSdkcDWIQQwtEgUq4etajwG6+wGIjfC9ARUKwKOdHxJd+utgHTgLn81ETizpsw4xddUS3W8VePedtaIQ=="
-		},
-		"srcset": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
-			"integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
-			"requires": {
-				"array-uniq": "^1.0.2",
-				"number-is-nan": "^1.0.0"
-			}
 		},
 		"sse-z": {
 			"version": "0.3.0",


### PR DESCRIPTION
'sanitize-html' doesn't appear to be imported/required anywhere?

(The motivation for the change is a desire to move to away from the old version 'sanitize-html'.)

@karlbom @evaliyev @nedalhy 
