### PR TITLE
Add retryAfter handling in summary retries

### DIFF
--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -5,7 +5,7 @@
 
 import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { Deferred, IPromiseTimer, IPromiseTimerResult, Timer } from "@fluidframework/common-utils";
-import { ISummaryConfiguration, MessageType } from "@fluidframework/protocol-definitions";
+import { ISummaryConfiguration, ISummaryNack, MessageType } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
     GenerateSummaryResult,
@@ -225,12 +225,12 @@ export class SummaryGenerator {
     public async summarize(
         reason: SummarizeReason,
         options: Omit<IGenerateSummaryOptions, "summaryLogger">,
-    ): Promise<boolean> {
+    ): Promise<{ success: true; } | { success: false; retryDelaySeconds?: number ;}> {
         ++this.summarizeCount;
         if (this.summarizing !== undefined) {
             // We do not expect this case. Log the error and let it try again anyway.
             this.logger.sendErrorEvent({ eventName: "ConcurrentSummarizeAttempt", reason });
-            return false;
+            return { success: false };
         }
 
         // GenerateSummary could take some time
@@ -241,7 +241,7 @@ export class SummaryGenerator {
             return this.summarizeCore(reason, options);
         } catch (error) {
             this.logger.sendErrorEvent({ eventName: "UnexpectedSummarizeError" }, error);
-            return false;
+            return { success: false };
         } finally {
             this.summarizing?.resolve();
             this.summarizing = undefined;
@@ -251,7 +251,7 @@ export class SummaryGenerator {
     private async summarizeCore(
         reason: SummarizeReason,
         options: Omit<IGenerateSummaryOptions, "summaryLogger">,
-    ): Promise<boolean> {
+    ): Promise<{ success: true; } | { success: false; retryDelaySeconds?: number ;}> {
         const { refreshLatestAck, fullTree } = options;
         const summarizeEvent = PerformanceEvent.start(this.logger, {
             eventName: "Summarize",
@@ -266,10 +266,11 @@ export class SummaryGenerator {
             message: keyof typeof summarizeErrors,
             error?: any,
             properties?: ITelemetryProperties,
-        ): false => {
+            retryDelaySeconds?: number,
+        ) => {
             this.raiseSummarizingError(summarizeErrors[message]);
             summarizeEvent.cancel({ ...properties, message }, error);
-            return false;
+            return { success: false, retryDelaySeconds };
         };
 
         // Wait to generate and send summary
@@ -363,12 +364,18 @@ export class SummaryGenerator {
             if (ackNack.type === MessageType.SummaryAck) {
                 this.heuristics.ackLastSent();
                 summarizeEvent.end({ ...telemetryProps, handle: ackNack.contents.handle, message: "summaryAck" });
-                return true;
+                return { success: true };
             } else {
+                // TODO: cast needed until dep on protocol-definitions version bump
+                const summaryNack = ackNack.contents as ISummaryNack & Partial<{
+                    message: string;
+                    retryAfter: number;
+                }>;
                 return fail(
                     "summaryNack",
-                    ackNack.contents.errorMessage,
+                    summaryNack.message ?? ackNack.contents.errorMessage,
                     telemetryProps,
+                    summaryNack.retryAfter,
                 );
             }
         } finally {


### PR DESCRIPTION
Fixes #6596 by adding an override delay between heuristic summarize attempts.

We can iterate on the exact implementation, but for now it has the following behavior:
1. if retryAfter is specified, then it will use that delay, overriding whatever normal heuristic delay exists
2. if retryAfter is specified once, we retry the exact with the same options (fullTree/refreshLatestAck)
3. if retryAfter is specified 2+ times in a row, we advance to the next set of options

Added just 2 tests for now.