### PR TITLE
Fix cell e2e test stability targeting real service

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -142,6 +142,10 @@ describeFullCompat("SharedCell", (getTestObjectProvider) => {
         sharedCell1.set("value1");
         sharedCell2.set("value2");
         sharedCell3.set("value0");
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedCell3.set("value3");
 
         verifyCellValues("value1", "value2", "value3");
@@ -155,6 +159,10 @@ describeFullCompat("SharedCell", (getTestObjectProvider) => {
         // set after delete
         sharedCell1.set("value1.1");
         sharedCell2.delete();
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedCell3.set("value1.3");
 
         verifyCellValues("value1.1", undefined, "value1.3");
@@ -185,6 +193,10 @@ describeFullCompat("SharedCell", (getTestObjectProvider) => {
         // delete after set
         sharedCell1.set("value3.1");
         sharedCell2.set("value3.2");
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedCell3.delete();
 
         verifyCellValues("value3.1", "value3.2", undefined);


### PR DESCRIPTION
When running locally, generated ops with be queue up in the order appear in the code.
But when running remotely targeting real service, the ops might get sent (or received by the server) in a different order, causing the test to fail randomly.

Fix it by add flush to outgoing ops before the final operation to make sure it is the last one to be sent out.

There are other patterns in other tests, and it will be fixed in separately PR.