### PR TITLE
Add FrsClient documentation to FF.com

### DIFF
--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -7,7 +7,11 @@ menuPosition: 2
 
 Azure Fluid Relay service (FRS) is a cloud-hosted Fluid service. You can connect your Fluid application to an Azure Fluid Relay instance using the `FrsClient` in the `@fluid-experimental/frs-client` package. `FrsClient` handles the logic of connecting your [Fluid Container]({{< relref "containers.md" >}}) to the service while keeping the container object itself service-agnostic. You can use one instance of this client to manage multiple containers.
 
-Let's take a look at how to go about using the `frs-client` in your app!
+The sections below will explain how to use `FrsClient` in your own application.
+
+{{< callout important >}}
+The steps below assume you are onboarded to Azure Fluid Relay service. Azure Fluid Relay is currently in _Private Preview_.
+{{< /callout >}}
 
 # Connecting to the Service
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -69,7 +69,7 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 Calls to `createContainer` and `getContainer` return an `FrsResources` object that contains a `FluidContainer` -- described above -- and a `containerServices` object.
 
-The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the Fluid DDSes and data objects within the container can be reused when moving to using `FrsClient`.
+The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the Fluid shared objects within the container can be reused when moving to using `FrsClient`.
 
 The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 
@@ -126,7 +126,5 @@ A sample `FrsMember` object looks like the following:
 Alongside the user ID and name, `FrsMember` objects also hold an array of `connections`. If the user is logged into the session with only one client, `connections` will only have one value in it with the ID of the client and if is in read/write mode. However, if the same user is logged in from multiple clients (i.e. they are logged in from different devices or have multiple browser tabs open with the same container), `connections` here will hold multiple values for each client. In the example data above, we can see that a user with name "Test User" and ID "0e662aca-9d7d-4ff0-8faf-9f8672b70f15" currently has the container open from two different clients.
 
 These functions and events can be combined to present a real-time view of the users in the current session.
-
-Every time the `membersChanged` event is sent, the new member roster is fetched and the view is updated accordingly.
 
 **Congratulations!** You have now succesfully connected your Fluid container to the FRS service and fetched back user details for the members in your collaborative session!!

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -59,9 +59,9 @@ const { fluidContainer, containerServices } = await frsClient.getContainer({ id:
 
 The `id` being passed into the container config is a unique identifier to a container instance. Any client that wants to join the same collaborative session just needs to call `getContainer` with the same container `id`.
 
-For the further information on how to start recording logs being emitted by Fluid, please see [Telemetry](../testing/telemetry.md)
+For the further information on how to start recording logs being emitted by Fluid, please see [Telemetry]({{< relref "telemetry.md" >}})
 
-The container being fetched back will hold the `initialObjects` as defined in the container schema. See [Data modeling](../build/data-modeling.md) to learn more about how to establish the schema and use the `FluidContainer` object.
+The container being fetched back will hold the `initialObjects` as defined in the container schema. See [Data modeling]({{< relref "data-modeling.md" >}}) to learn more about how to establish the schema and use the `FluidContainer` object.
 
 # Getting Audience Details
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -1,5 +1,5 @@
 ---
-title: Connect to a Fluid Service in Azure with FrsClient
+title: Connect to an Azure Fluid Relay service
 menuPosition: 2
 ---
 
@@ -20,7 +20,6 @@ To connect to our FRS instance, we first need to instaniate our `FrsClient`. Thi
 ```javascript
 const config = {
     tenantId: "myFrsTenantId",
-    // IMPORTANT: this token provider is suitable for testing ONLY. It is NOT secure.
     tokenProvider: new InsecureTokenProvider("myFrsTenantKey", { id: "UserId", name: "Test User" }),
     orderer: "https://myFrsOrdererUrl",
     storage: "https://myFrsStorageUrl",

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -32,6 +32,8 @@ Now that you have an instance of `FrsClient`, you can start using it to create o
 
 # Managing containers
 
+##  Token Providers
+
 The `FrsClient` API exposes `createContainer` and `getContainer` functions to create and get containers respectively. Both functions take in the below two properties:
 
 - A _container config_ that defines the ID of the container and an optional entry point for logging.

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -17,8 +17,8 @@ The steps below assume you are onboarded to Azure Fluid Relay service. Azure Flu
 
 To connect to our FRS instance, we first need to instaniate our `FrsClient`. This takes in, as configuration parameters, the tenant ID, orderer, and storage URLs that were provided as part of the FRS onboarding process. It also requires a token provider to generate the JWT token that will be used to authorize the current user against the service. The `InsecureTokenProvider` should only be used for testing purposes as it exposes the tenant key secret in your client-side code bundle. This should be replaced with an implementation of `ITokenProvider` that fetches the token from your own backend service that is responsible for signing it with the tenant key. 
 
-```typescript
-const config: FrsConnectionConfig = {
+```javascript
+const config = {
     tenantId: "myFrsTenantId",
     // IMPORTANT: this token provider is suitable for testing ONLY. It is NOT secure.
     tokenProvider: new InsecureTokenProvider("myFrsTenantKey", { id: "UserId", name: "Test User" }),
@@ -38,7 +38,7 @@ The `FrsClient` API exposes `createContainer` and `getContainer` functions to cr
 - A _container config_ that defines the ID of the container and an optional entry point for logging.
 - A _container schema_ that defines the container data model.
 
-```typescript
+```javascript
 const schema = {
     name: "my-container",
     initialObjects: {
@@ -71,7 +71,7 @@ Alongside the user ID and name, `FrsMember` objects also hold an array of `conne
 
 These callbacks and events can be combined to present a real-time view of the users in the current session.
 
-``` typescript
+``` javascript
 const { audience } = containerServices;
 const audienceDiv = document.createElement("div");
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -69,7 +69,7 @@ Alongside the user ID and name, `FrsMember` objects also hold an array of `conne
 
 `audience` also emits events for when the roster of members changes. `membersChanged` will fire for any roster changes, whereas `memberAdded` and `memberRemoved` will fire for their respective changes with the `clientId` and `member` values that have been modified.
 
-These callbacks and events can be combined to keep an updated view that represents the members in the current session.
+These callbacks and events can be combined to present a real-time view of the users in the current session.
 
 ``` typescript
 const { audience } = containerServices;

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -31,7 +31,7 @@ const client = new FrsClient(config);
 
 Now that you have an instance of `FrsClient`, you can start using it to create or load Fluid containers!
 
-# Managing Containers
+# Managing containers
 
 The `FrsClient` provides two functions on its API to create and get containers respectively. They both take in two parameters:
 - A container config that defines the ID of the container and an optional entrypoint for logging

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -51,7 +51,7 @@ await frsClient.createContainer({ id: "_unique-id_" }, schema);
 const { fluidContainer, containerServices } = await frsClient.getContainer({ id: "_unique-id_" }, schema);
 ```
 
-The ID that is being passed in to the container config can be thought of as the "filename" for the item holding the data for this container on the FRS backend. Any client that wants to join the same collaborative session just needs to call `getContainer` with the same container ID.
+The `id` being passed into the container config is a unique identifier to a container instance. Any client that wants to join the same collaborative session just needs to call `getContainer` with the same container `id`.
 
 For the further information on how to start recording logs being emitted by Fluid, please see [Telemetry](../testing/telemetry.md)
 
@@ -78,7 +78,7 @@ const audienceDiv = document.createElement("div");
 const onAudienceChanged = () => {
     const members = audience.getMembers();
     const self = audience.getMyself();
-    const memberNames: string[] = [];
+    const memberNames = [];
     members.forEach((member) => {
         if (member.userId !== self?.userId) {
             memberNames.push(member.userName);

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -33,9 +33,10 @@ Now that you have an instance of `FrsClient`, you can start using it to create o
 
 # Managing containers
 
-The `FrsClient` provides two functions on its API to create and get containers respectively. They both take in two parameters:
-- A container config that defines the ID of the container and an optional entrypoint for logging
-- A container schema that defines the DDSes and data objects that this container will hold
+The `FrsClient` API exposes `createContainer` and `getContainer` functions to create and get containers respectively. Both functions take in the below two properties:
+
+- A _container config_ that defines the ID of the container and an optional entry point for logging.
+- A _container schema_ that defines the container data model.
 
 ```typescript
 const schema = {

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -24,10 +24,10 @@ The `InsecureTokenProvider` should only be used for development purposes because
 
 ```javascript
 const config = {
-    tenantId: "myFrsTenantId",
-    tokenProvider: new InsecureTokenProvider("myFrsTenantKey", { id: "UserId", name: "Test User" }),
-    orderer: "https://myFrsOrdererUrl",
-    storage: "https://myFrsStorageUrl",
+    tenantId: "myTenantId",
+    tokenProvider: new InsecureTokenProvider("myTenantKey", { id: "UserId", name: "Test User" }),
+    orderer: "https://myOrdererUrl",
+    storage: "https://myStorageUrl",
 }
 
 const client = new FrsClient(config);
@@ -35,9 +35,11 @@ const client = new FrsClient(config);
 
 Now that you have an instance of `FrsClient`, you can start using it to create or load Fluid containers!
 
-# Managing containers
+## Token providers
 
-##  Token Providers
+Coming soon!
+
+# Managing containers
 
 The `FrsClient` API exposes `createContainer` and `getContainer` functions to create and get containers respectively. Both functions take in the below two properties:
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -15,7 +15,12 @@ The steps below assume you are onboarded to Azure Fluid Relay service. Azure Flu
 
 # Connecting to the Service
 
-To connect to our FRS instance, we first need to instaniate our `FrsClient`. This takes in, as configuration parameters, the tenant ID, orderer, and storage URLs that were provided as part of the FRS onboarding process. It also requires a token provider to generate the JWT token that will be used to authorize the current user against the service. The `InsecureTokenProvider` should only be used for testing purposes as it exposes the tenant key secret in your client-side code bundle. This should be replaced with an implementation of `ITokenProvider` that fetches the token from your own backend service that is responsible for signing it with the tenant key. 
+To connect to an Azure Fluid Relay instance you first need to create an `FrsClient`. You must provide some configuration parameters including the the tenant ID, orderer and storage URLs, and a token provider to generate the JSON Web Token (JWT) that will be used to authorize the current user against the service. The `frs-client` package provides an `InsecureTokenProvider` that can be used for development purposes.
+
+{{< callout danger >}}
+The `InsecureTokenProvider` should only be used for development purposes because **using it exposes the tenant key secret in your client-side code bundle.** This must be replaced with an implementation of `ITokenProvider` that fetches the token from your own backend service that is responsible for signing it with the tenant key.
+{{< /callout >}}
+
 
 ```javascript
 const config = {

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -94,6 +94,6 @@ onAudienceChanged();
 audience.on("membersChanged", onAudienceChanged);
 ```
 
-Every time the `membersChanged` events gets fired, we fetch the new member roster and update the view accordingly.
+Every time the `membersChanged` event is sent, the new member roster is fetched and the view is updated accordingly.
 
 **Congratulations!** You have now succesfully connected your Fluid container to the FRS service and fetched back user details for the members in your collaborative session!!

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -29,7 +29,7 @@ const config: FrsConnectionConfig = {
 const client = new FrsClient(config);
 ```
 
-Now that we have an instance of our client, we can start using it to create new or load existing Fluid containers!
+Now that you have an instance of `FrsClient`, you can start using it to create or load Fluid containers!
 
 # Managing Containers
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -1,5 +1,94 @@
 ---
 title: Connect to a Fluid Service in Azure with FrsClient
 menuPosition: 2
-status: placeholder
 ---
+
+# Introduction
+
+Fluid provides an implementation of its backend service, known as the Azure Fluid Relay Service (FRS), for clients to connect to. As part of the onboarding process, you will be provided a tenant ID, a tenant key, and orderer and storage URLs that will be used to connect your application to this service instance. The framework also provides a client-side package, `frs-client`, that will take in these configuration values to quickly allow you set up your collaborative application against the service instance. This package handles the logic of connecting your [Fluid Container](../build/containers.md) to the service while keeping the container object itself service-agnostic. You can use one instance of this client to manage multiple containers. 
+
+Let's take a look at how to go about using the `frs-client` in your app!
+
+# Connecting to the Service
+
+To connect to our FRS instance, we first need to instaniate our `FrsClient`. This takes in, as configuration parameters, the tenant ID, orderer, and storage URLs that were provided as part of the FRS onboarding process. It also requires a token provider to generate the JWT token that will be used to authorize the current user against the service. The `InsecureTokenProvider` should only be used for testing purposes as it exposes the tenant key secret in your client-side code bundle. This should be replaced with an implementation of `ITokenProvider` that fetches the token from your own backend service that is responsible for signing it with the tenant key. 
+
+```typescript
+const config: FrsConnectionConfig = {
+    tenantId: "myFrsTenantId",
+    // IMPORTANT: this token provider is suitable for testing ONLY. It is NOT secure.
+    tokenProvider: new InsecureTokenProvider("myFrsTenantKey", { id: "UserId", name: "Test User" }),
+    orderer: "https://myFrsOrdererUrl",
+    storage: "https://myFrsStorageUrl",
+}
+
+const client = new FrsClient(config);
+```
+
+Now that we have an instance of our client, we can start using it to create new or load existing Fluid containers!
+
+# Managing Containers
+
+The `FrsClient` provides two functions on its API to create and get containers respectively. They both take in two parameters:
+- A container config that defines the ID of the container and an optional entrypoint for logging
+- A container schema that defines the DDSes and data objects that this container will hold
+
+```typescript
+const schema = {
+    name: "my-container",
+    initialObjects: {
+        /* ... */
+    },
+    dynamicObjectTypes: [ /*...*/ ],
+}
+const frsClient = new FrsClient(config);
+await frsClient.createContainer({ id: "_unique-id_" }, schema);
+const { fluidContainer, containerServices } = await frsClient.getContainer({ id: "_unique-id_" }, schema);
+```
+
+The ID that is being passed in to the container config can be thought of as the "filename" for the item holding the data for this container on the FRS backend. Any client that wants to join the same collaborative session just needs to call `getContainer` with the same container ID.
+
+For the further information on how to start recording logs being emitted by Fluid, please see [Telemetry](../testing/telemetry.md)
+
+The container being fetched back will hold the `initialObjects` as defined in the container schema. Please read [Data modeling](../build/data-modeling.md) to see how to establish the schema and use the `fluidContainer` object.
+
+# Getting Audience Details
+
+Both calls to `createContainer` and `getContainer` return an `FrsResources` object that holds the Fluid container that we were discussing above as well as a `containerServices` object. Whereas the container itself will always stay the same regardless of which service it is being connected, the `containerServices` hold values that are specific to the FRS service. Within this object, we will find an `audience` value that can be used to manage the roster of users that are currently collaborating in the container.
+
+`audience` provides two callbacks that will return `FrsMember` objects that have a user ID and user name:
+- `getMembers` returns a map of all the users that are currently in the Fluid session
+- `getMyself` returns the current user on this client
+
+Alongside the user ID and name, `FrsMember` objects also hold an array of `connections`. If the user is logged into the session with only one client, `connections` will only have one value in it with the ID of the client and if is in read/write mode. However, if the same user is logged in from multiple clients, `connections` here will hold multiple values for each client.
+
+`audience` also emits events for when the roster of members changes. `membersChanged` will fire for any roster changes, whereas `memberAdded` and `memberRemoved` will fire for their respective changes with the `clientId` and `member` values that have been modified.
+
+These callbacks and events can be combined to keep an updated view that represents the members in the current session.
+
+``` typescript
+const { audience } = containerServices;
+const audienceDiv = document.createElement("div");
+
+const onAudienceChanged = () => {
+    const members = audience.getMembers();
+    const self = audience.getMyself();
+    const memberNames: string[] = [];
+    members.forEach((member) => {
+        if (member.userId !== self?.userId) {
+            memberNames.push(member.userName);
+        }
+    });
+    audienceDiv.innerHTML = `
+        Current User: ${self?.userName} <br />
+        Other Users: ${memberNames.join(", ")}
+    `;
+};
+
+onAudienceChanged();
+audience.on("membersChanged", onAudienceChanged);
+```
+
+Every time the `membersChanged` events gets fired, we fetch the new member roster and update the view accordingly.
+
+**Congratulations!** You have now succesfully connected your Fluid container to the FRS service and fetched back user details for the members in your collaborative session!!

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -73,15 +73,7 @@ The `FluidContainer` contains the Fluid data model and is service-agnostic. Any 
 
 The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 
-`audience` provides two callbacks that will return `FrsMember` objects that have a user ID and user name:
-- `getMembers` returns a map of all the users connected to the container.
-- `getMyself` returns the current user on this client.
-
-Alongside the user ID and name, `FrsMember` objects also hold an array of `connections`. If the user is logged into the session with only one client, `connections` will only have one value in it with the ID of the client and if is in read/write mode. However, if the same user is logged in from multiple clients, `connections` here will hold multiple values for each client.
-
-`audience` also emits events for when the roster of members changes. `membersChanged` will fire for any roster changes, whereas `memberAdded` and `memberRemoved` will fire for their respective changes with the `clientId` and `member` values that have been modified.
-
-These callbacks and events can be combined to present a real-time view of the users in the current session.
+Let's take a look at how you can use the `audience` object to maintain an updated view of all the members currently in a container.
 
 ``` javascript
 const { audience } = containerServices;
@@ -105,6 +97,35 @@ const onAudienceChanged = () => {
 onAudienceChanged();
 audience.on("membersChanged", onAudienceChanged);
 ```
+
+`audience` provides two functions that will return `FrsMember` objects that have a user ID and user name:
+- `getMembers` returns a map of all the users connected to the container. These values will change anytime a member joins or leaves the container.
+- `getMyself` returns the current user on this client.
+
+`audience` also emits events for when the roster of members changes. `membersChanged` will fire for any roster changes, whereas `memberAdded` and `memberRemoved` will fire for their respective changes with the `clientId` and `member` values that have been modified. After any of these events fire, a new call to `getMembers` will return the updated member roster.
+
+A sample `FrsMember` object looks like the following:
+
+```json
+{
+  "userId": "0e662aca-9d7d-4ff0-8faf-9f8672b70f15",
+  "userName": "Test User",
+  "connections": [
+    {
+      "id": "c699c3d1-a4a0-4e9e-aeb4-b33b00544a71",
+      "mode": "write"
+    },
+    {
+      "id": "0e662aca-9d7d-4ff0-8faf-9f8672b70f15",
+      "mode": "write"
+    }
+  ]
+}
+```
+
+Alongside the user ID and name, `FrsMember` objects also hold an array of `connections`. If the user is logged into the session with only one client, `connections` will only have one value in it with the ID of the client and if is in read/write mode. However, if the same user is logged in from multiple clients (i.e. they are logged in from different devices or have multiple browser tabs open with the same container), `connections` here will hold multiple values for each client. In the example data above, we can see that a user with name "Test User" and ID "0e662aca-9d7d-4ff0-8faf-9f8672b70f15" currently has the container open from two different clients.
+
+These functions and events can be combined to present a real-time view of the users in the current session.
 
 Every time the `membersChanged` event is sent, the new member roster is fetched and the view is updated accordingly.
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -62,8 +62,8 @@ The container being fetched back will hold the `initialObjects` as defined in th
 Both calls to `createContainer` and `getContainer` return an `FrsResources` object that holds the Fluid container that we were discussing above as well as a `containerServices` object. Whereas the container itself will always stay the same regardless of which service it is being connected, the `containerServices` hold values that are specific to the FRS service. Within this object, we will find an `audience` value that can be used to manage the roster of users that are currently collaborating in the container.
 
 `audience` provides two callbacks that will return `FrsMember` objects that have a user ID and user name:
-- `getMembers` returns a map of all the users that are currently in the Fluid session
-- `getMyself` returns the current user on this client
+- `getMembers` returns a map of all the users connected to the container.
+- `getMyself` returns the current user on this client.
 
 Alongside the user ID and name, `FrsMember` objects also hold an array of `connections`. If the user is logged into the session with only one client, `connections` will only have one value in it with the ID of the client and if is in read/write mode. However, if the same user is logged in from multiple clients, `connections` here will hold multiple values for each client.
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -5,7 +5,7 @@ menuPosition: 2
 
 # Introduction
 
-Fluid provides an implementation of its backend service, known as the Azure Fluid Relay Service (FRS), for clients to connect to. As part of the onboarding process, you will be provided a tenant ID, a tenant key, and orderer and storage URLs that will be used to connect your application to this service instance. The framework also provides a client-side package, `frs-client`, that will take in these configuration values to quickly allow you set up your collaborative application against the service instance. This package handles the logic of connecting your [Fluid Container](../build/containers.md) to the service while keeping the container object itself service-agnostic. You can use one instance of this client to manage multiple containers. 
+Azure Fluid Relay service (FRS) is a cloud-hosted Fluid service. You can connect your Fluid application to an Azure Fluid Relay instance using the `FrsClient` in the `@fluid-experimental/frs-client` package. `FrsClient` handles the logic of connecting your [Fluid Container]({{< relref "containers.md" >}}) to the service while keeping the container object itself service-agnostic. You can use one instance of this client to manage multiple containers.
 
 Let's take a look at how to go about using the `frs-client` in your app!
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -60,7 +60,11 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 # Getting Audience Details
 
-Both calls to `createContainer` and `getContainer` return an `FrsResources` object that holds the Fluid container that we were discussing above as well as a `containerServices` object. Whereas the container itself will always stay the same regardless of which service it is being connected, the `containerServices` hold values that are specific to the FRS service. Within this object, we will find an `audience` value that can be used to manage the roster of users that are currently collaborating in the container.
+Calls to `createContainer` and `getContainer` return an `FrsResources` object that contains a `FluidContainer` -- described above -- and a `containerServices` object.
+
+The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the Fluid DDSes and data objects within the container can be reused when moving to using `FrsClient`.
+
+The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 
 `audience` provides two callbacks that will return `FrsMember` objects that have a user ID and user name:
 - `getMembers` returns a map of all the users connected to the container.

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -55,7 +55,7 @@ The ID that is being passed in to the container config can be thought of as the 
 
 For the further information on how to start recording logs being emitted by Fluid, please see [Telemetry](../testing/telemetry.md)
 
-The container being fetched back will hold the `initialObjects` as defined in the container schema. Please read [Data modeling](../build/data-modeling.md) to see how to establish the schema and use the `fluidContainer` object.
+The container being fetched back will hold the `initialObjects` as defined in the container schema. See [Data modeling](../build/data-modeling.md) to learn more about how to establish the schema and use the `FluidContainer` object.
 
 # Getting Audience Details
 


### PR DESCRIPTION
Documentation walks through:
- Instantiating the FrsClient
- Using the client to create/get Fluid containers
- Using audience in the container services object to maintain a roster of FRS users