### PR TITLE
Fix map/directory e2e test stability targeting real service

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -194,6 +194,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 sharedDirectory1.set("testKey1", "value1");
                 sharedDirectory2.set("testKey1", "value2");
                 sharedDirectory3.set("testKey1", "value0");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 sharedDirectory3.set("testKey1", "value3");
 
                 expectAllBeforeValues("testKey1", "/", "value1", "value2", "value3");
@@ -207,6 +211,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // set after delete
                 sharedDirectory1.set("testKey1", "value1.1");
                 sharedDirectory2.delete("testKey1");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 sharedDirectory3.set("testKey1", "value1.3");
 
                 expectAllBeforeValues("testKey1", "/", "value1.1", undefined, "value1.3");
@@ -238,6 +246,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // delete after set
                 sharedDirectory1.set("testKey3", "value3.1");
                 sharedDirectory2.set("testKey3", "value3.2");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 sharedDirectory3.delete("testKey3");
 
                 expectAllBeforeValues("testKey3", "/", "value3.1", "value3.2", undefined);
@@ -251,6 +263,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // clear after set
                 sharedDirectory1.set("testKey1", "value1.1");
                 sharedDirectory2.set("testKey1", "value1.2");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 sharedDirectory3.clear();
 
                 expectAllBeforeValues("testKey1", "/", "value1.1", "value1.2", undefined);
@@ -285,6 +301,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // set after clear
                 sharedDirectory1.set("testKey3", "value3.1");
                 sharedDirectory2.clear();
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 sharedDirectory3.set("testKey3", "value3.3");
                 expectAllBeforeValues("testKey3", "/", "value3.1", undefined, "value3.3");
 
@@ -448,6 +468,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 root1SubDir.set("testKey1", "value1");
                 root2SubDir.set("testKey1", "value2");
                 root3SubDir.set("testKey1", "value0");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 root3SubDir.set("testKey1", "value3");
 
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1", "value2", "value3");
@@ -461,6 +485,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // set after delete
                 root1SubDir.set("testKey1", "value1.1");
                 root2SubDir.delete("testKey1");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 root3SubDir.set("testKey1", "value1.3");
 
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1.1", undefined, "value1.3");
@@ -491,6 +519,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // delete after set
                 root1SubDir.set("testKey3", "value3.1");
                 root2SubDir.set("testKey3", "value3.2");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 root3SubDir.delete("testKey3");
 
                 expectAllBeforeValues("testKey3", "/testSubDir", "value3.1", "value3.2", undefined);
@@ -504,6 +536,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // clear after set
                 root1SubDir.set("testKey1", "value1.1");
                 root2SubDir.set("testKey1", "value1.2");
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 root3SubDir.clear();
                 expectAllBeforeValues("testKey1", "/testSubDir", "value1.1", "value1.2", undefined);
                 assert.equal(root3SubDir.size, 0, "Incorrect map size after clear");
@@ -536,6 +572,10 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
                 // set after clear
                 root1SubDir.set("testKey3", "value3.1");
                 root2SubDir.clear();
+
+                // drain the outgoing so that the next set will come after
+                await provider.opProcessingController.processOutgoing();
+
                 root3SubDir.set("testKey3", "value3.3");
                 expectAllBeforeValues("testKey3", "/testSubDir", "value3.1", undefined, "value3.3");
 

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -168,6 +168,10 @@ describeFullCompat("SharedMap", (getTestObjectProvider) => {
         sharedMap1.set("testKey1", "value1");
         sharedMap2.set("testKey1", "value2");
         sharedMap3.set("testKey1", "value0");
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedMap3.set("testKey1", "value3");
 
         expectAllBeforeValues("testKey1", "value1", "value2", "value3");
@@ -181,6 +185,10 @@ describeFullCompat("SharedMap", (getTestObjectProvider) => {
         // set after delete
         sharedMap1.set("testKey1", "value1.1");
         sharedMap2.delete("testKey1");
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedMap3.set("testKey1", "value1.3");
 
         expectAllBeforeValues("testKey1", "value1.1", undefined, "value1.3");
@@ -211,6 +219,10 @@ describeFullCompat("SharedMap", (getTestObjectProvider) => {
         // delete after set
         sharedMap1.set("testKey3", "value3.1");
         sharedMap2.set("testKey3", "value3.2");
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedMap3.delete("testKey3");
 
         expectAllBeforeValues("testKey3", "value3.1", "value3.2", undefined);
@@ -224,6 +236,10 @@ describeFullCompat("SharedMap", (getTestObjectProvider) => {
         // clear after set
         sharedMap1.set("testKey1", "value1.1");
         sharedMap2.set("testKey1", "value1.2");
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedMap3.clear();
         expectAllBeforeValues("testKey1", "value1.1", "value1.2", undefined);
         assert.equal(sharedMap3.size, 0, "Incorrect map size after clear");
@@ -256,6 +272,10 @@ describeFullCompat("SharedMap", (getTestObjectProvider) => {
         // set after clear
         sharedMap1.set("testKey3", "value3.1");
         sharedMap2.clear();
+
+        // drain the outgoing so that the next set will come after
+        await provider.opProcessingController.processOutgoing();
+
         sharedMap3.set("testKey3", "value3.3");
         expectAllBeforeValues("testKey3", "value3.1", undefined, "value3.3");
 


### PR DESCRIPTION
Similar to PR #6774, but for map/directory

When running locally, generated ops with be queue up in the order appear in the code.
But when running remotely targeting real service, the ops might get sent (or received by the server) in a different order, causing the test to fail randomly.

Fix it by add flush to outgoing ops before the final operation to make sure it is the last one to be sent out.