### PR TITLE
Remove usages of readAndParseBlobs from sync constructors methods

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -71,7 +71,7 @@ import {
     ReadFluidDataStoreAttributes,
     WriteFluidDataStoreAttributes,
     getAttributesFormatVersion,
-    getFluidDataStoreAttributesFromStorageOrSnapshot,
+    getFluidDataStoreAttributes,
 } from "./summaryFormat";
 
 function createAttributes(
@@ -697,7 +697,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
         }
 
         if (!!tree && tree.blobs[dataStoreAttributesBlobName] !== undefined) {
-            // Need to rip through snapshot and use that to populate extraBlobs
+            // Need to get through snapshot and use that to populate extraBlobs
             const attributes =
                 await localReadAndParse<ReadFluidDataStoreAttributes>(tree.blobs[dataStoreAttributesBlobName]);
 
@@ -852,9 +852,9 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         let snapshot = this.snapshotTree;
         let attributes: ReadFluidDataStoreAttributes;
         if (snapshot !== undefined) {
-            // Need to rip through snapshot.
+            // Get the dataStore attributes.
             // Note: storage can be undefined in special case while detached.
-            attributes = await getFluidDataStoreAttributesFromStorageOrSnapshot(this.storage, snapshot);
+            attributes = await getFluidDataStoreAttributes(this.storage, snapshot);
             if (hasIsolatedChannels(attributes)) {
                 snapshot = snapshot.trees[channelsTreeName];
                 assert(snapshot !== undefined,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -26,7 +26,7 @@ import {
     TypedEventEmitter,
 } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { readAndParse, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { readAndParse } from "@fluidframework/driver-utils";
 import { BlobTreeEntry } from "@fluidframework/protocol-base";
 import {
     IClientDetails,
@@ -71,6 +71,7 @@ import {
     ReadFluidDataStoreAttributes,
     WriteFluidDataStoreAttributes,
     getAttributesFormatVersion,
+    getFluidDataStoreAttributesFromStorageOrSnapshot,
 } from "./summaryFormat";
 
 function createAttributes(
@@ -769,14 +770,14 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
 export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
     constructor(
         id: string,
-        pkg: Readonly<string[]>,
+        pkg: Readonly<string[]> | undefined,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
         scope: IFluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         private readonly snapshotTree: ISnapshotTree | undefined,
-        protected readonly isRootDataStore: boolean,
+        protected isRootDataStore: boolean | undefined,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */
@@ -848,25 +849,28 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
     }
 
     protected async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
-        assert(this.pkg !== undefined, 0x152 /* "pkg should be available in local data store" */);
-        assert(this.isRootDataStore !== undefined,
-            0x153 /* "isRootDataStore should be available in local data store" */);
-
         let snapshot = this.snapshotTree;
+        let attributes: ReadFluidDataStoreAttributes;
         if (snapshot !== undefined) {
+            // Need to rip through snapshot.
             // Note: storage can be undefined in special case while detached.
-            const attributes = this.storage !== undefined
-                ? await readAndParse<ReadFluidDataStoreAttributes>(
-                    this.storage, snapshot.blobs[dataStoreAttributesBlobName])
-                : readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
-                    snapshot.blobs, snapshot.blobs[dataStoreAttributesBlobName]);
-
+            attributes = await getFluidDataStoreAttributesFromStorageOrSnapshot(this.storage, snapshot);
             if (hasIsolatedChannels(attributes)) {
                 snapshot = snapshot.trees[channelsTreeName];
                 assert(snapshot !== undefined,
                     0x1ff /* "isolated channels subtree should exist in local datastore snapshot" */);
             }
+            if (this.pkg === undefined) {
+                this.pkg = JSON.parse(attributes.pkg) as string[];
+                // If there is no isRootDataStore in the attributes blob, set it to true. This ensures that data
+                // stores in older documents are not garbage collected incorrectly. This may lead to additional
+                // roots in the document but they won't break.
+                this.isRootDataStore = attributes.isRootDataStore ?? true;
+            }
         }
+        assert(this.pkg !== undefined, 0x152 /* "pkg should be available in local data store" */);
+        assert(this.isRootDataStore !== undefined,
+            0x153 /* "isRootDataStore should be available in local data store" */);
 
         return {
             pkg: this.pkg,
@@ -890,14 +894,14 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
     constructor(
         id: string,
-        pkg: string[],
+        pkg: string[] | undefined,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
         scope: IFluidObject & IFluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         snapshotTree: ISnapshotTree | undefined,
-        isRootDataStore: boolean,
+        isRootDataStore: boolean | undefined,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -37,7 +37,7 @@ import {
 } from "@fluidframework/runtime-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { BlobCacheStorageService, buildSnapshotTree, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { BlobCacheStorageService, buildSnapshotTree } from "@fluidframework/driver-utils";
 import { assert, Lazy } from "@fluidframework/common-utils";
 import { v4 as uuid } from "uuid";
 import { TreeTreeEntry } from "@fluidframework/protocol-base";
@@ -51,14 +51,7 @@ import {
     createAttributesBlob,
     LocalDetachedFluidDataStoreContext,
 } from "./dataStoreContext";
-import {
-    dataStoreAttributesBlobName,
-    IContainerRuntimeMetadata,
-    nonDataStorePaths,
-    rootHasIsolatedChannels,
-    ReadFluidDataStoreAttributes,
-    getAttributesFormatVersion,
-} from "./summaryFormat";
+import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summaryFormat";
 
  /**
   * This class encapsulates data store handling. Currently it is only used by the container runtime,
@@ -117,32 +110,16 @@ export class DataStores implements IDisposable {
                     throw new Error("Snapshot should be there to load from!!");
                 }
                 const snapshotTree = value;
-                // Need to rip through snapshot.
-                const attributes = readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
-                        snapshotTree.blobs,
-                        snapshotTree.blobs[dataStoreAttributesBlobName]);
-                // Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
-                // For snapshotFormatVersion = "0.1" (1) or above, pkg is jsonified, otherwise it is just a string.
-                // However the feature of loading a detached container from snapshot, is added when the
-                // snapshotFormatVersion is at least "0.1" (1), so we don't expect it to be anything else.
-                const formatVersion = getAttributesFormatVersion(attributes);
-                assert(formatVersion > 0,
-                    0x1d5 /* `Invalid snapshot format version ${attributes.snapshotFormatVersion}` */);
-                const pkgFromSnapshot = JSON.parse(attributes.pkg) as string[];
-
                 dataStoreContext = new LocalFluidDataStoreContext(
                     key,
-                    pkgFromSnapshot,
+                    undefined,
                     this.runtime,
                     this.runtime.storage,
                     this.runtime.scope,
                     this.getCreateChildSummarizerNodeFn(key, { type: CreateSummarizerNodeSource.FromSummary }),
                     (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
                     snapshotTree,
-                    // If there is no isRootDataStore in the attributes blob, set it to true. This ensures that data
-                    // stores in older documents are not garbage collected incorrectly. This may lead to additional
-                    // roots in the document but they won't break.
-                    attributes.isRootDataStore ?? true,
+                    undefined,
                 );
             }
             this.contexts.addBoundOrRemoted(dataStoreContext);

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { SummaryType } from "@fluidframework/protocol-definitions";
+import { assert } from "@fluidframework/common-utils";
+import { IDocumentStorageService } from "@fluidframework/driver-definitions";
+import { readAndParse, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 
 type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
@@ -148,4 +151,25 @@ export function wrapSummaryInChannelsTree(summarizeResult: ISummaryTreeWithStats
         tree: { [channelsTreeName]: summarizeResult.summary },
     };
     summarizeResult.stats.treeNodeCount++;
+}
+
+export async function getFluidDataStoreAttributesFromStorageOrSnapshot(
+    storage: IDocumentStorageService,
+    snapshot: ISnapshotTree,
+): Promise<ReadFluidDataStoreAttributes> {
+    // Need to rip through snapshot.
+    // Note: storage can be undefined in special case while detached.
+    const attributes = storage !== undefined
+        ? await readAndParse<ReadFluidDataStoreAttributes>(
+            storage, snapshot.blobs[dataStoreAttributesBlobName])
+        : readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
+            snapshot.blobs, snapshot.blobs[dataStoreAttributesBlobName]);
+    // Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
+    // For snapshotFormatVersion = "0.1" (1) or above, pkg is jsonified, otherwise it is just a string.
+    // However the feature of loading a detached container from snapshot, is added when the
+    // snapshotFormatVersion is at least "0.1" (1), so we don't expect it to be anything else.
+    const formatVersion = getAttributesFormatVersion(attributes);
+    assert(formatVersion > 0,
+        0x1d5 /* `Invalid snapshot format version ${attributes.snapshotFormatVersion}` */);
+    return attributes;
 }

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -153,11 +153,10 @@ export function wrapSummaryInChannelsTree(summarizeResult: ISummaryTreeWithStats
     summarizeResult.stats.treeNodeCount++;
 }
 
-export async function getFluidDataStoreAttributesFromStorageOrSnapshot(
+export async function getFluidDataStoreAttributes(
     storage: IDocumentStorageService,
     snapshot: ISnapshotTree,
 ): Promise<ReadFluidDataStoreAttributes> {
-    // Need to rip through snapshot.
     // Note: storage can be undefined in special case while detached.
     const attributes = storage !== undefined
         ? await readAndParse<ReadFluidDataStoreAttributes>(

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -31,7 +31,7 @@ import {
     ChildLogger,
     raiseConnectedEvent,
 } from "@fluidframework/telemetry-utils";
-import { buildSnapshotTree, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { buildSnapshotTree } from "@fluidframework/driver-utils";
 import {
     IClientDetails,
     IDocumentMessage,
@@ -69,7 +69,6 @@ import {
     IFluidDataStoreRuntime,
     IFluidDataStoreRuntimeEvents,
     IChannelFactory,
-    IChannelAttributes,
 } from "@fluidframework/datastore-definitions";
 import {
     cloneGCData,
@@ -250,12 +249,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                 // container from snapshot where we load detached container from a snapshot, isLocalDataStore would be
                 // true. In this case create a LocalChannelContext.
                 if (dataStoreContext.isLocalDataStore) {
-                    const channelAttributes = readAndParseFromBlobs<IChannelAttributes>(
-                        tree.trees[path].blobs, tree.trees[path].blobs[".attributes"]);
                     channelContext = new LocalChannelContext(
                         path,
                         this.sharedObjectRegistry,
-                        channelAttributes.type,
+                        undefined,
                         this,
                         this.dataStoreContext,
                         this.dataStoreContext.storage,

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -79,7 +79,7 @@ import {
 } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, summarizeChannel } from "./channelContext";
-import { LocalChannelContext } from "./localChannelContext";
+import { LocalChannelContext, RehydratedLocalChannelContext } from "./localChannelContext";
 import { RemoteChannelContext } from "./remoteChannelContext";
 
 export enum DataStoreMessageType {
@@ -249,10 +249,9 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                 // container from snapshot where we load detached container from a snapshot, isLocalDataStore would be
                 // true. In this case create a LocalChannelContext.
                 if (dataStoreContext.isLocalDataStore) {
-                    channelContext = new LocalChannelContext(
+                    channelContext = new RehydratedLocalChannelContext(
                         path,
                         this.sharedObjectRegistry,
-                        undefined,
                         this,
                         this.dataStoreContext,
                         this.dataStoreContext.storage,
@@ -379,8 +378,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
             this.dataStoreContext,
             this.dataStoreContext.storage,
             (content, localOpMetadata) => this.submitChannelOp(id, content, localOpMetadata),
-            (address: string) => this.setChannelDirty(address),
-            undefined);
+            (address: string) => this.setChannelDirty(address));
         this.contexts.set(id, context);
 
         if (this.contextsDeferred.has(id)) {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -79,7 +79,7 @@ import {
 } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, summarizeChannel } from "./channelContext";
-import { LocalChannelContext, RehydratedLocalChannelContext } from "./localChannelContext";
+import { LocalChannelContext, LocalChannelContextBase, RehydratedLocalChannelContext } from "./localChannelContext";
 import { RemoteChannelContext } from "./remoteChannelContext";
 
 export enum DataStoreMessageType {
@@ -169,7 +169,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     // This is used to break the recursion while attaching the graph. Also tells the attach state of the graph.
     private graphAttachState: AttachState = AttachState.Detached;
     private readonly deferredAttached = new Deferred<void>();
-    private readonly localChannelContextQueue = new Map<string, LocalChannelContext>();
+    private readonly localChannelContextQueue = new Map<string, LocalChannelContextBase>();
     private readonly notBoundedChannelContextSet = new Set<string>();
     private boundhandles: Set<IFluidHandle> | undefined;
     private _attachState: AttachState;
@@ -247,7 +247,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                 let channelContext: IChannelContext;
                 // If already exists on storage, then create a remote channel. However, if it is case of rehydrating a
                 // container from snapshot where we load detached container from a snapshot, isLocalDataStore would be
-                // true. In this case create a LocalChannelContext.
+                // true. In this case create a RehydratedLocalChannelContext.
                 if (dataStoreContext.isLocalDataStore) {
                     channelContext = new RehydratedLocalChannelContext(
                         path,
@@ -263,9 +263,9 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                     // the channel as attached. So mark it now. Otherwise add it to local channel context queue, so
                     // that it can be mark attached later with the data store.
                     if (dataStoreContext.attachState !== AttachState.Detached) {
-                        (channelContext as LocalChannelContext).markAttached();
+                        (channelContext as LocalChannelContextBase).markAttached();
                     } else {
-                        this.localChannelContextQueue.set(path, channelContext as LocalChannelContext);
+                        this.localChannelContextQueue.set(path, channelContext as LocalChannelContextBase);
                     }
                 } else {
                     channelContext = new RemoteChannelContext(
@@ -412,7 +412,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
             // If our data store is local then add the channel to the queue
             if (!this.localChannelContextQueue.has(channel.id)) {
-                this.localChannelContextQueue.set(channel.id, this.contexts.get(channel.id) as LocalChannelContext);
+                this.localChannelContextQueue.set(channel.id, this.contexts.get(channel.id) as LocalChannelContextBase);
             }
         }
     }
@@ -513,7 +513,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                         assert(!this.contexts.has(id),
                         0x17d, /* `Unexpected attach channel OP,
                             is in pendingAttach set: ${this.pendingAttach.has(id)},
-                            is local channel contexts: ${this.contexts.get(id) instanceof LocalChannelContext}` */);
+                            is local channel contexts: ${this.contexts.get(id) instanceof LocalChannelContextBase}` */);
 
                         const flatBlobs = new Map<string, ArrayBufferLike>();
                         const snapshotTree = buildSnapshotTree(attachMessage.snapshot.entries, flatBlobs);
@@ -733,7 +733,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
         // Craft the .attributes file for each shared object
         for (const [contextId, context] of this.contexts) {
-            if (!(context instanceof LocalChannelContext)) {
+            if (!(context instanceof LocalChannelContextBase)) {
                 throw new Error("Should only be called with local channel handles");
             }
 
@@ -816,7 +816,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
             this.submit(DataStoreMessageType.Attach, message);
         }
 
-        const context = this.contexts.get(channel.id) as LocalChannelContext;
+        const context = this.contexts.get(channel.id) as LocalChannelContextBase;
         context.markAttached();
     }
 

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -33,62 +33,24 @@ import { ChannelStorageService } from "./channelStorageService";
 /**
  * Channel context for a locally created channel
  */
-export class LocalChannelContext implements IChannelContext {
+class LocalChannelContextBase implements IChannelContext {
     public channel: IChannel | undefined;
     private attached = false;
-    private readonly pending: ISequencedDocumentMessage[] = [];
-    private readonly services: Lazy<{
-        readonly deltaConnection: ChannelDeltaConnection,
-        readonly objectStorage: ChannelStorageService,
-    }>;
-    private readonly dirtyFn: () => void;
-    private factory: IChannelFactory | undefined;
-
+    protected readonly pending: ISequencedDocumentMessage[] = [];
+    protected factory: IChannelFactory | undefined;
     constructor(
-        private readonly id: string,
-        private readonly registry: ISharedObjectRegistry,
-        type: string | undefined,
-        private readonly runtime: IFluidDataStoreRuntime,
-        private readonly dataStoreContext: IFluidDataStoreContext,
-        private readonly storageService: IDocumentStorageService,
-        private readonly submitFn: (content: any, localOpMetadata: unknown) => void,
-        dirtyFn: (address: string) => void,
-        private readonly snapshotTree: ISnapshotTree | undefined,
+        protected readonly id: string,
+        protected readonly registry: ISharedObjectRegistry,
+        protected readonly runtime: IFluidDataStoreRuntime,
+        private readonly servicesGetter: () => Lazy<{
+                readonly deltaConnection: ChannelDeltaConnection,
+                readonly objectStorage: ChannelStorageService,
+            }>,
     ) {
-        let blobMap: Map<string, ArrayBufferLike> | undefined;
-        const clonedSnapshotTree = cloneDeep(this.snapshotTree);
-        if (clonedSnapshotTree !== undefined) {
-            blobMap = new Map<string, ArrayBufferLike>();
-            this.collectExtraBlobsAndSanitizeSnapshot(clonedSnapshotTree, blobMap);
-        }
-        this.services = new Lazy(() => {
-            return createServiceEndpoints(
-                this.id,
-                this.dataStoreContext.connected,
-                this.submitFn,
-                this.dirtyFn,
-                this.storageService,
-                clonedSnapshotTree,
-                blobMap,
-            );
-        });
-        if (snapshotTree === undefined) {
-            assert(type !== undefined, "Factory Type should be defined");
-            this.factory = registry.get(type);
-            if (this.factory === undefined) {
-                throw new Error(`Channel Factory ${type} not registered`);
-            }
-            this.channel = this.factory.create(runtime, id);
-        }
-        this.dirtyFn = () => { dirtyFn(id); };
     }
 
     public async getChannel(): Promise<IChannel> {
-        if (this.channel === undefined) {
-            this.channel = await this.loadChannel()
-                // eslint-disable-next-line @typescript-eslint/no-throw-literal
-                .catch((err)=>{throw CreateProcessingError(err, undefined);});
-        }
+        assert(this.channel !== undefined, "Channel should be defined");
         return this.channel;
     }
 
@@ -99,7 +61,7 @@ export class LocalChannelContext implements IChannelContext {
     public setConnectionState(connected: boolean, clientId?: string) {
         // Connection events are ignored if the data store is not yet attached or loaded
         if (this.attached && this.isLoaded) {
-            this.services.value.deltaConnection.setConnectionState(connected);
+            this.servicesGetter().value.deltaConnection.setConnectionState(connected);
         }
     }
 
@@ -110,7 +72,7 @@ export class LocalChannelContext implements IChannelContext {
         // delay loading. So after the container is attached and some other client joins which start generating
         // ops for this channel. So not loaded local channel can still receive ops and we store them to process later.
         if (this.isLoaded) {
-            this.services.value.deltaConnection.process(message, local, localOpMetadata);
+            this.servicesGetter().value.deltaConnection.process(message, local, localOpMetadata);
         } else {
             assert(local === false,
                 0x189 /* "Should always be remote because a local dds shouldn't generate ops before loading" */);
@@ -121,7 +83,7 @@ export class LocalChannelContext implements IChannelContext {
     public reSubmit(content: any, localOpMetadata: unknown) {
         assert(this.isLoaded, 0x18a /* "Channel should be loaded to resubmit ops" */);
         assert(this.attached, 0x18b /* "Local channel must be attached when resubmitting op" */);
-        this.services.value.deltaConnection.reSubmit(content, localOpMetadata);
+        this.servicesGetter().value.deltaConnection.reSubmit(content, localOpMetadata);
     }
 
     public applyStashedOp() {
@@ -143,10 +105,88 @@ export class LocalChannelContext implements IChannelContext {
         return summarizeChannel(this.channel, true /* fullTree */, false /* trackState */);
     }
 
+    public markAttached(): void {
+        if (this.attached) {
+            throw new Error("Channel is already attached");
+        }
+
+        if (this.isLoaded) {
+            assert(!!this.channel, 0x192 /* "Channel should be there if loaded!!" */);
+            this.channel.connect(this.servicesGetter().value);
+        }
+        this.attached = true;
+    }
+
+    /**
+     * Returns the data used for garbage collection. This includes a list of GC nodes that represent this context.
+     * Each node has a set of outbound routes to other GC nodes in the document. This should be called only after
+     * the context has loaded.
+     * @param fullGC - true to bypass optimizations and force full generation of GC data.
+     */
+    public async getGCData(fullGC: boolean = false): Promise<IGarbageCollectionData> {
+        assert(this.isLoaded && this.channel !== undefined, 0x193 /* "Channel should be loaded to run GC" */);
+        return this.channel.getGCData(fullGC);
+    }
+
+    public updateUsedRoutes(usedRoutes: string[]) {
+        /**
+         * Currently, DDSs are always considered referenced and are not garbage collected.
+         * Once we have GC at DDS level, this channel context's used routes will be updated as per the passed
+         * value. See - https://github.com/microsoft/FluidFramework/issues/4611
+         */
+    }
+}
+
+export class RehydratedLocalChannelContext extends LocalChannelContextBase {
+    private readonly services: Lazy<{
+        readonly deltaConnection: ChannelDeltaConnection,
+        readonly objectStorage: ChannelStorageService,
+    }>;
+
+    private readonly dirtyFn: () => void;
+
+    constructor(
+        id: string,
+        registry: ISharedObjectRegistry,
+        runtime: IFluidDataStoreRuntime,
+        dataStoreContext: IFluidDataStoreContext,
+        storageService: IDocumentStorageService,
+        submitFn: (content: any, localOpMetadata: unknown) => void,
+        dirtyFn: (address: string) => void,
+        private readonly snapshotTree: ISnapshotTree,
+    ) {
+        super(id, registry, runtime, () => this.services);
+        let blobMap: Map<string, ArrayBufferLike> | undefined;
+        const clonedSnapshotTree = cloneDeep(this.snapshotTree);
+        if (clonedSnapshotTree !== undefined) {
+            blobMap = new Map<string, ArrayBufferLike>();
+            this.collectExtraBlobsAndSanitizeSnapshot(clonedSnapshotTree, blobMap);
+        }
+        this.services = new Lazy(() => {
+            return createServiceEndpoints(
+                this.id,
+                dataStoreContext.connected,
+                submitFn,
+                this.dirtyFn,
+                storageService,
+                clonedSnapshotTree,
+                blobMap,
+            );
+        });
+        this.dirtyFn = () => { dirtyFn(id); };
+    }
+
+    public async getChannel(): Promise<IChannel> {
+        if (this.channel === undefined) {
+            this.channel = await this.loadChannel()
+                // eslint-disable-next-line @typescript-eslint/no-throw-literal
+                .catch((err)=>{throw CreateProcessingError(err, undefined);});
+        }
+        return this.channel;
+    }
+
     private async loadChannel(): Promise<IChannel> {
         assert(!this.isLoaded, 0x18e /* "Channel must not already be loaded when loading" */);
-        assert(!!this.snapshotTree, 0x18f /* "Snapshot should be provided to load from!!" */);
-
         assert(await this.services.value.objectStorage.contains(".attributes"),
             0x190 /* ".attributes blob should be present" */);
         const attributes = await readAndParse<IChannelAttributes>(
@@ -175,18 +215,6 @@ export class LocalChannelContext implements IChannelContext {
         return this.channel;
     }
 
-    public markAttached(): void {
-        if (this.attached) {
-            throw new Error("Channel is already attached");
-        }
-
-        if (this.isLoaded) {
-            assert(!!this.channel, 0x192 /* "Channel should be there if loaded!!" */);
-            this.channel.connect(this.services.value);
-        }
-        this.attached = true;
-    }
-
     private collectExtraBlobsAndSanitizeSnapshot(snapshotTree: ISnapshotTree, blobMap: Map<string, ArrayBufferLike>) {
         const blobMapInitial = new Map(Object.entries(snapshotTree.blobs));
         for (const [blobName, blobId] of blobMapInitial.entries()) {
@@ -202,23 +230,40 @@ export class LocalChannelContext implements IChannelContext {
             this.collectExtraBlobsAndSanitizeSnapshot(value, blobMap);
         }
     }
+}
 
-    /**
-     * Returns the data used for garbage collection. This includes a list of GC nodes that represent this context.
-     * Each node has a set of outbound routes to other GC nodes in the document. This should be called only after
-     * the context has loaded.
-     * @param fullGC - true to bypass optimizations and force full generation of GC data.
-     */
-    public async getGCData(fullGC: boolean = false): Promise<IGarbageCollectionData> {
-        assert(this.isLoaded && this.channel !== undefined, 0x193 /* "Channel should be loaded to run GC" */);
-        return this.channel.getGCData(fullGC);
-    }
-
-    public updateUsedRoutes(usedRoutes: string[]) {
-        /**
-         * Currently, DDSs are always considered referenced and are not garbage collected.
-         * Once we have GC at DDS level, this channel context's used routes will be updated as per the passed
-         * value. See - https://github.com/microsoft/FluidFramework/issues/4611
-         */
+export class LocalChannelContext extends LocalChannelContextBase {
+    private readonly services: Lazy<{
+        readonly deltaConnection: ChannelDeltaConnection,
+        readonly objectStorage: ChannelStorageService,
+    }>;
+    private readonly dirtyFn: () => void;
+    constructor(
+        id: string,
+        registry: ISharedObjectRegistry,
+        type: string,
+        runtime: IFluidDataStoreRuntime,
+        dataStoreContext: IFluidDataStoreContext,
+        storageService: IDocumentStorageService,
+        submitFn: (content: any, localOpMetadata: unknown) => void,
+        dirtyFn: (address: string) => void,
+    ) {
+        super(id, registry, runtime, () => this.services);
+        assert(type !== undefined, "Factory Type should be defined");
+        this.factory = registry.get(type);
+        if (this.factory === undefined) {
+            throw new Error(`Channel Factory ${type} not registered`);
+        }
+        this.channel = this.factory.create(runtime, id);
+        this.services = new Lazy(() => {
+            return createServiceEndpoints(
+                this.id,
+                dataStoreContext.connected,
+                submitFn,
+                this.dirtyFn,
+                storageService,
+            );
+        });
+        this.dirtyFn = () => { dirtyFn(id); };
     }
 }

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -153,6 +153,7 @@ export class LocalChannelContext implements IChannelContext {
             this.services.value.objectStorage,
             ".attributes");
 
+        assert(this.factory === undefined, "Factory should be undefined before loading");
         this.factory = this.registry.get(attributes.type);
         if (this.factory === undefined) {
             throw new Error(`Channel Factory ${attributes.type} not registered`);

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -33,7 +33,7 @@ import { ChannelStorageService } from "./channelStorageService";
 /**
  * Channel context for a locally created channel
  */
-class LocalChannelContextBase implements IChannelContext {
+export abstract class LocalChannelContextBase implements IChannelContext {
     public channel: IChannel | undefined;
     private attached = false;
     protected readonly pending: ISequencedDocumentMessage[] = [];


### PR DESCRIPTION
Refer: #4746
This is part of PR: https://github.com/microsoft/FluidFramework/pull/6608
Removing the usage of readAndParseFromBlobs call from constructors methods since we are going to remove it in lieu of reading from storage while rehydrating container from snapshot which will be async. So stop extracting info from readAndParseFromBlobs until required while loading.