### PR TITLE
Refactor SegmentPropertiesManager for reuse

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -29,7 +29,7 @@ import * as ops from "./ops";
 import { PartialSequenceLengths } from "./partialLengths";
 import * as Properties from "./properties";
 import { SegmentGroupCollection } from "./segmentGroupCollection";
-import { SegmentPropertiesManager } from "./segmentPropertiesManager";
+import { PropertiesManager } from "./segmentPropertiesManager";
 
 export interface ReferencePosition {
     properties?: Properties.PropertySet;
@@ -88,7 +88,7 @@ export interface ISegment extends IMergeNodeCommon, IRemovalInfo {
     readonly type: string;
     readonly segmentGroups: SegmentGroupCollection;
     readonly trackingCollection: TrackingGroupCollection;
-    propertyManager?: SegmentPropertiesManager;
+    propertyManager?: PropertiesManager;
     localSeq?: number;
     localRemovedSeq?: number;
     seq?: number;  // If not present assumed to be previous to window min
@@ -452,7 +452,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     removedClientOverlap?: number[];
     readonly segmentGroups: SegmentGroupCollection = new SegmentGroupCollection(this);
     readonly trackingCollection: TrackingGroupCollection = new TrackingGroupCollection(this);
-    propertyManager?: SegmentPropertiesManager;
+    propertyManager?: PropertiesManager;
     properties?: Properties.PropertySet;
     localRefs?: LocalReferenceCollection;
     abstract readonly type: string;
@@ -461,9 +461,12 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
 
     addProperties(newProps: Properties.PropertySet, op?: ops.ICombiningOp, seq?: number, collabWindow?: CollaborationWindow) {
         if (!this.propertyManager) {
-            this.propertyManager = new SegmentPropertiesManager(this);
+            this.propertyManager = new PropertiesManager();
         }
-        return this.propertyManager.addProperties(newProps, op, seq, collabWindow);
+        if (!this.properties) {
+            this.properties = Properties.createMap<any>();
+        }
+        return this.propertyManager.addProperties(this.properties, newProps, op, seq, collabWindow);
     }
 
     hasProperty(key: string): boolean {
@@ -536,9 +539,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
         if (pos > 0) {
             const leafSegment = this.createSplitSegmentAt(pos);
             if (leafSegment) {
-                if (this.propertyManager) {
-                    this.propertyManager.copyTo(leafSegment);
-                }
+                this.copyPropertiesTo(leafSegment);
                 leafSegment.parent = this.parent;
 
                 // Give the leaf a temporary yet valid ordinal.
@@ -562,6 +563,15 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
                 }
             }
             return leafSegment;
+        }
+    }
+
+    private copyPropertiesTo(other: ISegment) {
+        if (this.propertyManager) {
+            if (this.properties) {
+                other.propertyManager = new PropertiesManager();
+                other.properties = this.propertyManager.copyTo(this.properties, other.properties, other.propertyManager);
+            }
         }
     }
 

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -7,15 +7,15 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { UnassignedSequenceNumber } from "./constants";
-import { CollaborationWindow, ISegment } from "./mergeTree";
+import { CollaborationWindow } from "./mergeTree";
 import { ICombiningOp, IMergeTreeAnnotateMsg } from "./ops";
 import * as Properties from "./properties";
 
-export class SegmentPropertiesManager {
+export class PropertiesManager {
     private pendingKeyUpdateCount: Properties.MapLike<number> | undefined;
     private pendingRewriteCount: number;
 
-    constructor(private readonly segment: ISegment) {
+    constructor() {
         this.pendingRewriteCount = 0;
     }
 
@@ -37,12 +37,12 @@ export class SegmentPropertiesManager {
     }
 
     public addProperties(
+        oldProps: Properties.PropertySet,
         newProps: Properties.PropertySet,
         op?: ICombiningOp,
         seq?: number,
         collabWindow?: CollaborationWindow): Properties.PropertySet | undefined {
-        if (!this.segment.properties) {
-            this.segment.properties = Properties.createMap<any>();
+        if (!this.pendingKeyUpdateCount) {
             this.pendingKeyUpdateCount = Properties.createMap<number>();
         }
 
@@ -72,11 +72,11 @@ export class SegmentPropertiesManager {
             }
             // We are re-writting so delete all the properties
             // not in the new props
-            for (const key of Object.keys(this.segment.properties)) {
+            for (const key of Object.keys(oldProps)) {
                 if (!newProps[key] && shouldModifyKey(key)) {
-                    deltas[key] = this.segment.properties[key];
+                    deltas[key] = oldProps[key];
                     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-                    delete this.segment.properties[key];
+                    delete oldProps[key];
                 }
             }
         }
@@ -85,15 +85,15 @@ export class SegmentPropertiesManager {
             if (collaborating) {
                 if (seq === UnassignedSequenceNumber) {
                     if (this.pendingKeyUpdateCount?.[key] === undefined) {
-                        this.pendingKeyUpdateCount![key] = 0;
+                        this.pendingKeyUpdateCount[key] = 0;
                     }
-                    this.pendingKeyUpdateCount![key]++;
+                    this.pendingKeyUpdateCount[key]++;
                 } else if (!shouldModifyKey(key)) {
                     continue;
                 }
             }
 
-            const previousValue: any = this.segment.properties[key];
+            const previousValue: any = oldProps[key];
             // The delta should be null if undefined, as thats how we encode delete
             deltas[key] = (previousValue === undefined) ? null : previousValue;
             let newValue: any;
@@ -104,30 +104,38 @@ export class SegmentPropertiesManager {
             }
             if (newValue === null) {
                 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-                delete this.segment.properties[key];
+                delete oldProps[key];
             } else {
-                this.segment.properties[key] = newValue;
+                oldProps[key] = newValue;
             }
         }
 
         return deltas;
     }
 
-    public copyTo(leafSegment: ISegment) {
-        if (this.segment.properties) {
-            leafSegment.properties = Properties.createMap<any>();
-            for (const key of Object.keys(this.segment.properties)) {
-                leafSegment.properties[key] = this.segment.properties[key];
+    public copyTo(
+        oldProps: Properties.PropertySet,
+        newProps: Properties.PropertySet | undefined,
+        newManager: PropertiesManager,
+    ): Properties.PropertySet | undefined {
+        if (oldProps) {
+            if (!newProps) {
+                // eslint-disable-next-line no-param-reassign
+                newProps = Properties.createMap<any>();
             }
-            if (this.segment.propertyManager) {
-                leafSegment.propertyManager = new SegmentPropertiesManager(leafSegment);
-                leafSegment.propertyManager.pendingRewriteCount = this.pendingRewriteCount;
-                leafSegment.propertyManager.pendingKeyUpdateCount = Properties.createMap<number>();
-                for (const key of Object.keys(this.pendingKeyUpdateCount!)) {
-                    leafSegment.propertyManager.pendingKeyUpdateCount[key] = this.pendingKeyUpdateCount![key];
-                }
+            if (!newManager) {
+                throw new Error("Must provide new PropertyManager");
+            }
+            for (const key of Object.keys(oldProps)) {
+                newProps[key] = oldProps[key];
+            }
+            newManager.pendingRewriteCount = this.pendingRewriteCount;
+            newManager.pendingKeyUpdateCount = Properties.createMap<number>();
+            for (const key of Object.keys(this.pendingKeyUpdateCount!)) {
+                newManager.pendingKeyUpdateCount[key] = this.pendingKeyUpdateCount![key];
             }
         }
+        return newProps;
     }
 
     public hasPendingProperties() {


### PR DESCRIPTION
Prepare SegmentPropertiesManager for reuse by the Interval class. Remove references to ISegment and rename to PropertiesManager.