### PR TITLE
Validate connection mode in driver layer rather than DeltaManager

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1010,9 +1010,13 @@ export class DeltaManager
         // If we asked for "write" and got "read", then file is read-only
         // But if we ask read, server can still give us write.
         const readonly = !connection.claims.scopes.includes(ScopeType.DocWrite);
+
+        // This connection mode validation logic is moving to the driver layer in 0.44.  These two asserts can be
+        // removed after those packages have released and become ubiquitous.
         assert(requestedMode === "read" || readonly === (this.connectionMode === "read"),
             0x0e7 /* "claims/connectionMode mismatch" */);
         assert(!readonly || this.connectionMode === "read", 0x0e8 /* "readonly perf with write connection" */);
+
         this.set_readonlyPermissions(readonly);
 
         this.refreshDelayInfo(this.deltaStreamDelayId);


### PR DESCRIPTION
Small change to improve layering.

Currently, `DeltaManager` inspects the successful connection to validate whether there is any mode mismatch or permissions violation ("write" mode without write scope).  However the driver layer seems the more appropriate place for these checks -- ideally any consumer of the driver can trust that the result of a successful `connectToDeltaStream()` call is actually a valid connection with valid properties, or else it should reject.

No hits on these asserts recently, FWIW.