### PR TITLE
Support changing Interval properties via PropertiesManager

### DIFF
--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -20,3 +20,4 @@ export * from "./sortedSegmentSet";
 export * from "./textSegment";
 export * from "./localReference";
 export * from "./snapshotLoader";
+export * from "./constants";

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -466,7 +466,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
         if (!this.properties) {
             this.properties = Properties.createMap<any>();
         }
-        return this.propertyManager.addProperties(this.properties, newProps, op, seq, collabWindow);
+        return this.propertyManager.addProperties(this.properties, newProps, op, seq, collabWindow && collabWindow.collaborating);
     }
 
     hasProperty(key: string): boolean {

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -7,7 +7,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { UnassignedSequenceNumber } from "./constants";
-import { CollaborationWindow } from "./mergeTree";
 import { ICombiningOp, IMergeTreeAnnotateMsg } from "./ops";
 import * as Properties from "./properties";
 
@@ -41,12 +40,10 @@ export class PropertiesManager {
         newProps: Properties.PropertySet,
         op?: ICombiningOp,
         seq?: number,
-        collabWindow?: CollaborationWindow): Properties.PropertySet | undefined {
+        collaborating: boolean = false): Properties.PropertySet | undefined {
         if (!this.pendingKeyUpdateCount) {
             this.pendingKeyUpdateCount = Properties.createMap<number>();
         }
-
-        const collaborating = collabWindow && collabWindow.collaborating;
 
         // There are outstanding local rewrites, so block all non-local changes
         if (this.pendingRewriteCount > 0 && seq !== UnassignedSequenceNumber && collaborating) {

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -23,8 +23,9 @@ export interface ISerializedInterval {
 
 export interface ISerializableInterval extends MergeTree.IInterval {
     properties: MergeTree.PropertySet;
+    propertyManager: MergeTree.PropertiesManager;
     serialize(client: MergeTree.Client);
-    addProperties(props: MergeTree.PropertySet);
+    addProperties(props: MergeTree.PropertySet, collaborating?: boolean, seq?: number);
     getIntervalId(): string | undefined;
 }
 
@@ -37,6 +38,7 @@ export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
 export class Interval implements ISerializableInterval {
     public properties: MergeTree.PropertySet;
     public auxProps: MergeTree.PropertySet[];
+    public propertyManager: MergeTree.PropertiesManager;
     constructor(
         public start: number,
         public end: number,
@@ -133,8 +135,21 @@ export class Interval implements ISerializableInterval {
         return this.properties;
     }
 
-    public addProperties(newProps: MergeTree.PropertySet, op?: MergeTree.ICombiningOp) {
-        this.properties = MergeTree.addProperties(this.properties, newProps, op);
+    public addProperties(
+        newProps: MergeTree.PropertySet,
+        collaborating: boolean = false,
+        seq?: number,
+        op?: MergeTree.ICombiningOp,
+    ) {
+        if (newProps) {
+            if (!this.propertyManager) {
+                this.propertyManager = new MergeTree.PropertiesManager();
+            }
+            if (!this.properties) {
+                this.properties = MergeTree.createMap<any>();
+            }
+            this.propertyManager.addProperties(this.properties, newProps, op, seq, collaborating);
+        }
     }
 
     public modify(label: string, start: number, end: number) {
@@ -150,6 +165,7 @@ export class Interval implements ISerializableInterval {
 
 export class SequenceInterval implements ISerializableInterval {
     public properties: MergeTree.PropertySet;
+    public propertyManager: MergeTree.PropertiesManager;
     private readonly checkMergeTree: MergeTree.MergeTree;
 
     constructor(
@@ -234,8 +250,21 @@ export class SequenceInterval implements ISerializableInterval {
             this.end.max(b.end), this.intervalType);
     }
 
-    public addProperties(newProps: MergeTree.PropertySet, op?: MergeTree.ICombiningOp) {
-        this.properties = MergeTree.addProperties(this.properties, newProps, op);
+    public addProperties(
+        newProps: MergeTree.PropertySet,
+        collab: boolean = false,
+        seq?: number,
+        op?: MergeTree.ICombiningOp,
+    ) {
+        if (newProps) {
+            if (!this.propertyManager) {
+                this.propertyManager = new MergeTree.PropertiesManager();
+            }
+            if (!this.properties) {
+                this.properties = MergeTree.createMap<any>();
+            }
+            this.propertyManager.addProperties(this.properties, newProps, op, seq, collab);
+        }
     }
 
     public overlapsPos(bstart: number, bend: number) {
@@ -941,6 +970,32 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
         return interval;
     }
 
+    public changeProperties(id: string, props: MergeTree.PropertySet) {
+        if (!this.attached) {
+            throw new Error("Attach must be called before accessing intervals");
+        }
+        if (typeof(id) !== "string") {
+            throw new Error("Change API requires an ID that is a string");
+        }
+        if (!props) {
+            throw new Error("changeProperties should be called with a property set");
+        }
+
+        const interval = this.getIntervalById(id);
+        if (interval) {
+            // Pass Unassigned as the sequence number to indicate that this is a local op that is waiting for an ack.
+            interval.addProperties(props, true, MergeTree.UnassignedSequenceNumber);
+            const serializedInterval: ISerializedInterval = interval.serialize(this.client);
+            // Emit a change op that will only change properties. Add the ID to the property bag provided by the caller.
+            serializedInterval.start = undefined;
+            serializedInterval.end = undefined;
+            serializedInterval.properties = props;
+            serializedInterval.properties[reservedIntervalIdKey] = interval.getIntervalId();
+            this.emitter.emit("change", undefined, serializedInterval);
+        }
+        this.emit("change", interval, true, undefined);
+    }
+
     public change(id: string, start?: number, end?: number): TInterval | undefined {
         if (!this.attached) {
             throw new Error("Attach must be called before accessing intervals");
@@ -956,6 +1011,11 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
             const serializedInterval: ISerializedInterval = interval.serialize(this.client);
             serializedInterval.start = start;
             serializedInterval.end = end;
+            // Emit a property bag containing only the ID, as we don't intend for this op to change any properties.
+            serializedInterval.properties =
+                {
+                    [reservedIntervalIdKey]: interval.getIntervalId(),
+                };
             this.emitter.emit("change", undefined, serializedInterval);
             this.addPendingChange(id, serializedInterval);
         }
@@ -1021,12 +1081,12 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     }
 
     private hasPendingChangeStart(id: string) {
-        const entries = this.pendingChangeStart.get(id);
+        const entries = this.pendingChangeStart?.get(id);
         return entries && entries.length !== 0;
     }
 
     private hasPendingChangeEnd(id: string) {
-        const entries = this.pendingChangeEnd.get(id);
+        const entries = this.pendingChangeEnd?.get(id);
         return entries && entries.length !== 0;
     }
 
@@ -1038,27 +1098,40 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
         if (local) {
             // This is an ack from the server. Remove the pending change.
             this.removePendingChange(serializedInterval);
+            const id: string = serializedInterval.properties[reservedIntervalIdKey];
+            const interval: TInterval = this.getIntervalById(id);
+            if (interval) {
+                // Let the propertyManager prune its pending change-properties set.
+                interval.propertyManager?.ackPendingProperties(
+                    {
+                        type: MergeTree.MergeTreeDeltaType.ANNOTATE,
+                        props: serializedInterval.properties,
+                    });
+            }
         }
         else {
             // If there are pending changes with this ID, don't apply the remote start/end change, as the local ack
             // should be the winning change.
-            let start;
-            let end;
             const id: string = serializedInterval.properties[reservedIntervalIdKey];
-            if (!this.hasPendingChangeStart(id)) {
-                start = serializedInterval.start;
-            }
-            if (!this.hasPendingChangeEnd(id)) {
-                end = serializedInterval.end;
-            }
-            if (start !== undefined || end !== undefined) {
-                // Change ops always have an ID.
-                const interval: TInterval = this.getIntervalById(id);
-                if (interval) {
-                    this.localCollection.changeInterval(interval, start, end);
-                    if (this.onDeserialize) {
-                        this.onDeserialize(interval);
-                    }
+            let interval: TInterval = this.getIntervalById(id);
+            if (interval) {
+                let start: number | undefined;
+                let end: number | undefined;
+                // Track pending start/end independently of one another.
+                if (!this.hasPendingChangeStart(id)) {
+                    start = serializedInterval.start;
+                }
+                if (!this.hasPendingChangeEnd(id)) {
+                    end = serializedInterval.end;
+                }
+                if (start !== undefined || end !== undefined) {
+                    // If changeInterval gives us a new interval, work with that one. Otherwise keep working with
+                    // the one we originally found in the tree.
+                    interval = this.localCollection.changeInterval(interval, start, end) ?? interval;
+                }
+                interval.addProperties(serializedInterval.properties, true, op.sequenceNumber);
+                if (this.onDeserialize) {
+                    this.onDeserialize(interval);
                 }
                 this.emit("changeInterval", interval, local, op);
             }

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -651,7 +651,45 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
                     interval2 = intervals2.getIntervalById(id1);
                     assert.strictEqual(interval2.start.getOffset(), 2, "Conflicting transparent change");
                     assert.strictEqual(interval2.end.getOffset(), 2, "Conflicting transparent change");
-                 }
+                }
+
+                if (typeof(intervals1.changeProperties) === "function" &&
+                    typeof(intervals2.changeProperties) === "function") {
+                    intervals1.changeProperties(id1, { prop1: "prop1" });
+                    intervals2.changeProperties(id1, { prop2: "prop2" });
+
+                    await provider.ensureSynchronized();
+
+                    interval1 = intervals1.getIntervalById(id1);
+                    assert.strictEqual(interval1.properties.prop1, "prop1", "Mismatch in changed properties 1");
+                    assert.strictEqual(interval1.properties.prop2, "prop2", "Mismatch in changed properties 2");
+                    interval2 = intervals2.getIntervalById(id1);
+                    assert.strictEqual(interval2.properties.prop1, "prop1", "Mismatch in changed properties 3");
+                    assert.strictEqual(interval2.properties.prop2, "prop2", "Mismatch in changed properties 4");
+
+                    intervals1.changeProperties(id1, { prop1: "no" });
+                    intervals2.changeProperties(id1, { prop1: "yes" });
+
+                    await provider.ensureSynchronized();
+
+                    assert.strictEqual(interval1.properties.prop1, "yes", "Mismatch in changed properties 5");
+                    assert.strictEqual(interval1.properties.prop2, "prop2", "Mismatch in changed properties 6");
+                    assert.strictEqual(interval2.properties.prop1, "yes", "Mismatch in changed properties 7");
+                    assert.strictEqual(interval2.properties.prop2, "prop2", "Mismatch in changed properties 8");
+
+                    intervals1.changeProperties(id1, { prop1: "maybe" });
+                    // eslint-disable-next-line no-null/no-null
+                    intervals2.changeProperties(id1, { prop1: null });
+
+                    await provider.ensureSynchronized();
+
+                    assert.strictEqual(Object.prototype.hasOwnProperty.call(interval1.properties, "prop1"), false,
+                        "Property not deleted 1");
+                    assert.strictEqual(interval1.properties.prop2, "prop2", "Mismatch in changed properties 9");
+                    assert.strictEqual(Object.prototype.hasOwnProperty.call(interval2.properties, "prop1"), false,
+                        "Property not deleted 2");
+                    assert.strictEqual(interval2.properties.prop2, "prop2", "Mismatch in changed properties 10");
+                }
 
                 // Conflicting removes
                 intervals1.removeIntervalById(id1);


### PR DESCRIPTION
Add a PropertiesManager to Interval and SequenceInterval and let it handle changes to Interval properties. Add a changeProperties API. Support cross-client property changes via the change op.