### PR TITLE
Improve documentation of telemetry tags

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -125,7 +125,6 @@ The `RouterliciousDocumentServiceFactory` constructor no longer accepts the foll
 - [ITelemetryLogger Remove redundant methods](#ITelemetryLogger-Remove-redundant-methods)
 - [fileOverwrittenInStorage](#fileOverwrittenInStorage)
 - [absolutePath use in IFluidHandle is deprecated](#absolutepath-use-in-ifluidhandle-is-deprecated)
-- [ITelemetryBaseLogger now has a supportsTags property (not breaking)](#itelemetrybaselogger-now-has-a-supportstags-property-not-breaking)
 
 ### connect event removed from Container
 The `"connect"` event would previously fire on the `Container` after `connect_document_success` was received from the server (which likely happens before the client's own join message is processed).  This event does not represent a safe-to-use state, and has been removed.  To detect when the `Container` is fully connected, the `"connected"` event should be used instead.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -106,7 +106,7 @@ Telemetry properties on logs *can (but are **not** yet required to)* now be tagg
 
 _\[edit\]_
 
-This actually was a breaking change in 0.40, in that the signature of `ITelemetryBaseLogger.send` changed to
+This actually was a breaking change in 0.40, in that the type of the `event` parameter of `ITelemetryBaseLogger.send` changed to
 a more inclusive type which needs to be accounted for in implementations.  However, in releases 0.40 through 0.44,
 _no tagged events are sent to any ITelemetryBaseLogger by the Fluid Framework_.  We are preparing to do so
 soon, and will include an entry in BREAKING.md when we do.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -104,6 +104,13 @@ See [AgentScheduler-related deprecations](#AgentScheduler-related-deprecations) 
 ### ITelemetryProperties may be tagged for privacy purposes
 Telemetry properties on logs *can (but are **not** yet required to)* now be tagged. This is **not** a breaking change in 0.40, but users are strongly encouraged to add support for tags (see [UPCOMING.md](./UPCOMING.md) for more details).
 
+_\[edit\]_
+
+This actually was a breaking change in 0.40, in that the signature of `ITelemetryBaseLogger.send` changed to
+a more inclusive type which needs to be accounted for in implementations.  However, in releases 0.40 through 0.44,
+_no tagged events are sent to any ITelemetryBaseLogger by the Fluid Framework_.  We are preparing to do so
+soon, and will include an entry in BREAKING.md when we do.
+
 ### IContainerRuntimeDirtyable removed
 The `IContainerRuntimeDirtyable` interface and `isMessageDirtyable()` method were deprecated in release 0.38.  They have now been removed in 0.40.  Please refer to the breaking change notice in 0.38 for instructions on migrating away from use of this interface.
 

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -2,13 +2,17 @@
 
 Below is a list of some upcoming breaking changes for users to be aware of and to plan for, but not ones that are slated for the next release.
 
-### ITelemetryProperties may be tagged for privacy purposes (0.41+)
-As of the 0.40 release, telemetry properties on logs now may be tagged, meaning the property value may have the shape
+### Fluid Framework will begin sending tagged telemetry props to ITelemetryBaseLogger.send (0.45+)
+
+As of the 0.40 release, telemetry properties on logging events may be tagged, meaning the property value may have the shape
 `{ value: foo, tag: someString }` instead of merely a primitive value. Unwrapped/untagged values are still supported.
-See the updated type definition of `ITelemetryProperties` in @fluidframework/common-definitions v 0.21.
-`ITelemetryBaseLogger.send` should be updated to handle these tagged values.
+See the updated type definition of `ITelemetryProperties` in @fluidframework/common-definitions v0.21 (and v0.20.1).
+This was a breaking change that requires an update to `ITelemetryBaseLogger.send` to handle these tagged values.
+
+However, for versions 0.40 through 0.44, the Fluid Framework is refraining from logging any tagged properties, to ease the
+transition - i.e. a host may implement naive tag handling like dropping all tagged properties to address the breaking API change.
+
+We expect that the 0.45 release will introduce some cases where tagged properties are logged, so before integrating that release
+hosts should take care to properly handle tagged properties by inspecting the tag and logging, hashing, or redacting the value.
 See [this code](https://github.com/microsoft/FluidFramework/blob/main/packages/utils/telemetry-utils/src/logger.ts#L79-L107)
-for an example of how to handle known tags, and update `supportsTags` to `true` when the logger properly handles tags.
-Until then, in `ITelemetryBaseLogger.send` you may safely cast `event: ITelemetryProperties` to
-`{ [index: string]: TelemetryEventPropertyType; }` and continue handling as-is,
-since the FluidFramework will continue to handle tagged values itself unless `supportsTags` is `true`.
+for an example of how to handle tags.

--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -1,8 +1,7 @@
 ## 0.21 Breaking changes
 
-- [ITelemetryBaseLogger.supportsTags deprecated](#ITelemetryBaseLogger.supportstags-deprecated)
+- [ITelemetryBaseLogger.supportsTags deleted](#ITelemetryBaseLogger.supportstags-deleted)
 
-### ITelemetryBaseLogger.supportsTags deprecated
-We are deprecating use of supportsTags and instead going to handle tags directly at the loader/runtime boundary
-via `IContainerContext`. Other than this boundary, all loggers can assume full support for tags on all telemetry events.
-This will involve a change in `container-definitions`, which is packaged as part of the `build-common` release.
+### ITelemetryBaseLogger.supportsTags deleted
+Proper support for tagged events will be assumed going forward.  Only at the loader-runtime boundary do we retain
+a concession for backwards compatibility, but that's done outside of this interface.

--- a/common/lib/container-definitions/BREAKING.md
+++ b/common/lib/container-definitions/BREAKING.md
@@ -11,3 +11,4 @@ but a large number of useful properties off the offending message, via `CreatePr
 ### IContainerContext.logger deprecated
 Use `IContainerContext.taggedLogger` instead if present. If it's missing and you must use `logger`,
 be sure to handle tagged data before sending events to it.
+`logger` won't be removed for a very long time since old loaders could remain in production for quite some time.

--- a/common/lib/container-definitions/BREAKING.md
+++ b/common/lib/container-definitions/BREAKING.md
@@ -1,8 +1,13 @@
 ## 0.40 Breaking changes
 
 - [IErrorBase.sequenceNumber removed](#IErrorBase.sequenceNumber-removed)
+- [IContainerContext.logger deprecated](#IContainerContext.logger-deprecated)
 
 ### IErrorBase.sequenceNumber removed
 This field was used for logging and this was probably not the right abstraction for it to live in.
 But practically speaking, the only places it was set have been updated to log not just sequenceNumber
 but a large number of useful properties off the offending message, via `CreateProcessingError`.
+
+### IContainerContext.logger deprecated
+Use `IContainerContext.taggedLogger` instead if present. If it's missing and you must use `logger`,
+be sure to handle tagged data before sending events to it.

--- a/docs/content/docs/testing/telemetry.md
+++ b/docs/content/docs/testing/telemetry.md
@@ -49,11 +49,10 @@ is used by `Loader` to pipe to container's telemetry system.
 
 ### Properties and methods
 
-The interface contains a `supportTags` property and a `send()` method as shown:
+The interface contains a `send()` method as shown:
 
 ```ts
 export interface ITelemetryBaseLogger {
-  supportsTags?: true;
   send(event: ITelemetryBaseEvent): void;
 }
 ```
@@ -122,36 +121,32 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
   category: string;
   eventName: string;
 }
-```
 
-The `ITelemetryBaseEvent` contains `category` and `eventName` properties for labeling and defining a telemetry event.
-
-- `ITelemetryProperties` extended by `ITelemetryBaseEvent`, is a type with a string index signature, the values are
-   either tagged (`ITaggedTelemetryPropertyType`) or untagged (`TelemetryEventPropertyType`) primitives (`string`,
-   `boolean`, `number`, `undefined`). It is imperative for you to know how to interpret and process these tagged values.
-  - Tags are strings used to classify different events. In a simple logger, all events are untagged and handled the same
-    by your logger's implementation. However, in some scenarios, where some data should be handled separately (for
-    example, private customer data), those events could be tagged with a unique string so they could be treated
-    differently downstream.
-
- ```ts
- export interface ITelemetryProperties {
+export interface ITelemetryProperties {
     [index: string]: TelemetryEventPropertyType | ITaggedTelemetryPropertyType;
 }
-```
 
-`ITelemetryProperties` values take untagged (`TelemetryEventPropertyType`) or tagged (`ITaggedTelemetryPropertyType`)
-primitives.
-
-- `TelemetryEventPropertyType` takes only `string`, `boolean`, `number`, `undefined` primitives.
-- `ITaggedTelemetryPropertyType` is an interface that takes `TelemetryEventPropertyType` and a tag.
-
-```ts
 export interface ITaggedTelemetryPropertyType {
   value: TelemetryEventPropertyType,
   tag: string,
 }
+
+export type TelemetryEventPropertyType = string | number | boolean | undefined;
 ```
+
+The `ITelemetryBaseEvent` interface contains `category` and `eventName` properties for labeling and defining a telemetry event,
+and extends `ITelemetryProperties` which has a string index signature. The values of the index signature are
+either tagged (`ITaggedTelemetryPropertyType`) or untagged (`TelemetryEventPropertyType`) primitives (`string`,
+`boolean`, `number`, `undefined`).
+
+### Understanding Tags
+
+Tags are strings used to classify the properties on telemetry events. In the course of operation,
+the Fluid Framework may emit events with tagged properties, so implementations of `ITelemetryBaseLogger` must be
+prepared to check for and interpret any tags.  Generally speaking, when logging to the user's console, tags can
+be ignored and tagged values logged plainly, but when transmitting tagged properties to a telemetry service,
+care should be taken to only log tagged properties where the tag is explicitly understood to indicate the value
+is safe to log from a data privacy standpoint.
 
 ### Category
 


### PR DESCRIPTION
Our plan has changed in terms of how to roll out support for tagged properties on telemetry events, so I wanted to update some documentation in the repo about it:

* Telemetry.md
* Several BREAKING.md (some retroactively)
* UPCOMING.md

One specific goal - in main there should be no more references to `supportsTags`, since starting with 0.45 tag support will be assumed (Internal Msft note -- it's already done for Office Fluid Logger).