### PR TITLE
The idleTimer is not benefitting from restart

### DIFF
--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -172,12 +172,13 @@ const summarizeErrors = {
      * Runs the heuristic to determine if it should try to summarize.
      */
     public run() {
-        this.idleTimer.clear();
         const timeSinceLastSummary = Date.now() - this.lastAcked.summaryTime;
         const opCountSinceLastSummary = this.lastOpSeqNumber - this.lastAcked.refSequenceNumber;
         if (timeSinceLastSummary > this.configuration.maxTime) {
+            this.idleTimer.clear();
             this.trySummarize("maxTime");
         } else if (opCountSinceLastSummary > this.configuration.maxOps) {
+            this.idleTimer.clear();
             this.trySummarize("maxOps");
         } else {
             this.idleTimer.restart();


### PR DESCRIPTION
Previously calling `idleTimer.clear()` first, then calling restart meant that we were always calling `clearTimeout` then `setTimeout` again, which meant we weren't leveraging the potential perf boost of `Timer.restart()`.

Changed to only call `idleTimer.clear()` in the other branches of the case statements, and not for the restart case. The end result should be a performance boost in the case of rapid inbound ops, which normally would trigger many `clearTimeout` -> `setTimeout` calls. Now it should lazily call the `clearTimeout`/`setTimeout` by recomputing the new end time.