### PR TITLE
Add signal manager data object for fluid static

### DIFF
--- a/examples/data-objects/focus-tracker/README.md
+++ b/examples/data-objects/focus-tracker/README.md
@@ -2,7 +2,7 @@
 
 **_This demo is a work-in-progress_**
 
-**Focus Tracker** is an example that demonstrates how transient state of audience members can be tracked among other audience members using signals.  It does so using fluid-static's `FluidContainer`, `ServiceAudience`, and `ISignalManager`.
+**Focus Tracker** is an example that demonstrates how transient state of audience members can be tracked among other audience members using signals.  It does so using fluid-static's `FluidContainer`, `ServiceAudience`, and `ISignaler`.
 
 This implementation visualizes the Container in a standalone application, rather than using the webpack-fluid-loader environment that most of our examples use.  This implementation relies on [Tinylicious](/server/tinylicious), so there are a few extra steps to get started.  We bring our own view that we will bind to the data in the container.
 

--- a/examples/data-objects/focus-tracker/README.md
+++ b/examples/data-objects/focus-tracker/README.md
@@ -2,7 +2,7 @@
 
 **_This demo is a work-in-progress_**
 
-**Focus Tracker** is an example that demonstrates how transient state of audience members can be tracked among other audience members using signals.
+**Focus Tracker** is an example that demonstrates how transient state of audience members can be tracked among other audience members using signals.  It does so using fluid-static's `FluidContainer`, `ServiceAudience`, and `ISignalManager`.
 
 This implementation visualizes the Container in a standalone application, rather than using the webpack-fluid-loader environment that most of our examples use.  This implementation relies on [Tinylicious](/server/tinylicious), so there are a few extra steps to get started.  We bring our own view that we will bind to the data in the container.
 

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -36,6 +36,7 @@
     "@fluid-experimental/fluid-static": "^0.44.0",
     "@fluid-experimental/tinylicious-client": "^0.44.0",
     "@fluidframework/common-definitions": "^0.20.1",
+    "@fluidframework/common-utils": "^0.31.0",
     "@fluidframework/container-definitions": "^0.39.5",
     "@fluidframework/runtime-definitions": "^0.44.0",
     "react": "^16.10.2",

--- a/examples/data-objects/focus-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/focus-tracker/src/FocusTracker.ts
@@ -10,6 +10,7 @@ import {
     DataObjectFactory,
     IMember,
     IServiceAudience,
+    ISignalManager,
     SignalManager,
 } from "@fluid-experimental/fluid-framework";
 
@@ -18,8 +19,9 @@ export interface IFocusTrackerEvents extends IEvent {
 }
 
 /**
- * Data object example of using the audience with signals to track focus
- * state of connected clients without writing changes to a DDS
+ * Data object example of using the audience with signals to track focus state of connected clients
+ * without writing changes to a DDS.  It exists as a data object for demonstative purposes, and its
+ * logic could all be extracted for fluid-static and used without the data object wrapper.
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents> implements EventEmitter {
@@ -52,20 +54,20 @@ export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents>
         return this._audience;
     }
 
-    private _signalManager: SignalManager | undefined;
-    private get signalManager(): SignalManager {
+    private _signalManager: ISignalManager | undefined;
+    private get signalManager(): ISignalManager {
         if (this._signalManager === undefined) {
             throw new Error("no signalManager");
         }
         return this._signalManager;
     }
 
-    public init(newAudience: IServiceAudience<IMember>) {
+    public init(newAudience: IServiceAudience<IMember>, signalManager?: ISignalManager) {
         if (this._audience !== undefined || this._signalManager !== undefined) {
             throw new Error("init only once");
         }
         this._audience = newAudience;
-        this._signalManager = new SignalManager(this.runtime);
+        this._signalManager = signalManager ?? new SignalManager(this.runtime);
 
         this._audience.on("memberAdded", (clientId: string, member: IMember) => {
             this.emit("focusChanged");

--- a/examples/data-objects/focus-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/focus-tracker/src/FocusTracker.ts
@@ -10,8 +10,8 @@ import {
     DataObjectFactory,
     IMember,
     IServiceAudience,
-    ISignalManager,
-    SignalManager,
+    ISignaler,
+    Signaler,
 } from "@fluid-experimental/fluid-framework";
 
 export interface IFocusTrackerEvents extends IEvent {
@@ -54,20 +54,20 @@ export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents>
         return this._audience;
     }
 
-    private _signalManager: ISignalManager | undefined;
-    private get signalManager(): ISignalManager {
+    private _signalManager: ISignaler | undefined;
+    private get signalManager(): ISignaler {
         if (this._signalManager === undefined) {
             throw new Error("no signalManager");
         }
         return this._signalManager;
     }
 
-    public init(newAudience: IServiceAudience<IMember>, signalManager?: ISignalManager) {
+    public init(newAudience: IServiceAudience<IMember>, signalManager?: ISignaler) {
         if (this._audience !== undefined || this._signalManager !== undefined) {
             throw new Error("init only once");
         }
         this._audience = newAudience;
-        this._signalManager = signalManager ?? new SignalManager(this.runtime);
+        this._signalManager = signalManager ?? new Signaler(this.runtime);
 
         this._audience.on("memberAdded", (clientId: string, member: IMember) => {
             this.emit("focusChanged");

--- a/examples/data-objects/focus-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/focus-tracker/src/FocusTracker.ts
@@ -3,15 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { EventEmitter } from "events";
 import { IEvent } from "@fluidframework/common-definitions";
+import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {
-    DataObject,
-    DataObjectFactory,
+    FluidContainer,
     IMember,
     IServiceAudience,
-    ISignaler,
-    Signaler,
+    SignalManager,
 } from "@fluid-experimental/fluid-framework";
 
 export interface IFocusTrackerEvents extends IEvent {
@@ -19,12 +17,10 @@ export interface IFocusTrackerEvents extends IEvent {
 }
 
 /**
- * Data object example of using the audience with signals to track focus state of connected clients
- * without writing changes to a DDS.  It exists as a data object for demonstative purposes, and its
- * logic could all be extracted for fluid-static and used without the data object wrapper.
+ * Example of using the audience with signals to track focus state of connected clients
+ * without writing changes to a DDS.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents> implements EventEmitter {
+export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     private static readonly focusSignalType = "changedFocus";
 
     /**
@@ -46,33 +42,17 @@ export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents>
         this.emit("focusChanged");
     };
 
-    private _audience: IServiceAudience<IMember> | undefined;
-    public get audience(): IServiceAudience<IMember> {
-        if (this._audience === undefined) {
-            throw new Error("no audience");
-        }
-        return this._audience;
-    }
+    public constructor(
+        container: FluidContainer,
+        public readonly audience: IServiceAudience<IMember>,
+        private readonly signalManager: SignalManager,
+    ) {
+        super();
 
-    private _signalManager: ISignaler | undefined;
-    private get signalManager(): ISignaler {
-        if (this._signalManager === undefined) {
-            throw new Error("no signalManager");
-        }
-        return this._signalManager;
-    }
-
-    public init(newAudience: IServiceAudience<IMember>, signalManager?: ISignaler) {
-        if (this._audience !== undefined || this._signalManager !== undefined) {
-            throw new Error("init only once");
-        }
-        this._audience = newAudience;
-        this._signalManager = signalManager ?? new Signaler(this.runtime);
-
-        this._audience.on("memberAdded", (clientId: string, member: IMember) => {
+        this.audience.on("memberAdded", (clientId: string, member: IMember) => {
             this.emit("focusChanged");
         });
-        this._audience.on("memberRemoved", (clientId: string, member: IMember) => {
+        this.audience.on("memberRemoved", (clientId: string, member: IMember) => {
             const clientIdMap = this.focusMap.get(member.userId);
             if (clientIdMap !== undefined) {
                 clientIdMap.delete(clientId);
@@ -83,6 +63,9 @@ export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents>
             this.emit("focusChanged");
         });
 
+        this.signalManager.on("error", (error) => {
+            this.emit("error", error);
+        });
         this.signalManager.onSignal(FocusTracker.focusSignalType, (clientId, local, payload) => {
             this.onFocusSignalFn(clientId, payload);
         });
@@ -95,21 +78,12 @@ export class FocusTracker extends DataObject<{}, undefined, IFocusTrackerEvents>
         window.addEventListener("blur", () => {
             this.sendFocusSignal(false);
         });
-        this.runtime.on("connected", () => {
+
+        container.on("connected", () => {
             this.signalManager.requestBroadcast(FocusTracker.focusSignalType);
         });
         this.signalManager.requestBroadcast(FocusTracker.focusSignalType);
     }
-
-    public static get Name() { return "@fluid-example/focus-tracker"; }
-
-    public static readonly factory = new DataObjectFactory<FocusTracker, undefined, undefined, IFocusTrackerEvents>
-    (
-        FocusTracker.Name,
-        FocusTracker,
-        [],
-        {},
-    );
 
     /**
      * Alert all connected clients that there has been a change to a client's focus

--- a/examples/data-objects/focus-tracker/src/app.ts
+++ b/examples/data-objects/focus-tracker/src/app.ts
@@ -22,7 +22,6 @@ export const containerSchema: ContainerSchema = {
     name: "focus-tracker-container",
     initialObjects: {
         /* [id]: DataObject */
-        focusTracker: FocusTracker,
         signalManager: SignalManager,
     },
 };
@@ -58,8 +57,11 @@ async function start(): Promise<void> {
 
     // Render page focus information for audience members
     const contentDiv = document.getElementById("content") as HTMLDivElement;
-    const focusTracker = fluidContainer.initialObjects.focusTracker as FocusTracker;
-    focusTracker.init(containerServices.audience, fluidContainer.initialObjects.signalManager as SignalManager);
+    const focusTracker = new FocusTracker(
+        fluidContainer,
+        containerServices.audience,
+        fluidContainer.initialObjects.signalManager as SignalManager,
+    );
     renderFocusPresence(focusTracker, contentDiv);
 }
 

--- a/examples/data-objects/focus-tracker/src/app.ts
+++ b/examples/data-objects/focus-tracker/src/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerSchema, SignalManagerDO } from "@fluid-experimental/fluid-static";
+import { ContainerSchema, SignalManager } from "@fluid-experimental/fluid-static";
 import { TinyliciousClient, TinyliciousMember } from "@fluid-experimental/tinylicious-client";
 import { FocusTracker } from "./FocusTracker";
 
@@ -23,7 +23,7 @@ export const containerSchema: ContainerSchema = {
     initialObjects: {
         /* [id]: DataObject */
         focusTracker: FocusTracker,
-        signalManager: SignalManagerDO,
+        signalManager: SignalManager,
     },
 };
 
@@ -59,7 +59,7 @@ async function start(): Promise<void> {
     // Render page focus information for audience members
     const contentDiv = document.getElementById("content") as HTMLDivElement;
     const focusTracker = fluidContainer.initialObjects.focusTracker as FocusTracker;
-    focusTracker.init(containerServices.audience, fluidContainer.initialObjects.signalManager as SignalManagerDO);
+    focusTracker.init(containerServices.audience, fluidContainer.initialObjects.signalManager as SignalManager);
     renderFocusPresence(focusTracker, contentDiv);
 }
 

--- a/examples/data-objects/focus-tracker/src/app.ts
+++ b/examples/data-objects/focus-tracker/src/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerSchema } from "@fluid-experimental/fluid-static";
+import { ContainerSchema, SignalManagerDO } from "@fluid-experimental/fluid-static";
 import { TinyliciousClient, TinyliciousMember } from "@fluid-experimental/tinylicious-client";
 import { FocusTracker } from "./FocusTracker";
 
@@ -23,6 +23,7 @@ export const containerSchema: ContainerSchema = {
     initialObjects: {
         /* [id]: DataObject */
         focusTracker: FocusTracker,
+        signalManager: SignalManagerDO,
     },
 };
 
@@ -58,7 +59,7 @@ async function start(): Promise<void> {
     // Render page focus information for audience members
     const contentDiv = document.getElementById("content") as HTMLDivElement;
     const focusTracker = fluidContainer.initialObjects.focusTracker as FocusTracker;
-    focusTracker.init(containerServices.audience);
+    focusTracker.init(containerServices.audience, fluidContainer.initialObjects.signalManager as SignalManagerDO);
     renderFocusPresence(focusTracker, contentDiv);
 }
 

--- a/examples/data-objects/focus-tracker/src/index.ts
+++ b/examples/data-objects/focus-tracker/src/index.ts
@@ -3,14 +3,4 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluid-experimental/fluid-framework";
-import { FocusTracker } from "./FocusTracker";
-
 export * from "./FocusTracker";
-
-export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    FocusTracker.factory,
-    new Map([
-        [FocusTracker.Name, Promise.resolve(FocusTracker.factory)],
-    ]),
-);

--- a/experimental/framework/fluid-static/src/signalManager.ts
+++ b/experimental/framework/fluid-static/src/signalManager.ts
@@ -188,7 +188,7 @@ export class Signaler extends TypedEventEmitter<IErrorEvent> implements ISignale
 }
 
 /**
- * Note: currently experiemental and under development
+ * Note: currently experimental and under development
  *
  * DataObject implementation of ISignaler for fluid-static plug-and-play.  Allows fluid-static
  * users to get an ISignaler without a custom DO.  Where possible, consumers should instead


### PR DESCRIPTION
This already came up before in an earlier PR, but was converted to a standalone class.  After some discussion, we decided providing it as a DO was  a preferable starting point over adding it as a first class API on the FluidContainer class (or adding it as part of container services because those are expected to be service specific).  The reasoning being we must do one of the 3 (or some variant thereof) because we are not providing a way to use the standalone class as part of v1, and because it's much easier to promote the SignalManger to a first class API later if needed than the other way around.

We do not expect developers to create lots of these (and agitate issues related to its being a DO), but we will keep it in mind as part of observing usage to decide if it needs to change.