### PR TITLE
Create an API to change the start-end and/or properties of an interval

### DIFF
--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -1156,6 +1156,7 @@ export interface IInterval {
     compare(b: IInterval): number;
     compareStart(b: IInterval): number;
     compareEnd(b: IInterval): number;
+    modify(label: string, start: number, end: number);
     overlaps(b: IInterval): boolean;
     union(b: IInterval): IInterval;
 }

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -101,6 +101,10 @@ export class LocalReference implements ReferencePosition {
         this.properties = addProperties(this.properties, newProps, op);
     }
 
+    public getClient() {
+        return this.client;
+    }
+
     public getSegment() {
         return this.segment;
     }

--- a/packages/dds/merge-tree/src/test/collections.intervalTree.ts
+++ b/packages/dds/merge-tree/src/test/collections.intervalTree.ts
@@ -42,6 +42,12 @@ class TestInterval implements IInterval {
         return new TestInterval(Math.min(this.start, b.start),
             Math.max(this.end, b.end));
     }
+
+    public modify(label: string, start: number, end: number): TestInterval {
+        this.start = start;
+        this.end = end;
+        return this;
+    }
 }
 
 describe("Collections.IntervalTree", () => {

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -347,8 +347,13 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const sharedStringBefore = await defaultDataStoreBefore.getSharedObject<SharedString>(sharedStringId);
             const intervalsBefore = sharedStringBefore.getIntervalCollection("intervals");
             sharedStringBefore.insertText(0, "Hello");
-            intervalsBefore.add(0, 0, IntervalType.SlideOnRemove);
-            intervalsBefore.add(0, 1, IntervalType.SlideOnRemove);
+            const interval0 = intervalsBefore.add(0, 0, IntervalType.SlideOnRemove);
+            const interval1 = intervalsBefore.add(0, 1, IntervalType.SlideOnRemove);
+
+            if (typeof(intervalsBefore.change) === "function") {
+                intervalsBefore.change(interval0.getIntervalId(), 2, 3);
+                intervalsBefore.change(interval1.getIntervalId(), 0, 3);
+            }
 
             const snapshotTree = container.serialize();
 
@@ -365,11 +370,14 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             for (const interval of intervalsBefore) {
                 if (typeof(interval.getIntervalId) === "function") {
                     const id = interval.getIntervalId();
-                    assert.notStrictEqual(id ?? intervalsAfter.getIntervalById(id as unknown as string), undefined,
-                                        "Interval not present after rehydration");
-                    intervalsAfter.removeIntervalById(id as unknown as string);
-                    assert.strictEqual(intervalsAfter.getIntervalById(id as unknown as string), undefined,
-                                        "Interval not deleted");
+                    assert.strictEqual(typeof(id), "string");
+                    if (id) {
+                        assert.notStrictEqual(intervalsAfter.getIntervalById(id), undefined,
+                            "Interval not present after rehydration");
+                        intervalsAfter.removeIntervalById(id);
+                        assert.strictEqual(intervalsAfter.getIntervalById(id), undefined,
+                            "Interval not deleted");
+                    }
                 }
                 else {
                     intervalsAfter.delete(interval.start.getOffset(), interval.end.getOffset());

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -109,6 +109,17 @@ function testIntervalOperations(intervalCollection: IntervalCollection<SequenceI
     }
     assert.strictEqual(i, tempArray.length, "Interval omitted from forward iteration with start position");
 
+    iterator = intervalCollection.CreateForwardIteratorWithEndPosition(2);
+    tempArray = [];
+    tempArray[0] = intervalArray[2];
+    tempArray[1] = intervalArray[5];
+    tempArray[2] = intervalArray[8];
+    for (i = 0, result = iterator.next(); !result.done; i++, result = iterator.next()) {
+        interval = result.value;
+        assert.strictEqual(interval, tempArray[i], "Mismatch in forward iteration with start position");
+    }
+    assert.strictEqual(i, tempArray.length, "Interval omitted from forward iteration with start position");
+
     iterator = intervalCollection.CreateBackwardIteratorWithStartPosition(0);
     tempArray = [];
     tempArray[0] = intervalArray[2];
@@ -393,7 +404,7 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
 
             sharedString1.insertText(0, "012");
             const intervals1 = sharedString1.getIntervalCollection("intervals");
-            const intervalArray: SequenceInterval[] = [];
+            const intervalArray: any[] = [];
             let interval: SequenceInterval;
 
             intervalArray[0] = intervals1.add(0, 0, IntervalType.SlideOnRemove);
@@ -577,6 +588,43 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
                 assert.notStrictEqual(interval2, undefined, "Interval missing from collection 2");
                 for (const interval of intervals2) {
                     assert.strictEqual(interval, interval2, "Oddball interval found in client 2");
+                }
+
+                if (typeof(intervals1.change) === "function" &&
+                    typeof(intervals2.change) === "function") {
+                    // Conflicting changes
+                    intervals1.change(id1, 1, 2);
+                    intervals2.change(id1, 2, 1);
+
+                    await provider.ensureSynchronized();
+
+                    assert.strictEqual(interval1?.getIntervalId(), id1);
+                    assert.strictEqual(interval2?.getIntervalId(), id1);
+                    for (interval1 of intervals1) {
+                        const id = interval1.getIntervalId();
+                        if (id) {
+                            if (interval1.start.getOffset() !== intervals2.getIntervalById(id)?.start.getOffset()) {
+                                assert.fail();
+                            }
+                            assert.strictEqual(interval1.start.getOffset(),
+                                               intervals2.getIntervalById(id)?.start.getOffset(),
+                                               "Conflicting changes");
+                            assert.strictEqual(interval1.end.getOffset(),
+                                               intervals2.getIntervalById(id)?.end.getOffset(),
+                                               "Conflicting changes");
+                        }
+                    }
+                    for (interval2 of intervals2) {
+                        const id = interval2.getIntervalId();
+                        if (id) {
+                            assert.strictEqual(interval2.start.getOffset(),
+                                               intervals1.getIntervalById(id)?.start.getOffset(),
+                                               "Conflicting changes");
+                            assert.strictEqual(interval2.end.getOffset(),
+                                               intervals1.getIntervalById(id)?.end.getOffset(),
+                                               "Conflicting changes");
+                        }
+                    }
                 }
 
                 // Conflicting removes


### PR DESCRIPTION
Support changing the start, end, and properties of an interval. To avoid out-of-order toggling of start and end across clients, keep track of local change ops that are waiting for an ack from the server and don't accept remote start/end changes if pending changes for the given interval exist.