### PR TITLE
Split out part of RunningSummarizer into SummaryGenerator

### DIFF
--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -3,212 +3,30 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
-import { Deferred, IPromiseTimerResult, PromiseTimer, Timer } from "@fluidframework/common-utils";
+import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
+import { Deferred, PromiseTimer } from "@fluidframework/common-utils";
 import {
     ISequencedDocumentMessage,
     ISequencedDocumentSystemMessage,
     ISummaryConfiguration,
     MessageType,
 } from "@fluidframework/protocol-definitions";
-import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
 import {
-    GenerateSummaryResult,
-    IGenerateSummaryOptions,
     ISummarizer,
     ISummarizerInternalsProvider,
 } from "./summarizerTypes";
 import { IClientSummaryWatcher, SummaryCollection } from "./summaryCollection";
+import {
+    checkNotTimeout,
+    ISummaryAttempt,
+    SummarizeReason,
+    SummarizerHeuristics,
+    SummaryGenerator,
+} from "./summaryGenerator";
 
-// Send some telemetry if generate summary takes too long
-const maxSummarizeTimeoutTime = 20000; // 20 sec
-const maxSummarizeTimeoutCount = 5; // Double and resend 5 times
 const maxSummarizeAckWaitTime = 10 * 60 * 1000; // 10 minutes
-
 const minOpsForLastSummary = 50;
-
-type SummarizeReason =
-    /**
-     * Attempt to summarize after idle timeout has elapsed.
-     * Idle timer restarts whenever an op is received. So this
-     * triggers only after some amount of time has passed with
-     * no ops being received.
-     */
-    | "idle"
-    /**
-     * Attempt to summarize after a maximum time since last
-     * successful summary has passed. This measures time since
-     * last summary ack op was processed.
-     */
-    | "maxTime"
-    /**
-     * Attempt to summarize after a maximum number of ops have
-     * passed since the last successful summary. This compares
-     * op sequence numbers with the reference sequence number
-     * of the summarize op corresponding to the last summary
-     * ack op.
-     */
-    | "maxOps"
-    /**
-     * Special case to generate a summary in response to a Save op.
-     * @deprecated - do not use save ops
-     */
-    | `save;${string}: ${string}`
-    /**
-     * Special case to attempt to summarize one last time before the
-     * summarizer client closes itself. This is to prevent cases where
-     * the summarizer client never gets a chance to summarize, because
-     * there are too many outstanding ops and/or parent client cannot
-     * stay connected long enough for summarizer client to catch up.
-     */
-    | "lastSummary"
-    /** Previous summary attempt failed, and we are retrying. */
-    | `retry${number}`;
-
-const summarizeErrors = {
-    /**
-     * Error encountered while generating the summary tree, uploading
-     * it to storage, or submitting the op. It could be a result of
-     * the client becoming disconnected while generating or an actual error.
-     */
-    generateSummaryFailure: "Error while generating or submitting summary",
-    /**
-     * The summaryAckWaitTimeout time has elapsed before receiving the summarize op
-     * sent by this summarize attempt. It is expected to be broadcast quickly.
-     */
-    summaryOpWaitTimeout: "Timeout while waiting for summarize op broadcast",
-    /**
-     * The summaryAckWaitTimeout time has elapsed before receiving either a
-     * summaryAck or summaryNack op from the server in response to this
-     * summarize attempt. It is expected that the server should respond.
-     */
-    summaryAckWaitTimeout: "Timeout while waiting for summaryAck/summaryNack op",
-    /**
-     * The server responded with a summaryNack op, thus rejecting this
-     * summarize attempt.
-     */
-    summaryNack: "Server rejected summary via summaryNack op",
-} as const;
-
-/**
- * Data about a summary attempt
- */
-export interface ISummaryAttempt {
-    /**
-     * Reference sequence number when summary was generated or attempted
-     */
-    readonly refSequenceNumber: number;
-
-    /**
-     * Time of summary attempt after it was sent or attempted
-     */
-    readonly summaryTime: number;
-
-    /**
-     * Sequence number of summary op
-     */
-    summarySequenceNumber?: number;
-}
-
-const checkNotTimeout = <T>(something: T | IPromiseTimerResult | undefined): something is T => {
-    if (something === undefined) {
-        return false;
-    }
-    return (something as IPromiseTimerResult).timerResult === undefined;
-};
-
-/**
- * This class contains the heuristics for when to summarize.
- */
-class SummarizerHeuristics {
-    private _lastAttempted: ISummaryAttempt;
-    private _lastAcked: ISummaryAttempt;
-
-    /**
-     * Last sent summary attempt
-     */
-    public get lastAttempted(): ISummaryAttempt {
-        return this._lastAttempted;
-    }
-
-    /**
-     * Last acked summary attempt
-     */
-    public get lastAcked(): ISummaryAttempt {
-        return this._lastAcked;
-    }
-
-    private readonly idleTimer: Timer;
-
-    public constructor(
-        private readonly configuration: ISummaryConfiguration,
-        private readonly trySummarize: (reason: SummarizeReason) => void,
-        /**
-         * Last received op sequence number
-         */
-        public lastOpSeqNumber: number,
-        firstAck: ISummaryAttempt,
-    ) {
-        this._lastAttempted = firstAck;
-        this._lastAcked = firstAck;
-        this.idleTimer = new Timer(
-            this.configuration.idleTime,
-            () => this.trySummarize("idle"));
-    }
-
-    /**
-     * Sets the last attempted summary and last acked summary.
-     * @param lastSummary - last acked summary
-     */
-    public initialize(lastSummary: ISummaryAttempt) {
-        this._lastAttempted = lastSummary;
-        this._lastAcked = lastSummary;
-    }
-
-    /**
-     * Records a summary attempt. If the attempt was successfully sent,
-     * provide the reference sequence number, otherwise it will be set
-     * to the last seen op sequence number.
-     * @param refSequenceNumber - reference sequence number of sent summary
-     */
-    public recordAttempt(refSequenceNumber?: number) {
-        this._lastAttempted = {
-            refSequenceNumber: refSequenceNumber ?? this.lastOpSeqNumber,
-            summaryTime: Date.now(),
-        };
-    }
-
-    /**
-     * Mark the last sent summary attempt as acked.
-     */
-    public ackLastSent() {
-        this._lastAcked = this.lastAttempted;
-    }
-
-    /**
-     * Runs the heuristic to determine if it should try to summarize.
-     */
-    public run() {
-        this.idleTimer.clear();
-        const timeSinceLastSummary = Date.now() - this.lastAcked.summaryTime;
-        const opCountSinceLastSummary = this.lastOpSeqNumber - this.lastAcked.refSequenceNumber;
-
-        if (timeSinceLastSummary > this.configuration.maxTime) {
-            this.trySummarize("maxTime");
-        } else if (opCountSinceLastSummary > this.configuration.maxOps) {
-            this.trySummarize("maxOps");
-        } else {
-            this.idleTimer.restart();
-        }
-    }
-
-    /**
-     * Disposes of resources.
-     */
-    public dispose() {
-        this.idleTimer.clear();
-    }
-}
 
 /**
  * An instance of RunningSummarizer manages the heuristics for summarizing.
@@ -253,12 +71,11 @@ export class RunningSummarizer implements IDisposable {
 
     private stopping = false;
     private _disposed = false;
-    private summarizing: Deferred<void> | undefined;
-    private summarizeCount: number = 0;
+    private summarizingLock: Promise<void> | undefined;
     private tryWhileSummarizing = false;
-    private readonly summarizeTimer: Timer;
     private readonly pendingAckTimer: PromiseTimer;
     private readonly heuristics: SummarizerHeuristics;
+    private readonly generator: SummaryGenerator;
     private readonly logger: ITelemetryLogger;
 
     private constructor(
@@ -275,17 +92,13 @@ export class RunningSummarizer implements IDisposable {
         private readonly summaryCollection: SummaryCollection,
     ) {
         this.logger = ChildLogger.create(
-            baseLogger, "Running", { all: { summaryGenTag: () => this.summarizeCount } });
+            baseLogger, "Running", { all: { summaryGenTag: () => this.generator.getSummarizeCount() } });
 
         this.heuristics = new SummarizerHeuristics(
             configuration,
             (reason) => this.trySummarize(reason),
             lastOpSeqNumber,
             firstAck);
-
-        this.summarizeTimer = new Timer(
-            maxSummarizeTimeoutTime,
-            () => this.summarizeTimerHandler(maxSummarizeTimeoutTime, 1));
 
         // Cap the maximum amount of time client will wait for a summarize op ack to maxSummarizeAckWaitTime
         // configuration.maxAckWaitTime is composed from defaults, server values, and runtime overrides
@@ -317,12 +130,21 @@ export class RunningSummarizer implements IDisposable {
                 this.pendingAckTimer.clear();
             }
         });
+
+        this.generator = new SummaryGenerator(
+            this.pendingAckTimer,
+            this.heuristics,
+            this.internalsProvider,
+            this.raiseSummarizingError,
+            this.summaryWatcher,
+            this.logger,
+        );
     }
 
     public dispose(): void {
         this.summaryWatcher.dispose();
         this.heuristics.dispose();
-        this.summarizeTimer.clear();
+        this.generator.dispose();
         this.pendingAckTimer.clear();
         this._disposed = true;
     }
@@ -383,7 +205,10 @@ export class RunningSummarizer implements IDisposable {
             return;
         }
         if (this.stopping) {
-            await this.summarizing?.promise;
+            await Promise.all([
+                this.summarizingLock,
+                this.generator.waitSummarizing(),
+            ]);
             return;
         }
         this.stopping = true;
@@ -393,7 +218,10 @@ export class RunningSummarizer implements IDisposable {
             // This resolves when the current pending summary is acked or fails.
             // We wait for the result in case a safe summary is needed, and to get
             // better telemetry.
-            await this.summarizing?.promise;
+            await Promise.all([
+                this.summarizingLock,
+                this.generator.waitSummarizing(),
+            ]);
         }
     }
 
@@ -419,15 +247,14 @@ export class RunningSummarizer implements IDisposable {
     }
 
     private trySummarize(reason: SummarizeReason): void {
-        if (this.summarizing !== undefined) {
-            // We can't summarize if we are already
+        if (this.summarizingLock !== undefined || this.generator.isSummarizing()) {
+            // Indicate that heuristics tried to summarize, and check immediately
+            // after completion if heuristics still indicate we should summarize.
             this.tryWhileSummarizing = true;
             return;
         }
-
-        // GenerateSummary could take some time
-        // mark that we are currently summarizing to prevent concurrent summarizing
-        this.summarizing = new Deferred<void>();
+        const summarizingLock = new Deferred<void>();
+        this.summarizingLock = summarizingLock.promise;
 
         (async () => {
             const attempts = [
@@ -442,7 +269,7 @@ export class RunningSummarizer implements IDisposable {
                     await new Promise((resolve) => setTimeout(resolve, delayMinutes * 1000 * 60));
                 }
                 const attemptReason = i > 0 ? `retry${i}` as `retry${number}` : reason;
-                if (await this.summarize(attemptReason, options) === true) {
+                if (await this.generator.summarize(attemptReason, options) === true) {
                     return;
                 }
             }
@@ -450,171 +277,16 @@ export class RunningSummarizer implements IDisposable {
             this.logger.sendErrorEvent({ eventName: "FailToSummarize" });
             this.internalsProvider.stop("failToSummarize");
         })().finally(() => {
-            this.summarizing?.resolve();
-            this.summarizing = undefined;
-            if (this.tryWhileSummarizing && !this.stopping && !this.disposed) {
+            summarizingLock.resolve();
+            this.summarizingLock = undefined;
+            if (this.tryWhileSummarizing) {
                 this.tryWhileSummarizing = false;
-                this.heuristics.run();
+                if (!this.stopping && !this._disposed) {
+                    this.heuristics.run();
+                }
             }
         }).catch((error) => {
             this.logger.sendErrorEvent({ eventName: "UnexpectedSummarizeError" }, error);
         });
-    }
-
-    /**
-     * Generates summary and listens for broadcast and ack/nack.
-     * Returns true for ack, false for nack, and undefined for failure or timeout.
-     * @param reason - reason for summarizing
-     * @param options - refreshLatestAck to fetch summary ack info from server,
-     * fullTree to generate tree without any summary handles even if unchanged
-     */
-     private async summarize(
-        reason: SummarizeReason,
-        options: Omit<IGenerateSummaryOptions, "summaryLogger">,
-    ): Promise<boolean> {
-        ++this.summarizeCount;
-        const { refreshLatestAck, fullTree } = options;
-        const summarizeEvent = PerformanceEvent.start(this.logger, {
-            eventName: "Summarize",
-            reason,
-            refreshLatestAck,
-            fullTree,
-            timeSinceLastAttempt: Date.now() - this.heuristics.lastAttempted.summaryTime,
-            timeSinceLastSummary: Date.now() - this.heuristics.lastAcked.summaryTime,
-        });
-        // Helper function to report failures and return.
-        const fail = (
-            message: keyof typeof summarizeErrors,
-            error?: any,
-            properties?: ITelemetryProperties,
-        ): false => {
-            this.raiseSummarizingError(summarizeErrors[message]);
-            summarizeEvent.cancel({ ...properties, message }, error);
-            return false;
-        };
-
-        // Wait to generate and send summary
-        this.summarizeTimer.start();
-        // Use record type to prevent unexpected value types
-        let summaryData: GenerateSummaryResult | undefined;
-        let generateTelemetryProps: Record<string, string | number | boolean | undefined> = {};
-        try {
-            summaryData = await this.internalsProvider.generateSummary({
-                fullTree,
-                refreshLatestAck,
-                summaryLogger: this.logger,
-            });
-
-            // Cumulatively add telemetry properties based on how far generateSummary went.
-            // This is based on the stages:
-            // 1. base - stopped before the summary tree was generated
-            // 2. generate - stopped before the summary was uploaded to storage
-            // 3. upload - stopped before the summarize op was submitted
-            // 4. submit - completed submitting the summarize op
-            const { referenceSequenceNumber: refSequenceNumber } = summaryData;
-            generateTelemetryProps = {
-                refSequenceNumber,
-                opsSinceLastAttempt: refSequenceNumber - this.heuristics.lastAttempted.refSequenceNumber,
-                opsSinceLastSummary: refSequenceNumber - this.heuristics.lastAcked.refSequenceNumber,
-            };
-            if (summaryData.stage !== "base") {
-                // If not base, it at least generated the summary tree.
-                generateTelemetryProps = {
-                    ...generateTelemetryProps,
-                    ...summaryData.summaryStats,
-                    generateDuration: summaryData.generateDuration,
-                };
-
-                if (summaryData.stage !== "generate") {
-                    // If neither base nor generate, it at least uploaded to storage.
-                    generateTelemetryProps = {
-                        ...generateTelemetryProps,
-                        handle: summaryData.handle,
-                        uploadDuration: summaryData.uploadDuration,
-                    };
-
-                    if (summaryData.stage !== "upload") {
-                        // If neither base, generate, nor upload, then it submitted the op.
-                        generateTelemetryProps = {
-                            ...generateTelemetryProps,
-                            clientSequenceNumber: summaryData.clientSequenceNumber,
-                            submitOpDuration: summaryData.submitOpDuration,
-                        };
-                    }
-                }
-            }
-
-            this.logger.sendTelemetryEvent({ eventName: "GenerateSummary", ...generateTelemetryProps });
-            if (summaryData.stage !== "submit") {
-                return fail("generateSummaryFailure", summaryData.error, generateTelemetryProps);
-            }
-        } catch (error) {
-            return fail("generateSummaryFailure", error, generateTelemetryProps);
-        } finally {
-            this.heuristics.recordAttempt(summaryData?.referenceSequenceNumber);
-            this.summarizeTimer.clear();
-        }
-
-        try {
-            const pendingTimeoutP = this.pendingAckTimer.start().catch(() => undefined);
-            const summary = this.summaryWatcher.watchSummary(summaryData.clientSequenceNumber);
-
-            // Wait for broadcast
-            const summarizeOp = await Promise.race([summary.waitBroadcast(), pendingTimeoutP]);
-            if (!checkNotTimeout(summarizeOp)) {
-                return fail("summaryOpWaitTimeout");
-            }
-
-            const broadcastDuration = Date.now() - this.heuristics.lastAttempted.summaryTime;
-            this.heuristics.lastAttempted.summarySequenceNumber = summarizeOp.sequenceNumber;
-            this.logger.sendTelemetryEvent({
-                eventName: "SummaryOp",
-                timeWaiting: broadcastDuration,
-                refSequenceNumber: summarizeOp.referenceSequenceNumber,
-                summarySequenceNumber: summarizeOp.sequenceNumber,
-                handle: summarizeOp.contents.handle,
-            });
-
-            // Wait for ack/nack
-            const ackNack = await Promise.race([summary.waitAckNack(), pendingTimeoutP]);
-            if (!checkNotTimeout(ackNack)) {
-                return fail("summaryAckWaitTimeout");
-            }
-            this.pendingAckTimer.clear();
-
-            // Update for success/failure
-            const ackNackDuration = Date.now() - this.heuristics.lastAttempted.summaryTime;
-            const telemetryProps: Record<string, number> = {
-                timeWaiting: ackNackDuration,
-                sequenceNumber: ackNack.sequenceNumber,
-                summarySequenceNumber: ackNack.contents.summaryProposal.summarySequenceNumber,
-            };
-            if (ackNack.type === MessageType.SummaryAck) {
-                this.heuristics.ackLastSent();
-                summarizeEvent.end({ ...telemetryProps, handle: ackNack.contents.handle, message: "summaryAck" });
-                return true;
-            } else {
-                return fail(
-                    "summaryNack",
-                    ackNack.contents.errorMessage,
-                    telemetryProps,
-                );
-            }
-        } finally {
-            this.pendingAckTimer.clear();
-        }
-    }
-
-    private summarizeTimerHandler(time: number, count: number) {
-        this.logger.sendPerformanceEvent({
-            eventName: "SummarizeTimeout",
-            timeoutTime: time,
-            timeoutCount: count,
-        });
-        if (count < maxSummarizeTimeoutCount) {
-            // Double and start a new timer
-            const nextTime = time * 2;
-            this.summarizeTimer.start(nextTime, () => this.summarizeTimerHandler(nextTime, count + 1));
-        }
     }
 }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -22,7 +22,7 @@ import { create404Response } from "@fluidframework/runtime-utils";
 import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
 import { SummaryCollection } from "./summaryCollection";
 import { SummarizerHandle } from "./summarizerHandle";
-import { ISummaryAttempt, RunningSummarizer } from "./runningSummarizer";
+import { RunningSummarizer } from "./runningSummarizer";
 import {
     GenerateSummaryResult,
     IGenerateSummaryOptions,
@@ -191,11 +191,6 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             initSummarySeqNumber: this.runtime.deltaManager.initialSequenceNumber,
         });
 
-        const initialAttempt: ISummaryAttempt = {
-            refSequenceNumber: this.runtime.deltaManager.initialSequenceNumber,
-            summaryTime: Date.now(),
-        };
-
         const runningSummarizer = await RunningSummarizer.start(
             startResult.clientId,
             onBehalfOf,
@@ -204,7 +199,10 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             this.configurationGetter(),
             this /* Pick<ISummarizerInternalsProvider, "generateSummary"> */,
             this.runtime.deltaManager.lastSequenceNumber,
-            initialAttempt,
+            { /** Initial summary attempt */
+                refSequenceNumber: this.runtime.deltaManager.initialSequenceNumber,
+                summaryTime: Date.now(),
+            } as const,
             (description: string) => {
                 if (!this._disposed) {
                     this.emit("summarizingError", createSummarizingWarning(`Summarizer: ${description}`, true));

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -1,0 +1,395 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
+import { Deferred, IPromiseTimer, IPromiseTimerResult, Timer } from "@fluidframework/common-utils";
+import { ISummaryConfiguration, MessageType } from "@fluidframework/protocol-definitions";
+import { PerformanceEvent } from "@fluidframework/telemetry-utils";
+import {
+    GenerateSummaryResult,
+    IGenerateSummaryOptions,
+    ISummarizerInternalsProvider,
+} from "./summarizerTypes";
+import { IClientSummaryWatcher } from "./summaryCollection";
+
+export const checkNotTimeout = <T>(something: T | IPromiseTimerResult | undefined): something is T => {
+    if (something === undefined) {
+        return false;
+    }
+    return (something as IPromiseTimerResult).timerResult === undefined;
+};
+
+// Send some telemetry if generate summary takes too long
+const maxSummarizeTimeoutTime = 20000; // 20 sec
+const maxSummarizeTimeoutCount = 5; // Double and resend 5 times
+
+/**
+ * Data about a summary attempt
+ */
+export interface ISummaryAttempt {
+    /**
+     * Reference sequence number when summary was generated or attempted
+     */
+    readonly refSequenceNumber: number;
+
+    /**
+     * Time of summary attempt after it was sent or attempted
+     */
+    readonly summaryTime: number;
+
+    /**
+     * Sequence number of summary op
+     */
+    summarySequenceNumber?: number;
+}
+
+export type SummarizeReason =
+    /**
+     * Attempt to summarize after idle timeout has elapsed.
+     * Idle timer restarts whenever an op is received. So this
+     * triggers only after some amount of time has passed with
+     * no ops being received.
+     */
+    | "idle"
+    /**
+     * Attempt to summarize after a maximum time since last
+     * successful summary has passed. This measures time since
+     * last summary ack op was processed.
+     */
+    | "maxTime"
+    /**
+     * Attempt to summarize after a maximum number of ops have
+     * passed since the last successful summary. This compares
+     * op sequence numbers with the reference sequence number
+     * of the summarize op corresponding to the last summary
+     * ack op.
+     */
+    | "maxOps"
+    /**
+     * Special case to generate a summary in response to a Save op.
+     * @deprecated - do not use save ops
+     */
+    | `save;${string}: ${string}`
+    /**
+     * Special case to attempt to summarize one last time before the
+     * summarizer client closes itself. This is to prevent cases where
+     * the summarizer client never gets a chance to summarize, because
+     * there are too many outstanding ops and/or parent client cannot
+     * stay connected long enough for summarizer client to catch up.
+     */
+    | "lastSummary"
+    /** Previous summary attempt failed, and we are retrying. */
+    | `retry${number}`
+    /** On-demand summary requested with specified reason. */
+    | `onDemand;${string}`;
+const summarizeErrors = {
+    /**
+     * Error encountered while generating the summary tree, uploading
+     * it to storage, or submitting the op. It could be a result of
+     * the client becoming disconnected while generating or an actual error.
+     */
+    generateSummaryFailure: "Error while generating or submitting summary",
+    /**
+     * The summaryAckWaitTimeout time has elapsed before receiving the summarize op
+     * sent by this summarize attempt. It is expected to be broadcast quickly.
+     */
+    summaryOpWaitTimeout: "Timeout while waiting for summarize op broadcast",
+    /**
+     * The summaryAckWaitTimeout time has elapsed before receiving either a
+     * summaryAck or summaryNack op from the server in response to this
+     * summarize attempt. It is expected that the server should respond.
+     */
+    summaryAckWaitTimeout: "Timeout while waiting for summaryAck/summaryNack op",
+    /**
+     * The server responded with a summaryNack op, thus rejecting this
+     * summarize attempt.
+     */
+    summaryNack: "Server rejected summary via summaryNack op",
+} as const;
+/**
+ * This class contains the heuristics for when to summarize.
+ */
+ export class SummarizerHeuristics {
+    private _lastAttempted: ISummaryAttempt;
+    private _lastAcked: ISummaryAttempt;
+    /**
+     * Last sent summary attempt
+     */
+    public get lastAttempted(): ISummaryAttempt {
+        return this._lastAttempted;
+    }
+    /**
+     * Last acked summary attempt
+     */
+    public get lastAcked(): ISummaryAttempt {
+        return this._lastAcked;
+    }
+    private readonly idleTimer: Timer;
+    public constructor(
+        private readonly configuration: ISummaryConfiguration,
+        private readonly trySummarize: (reason: SummarizeReason) => void,
+        /**
+         * Last received op sequence number
+         */
+        public lastOpSeqNumber: number,
+        firstAck: ISummaryAttempt,
+    ) {
+        this._lastAttempted = firstAck;
+        this._lastAcked = firstAck;
+        this.idleTimer = new Timer(
+            this.configuration.idleTime,
+            () => this.trySummarize("idle"));
+    }
+    /**
+     * Sets the last attempted summary and last acked summary.
+     * @param lastSummary - last acked summary
+     */
+    public initialize(lastSummary: ISummaryAttempt) {
+        this._lastAttempted = lastSummary;
+        this._lastAcked = lastSummary;
+    }
+    /**
+     * Records a summary attempt. If the attempt was successfully sent,
+     * provide the reference sequence number, otherwise it will be set
+     * to the last seen op sequence number.
+     * @param refSequenceNumber - reference sequence number of sent summary
+     */
+    public recordAttempt(refSequenceNumber?: number) {
+        this._lastAttempted = {
+            refSequenceNumber: refSequenceNumber ?? this.lastOpSeqNumber,
+            summaryTime: Date.now(),
+        };
+    }
+    /**
+     * Mark the last sent summary attempt as acked.
+     */
+    public ackLastSent() {
+        this._lastAcked = this.lastAttempted;
+    }
+    /**
+     * Runs the heuristic to determine if it should try to summarize.
+     */
+    public run() {
+        this.idleTimer.clear();
+        const timeSinceLastSummary = Date.now() - this.lastAcked.summaryTime;
+        const opCountSinceLastSummary = this.lastOpSeqNumber - this.lastAcked.refSequenceNumber;
+        if (timeSinceLastSummary > this.configuration.maxTime) {
+            this.trySummarize("maxTime");
+        } else if (opCountSinceLastSummary > this.configuration.maxOps) {
+            this.trySummarize("maxOps");
+        } else {
+            this.idleTimer.restart();
+        }
+    }
+    /**
+     * Disposes of resources.
+     */
+    public dispose() {
+        this.idleTimer.clear();
+    }
+}
+
+/**
+ * This class generates and tracks a summary attempt.
+ */
+export class SummaryGenerator {
+    private summarizing: Deferred<void> | undefined;
+    public isSummarizing() { return this.summarizing !== undefined; }
+    public async waitSummarizing() { await this.summarizing?.promise; }
+    private summarizeCount = 0;
+    public getSummarizeCount() { return this.summarizeCount; }
+    private readonly summarizeTimer: Timer;
+    constructor(
+        private readonly pendingAckTimer: IPromiseTimer,
+        private readonly heuristics: SummarizerHeuristics,
+        private readonly internalsProvider: Pick<ISummarizerInternalsProvider, "generateSummary">,
+        private readonly raiseSummarizingError: (description: string) => void,
+        private readonly summaryWatcher: Pick<IClientSummaryWatcher, "watchSummary">,
+        private readonly logger: ITelemetryLogger,
+    ) {
+        this.summarizeTimer = new Timer(
+            maxSummarizeTimeoutTime,
+            () => this.summarizeTimerHandler(maxSummarizeTimeoutTime, 1),
+        );
+    }
+
+    /**
+     * Generates summary and listens for broadcast and ack/nack.
+     * Returns true for ack, false for nack, and undefined for failure or timeout.
+     * @param reason - reason for summarizing
+     * @param options - refreshLatestAck to fetch summary ack info from server,
+     * fullTree to generate tree without any summary handles even if unchanged
+     */
+    public async summarize(
+        reason: SummarizeReason,
+        options: Omit<IGenerateSummaryOptions, "summaryLogger">,
+    ): Promise<boolean> {
+        ++this.summarizeCount;
+        if (this.summarizing !== undefined) {
+            // We do not expect this case. Log the error and let it try again anyway.
+            this.logger.sendErrorEvent({ eventName: "ConcurrentSummarizeAttempt", reason });
+            return false;
+        }
+
+        // GenerateSummary could take some time
+        // mark that we are currently summarizing to prevent concurrent summarizing
+        this.summarizing = new Deferred<void>();
+
+        try {
+            return this.summarizeCore(reason, options);
+        } catch (error) {
+            this.logger.sendErrorEvent({ eventName: "UnexpectedSummarizeError" }, error);
+            return false;
+        } finally {
+            this.summarizing?.resolve();
+            this.summarizing = undefined;
+        }
+    }
+
+    private async summarizeCore(
+        reason: SummarizeReason,
+        options: Omit<IGenerateSummaryOptions, "summaryLogger">,
+    ): Promise<boolean> {
+        const { refreshLatestAck, fullTree } = options;
+        const summarizeEvent = PerformanceEvent.start(this.logger, {
+            eventName: "Summarize",
+            reason,
+            refreshLatestAck,
+            fullTree,
+            timeSinceLastAttempt: Date.now() - this.heuristics.lastAttempted.summaryTime,
+            timeSinceLastSummary: Date.now() - this.heuristics.lastAcked.summaryTime,
+        });
+        // Helper function to report failures and return.
+        const fail = (
+            message: keyof typeof summarizeErrors,
+            error?: any,
+            properties?: ITelemetryProperties,
+        ): false => {
+            this.raiseSummarizingError(summarizeErrors[message]);
+            summarizeEvent.cancel({ ...properties, message }, error);
+            return false;
+        };
+
+        // Wait to generate and send summary
+        this.summarizeTimer.start();
+        // Use record type to prevent unexpected value types
+        let summaryData: GenerateSummaryResult | undefined;
+        let generateTelemetryProps: Record<string, string | number | boolean | undefined> = {};
+        try {
+            summaryData = await this.internalsProvider.generateSummary({
+                fullTree,
+                refreshLatestAck,
+                summaryLogger: this.logger,
+            });
+
+            // Cumulatively add telemetry properties based on how far generateSummary went.
+            const { referenceSequenceNumber: refSequenceNumber } = summaryData;
+            generateTelemetryProps = {
+                refSequenceNumber,
+                opsSinceLastAttempt: refSequenceNumber - this.heuristics.lastAttempted.refSequenceNumber,
+                opsSinceLastSummary: refSequenceNumber - this.heuristics.lastAcked.refSequenceNumber,
+            };
+            if (summaryData.stage !== "base") {
+                generateTelemetryProps = {
+                    ...generateTelemetryProps,
+                    ...summaryData.summaryStats,
+                    generateDuration: summaryData.generateDuration,
+                };
+
+                if (summaryData.stage !== "generate") {
+                    generateTelemetryProps = {
+                        ...generateTelemetryProps,
+                        handle: summaryData.handle,
+                        uploadDuration: summaryData.uploadDuration,
+                    };
+
+                    if (summaryData.stage !== "upload") {
+                        generateTelemetryProps = {
+                            ...generateTelemetryProps,
+                            clientSequenceNumber: summaryData.clientSequenceNumber,
+                            submitOpDuration: summaryData.submitOpDuration,
+                        };
+                    }
+                }
+            }
+
+            this.logger.sendTelemetryEvent({ eventName: "GenerateSummary", ...generateTelemetryProps });
+            if (summaryData.stage !== "submit") {
+                return fail("generateSummaryFailure", summaryData.error, generateTelemetryProps);
+            }
+        } catch (error) {
+            return fail("generateSummaryFailure", error, generateTelemetryProps);
+        } finally {
+            this.heuristics.recordAttempt(summaryData?.referenceSequenceNumber);
+            this.summarizeTimer.clear();
+        }
+
+        try {
+            const pendingTimeoutP = this.pendingAckTimer.start().catch(() => undefined);
+            const summary = this.summaryWatcher.watchSummary(summaryData.clientSequenceNumber);
+
+            // Wait for broadcast
+            const summarizeOp = await Promise.race([summary.waitBroadcast(), pendingTimeoutP]);
+            if (!checkNotTimeout(summarizeOp)) {
+                return fail("summaryOpWaitTimeout");
+            }
+
+            const broadcastDuration = Date.now() - this.heuristics.lastAttempted.summaryTime;
+            this.heuristics.lastAttempted.summarySequenceNumber = summarizeOp.sequenceNumber;
+            this.logger.sendTelemetryEvent({
+                eventName: "SummaryOp",
+                timeWaiting: broadcastDuration,
+                refSequenceNumber: summarizeOp.referenceSequenceNumber,
+                summarySequenceNumber: summarizeOp.sequenceNumber,
+                handle: summarizeOp.contents.handle,
+            });
+
+            // Wait for ack/nack
+            const ackNack = await Promise.race([summary.waitAckNack(), pendingTimeoutP]);
+            if (!checkNotTimeout(ackNack)) {
+                return fail("summaryAckWaitTimeout");
+            }
+            this.pendingAckTimer.clear();
+
+            // Update for success/failure
+            const ackNackDuration = Date.now() - this.heuristics.lastAttempted.summaryTime;
+            const telemetryProps: Record<string, number> = {
+                timeWaiting: ackNackDuration,
+                sequenceNumber: ackNack.sequenceNumber,
+                summarySequenceNumber: ackNack.contents.summaryProposal.summarySequenceNumber,
+            };
+            if (ackNack.type === MessageType.SummaryAck) {
+                this.heuristics.ackLastSent();
+                summarizeEvent.end({ ...telemetryProps, handle: ackNack.contents.handle, message: "summaryAck" });
+                return true;
+            } else {
+                return fail(
+                    "summaryNack",
+                    ackNack.contents.errorMessage,
+                    telemetryProps,
+                );
+            }
+        } finally {
+            this.pendingAckTimer.clear();
+        }
+    }
+
+    private summarizeTimerHandler(time: number, count: number) {
+        this.logger.sendPerformanceEvent({
+            eventName: "SummarizeTimeout",
+            timeoutTime: time,
+            timeoutCount: count,
+        });
+        if (count < maxSummarizeTimeoutCount) {
+            // Double and start a new timer
+            const nextTime = time * 2;
+            this.summarizeTimer.start(nextTime, () => this.summarizeTimerHandler(nextTime, count + 1));
+        }
+    }
+
+    public dispose() {
+        this.summarizeTimer.clear();
+    }
+}


### PR DESCRIPTION
This is a refactor PR as part of #6382 (Part 2/3)
PR #6783 should be merged first.

Break out SummarizerHeuristics and the generate summary function into a new SummaryGenerator class in a new file: summaryGenerator.ts. The goal of this refactor is to reduce complexity and size of RunningSummarizer.ts.

The new breakdown is as follows:
- summarizer.ts - Summarizer is the main entry-point class for summarizing. Handles starting and stopping of summarizing process and heuristics via `run()` and `stop()`.
- runningSummarizer.ts - RunningSummarizer is the class created and existing until `stop()` is called. It manages the heuristics and summarizing attempts by hooking up to op events.
- summaryGenerator.ts - SummaryGenerator is the code that runs to submit a summarize op, but also track it for ack/nack via the `summarize()` function. SummarizerHeuristics includes the code to check the op count/time difference for determining when to summarize.