### PR TITLE
Deprecate IFluidObjectCollection and remove remaining usage

### DIFF
--- a/examples/data-objects/math/package.json
+++ b/examples/data-objects/math/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@fluid-example/client-ui-lib": "^0.44.0",
     "@fluid-example/flow-util-lib": "^0.44.0",
-    "@fluid-example/fluid-object-interfaces": "^0.44.0",
     "@fluid-example/search-menu": "^0.44.0",
     "@fluidframework/core-interfaces": "^0.39.5",
     "@fluidframework/data-object-base": "^0.44.0",

--- a/examples/data-objects/math/src/mathComponent.ts
+++ b/examples/data-objects/math/src/mathComponent.ts
@@ -17,7 +17,6 @@ import {
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle } from "@fluidframework/datastore";
-import { IFluidObjectCollection } from "@fluid-example/fluid-object-interfaces";
 import { SharedDirectory, ISharedDirectory } from "@fluidframework/map";
 import * as MergeTree from "@fluidframework/merge-tree";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
@@ -487,7 +486,7 @@ const endIdPrefix = "end-";
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IMathOptions extends IFluidHTMLOptions { }
 
-export class MathCollection extends LazyLoadedDataObject<ISharedDirectory> implements IFluidObjectCollection {
+export class MathCollection extends LazyLoadedDataObject<ISharedDirectory> {
     private static readonly factory = new LazyLoadedDataObjectFactory<MathCollection>(
         "@fluid-example/math",
         MathCollection,
@@ -513,7 +512,6 @@ export class MathCollection extends LazyLoadedDataObject<ISharedDirectory> imple
     }
 
     public get IFluidLoadable() { return this; }
-    public get IFluidObjectCollection() { return this; }
     public get IFluidRouter() { return this; }
 
     private combinedMathText: Sequence.SharedString;

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@fluid-example/clicker": "^0.44.0",
     "@fluid-example/codemirror": "^0.44.0",
-    "@fluid-example/fluid-object-interfaces": "^0.44.0",
     "@fluid-example/prosemirror": "^0.44.0",
     "@fluid-example/spaces": "^0.44.0",
     "@fluid-experimental/last-edited": "^0.44.0",

--- a/examples/utils/fluid-object-interfaces/src/collection.ts
+++ b/examples/utils/fluid-object-interfaces/src/collection.ts
@@ -10,7 +10,6 @@ declare module "@fluidframework/core-interfaces" {
     export interface IFluidObject extends Readonly<Partial<IProvideFluidObjectCollection>> { }
 }
 
-
 /**
  * @deprecated This example will be removed in a future release.
  */
@@ -36,7 +35,7 @@ export interface IFluidObjectCollection extends IProvideFluidObjectCollection {
      * @deprecated This example will be removed in a future release.
      */
     createCollectionItem<TOpt = Record<string, unknown>>(options?: TOpt): IFluidObject;
-    
+
     /**
      * @deprecated This example will be removed in a future release.
      */

--- a/examples/utils/fluid-object-interfaces/src/collection.ts
+++ b/examples/utils/fluid-object-interfaces/src/collection.ts
@@ -10,18 +10,36 @@ declare module "@fluidframework/core-interfaces" {
     export interface IFluidObject extends Readonly<Partial<IProvideFluidObjectCollection>> { }
 }
 
+
+/**
+ * @deprecated This example will be removed in a future release.
+ */
 export const IFluidObjectCollection: keyof IProvideFluidObjectCollection = "IFluidObjectCollection";
 
+/**
+ * @deprecated This example will be removed in a future release.
+ */
 export interface IProvideFluidObjectCollection {
+    /**
+     * @deprecated This example will be removed in a future release.
+     */
     readonly IFluidObjectCollection: IFluidObjectCollection;
 }
 
 /**
  * A data store that implements a collection of Fluid objects.  Typically, the
  * fluid objects in the collection would be like-typed.
+ * @deprecated This example will be removed in a future release.
  */
 export interface IFluidObjectCollection extends IProvideFluidObjectCollection {
+    /**
+     * @deprecated This example will be removed in a future release.
+     */
     createCollectionItem<TOpt = Record<string, unknown>>(options?: TOpt): IFluidObject;
+    
+    /**
+     * @deprecated This example will be removed in a future release.
+     */
     removeCollectionItem(instance: IFluidObject): void;
     // Need iteration
 }


### PR DESCRIPTION
This change deprecates the `IFluidObjectCollection` interface from the `@fluid-example/fluid-object-interfaces` package and removes all usage from the repo.  I stop short of removal for now because the Fluid app has taken a dependency on it.

Apps which compose components (e.g. shared-text, spaces) don't really benefit from knowing they can create an instance from a collection without knowing the nature of the instance. The math collection is a good proof of this: `FlowView` doesn't (can't) actually use it as an anonymous collection but rather a strongly typed `IMathCollection`.  The conflict arises because the IFluid* interfaces promise anonymous usage, but passing a valid `options` argument forces the caller to break through that anonymity.  As a result, the `IFluidObjectCollection` interface is just overhead.