### PR TITLE
Remove readAndParseFromBlobs api as no longer needed

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -295,6 +295,11 @@ export class RateLimiter {
 // @public
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
 
+// @public
+export function readAndParseFromBlobs<T>(blobs: {
+    [index: string]: string;
+}, id: string): T;
+
 // @public (undocumented)
 export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal): IStream<ISequencedDocumentMessage[]>;
 

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -295,7 +295,7 @@ export class RateLimiter {
 // @public
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
 
-// @public
+// @public @deprecated (undocumented)
 export function readAndParseFromBlobs<T>(blobs: {
     [index: string]: string;
 }, id: string): T;

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -295,11 +295,6 @@ export class RateLimiter {
 // @public
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
 
-// @public
-export function readAndParseFromBlobs<T>(blobs: {
-    [index: string]: string;
-}, id: string): T;
-
 // @public (undocumented)
 export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal): IStream<ISequencedDocumentMessage[]>;
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -49,7 +49,6 @@ import {
     isOnline,
     ensureFluidResolvedUrl,
     combineAppAndProtocolSummary,
-    readAndParseFromBlobs,
     runWithRetry,
 } from "@fluidframework/driver-utils";
 import {
@@ -1315,14 +1314,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         blobs.forEach((value, key) => {
             this.storageBlobs.set(key, value);
         });
-        const attributes = await this.getDocumentAttributes(undefined, snapshotTree);
+        const attributes = await this.getDocumentAttributes(this.storage, snapshotTree);
         assert(attributes.sequenceNumber === 0, 0x0db /* "Seq number in detached container should be 0!!" */);
         this.attachDeltaManagerOpHandler(attributes);
 
         // ...load in the existing quorum
         // Initialize the protocol handler
         this._protocolHandler =
-            await this.loadAndInitializeProtocolState(attributes, undefined, snapshotTree);
+            await this.loadAndInitializeProtocolState(attributes, this.storage, snapshotTree);
 
         await this.instantiateContextDetached(
             true, // existing
@@ -1356,7 +1355,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     private async getDocumentAttributes(
-        storage: IDocumentStorageService | undefined,
+        storage: IDocumentStorageService,
         tree: ISnapshotTree | undefined,
     ): Promise<IDocumentAttributes> {
         if (tree === undefined) {
@@ -1373,8 +1372,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             ? tree.trees[".protocol"].blobs.attributes
             : tree.blobs[".attributes"];
 
-        const attributes = storage !== undefined ? await readAndParse<IDocumentAttributes>(storage, attributesHash)
-            : readAndParseFromBlobs<IDocumentAttributes>(tree.trees[".protocol"].blobs, attributesHash);
+        const attributes = await readAndParse<IDocumentAttributes>(storage, attributesHash);
 
         // Backward compatibility for older summaries with no term
         if (attributes.term === undefined) {
@@ -1386,7 +1384,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     private async loadAndInitializeProtocolState(
         attributes: IDocumentAttributes,
-        storage: IDocumentStorageService | undefined,
+        storage: IDocumentStorageService,
         snapshot: ISnapshotTree | undefined,
     ): Promise<ProtocolOpHandler> {
         let members: [string, ISequencedClient][] = [];
@@ -1395,20 +1393,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         if (snapshot !== undefined) {
             const baseTree = ".protocol" in snapshot.trees ? snapshot.trees[".protocol"] : snapshot;
-            if (storage !== undefined) {
-                [members, proposals, values] = await Promise.all([
-                    readAndParse<[string, ISequencedClient][]>(storage, baseTree.blobs.quorumMembers),
-                    readAndParse<[number, ISequencedProposal, string[]][]>(storage, baseTree.blobs.quorumProposals),
-                    readAndParse<[string, ICommittedProposal][]>(storage, baseTree.blobs.quorumValues),
-                ]);
-            } else {
-                members = readAndParseFromBlobs<[string, ISequencedClient][]>(snapshot.trees[".protocol"].blobs,
-                    baseTree.blobs.quorumMembers);
-                proposals = readAndParseFromBlobs<[number, ISequencedProposal, string[]][]>(
-                    snapshot.trees[".protocol"].blobs, baseTree.blobs.quorumProposals);
-                values = readAndParseFromBlobs<[string, ICommittedProposal][]>(snapshot.trees[".protocol"].blobs,
-                    baseTree.blobs.quorumValues);
-            }
+            [members, proposals, values] = await Promise.all([
+                readAndParse<[string, ISequencedClient][]>(storage, baseTree.blobs.quorumMembers),
+                readAndParse<[number, ISequencedProposal, string[]][]>(storage, baseTree.blobs.quorumProposals),
+                readAndParse<[string, ICommittedProposal][]>(storage, baseTree.blobs.quorumValues),
+            ]);
         }
 
         const protocolHandler = await this.initializeProtocolState(

--- a/packages/loader/driver-utils/src/readAndParse.ts
+++ b/packages/loader/driver-utils/src/readAndParse.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { bufferToString } from "@fluidframework/common-utils";
+import { bufferToString, fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 
 /**
@@ -16,5 +16,19 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 export async function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T> {
     const blob = await storage.readBlob(id);
     const decoded = bufferToString(blob, "utf8");
+    return JSON.parse(decoded) as T;
+}
+
+/**
+ * @deprecated - Older Runtime needs to use this api.
+ * Read a blob from map, decode it (from "base64") and JSON.parse it into object of type T
+ *
+ * @param blobs - the blob map to read from
+ * @param id - the id of the blob to read and parse
+ * @returns the object that we decoded and JSON.parse
+ */
+ export function readAndParseFromBlobs<T>(blobs: {[index: string]: string}, id: string): T {
+    const encoded = blobs[id];
+    const decoded = fromBase64ToUtf8(encoded);
     return JSON.parse(decoded) as T;
 }

--- a/packages/loader/driver-utils/src/readAndParse.ts
+++ b/packages/loader/driver-utils/src/readAndParse.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { bufferToString, fromBase64ToUtf8 } from "@fluidframework/common-utils";
+import { bufferToString } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 
 /**
@@ -16,18 +16,5 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 export async function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T> {
     const blob = await storage.readBlob(id);
     const decoded = bufferToString(blob, "utf8");
-    return JSON.parse(decoded) as T;
-}
-
-/**
- * Read a blob from map, decode it (from "base64") and JSON.parse it into object of type T
- *
- * @param blobs - the blob map to read from
- * @param id - the id of the blob to read and parse
- * @returns the object that we decoded and JSON.parse
- */
-export function readAndParseFromBlobs<T>(blobs: {[index: string]: string}, id: string): T {
-    const encoded = blobs[id];
-    const decoded = fromBase64ToUtf8(encoded);
     return JSON.parse(decoded) as T;
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -44,11 +44,7 @@ import {
     PerformanceEvent,
 } from "@fluidframework/telemetry-utils";
 import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
-import {
-    readAndParse,
-    readAndParseFromBlobs,
-    BlobAggregationStorage,
-} from "@fluidframework/driver-utils";
+import { readAndParse, BlobAggregationStorage } from "@fluidframework/driver-utils";
 import { CreateContainerError } from "@fluidframework/container-utils";
 import { runGarbageCollection } from "@fluidframework/garbage-collector";
 import {
@@ -570,13 +566,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const tryFetchBlob = async <T>(blobName: string): Promise<T | undefined> => {
             const blobId = context.baseSnapshot?.blobs[blobName];
             if (context.baseSnapshot && blobId) {
-                if (context.attachState === AttachState.Attached) {
-                    // IContainerContext storage api return type still has undefined in 0.39 package version.
-                    // So once we release 0.40 container-defn package we can remove this check.
-                    assert(storage !== undefined, 0x1f5 /* "Attached state should have storage" */);
-                    return readAndParse<T>(storage, blobId);
-                }
-                return readAndParseFromBlobs<T>(context.baseSnapshot.blobs, blobId);
+                // IContainerContext storage api return type still has undefined in 0.39 package version.
+                // So once we release 0.40 container-defn package we can remove this check.
+                assert(storage !== undefined, 0x1f5 /* "Attached state should have storage" */);
+                return readAndParse<T>(storage, blobId);
             }
         };
         const chunks = await tryFetchBlob<[string, string[]][]>(chunksBlobName) ?? [];

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { readAndParse, readAndParseFromBlobs } from "@fluidframework/driver-utils";
+import { readAndParse } from "@fluidframework/driver-utils";
 import { ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 
@@ -157,12 +157,8 @@ export async function getFluidDataStoreAttributes(
     storage: IDocumentStorageService,
     snapshot: ISnapshotTree,
 ): Promise<ReadFluidDataStoreAttributes> {
-    // Note: storage can be undefined in special case while detached.
-    const attributes = storage !== undefined
-        ? await readAndParse<ReadFluidDataStoreAttributes>(
-            storage, snapshot.blobs[dataStoreAttributesBlobName])
-        : readAndParseFromBlobs<ReadFluidDataStoreAttributes>(
-            snapshot.blobs, snapshot.blobs[dataStoreAttributesBlobName]);
+    const attributes = await readAndParse<ReadFluidDataStoreAttributes>(
+        storage, snapshot.blobs[dataStoreAttributesBlobName]);
     // Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
     // For snapshotFormatVersion = "0.1" (1) or above, pkg is jsonified, otherwise it is just a string.
     // However the feature of loading a detached container from snapshot, is added when the


### PR DESCRIPTION
Refer: #4746
This is second part of above issue and part of draft PR: https://github.com/microsoft/FluidFramework/pull/6608

Remove readAndParseFromBlobs api as no longer needed as we always have storage even in detached container and read from blobs(using storage) in rehydrating detached container from snapshot.
