### PR TITLE
Include common/lib packages in docs build inputs

### DIFF
--- a/tools/pipelines/build-docs-latest.yml
+++ b/tools/pipelines/build-docs-latest.yml
@@ -42,6 +42,14 @@ resources:
     source: Build - common-definitions
   - pipeline: common_utils
     source: Build - common-utils
+  - pipeline: container_definitions
+    source: Build - container-definitions
+  - pipeline: core_interfaces
+    source: Build - core-interfaces
+  - pipeline: driver_definitions
+    source: Build - driver-definitions
+  - pipeline: protocol_definitions
+    source: Build - protocol-definitions
   - pipeline: client
     source: Build - client packages
     trigger:

--- a/tools/pipelines/templates/build-docs-steps.yml
+++ b/tools/pipelines/templates/build-docs-steps.yml
@@ -43,6 +43,14 @@ steps:
   artifact: _api-extractor-temp
 - download: common_utils
   artifact: _api-extractor-temp
+- download: container_definitions
+  artifact: _api-extractor-temp
+- download: core_interfaces
+  artifact: _api-extractor-temp
+- download: driver_definitions
+  artifact: _api-extractor-temp
+- download: protocol_definitions
+  artifact: _api-extractor-temp
 - download: client
   artifact: _api-extractor-temp
 - download: server
@@ -66,7 +74,7 @@ steps:
     OverWrite: false
     flattenFolders: true
     CleanTargetFolder: true
-    
+
 - task: UseNode@1
   displayName: Use Node 12.x
   inputs:


### PR DESCRIPTION
With the recent package reorganization, some several packages stopped being included in docs builds. This should restore those packages in the docs build. I have already created the pipelines themselves in ADO.