### PR TITLE
Rev 'Historian' package-lock.json

### DIFF
--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -336,9 +336,9 @@
 			"integrity": "sha512-cNc6YhJ95VE121aKbgA5SDTGk8vNTkl42SEPl4Y8PyXGOL5Jldx0a5Ei6Xs7GkqG7eiZ9uKb2u+POqGJ2OdJ3w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.25384",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.25384.tgz",
-			"integrity": "sha512-ecvIOQ4RKkuyTc6BIkNpfBBcSPqjJcc9dhxL1p3auDxz3c55+2B007Fa4kpC00VdDzzRRrgH0ZqNfws8WZmzmQ==",
+			"version": "0.2.29883",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.29883.tgz",
+			"integrity": "sha512-HEAnwYEHi4ARjg6CrNck/9DrSI0DcfR0bsMS8zUwoWtTK0xoo93lSItHQjMP3XFOGdghkCqIH3A8VIBgm0sFSQ==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -361,15 +361,6 @@
 				"ts-morph": "^7.1.2"
 			},
 			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -378,12 +369,6 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -402,9 +387,9 @@
 			},
 			"dependencies": {
 				"typescript": {
-					"version": "3.9.9",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-					"integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 					"dev": true
 				}
 			}
@@ -3405,15 +3390,6 @@
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -3502,12 +3478,6 @@
 							}
 						}
 					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -3526,17 +3496,17 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 					"dev": true
 				}
 			}
 		},
 		"@oclif/errors": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.4.tgz",
-			"integrity": "sha512-pJKXyEqwdfRTUdM8n5FIHiQQHg5ETM0Wlso8bF9GodczO40mF5Z3HufnYWJE7z8sGKxOeJCdbAVZbS8Y+d5GCw==",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
+			"integrity": "sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==",
 			"dev": true,
 			"requires": {
 				"clean-stack": "^3.0.0",
@@ -3761,12 +3731,29 @@
 			}
 		},
 		"@octokit/auth-token": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-			"integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+			"integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^5.0.0"
+				"@octokit/types": "^6.0.3"
+			},
+			"dependencies": {
+				"@octokit/openapi-types": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
+					"integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==",
+					"dev": true
+				},
+				"@octokit/types": {
+					"version": "6.19.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
+					"integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+					"dev": true,
+					"requires": {
+						"@octokit/openapi-types": "^8.3.0"
+					}
+				}
 			}
 		},
 		"@octokit/core": {
@@ -3991,30 +3978,43 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.9",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
-			"integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+			"integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
-				"@octokit/request-error": "^2.0.0",
-				"@octokit/types": "^5.0.0",
-				"deprecation": "^2.0.0",
+				"@octokit/request-error": "^2.1.0",
+				"@octokit/types": "^6.16.1",
 				"is-plain-object": "^5.0.0",
 				"node-fetch": "^2.6.1",
-				"once": "^1.4.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
+				"@octokit/openapi-types": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
+					"integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==",
+					"dev": true
+				},
 				"@octokit/request-error": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-					"integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+					"integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
 					"dev": true,
 					"requires": {
-						"@octokit/types": "^5.0.1",
+						"@octokit/types": "^6.0.3",
 						"deprecation": "^2.0.0",
 						"once": "^1.4.0"
+					}
+				},
+				"@octokit/types": {
+					"version": "6.19.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
+					"integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+					"dev": true,
+					"requires": {
+						"@octokit/openapi-types": "^8.3.0"
 					}
 				},
 				"is-plain-object": {
@@ -4143,18 +4143,6 @@
 				"typescript": "~3.9.7"
 			},
 			"dependencies": {
-				"array-differ": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-					"integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-					"dev": true
-				},
-				"arrify": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-					"dev": true
-				},
 				"multimatch": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -4169,9 +4157,9 @@
 					}
 				},
 				"typescript": {
-					"version": "3.9.9",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-					"integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 					"dev": true
 				}
 			}
@@ -4254,9 +4242,9 @@
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
 			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
@@ -5433,9 +5421,9 @@
 			}
 		},
 		"before-after-hook": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+			"integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
 			"dev": true
 		},
 		"binary": {
@@ -6169,7 +6157,7 @@
 		"colors": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g="
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
 		},
 		"colorspace": {
 			"version": "1.1.2",
@@ -6963,7 +6951,7 @@
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
 				"nice-try": "^1.0.4",
@@ -6976,7 +6964,7 @@
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -6991,9 +6979,9 @@
 			}
 		},
 		"danger": {
-			"version": "10.6.4",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-10.6.4.tgz",
-			"integrity": "sha512-M8W1wP4SaFQHYwXTP8kgc6D0FPmxT9YJg8U19CjcDYmyAK+iU9R4GlX8lmNkJ+kX19yym5M5hzB0aIbWfVD/1g==",
+			"version": "10.6.6",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-10.6.6.tgz",
+			"integrity": "sha512-RBqANs6xbWSCqZMy3+/eIYuC9kd7g5NqJ8PqDJKylPhvBoJEDkDrHQvExYHiP2UquvaZcPWsKohmOQXrosrpdw==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -9867,26 +9855,6 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -10015,9 +9983,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -11692,9 +11660,9 @@
 			}
 		},
 		"macos-release": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
-			"integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
+			"integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==",
 			"dev": true
 		},
 		"make-dir": {
@@ -12788,7 +12756,7 @@
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
 		"nise": {
@@ -15185,9 +15153,9 @@
 			}
 		},
 		"repeat-element": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
 			"dev": true
 		},
 		"repeat-string": {
@@ -15318,9 +15286,9 @@
 					}
 				},
 				"yargs-parser": {
-					"version": "20.2.7",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-					"integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+					"version": "20.2.9",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 					"dev": true
 				}
 			}
@@ -16301,9 +16269,9 @@
 			}
 		},
 		"source-map-url": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+			"integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
 			"dev": true
 		},
 		"sparse-bitfield": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -321,9 +321,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.25384",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.25384.tgz",
-      "integrity": "sha512-ecvIOQ4RKkuyTc6BIkNpfBBcSPqjJcc9dhxL1p3auDxz3c55+2B007Fa4kpC00VdDzzRRrgH0ZqNfws8WZmzmQ==",
+      "version": "0.2.29883",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.29883.tgz",
+      "integrity": "sha512-HEAnwYEHi4ARjg6CrNck/9DrSI0DcfR0bsMS8zUwoWtTK0xoo93lSItHQjMP3XFOGdghkCqIH3A8VIBgm0sFSQ==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -346,15 +346,6 @@
         "ts-morph": "^7.1.2"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -363,12 +354,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
         }
       }
     },
@@ -387,9 +372,9 @@
       },
       "dependencies": {
         "typescript": {
-          "version": "3.9.9",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
           "dev": true
         }
       }
@@ -2886,15 +2871,6 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2983,12 +2959,6 @@
               }
             }
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
         }
       }
     },
@@ -3007,17 +2977,17 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
           "dev": true
         }
       }
     },
     "@oclif/errors": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.4.tgz",
-      "integrity": "sha512-pJKXyEqwdfRTUdM8n5FIHiQQHg5ETM0Wlso8bF9GodczO40mF5Z3HufnYWJE7z8sGKxOeJCdbAVZbS8Y+d5GCw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
+      "integrity": "sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==",
       "dev": true,
       "requires": {
         "clean-stack": "^3.0.0",
@@ -3242,12 +3212,29 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^6.0.3"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
+          "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "6.19.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
+          "integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^8.3.0"
+          }
+        }
       }
     },
     "@octokit/core": {
@@ -3472,30 +3459,43 @@
       }
     },
     "@octokit/request": {
-      "version": "5.4.9",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
-      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^5.0.0",
-        "deprecation": "^2.0.0",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.1",
-        "once": "^1.4.0",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
+          "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==",
+          "dev": true
+        },
         "@octokit/request-error": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-          "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+          "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
           "dev": true,
           "requires": {
-            "@octokit/types": "^5.0.1",
+            "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "6.19.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
+          "integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^8.3.0"
           }
         },
         "is-plain-object": {
@@ -3593,18 +3593,6 @@
         "typescript": "~3.9.7"
       },
       "dependencies": {
-        "array-differ": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-          "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-          "dev": true
-        },
-        "arrify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-          "dev": true
-        },
         "multimatch": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -3619,9 +3607,9 @@
           }
         },
         "typescript": {
-          "version": "3.9.9",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
           "dev": true
         }
       }
@@ -3699,9 +3687,9 @@
       }
     },
     "@types/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -4574,14 +4562,6 @@
       "dev": true,
       "requires": {
         "retry": "0.12.0"
-      },
-      "dependencies": {
-        "retry": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-          "dev": true
-        }
       }
     },
     "asynckit": {
@@ -4707,9 +4687,9 @@
       }
     },
     "before-after-hook": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
     "binary-extensions": {
@@ -5254,7 +5234,7 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g=",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "columnify": {
@@ -6088,7 +6068,7 @@
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
@@ -6101,15 +6081,15 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
     },
     "danger": {
-      "version": "10.6.4",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.6.4.tgz",
-      "integrity": "sha512-M8W1wP4SaFQHYwXTP8kgc6D0FPmxT9YJg8U19CjcDYmyAK+iU9R4GlX8lmNkJ+kX19yym5M5hzB0aIbWfVD/1g==",
+      "version": "10.6.6",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.6.6.tgz",
+      "integrity": "sha512-RBqANs6xbWSCqZMy3+/eIYuC9kd7g5NqJ8PqDJKylPhvBoJEDkDrHQvExYHiP2UquvaZcPWsKohmOQXrosrpdw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -6148,14 +6128,6 @@
         "readline-sync": "^1.4.9",
         "require-from-string": "^2.0.2",
         "supports-hyperlinks": "^1.0.1"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-          "dev": true
-        }
       }
     },
     "dargs": {
@@ -8144,6 +8116,12 @@
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "dev": true
     },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -8446,26 +8424,6 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -8575,9 +8533,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -9241,114 +9199,6 @@
         "es-abstract": "^1.18.0-next.2",
         "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
-          "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
-            "is-callable": "^1.2.3",
-            "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
-            "object-inspect": "^1.10.3",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
-          },
-          "dependencies": {
-            "has-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-              "dev": true
-            }
-          }
-        },
-        "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
-        },
-        "is-negative-zero": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-          "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
-          },
-          "dependencies": {
-            "has-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-              "dev": true
-            }
-          }
-        },
-        "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
-          "dev": true
-        },
-        "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
-        },
-        "string.prototype.trimend": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "string.prototype.trimstart": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        }
       }
     },
     "is-typedarray": {
@@ -10205,9 +10055,9 @@
       }
     },
     "macos-release": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
-      "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
+      "integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==",
       "dev": true
     },
     "make-dir": {
@@ -11134,7 +10984,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-cleanup": {
@@ -13126,9 +12976,9 @@
       }
     },
     "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
       "dev": true
     },
     "repeat-string": {
@@ -13250,9 +13100,9 @@
           }
         },
         "yargs-parser": {
-          "version": "20.2.7",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
       }
@@ -13840,9 +13690,9 @@
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
     },
     "spawn-command": {
@@ -14936,9 +14786,9 @@
       "dev": true
     },
     "util": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -15073,114 +14923,6 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.1",
         "is-typed-array": "^1.1.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
-          "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
-            "is-callable": "^1.2.3",
-            "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
-            "object-inspect": "^1.10.3",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
-          },
-          "dependencies": {
-            "has-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-              "dev": true
-            }
-          }
-        },
-        "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
-        },
-        "is-negative-zero": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-          "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
-          },
-          "dependencies": {
-            "has-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-              "dev": true
-            }
-          }
-        },
-        "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
-          "dev": true
-        },
-        "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
-        },
-        "string.prototype.trimend": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "string.prototype.trimstart": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        }
       }
     },
     "wide-align": {


### PR DESCRIPTION
Rev's the 'Historian' package-lock.json to pick up latest changes to policy-check.

Because Historian's 'package-lock.json' was a bit stale, I'm doing this one separately from #6743.

@tanviraumi, @anthony-murphy - Does Historian need manual testing to verify the changes?