### PR TITLE
ICM: usage of aggregate blobs results in failed doc on open

### DIFF
--- a/packages/loader/driver-utils/src/blobAggregationStorage.ts
+++ b/packages/loader/driver-utils/src/blobAggregationStorage.ts
@@ -102,7 +102,7 @@ export abstract class SnapshotExtractor {
     public async unpackSnapshotCore(snapshot: ISnapshotTree, level = 0): Promise<void> {
         // for now only working at data store level, i.e.
         // .app/DataStore/...
-        if (level >= 2) {
+        if (level >= 3) {
             return;
         }
 


### PR DESCRIPTION
Adjust depth level to address latest ICM incident due to addition of .channels sub-path in hierarchy
https://github.com/microsoft/FluidFramework/issues/6784 tracks long term testability