### PR TITLE
Publish task-manager and property-dds docs

### DIFF
--- a/docs/data/packages.yaml
+++ b/docs/data/packages.yaml
@@ -7,6 +7,8 @@ distributed-data-structures:
 - "@fluidframework/ordered-collection"
 - "@fluidframework/register-collection"
 - "@fluidframework/sequence"
+- "@fluid-experimental/task-manager"
+- "@fluid-experimental/property-dds"
 - custom:
     title: "SharedString"
     url: "/docs/apis/sequence/sharedstring/"


### PR DESCRIPTION
I missed these two ddses in an earlier commit.