### PR TITLE
Policy-Check: Allow package-lock.json with no dependencies

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
@@ -11,7 +11,7 @@ import {
 
 const filePattern = /^.*?[^_]package-lock\.json$/i; // Ignore _package-lock.json
 const urlPattern = /(https?[^"@]+)(\/@.+|\/[^/]+\/-\/.+tgz)/g;
-const versionPattern = /"lockfileVersion"\s*:\s*1\s*,/g;
+const versionPattern = /"lockfileVersion"\s*:\s*\b1\b/g;
 
 export const handlers: Handler[] = [
     {
@@ -47,6 +47,7 @@ export const handlers: Handler[] = [
         name: "package-lockfiles-npm-version",
         match: filePattern,
         handler: file => {
+            console.log(`lock: ${file}`);
             const content = readFile(file);
             if (content.match(versionPattern) === null) {
                 return `Unexpected 'lockFileVersion' (Please use NPM v6: 'npm i -g npm@latest-6'): ${file}`;

--- a/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/lockfiles.ts
@@ -47,7 +47,6 @@ export const handlers: Handler[] = [
         name: "package-lockfiles-npm-version",
         match: filePattern,
         handler: file => {
-            console.log(`lock: ${file}`);
             const content = readFile(file);
             if (content.match(versionPattern) === null) {
                 return `Unexpected 'lockFileVersion' (Please use NPM v6: 'npm i -g npm@latest-6'): ${file}`;


### PR DESCRIPTION
@tylerbutler - the reason NPM v7 has been slipping through policy-check is that we hadn't yet deployed a version of the build-tools that contains my update.

I went to manually deploy these this morning and found that I first need to make a tweak to my regex.  Our repo now contains a generated 'package-lock.json' that has no dependencies (and therefore no trailing comma after '"lockFileVersion": 1').