### PR TITLE
Fix consensus dds e2e test stability targeting real service

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -244,6 +244,13 @@ function generate(
                 assert.strictEqual(value, "testValue");
                 return ConsensusResult.Release;
             });
+
+            // Needs to make sure the acquire get sent and sequenced before wait/acquire/complete in collection2
+            await provider.opProcessingController.processOutgoing();
+
+            // processOutgoing pauses all processing afterwards, just resume everything.
+            provider.opProcessingController.resumeProcessing();
+
             const waitAcquireCompleteP = waitAcquireAndComplete(collection2);
 
             assert.equal(await acquireReleaseP, true);


### PR DESCRIPTION
Similar to PR #6774, but for ConsensusQueueCollection/ConsensusRegisterCollection

When running locally, generated ops with be queue up in the order appear in the code.
But when running remotely targeting real service, the ops might get sent (or received by the server) in a different order, causing the test to fail randomly.

Fix it by add flush to outgoing ops before the final operation to make sure it is the last one to be sent out.