### PR TITLE
Split IQuorum interface into client members vs proposal interfaces

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -260,7 +260,7 @@ export interface IQueueMessage {
 export interface IQuorum extends Omit<IQuorumClients, "on" | "once" | "off">, Omit<IQuorumProposals, "on" | "once" | "off">, IEventProvider<IQuorumEvents> {
 }
 
-// @public (undocumented)
+// @public
 export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents>, IDisposable {
     // (undocumented)
     getMember(clientId: string): ISequencedClient | undefined;
@@ -268,7 +268,7 @@ export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents>, ID
     getMembers(): Map<string, ISequencedClient>;
 }
 
-// @public (undocumented)
+// @public
 export interface IQuorumClientsEvents extends IErrorEvent {
     // (undocumented)
     (event: "addMember", listener: (clientId: string, details: ISequencedClient) => void): any;
@@ -276,10 +276,10 @@ export interface IQuorumClientsEvents extends IErrorEvent {
     (event: "removeMember", listener: (clientId: string) => void): any;
 }
 
-// @public (undocumented)
+// @public
 export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
 
-// @public (undocumented)
+// @public
 export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>, IDisposable {
     // (undocumented)
     get(key: string): any;
@@ -291,7 +291,7 @@ export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>
     propose(key: string, value: any): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export interface IQuorumProposalsEvents extends IErrorEvent {
     // (undocumented)
     (event: "addProposal", listener: (proposal: IPendingProposal) => void): any;

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -257,15 +257,34 @@ export interface IQueueMessage {
 }
 
 // @public
-export interface IQuorum extends IEventProvider<IQuorumEvents>, IDisposable {
-    // (undocumented)
-    get(key: string): any;
-    // (undocumented)
-    getApprovalData(key: string): ICommittedProposal | undefined;
+export interface IQuorum extends Omit<IQuorumClients, "on" | "once" | "off">, Omit<IQuorumProposals, "on" | "once" | "off">, IEventProvider<IQuorumEvents> {
+}
+
+// @public (undocumented)
+export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents>, IDisposable {
     // (undocumented)
     getMember(clientId: string): ISequencedClient | undefined;
     // (undocumented)
     getMembers(): Map<string, ISequencedClient>;
+}
+
+// @public (undocumented)
+export interface IQuorumClientsEvents extends IErrorEvent {
+    // (undocumented)
+    (event: "addMember", listener: (clientId: string, details: ISequencedClient) => void): any;
+    // (undocumented)
+    (event: "removeMember", listener: (clientId: string) => void): any;
+}
+
+// @public (undocumented)
+export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
+
+// @public (undocumented)
+export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>, IDisposable {
+    // (undocumented)
+    get(key: string): any;
+    // (undocumented)
+    getApprovalData(key: string): ICommittedProposal | undefined;
     // (undocumented)
     has(key: string): boolean;
     // (undocumented)
@@ -273,11 +292,7 @@ export interface IQuorum extends IEventProvider<IQuorumEvents>, IDisposable {
 }
 
 // @public (undocumented)
-export interface IQuorumEvents extends IErrorEvent {
-    // (undocumented)
-    (event: "addMember", listener: (clientId: string, details: ISequencedClient) => void): any;
-    // (undocumented)
-    (event: "removeMember", listener: (clientId: string) => void): any;
+export interface IQuorumProposalsEvents extends IErrorEvent {
     // (undocumented)
     (event: "addProposal", listener: (proposal: IPendingProposal) => void): any;
     // (undocumented)

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -56,9 +56,12 @@ export interface IPendingProposal extends ISequencedProposal {
     readonly rejectionDisabled: boolean;
 }
 
-export interface IQuorumEvents extends IErrorEvent {
+export interface IQuorumClientsEvents extends IErrorEvent {
     (event: "addMember", listener: (clientId: string, details: ISequencedClient) => void);
     (event: "removeMember", listener: (clientId: string) => void);
+}
+
+export interface IQuorumProposalsEvents extends IErrorEvent {
     (event: "addProposal", listener: (proposal: IPendingProposal) => void);
     (
         event: "approveProposal",
@@ -76,10 +79,15 @@ export interface IQuorumEvents extends IErrorEvent {
         listener: (sequenceNumber: number, key: string, value: any, rejections: string[]) => void);
 }
 
-/**
- * Class representing agreed upon values in a quorum
- */
-export interface IQuorum extends IEventProvider<IQuorumEvents>, IDisposable {
+export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
+
+export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents>, IDisposable {
+    getMembers(): Map<string, ISequencedClient>;
+
+    getMember(clientId: string): ISequencedClient | undefined;
+}
+
+export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>, IDisposable {
     propose(key: string, value: any): Promise<void>;
 
     has(key: string): boolean;
@@ -87,11 +95,15 @@ export interface IQuorum extends IEventProvider<IQuorumEvents>, IDisposable {
     get(key: string): any;
 
     getApprovalData(key: string): ICommittedProposal | undefined;
-
-    getMembers(): Map<string, ISequencedClient>;
-
-    getMember(clientId: string): ISequencedClient | undefined;
 }
+
+/**
+ * Class representing agreed upon values in a quorum
+ */
+export interface IQuorum extends
+    Omit<IQuorumClients, "on" | "once" | "off">,
+    Omit<IQuorumProposals, "on" | "once" | "off">,
+    IEventProvider<IQuorumEvents> { }
 
 export interface IProtocolState {
     sequenceNumber: number;

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -56,11 +56,17 @@ export interface IPendingProposal extends ISequencedProposal {
     readonly rejectionDisabled: boolean;
 }
 
+/**
+ * Events fired by a Quorum in response to client tracking.
+ */
 export interface IQuorumClientsEvents extends IErrorEvent {
     (event: "addMember", listener: (clientId: string, details: ISequencedClient) => void);
     (event: "removeMember", listener: (clientId: string) => void);
 }
 
+/**
+ * Events fired by a Quorum in response to proposal tracking.
+ */
 export interface IQuorumProposalsEvents extends IErrorEvent {
     (event: "addProposal", listener: (proposal: IPendingProposal) => void);
     (
@@ -79,14 +85,23 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
         listener: (sequenceNumber: number, key: string, value: any, rejections: string[]) => void);
 }
 
+/**
+ * All events fired by an IQuorum, both client tracking and proposal tracking.
+ */
 export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
 
+/**
+ * Interface for tracking clients in the Quorum.
+ */
 export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents>, IDisposable {
     getMembers(): Map<string, ISequencedClient>;
 
     getMember(clientId: string): ISequencedClient | undefined;
 }
 
+/**
+ * Interface for tracking proposals in the Quorum.
+ */
 export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>, IDisposable {
     propose(key: string, value: any): Promise<void>;
 
@@ -98,7 +113,7 @@ export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>
 }
 
 /**
- * Class representing agreed upon values in a quorum
+ * Interface combining tracking of clients as well as proposals in the Quorum.
  */
 export interface IQuorum extends
     Omit<IQuorumClients, "on" | "once" | "off">,


### PR DESCRIPTION
Aligns with bullet 4 from #6274

Splitting the `IQuorum` interface into its two responsibilities, of maintaining the client list vs. proposals.  Idea would be to permit usage of the proposal side only from within `Container`, making `getQuorum()` return an `IQuorumClients` rather than the full `IQuorum`.

An alternate approach, perhaps:  just drop the proposal interfaces from `IQuorum` since the `Container` can just work with the `Quorum` anyway.