### PR TITLE
Additional op and wait tracing in tests

### DIFF
--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -340,6 +340,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
         for (const container of containersToApply) {
             const record = this.containers.get(container);
             if (record !== undefined && record.paused) {
+                debugWait(`${record.index}: container resumed`);
                 container.deltaManager.inbound.resume();
                 container.deltaManager.outbound.resume();
                 resumed.push(container);
@@ -359,6 +360,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
         for (const container of containersToApply) {
             const record = this.containers.get(container);
             if (record !== undefined && !record.paused) {
+                debugWait(`${record.index}: container paused`);
                 pauseP.push(container.deltaManager.inbound.pause());
                 pauseP.push(container.deltaManager.outbound.pause());
                 record.paused = true;
@@ -463,45 +465,57 @@ export class LoaderContainerTracker implements IOpProcessingController {
     private setupTrace(container: IContainer, index: number) {
         if (debugOp.enabled) {
             const getContentsString = (type: string, msgContents: any) => {
-                if (type !== MessageType.Operation) {
-                    if (typeof msgContents === "string") { return msgContents; }
-                    return JSON.stringify(msgContents);
-                }
-                let address = "";
-                let contents = JSON.parse(msgContents);
-                // eslint-disable-next-line no-null/no-null
-                while (contents !== undefined && contents !== null) {
-                    if (contents.contents?.address !== undefined) {
-                        address += `/${contents.contents.address}`;
-                        contents = contents.contents.contents;
-                    } else if (contents.content?.address !== undefined) {
-                        address += `/${contents.content.address}`;
-                        contents = contents.content.contents;
-                    } else {
-                        break;
+                try {
+                    if (type !== MessageType.Operation) {
+                        if (typeof msgContents === "string") { return msgContents; }
+                        return JSON.stringify(msgContents);
                     }
+                    let address = "";
+
+                    // contents comes in the wire as JSON string ("push" event)
+                    // But already parsed when apply ("op" event)
+                    let contents = typeof msgContents === "string" ?
+                        JSON.parse(msgContents) : msgContents;
+                    // eslint-disable-next-line no-null/no-null
+                    while (contents !== undefined && contents !== null) {
+                        if (contents.contents?.address !== undefined) {
+                            address += `/${contents.contents.address}`;
+                            contents = contents.contents.contents;
+                        } else if (contents.content?.address !== undefined) {
+                            address += `/${contents.content.address}`;
+                            contents = contents.content.contents;
+                        } else {
+                            break;
+                        }
+                    }
+                    if (address) {
+                        return `${address} ${JSON.stringify(contents)}`;
+                    }
+                    return JSON.stringify(contents);
+                } catch (e) {
+                    return `${e.message}: ${e.stack}`;
                 }
-                if (address) {
-                    return `${address} ${JSON.stringify(contents)}`;
-                }
-                return JSON.stringify(contents);
             };
             debugOp(`${index}: ADD: clientId: ${(container as Container).clientId}`);
             container.deltaManager.outbound.on("op", (messages) => {
                 for (const msg of messages) {
                     debugOp(`${index}: OUT:          `
                         + `cli: ${msg.clientSequenceNumber.toString().padStart(3)} `
-                        + `         ${msg.type} ${getContentsString(msg.type, msg.contents)}`);
+                        + `rsq: ${msg.referenceSequenceNumber.toString().padStart(3)} `
+                        + `${msg.type} ${getContentsString(msg.type, msg.contents)}`);
                 }
             });
-            container.deltaManager.inbound.on("push", (msg) => {
-                const clientSeq = msg.clientId === (container as Container).clientId ?
-                    `cli: ${msg.clientSequenceNumber.toString().padStart(3)}` : "        ";
-                debugOp(`${index}: IN : seq: ${msg.sequenceNumber.toString().padStart(3)} `
-                    + `${clientSeq} min: ${msg.minimumSequenceNumber.toString().padStart(3)} `
-                    + `${msg.type} ${getContentsString(msg.type, msg.contents)}`);
-            });
-
+            const getInboundHandler = (type: string) => {
+                return (msg: ISequencedDocumentMessage) => {
+                    const clientSeq = msg.clientId === (container as Container).clientId ?
+                        `cli: ${msg.clientSequenceNumber.toString().padStart(3)}` : "        ";
+                    debugOp(`${index}: ${type}: seq: ${msg.sequenceNumber.toString().padStart(3)} `
+                        + `${clientSeq} min: ${msg.minimumSequenceNumber.toString().padStart(3)} `
+                        + `${msg.type} ${getContentsString(msg.type, msg.contents)}`);
+                };
+            };
+            container.deltaManager.inbound.on("push", getInboundHandler("IN "));
+            container.deltaManager.inbound.on("op", getInboundHandler("OP "));
             container.deltaManager.on("connect", (details) => {
                 debugOp(`${index}: CON: clientId: ${details.clientId}`);
             });


### PR DESCRIPTION
Add trace for:
- when we pause or resumed op processing
- when op being processed
- reference sequence number of an op sent

These are existing debug traces that can be turned on by setting the env DEBUG=fluid:test-utils for tracing ops and waiting