### PR TITLE
Remove all usages of gcData in summarize

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -410,7 +410,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         // Add GC details to the summary.
         const gcDetails: IGarbageCollectionSummaryDetails = {
             usedRoutes: this.summarizerNode.usedRoutes,
-            gcData: summarizeResult.gcData,
+            gcData: this.summarizerNode.gcData,
         };
         addBlobToSummary(summarizeResult, gcBlobKey, JSON.stringify(gcDetails));
 
@@ -831,7 +831,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         // Add GC details to the summary.
         const gcDetails: IGarbageCollectionSummaryDetails = {
             usedRoutes: this.summarizerNode.usedRoutes,
-            gcData: summarizeResult.gcData,
+            gcData: this.summarizerNode.gcData,
         };
         addBlobToSummary(summarizeResult, gcBlobKey, JSON.stringify(gcDetails));
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -718,9 +718,11 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                 const contextSummary = await context.summarize(true /* fullTree */, trackState);
                 summaryBuilder.addWithStats(contextId, contextSummary);
 
-                // Prefix the child's id to the ids of its GC nodes. This gradually builds the id of each node
-                // to be a path from the root.
-                gcDataBuilder.prefixAndAddNodes(contextId, contextSummary.gcData.gcNodes);
+                if (contextSummary.gcData !== undefined) {
+                    // Prefix the child's id to the ids of its GC nodes. This gradually builds the id of each node
+                    // to be a path from the root.
+                    gcDataBuilder.prefixAndAddNodes(contextId, contextSummary.gcData.gcNodes);
+                }
             }));
 
         this.updateGCNodes(gcDataBuilder);
@@ -751,9 +753,11 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                         0x180 /* "getAttachSummary should always return a tree" */);
                     summaryTree = { stats: contextSummary.stats, summary: contextSummary.summary };
 
-                    // Prefix the child's id to the ids of its GC nodest. This gradually builds the id of each node
-                    // to be a path from the root.
-                    gcDataBuilder.prefixAndAddNodes(contextId, contextSummary.gcData.gcNodes);
+                    if (contextSummary.gcData !== undefined) {
+                        // Prefix the child's id to the ids of its GC nodest. This gradually builds the id of each node
+                        // to be a path from the root.
+                        gcDataBuilder.prefixAndAddNodes(contextId, contextSummary.gcData.gcNodes);
+                    }
                 } else {
                     // If this channel is not yet loaded, then there should be no changes in the snapshot from which
                     // it was created as it is detached container. So just use the previous snapshot.

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -169,6 +169,9 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     /** The routes in this node that are currently in use. */
     readonly usedRoutes: string[];
 
+    /** The garbage collection data of the node. */
+    readonly gcData: IGarbageCollectionData | undefined;
+
     summarize(fullTree: boolean, trackState?: boolean): Promise<IContextSummarizeResult>;
     createChild(
         /** Summarize function */

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -144,6 +144,13 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     }
 
     public async summarize(fullTree: boolean, trackState: boolean = true): Promise<IContextSummarizeResult> {
+        if (!this.gcDisabled) {
+            // Load GC details from the initial summary, if it's not already loaded. If this is the first time this
+            // node is being summarized, the used routes in it are needed to find out if this node has changed since
+            // last summary. If it hasn't changed, the GC data in it needs to be returned as part of the summary.
+            await this.loadInitialGCSummaryDetails();
+        }
+
         // If GC is not disabled and we are tracking a summary, GC should have run and updated the used routes for this
         //  summary by calling updateUsedRoutes which sets wipSerializedUsedRoutes.
         if (!this.gcDisabled && this.isTrackingInProgress()) {

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -144,11 +144,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     }
 
     public async summarize(fullTree: boolean, trackState: boolean = true): Promise<IContextSummarizeResult> {
-        // Load GC details from the initial summary, if it's not already loaded. If this is the first time this node is
-        // being summarized, the used routes in it are needed to find out if this node has changed since last summary.
-        // If it hasn't changed, the GC data in it needs to be returned as part of the summary.
-        await this.loadInitialGCSummaryDetails();
-
         // If GC is not disabled and we are tracking a summary, GC should have run and updated the used routes for this
         //  summary by calling updateUsedRoutes which sets wipSerializedUsedRoutes.
         if (!this.gcDisabled && this.isTrackingInProgress()) {
@@ -176,7 +171,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 
     private async summarizeInternal(fullTree: boolean, trackState: boolean): Promise<ISummarizeInternalResult> {
         const summarizeResult = await this.summarizeFn(fullTree, trackState);
-        if (summarizeResult.gcData !== undefined) {
+        if (summarizeResult.gcData !== undefined && !this.gcDisabled) {
             this._gcData = cloneGCData(summarizeResult.gcData);
         }
         return summarizeResult;


### PR DESCRIPTION
Fixes #6223.

With #6252, if GC is enabled, the GC data generated by getGCData is stored in the GC blob in summary. However, gcData from summarize is still being used in couple of places. This PR removes them so that we can remove returning gcData in summarize. This is tracked via #6772.

Since we are no longer writing GC data to GC blobs in the snapshot tests, the test data repo needs updating - https://github.com/microsoft/FluidFrameworkTestData/pull/21