### PR TITLE
Refactor generateSummary return types and split out summarizer types to separate file

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -83,7 +83,6 @@ import {
     NamedFluidDataStoreRegistryEntries,
     ISummaryTreeWithStats,
     ISummarizeInternalResult,
-    ISummaryStats,
     IChannelSummarizeResult,
     CreateChildSummarizerNodeParam,
     SummarizeInternalFn,
@@ -107,7 +106,7 @@ import { v4 as uuid } from "uuid";
 import { ContainerFluidHandleContext } from "./containerHandleContext";
 import { FluidDataStoreRegistry } from "./dataStoreRegistry";
 import { debug } from "./debug";
-import { ISummarizerRuntime, ISummarizerInternalsProvider, Summarizer, IGenerateSummaryOptions } from "./summarizer";
+import { Summarizer } from "./summarizer";
 import { SummaryManager } from "./summaryManager";
 import { DeltaScheduler } from "./deltaScheduler";
 import { ReportOpPerfTelemetry } from "./connectionTelemetry";
@@ -128,6 +127,13 @@ import { SummaryCollection } from "./summaryCollection";
 import { getLocalStorageFeatureGate } from "./localStorageFeatureGates";
 import { ISerializedElection, OrderedClientCollection, OrderedClientElection } from "./orderedClientElection";
 import { SummarizerClientElection } from "./summarizerClientElection";
+import {
+    GenerateSummaryData,
+    IGeneratedSummaryStats,
+    IGenerateSummaryOptions,
+    ISummarizerInternalsProvider,
+    ISummarizerRuntime,
+} from "./summarizerTypes";
 
 export enum ContainerMessageType {
     // An op to be delivered to store
@@ -156,36 +162,6 @@ export interface ContainerRuntimeMessage {
     contents: any;
     type: ContainerMessageType;
 }
-
-export interface IGeneratedSummaryStats extends ISummaryStats{
-    dataStoreCount: number;
-    summarizedDataStoreCount: number;
-}
-
-export interface IGeneratedSummaryData {
-    readonly summaryStats: IGeneratedSummaryStats;
-    readonly generateDuration?: number;
-}
-
-export interface IUploadedSummaryData {
-    readonly handle: string;
-    readonly uploadDuration?: number;
-}
-
-export interface IUnsubmittedSummaryData extends Partial<IGeneratedSummaryData>, Partial<IUploadedSummaryData> {
-    readonly referenceSequenceNumber: number;
-    readonly submitted: false;
-    readonly error: any;
-}
-
-export interface ISubmittedSummaryData extends IGeneratedSummaryData, IUploadedSummaryData {
-    readonly referenceSequenceNumber: number;
-    readonly submitted: true;
-    readonly clientSequenceNumber: number;
-    readonly submitOpDuration?: number;
-}
-
-export type GenerateSummaryData = IUnsubmittedSummaryData | ISubmittedSummaryData;
 
 // Consider idle 5s of no activity. And snapshot if a minute has gone by with no snapshot.
 const IdleDetectionTime = 5000;
@@ -1730,14 +1706,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 return { continue: true };
             };
 
-            const attemptData: Omit<IUnsubmittedSummaryData, "error"> = {
-                referenceSequenceNumber: summaryRefSeqNum,
-                submitted: false,
-            };
-
             let continueResult = checkContinue();
             if (!continueResult.continue) {
-                return { ...attemptData, error: continueResult.error };
+                return { stage: "aborted", referenceSequenceNumber: summaryRefSeqNum, error: continueResult.error };
             }
 
             // If the GC version that this container is loaded from differs from the current GC version that this
@@ -1759,7 +1730,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     fullGC: this.runtimeOptions.gcOptions.runFullGC || forceRegenerateData,
                 });
             } catch (error) {
-                return { ...attemptData, error };
+                return { stage: "aborted", referenceSequenceNumber: summaryRefSeqNum, error };
             }
 
             // Counting dataStores and handles
@@ -1772,20 +1743,20 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const handleCount = Object.values(dataStoreTree.tree).filter(
                 (value) => value.type === SummaryType.Handle).length;
 
-            const stats: IGeneratedSummaryStats = {
+            const summaryStats: IGeneratedSummaryStats = {
                 dataStoreCount: this.dataStores.size,
                 summarizedDataStoreCount: this.dataStores.size - handleCount,
                 ...summarizeResult.stats,
             };
-
-            const generateData: IGeneratedSummaryData = {
-                summaryStats: stats,
+            const generateSummaryData = {
+                referenceSequenceNumber: summaryRefSeqNum,
+                summaryStats,
                 generateDuration: trace.trace().duration,
-            };
+            } as const;
 
             continueResult = checkContinue();
             if (!continueResult.continue) {
-                return { ...attemptData, ...generateData, error: continueResult.error };
+                return { stage: "generated", ...generateSummaryData, error: continueResult.error };
             }
 
             const lastAck = this.summaryCollection.latestAck;
@@ -1806,7 +1777,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             try {
                 handle = await this.storage.uploadSummaryWithContext(summarizeResult.summary, summaryContext);
             } catch (error) {
-                return { ...attemptData, ...generateData, error };
+                return { stage: "generated", ...generateSummaryData, error };
             }
 
             const parent = summaryContext.ackHandle;
@@ -1817,31 +1788,30 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 message,
                 parents: parent ? [parent] : [],
             };
-            const uploadData: IUploadedSummaryData = {
+            const uploadData = {
+                ...generateSummaryData,
                 handle,
                 uploadDuration: trace.trace().duration,
-            };
+            } as const;
 
             continueResult = checkContinue();
             if (!continueResult.continue) {
-                return { ...attemptData, ...generateData, ...uploadData, error: continueResult.error };
+                return { stage: "uploaded", ...uploadData, error: continueResult.error };
             }
 
             let clientSequenceNumber: number;
             try {
                 clientSequenceNumber = this.submitSystemMessage(MessageType.Summarize, summaryMessage);
             } catch (error) {
-                return { ...attemptData, ...generateData, ...uploadData, error };
+                return { stage: "uploaded", ...uploadData, error };
             }
 
-            const submitData: ISubmittedSummaryData = {
-                ...attemptData,
-                ...generateData,
+            const submitData = {
+                stage: "submitted",
                 ...uploadData,
-                submitted: true,
                 clientSequenceNumber,
                 submitOpDuration: trace.trace().duration,
-            };
+            } as const;
 
             this.summarizerNode.completeSummary(handle);
 

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -9,4 +9,5 @@ export * from "./dataStoreRegistry";
 export * from "./pendingStateManager";
 export * from "./runWhileConnectedCoordinator";
 export * from "./summarizer";
+export * from "./summarizerTypes";
 export * from "./summaryCollection";

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -24,7 +24,7 @@ import { SummaryCollection } from "./summaryCollection";
 import { SummarizerHandle } from "./summarizerHandle";
 import { ISummaryAttempt, RunningSummarizer } from "./runningSummarizer";
 import {
-    GenerateSummaryData,
+    GenerateSummaryResult,
     IGenerateSummaryOptions,
     ISummarizer,
     ISummarizerInternalsProvider,
@@ -262,7 +262,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     }
 
     /** Implementation of SummarizerInternalsProvider.generateSummary */
-    public async generateSummary(options: IGenerateSummaryOptions): Promise<GenerateSummaryData> {
+    public async generateSummary(options: IGenerateSummaryOptions): Promise<GenerateSummaryResult> {
         const result = this.internalsProvider.generateSummary(options);
 
         if (this.onBehalfOfClientId !== this.runtime.summarizerClientId

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -4,74 +4,36 @@
  */
 
 import { EventEmitter } from "events";
-import {
-    IEvent,
-    IEventProvider,
-    ITelemetryLogger,
-} from "@fluidframework/common-definitions";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { Deferred } from "@fluidframework/common-utils";
 import { ChildLogger, LoggingError } from "@fluidframework/telemetry-utils";
 import {
-    IFluidRouter,
-    IFluidRunnable,
     IRequest,
     IResponse,
     IFluidHandleContext,
     IFluidHandle,
-    IFluidLoadable,
 } from "@fluidframework/core-interfaces";
-import { ContainerWarning, IDeltaManager } from "@fluidframework/container-definitions";
 import { wrapError } from "@fluidframework/container-utils";
 import {
-    IDocumentMessage,
     ISequencedDocumentMessage,
     ISummaryConfiguration,
 } from "@fluidframework/protocol-definitions";
 import { create404Response } from "@fluidframework/runtime-utils";
-import { GenerateSummaryData } from "./containerRuntime";
-import { IConnectableRuntime, RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
+import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
 import { SummaryCollection } from "./summaryCollection";
 import { SummarizerHandle } from "./summarizerHandle";
 import { ISummaryAttempt, RunningSummarizer } from "./runningSummarizer";
-
-declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideSummarizer>> { }
-}
-
-export const ISummarizer: keyof IProvideSummarizer = "ISummarizer";
-
-export interface IProvideSummarizer {
-    readonly ISummarizer: ISummarizer;
-}
-
-export interface IGenerateSummaryOptions {
-    /** True to generate the full tree with no handle reuse optimizations; defaults to false */
-    fullTree?: boolean,
-    /** True to ask the server what the latest summary is first */
-    refreshLatestAck: boolean,
-    /** Logger to use for correlated summary events */
-    summaryLogger: ITelemetryLogger,
-}
-
-export interface ISummarizerInternalsProvider {
-    /** Encapsulates the work to walk the internals of the running container to generate a summary */
-    generateSummary(options: IGenerateSummaryOptions): Promise<GenerateSummaryData>;
-
-    /** Callback whenever a new SummaryAck is received, to update internal tracking state */
-    refreshLatestSummaryAck(
-        proposalHandle: string,
-        ackHandle: string,
-        summaryLogger: ITelemetryLogger,
-    ): Promise<void>;
-}
+import {
+    GenerateSummaryData,
+    IGenerateSummaryOptions,
+    ISummarizer,
+    ISummarizerInternalsProvider,
+    ISummarizerRuntime,
+    ISummarizingWarning,
+    SummarizerStopReason,
+} from "./summarizerTypes";
 
 const summarizingError = "summarizingError";
-
-export interface ISummarizingWarning extends ContainerWarning {
-    readonly errorType: "summarizingError";
-    readonly logged: boolean;
-}
 
 export class SummarizingWarning extends LoggingError implements ISummarizingWarning {
     readonly errorType = summarizingError;
@@ -89,56 +51,6 @@ export class SummarizingWarning extends LoggingError implements ISummarizingWarn
 
 export const createSummarizingWarning =
     (details: string, logged: boolean) => new SummarizingWarning(details, logged);
-
-export interface ISummarizerEvents extends IEvent {
-    /**
-     * An event indicating that the Summarizer is having problems summarizing
-     */
-    (event: "summarizingError", listener: (error: ISummarizingWarning) => void);
-}
-export type SummarizerStopReason =
-    /** Summarizer client failed to summarize in all 3 consecutive attempts. */
-    | "failToSummarize"
-    /**
-     * Summarizer client detected that its parent is no longer elected the summarizer.
-     * Normally, the parent client would realize it is disconnected first and call stop
-     * giving a "parentNotConnected" stop reason. If the summarizer client attempts to
-     * generate a summary and realizes at that moment that the parent is not elected,
-     * only then will it stop itself with this message.
-     */
-    | "parentNoLongerSummarizer"
-    /** Parent client reported that it is no longer connected. */
-    | "parentNotConnected"
-    /**
-     * Parent client reported that it is no longer elected the summarizer.
-     * This is the normal flow; a disconnect will always trigger the parent
-     * client to no longer be elected as responsible for summaries. Then it
-     * tries to stop its spawned summarizer client.
-     */
-    | "parentShouldNotSummarize"
-    /** Parent client reported that it is disposed. */
-    | "disposed";
-export interface ISummarizer
-    extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidRunnable, IFluidLoadable {
-    /**
-     * Returns a promise that will be resolved with the next Summarizer after context reload
-     */
-    setSummarizer(): Promise<Summarizer>;
-    stop(reason?: SummarizerStopReason): void;
-    run(onBehalfOf: string): Promise<void>;
-    updateOnBehalfOf(onBehalfOf: string): void;
-}
-
-export interface ISummarizerRuntime extends IConnectableRuntime {
-    readonly logger: ITelemetryLogger;
-    readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    readonly summarizerClientId: string | undefined;
-    nextSummarizerD?: Deferred<Summarizer>;
-    closeFn(): void;
-    on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
-    on(event: "disconnected", listener: () => void): this;
-    removeListener(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
-}
 
 /**
  * Summarizer is responsible for coordinating when to send generate and send summaries.
@@ -344,8 +256,8 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         }
     }
 
-    public async setSummarizer(): Promise<Summarizer> {
-        this.runtime.nextSummarizerD = new Deferred<Summarizer>();
+    public async setSummarizer(): Promise<ISummarizer> {
+        this.runtime.nextSummarizerD = new Deferred<ISummarizer>();
         return this.runtime.nextSummarizerD.promise;
     }
 

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -1,0 +1,139 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    IEvent,
+    IEventProvider,
+    ITelemetryLogger,
+} from "@fluidframework/common-definitions";
+import { Deferred } from "@fluidframework/common-utils";
+import {
+    IFluidRouter,
+    IFluidRunnable,
+    IFluidLoadable,
+} from "@fluidframework/core-interfaces";
+import { ContainerWarning, IDeltaManager } from "@fluidframework/container-definitions";
+import {
+    IDocumentMessage,
+    ISequencedDocumentMessage,
+} from "@fluidframework/protocol-definitions";
+import { ISummaryStats } from "@fluidframework/runtime-definitions";
+import { IConnectableRuntime } from "./runWhileConnectedCoordinator";
+
+declare module "@fluidframework/core-interfaces" {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    export interface IFluidObject extends Readonly<Partial<IProvideSummarizer>> { }
+}
+
+export const ISummarizer: keyof IProvideSummarizer = "ISummarizer";
+
+export interface IProvideSummarizer {
+    readonly ISummarizer: ISummarizer;
+}
+
+export interface ISummarizerInternalsProvider {
+    /** Encapsulates the work to walk the internals of the running container to generate a summary */
+    generateSummary(options: IGenerateSummaryOptions): Promise<GenerateSummaryData>;
+
+    /** Callback whenever a new SummaryAck is received, to update internal tracking state */
+    refreshLatestSummaryAck(
+        proposalHandle: string,
+        ackHandle: string,
+        summaryLogger: ITelemetryLogger,
+    ): Promise<void>;
+}
+
+export interface ISummarizingWarning extends ContainerWarning {
+    readonly errorType: "summarizingError";
+    readonly logged: boolean;
+}
+
+export interface ISummarizerRuntime extends IConnectableRuntime {
+    readonly logger: ITelemetryLogger;
+    readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    readonly summarizerClientId: string | undefined;
+    nextSummarizerD?: Deferred<ISummarizer>;
+    closeFn(): void;
+    on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
+    on(event: "disconnected", listener: () => void): this;
+    removeListener(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
+}
+
+export interface IGenerateSummaryOptions {
+    /** True to generate the full tree with no handle reuse optimizations; defaults to false */
+    fullTree?: boolean,
+    /** True to ask the server what the latest summary is first */
+    refreshLatestAck: boolean,
+    /** Logger to use for correlated summary events */
+    summaryLogger: ITelemetryLogger,
+}
+
+export interface IGeneratedSummaryStats extends ISummaryStats {
+    dataStoreCount: number;
+    summarizedDataStoreCount: number;
+}
+export interface IBaseSummaryData {
+    readonly referenceSequenceNumber: number;
+}
+export interface IGenerateSummaryData {
+    readonly summaryStats: IGeneratedSummaryStats;
+    readonly generateDuration: number;
+}
+export interface IUploadSummaryData {
+    readonly handle: string;
+    readonly uploadDuration: number;
+}
+export interface ISubmitSummaryData {
+    readonly clientSequenceNumber: number;
+    readonly submitOpDuration: number;
+}
+export type GenerateSummaryData =
+    ({ error: any; } & (
+        | ({ stage: "aborted"; } & IBaseSummaryData)
+        | ({ stage: "generated"; } & IGenerateSummaryData & IBaseSummaryData)
+        | ({ stage: "uploaded"; } & IUploadSummaryData & IGenerateSummaryData & IBaseSummaryData)
+    ))
+    | ({ stage: "submitted"; } & ISubmitSummaryData & IUploadSummaryData & IGenerateSummaryData & IBaseSummaryData);
+
+export type SummarizerStopReason =
+    /** Summarizer client failed to summarize in all 3 consecutive attempts. */
+    | "failToSummarize"
+    /**
+     * Summarizer client detected that its parent is no longer elected the summarizer.
+     * Normally, the parent client would realize it is disconnected first and call stop
+     * giving a "parentNotConnected" stop reason. If the summarizer client attempts to
+     * generate a summary and realizes at that moment that the parent is not elected,
+     * only then will it stop itself with this message.
+     */
+    | "parentNoLongerSummarizer"
+    /** Parent client reported that it is no longer connected. */
+    | "parentNotConnected"
+    /**
+     * Parent client reported that it is no longer elected the summarizer.
+     * This is the normal flow; a disconnect will always trigger the parent
+     * client to no longer be elected as responsible for summaries. Then it
+     * tries to stop its spawned summarizer client.
+     */
+    | "parentShouldNotSummarize"
+    /** Parent client reported that it is disposed. */
+    | "disposed";
+
+export interface ISummarizerEvents extends IEvent {
+    /**
+     * An event indicating that the Summarizer is having problems summarizing
+     */
+    (event: "summarizingError", listener: (error: ISummarizingWarning) => void);
+}
+
+export interface ISummarizer
+    extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidRunnable, IFluidLoadable {
+    /**
+     * Returns a promise that will be resolved with the next Summarizer after context reload
+     */
+    setSummarizer(): Promise<ISummarizer>;
+    stop(reason?: SummarizerStopReason): void;
+    run(onBehalfOf: string): Promise<void>;
+    updateOnBehalfOf(onBehalfOf: string): void;
+}

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -11,9 +11,10 @@ import { IFluidObject, IRequest } from "@fluidframework/core-interfaces";
 import { IContainerContext, LoaderHeader } from "@fluidframework/container-definitions";
 import { ISequencedClient } from "@fluidframework/protocol-definitions";
 import { DriverHeader } from "@fluidframework/driver-definitions";
-import { ISummarizer, createSummarizingWarning, ISummarizingWarning, SummarizerStopReason } from "./summarizer";
+import { createSummarizingWarning } from "./summarizer";
 import { SummarizerClientElection, summarizerClientType } from "./summarizerClientElection";
 import { Throttler } from "./throttler";
+import { ISummarizer, ISummarizingWarning, SummarizerStopReason } from "./summarizerTypes";
 
 const defaultInitialDelayMs = 5000;
 const opsToBypassInitialDelay = 4000;

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { MockDeltaManager, MockLogger } from "@fluidframework/test-runtime-utils";
 import { RunningSummarizer } from "../runningSummarizer";
-import { SummarizerStopReason } from "../summarizer";
+import { SummarizerStopReason } from "../summarizerTypes";
 import { SummaryCollection } from "../summaryCollection";
 
 describe("Runtime", () => {
@@ -105,8 +105,11 @@ describe("Runtime", () => {
                                 await deferGenerateSummary.promise;
                             }
                             return {
+                                stage: "submitted",
                                 referenceSequenceNumber: lastRefSeq,
-                                submitted: true,
+                                generateDuration: 0,
+                                uploadDuration: 0,
+                                submitOpDuration: 0,
                                 summaryStats: {
                                     treeNodeCount: 0,
                                     blobNodeCount: 0,
@@ -118,7 +121,7 @@ describe("Runtime", () => {
                                 },
                                 handle: "test-handle",
                                 clientSequenceNumber: lastClientSeq,
-                            };
+                            } as const;
                         },
                         stop(reason?: SummarizerStopReason) {
                             // do nothing

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -105,7 +105,7 @@ describe("Runtime", () => {
                                 await deferGenerateSummary.promise;
                             }
                             return {
-                                stage: "submitted",
+                                stage: "submit",
                                 referenceSequenceNumber: lastRefSeq,
                                 generateDuration: 0,
                                 uploadDuration: 0,


### PR DESCRIPTION
This is a refactor PR as part of #6382 (Part 1/3)

Move most summarizer type definitions to new summarizerTypes.ts file. This is part of a goal to shrink Summarizer.ts and RunningSummarizer.ts complexity and size.

Change return type of ContainerRuntime.generateSummary to use "stages" to indicate how far along it got.
1. "aborted" - stopped before any progress was made
2. "generated" - stopped after summary tree was generated
3. "uploaded" - stopped after summary was uploaded to storage
4. "submitted" - stopped after summarize op was submitted
