### PR TITLE
Export Types Only from Common Defs

### DIFF
--- a/common/lib/common-definitions/src/index.ts
+++ b/common/lib/common-definitions/src/index.ts
@@ -3,6 +3,29 @@
  * Licensed under the MIT License.
  */
 
-export * from "./disposable";
-export * from "./events";
-export * from "./logger";
+export type {
+    IDisposable
+} from "./disposable";
+export type {
+    ExtendEventProvider,
+    IErrorEvent,
+    IEvent,
+    IEventProvider,
+    IEventThisPlaceHolder,
+    IEventTransformer,
+    ReplaceIEventThisPlaceHolder,
+    TransformedEvent,
+} from "./events";
+export type {
+    ILoggingError,
+    ITaggedTelemetryPropertyType,
+    ITelemetryBaseEvent,
+    ITelemetryBaseLogger,
+    ITelemetryErrorEvent,
+    ITelemetryGenericEvent,
+    ITelemetryLogger,
+    ITelemetryPerformanceEvent,
+    ITelemetryProperties,
+    TelemetryEventCategory,
+    TelemetryEventPropertyType,
+} from "./logger";

--- a/common/lib/common-definitions/src/index.ts
+++ b/common/lib/common-definitions/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 export type {
-    IDisposable
+    IDisposable,
 } from "./disposable";
 export type {
     ExtendEventProvider,


### PR DESCRIPTION
[Exporting as type only](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)  ensures there are no runtime impacts. 

related to #6540 