### PR TITLE
[0.39 release] Deprecate supports tags in common-definition 0.20.x

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -39,7 +39,7 @@ Rather than retrieving the absolute path, ostensibly to be stored, one should in
 
 The signature of `ITelemetryBaseLogger.send` changed to a more inclusive type which needs to be accounted for in implementations.
 However, in 0.39, _no tagged events are sent to any ITelemetryBaseLogger by the Fluid Framework_, so tags can initially be ignored.
-See [UPCOMING.md in main](https://github.com/microsoft/FluidFramework/blob/be4f26d0ba9de18a69fa9d71a0cf8dc3e15e0452/UPCOMING.md) for
+See [UPCOMING.md in main](https://github.com/microsoft/FluidFramework/blob/4a5920457a1d867f3071a13bfd5a5fa8c2025ca9/UPCOMING.md) for
 more info on the transition plan.
 
 ## 0.38 Breaking changes

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,7 @@
 - [ITelemetryLogger Remove redundant methods](#ITelemetryLogger-Remove-redundant-methods)
 - [fileOverwrittenInStorage](#fileOverwrittenInStorage)
 - [absolutePath use in IFluidHandle is deprecated](#absolutepath-use-in-ifluidhandle-is-deprecated)
+- [ITelemetryBaseLogger.send signature change](#ITelemetryBaseLogger.send-signature-change) _(as of @fluidframework/common-definitions@0.20.1)_
 
 ### connect event removed from Container
 The `"connect"` event would previously fire on the `Container` after `connect_document_success` was received from the server (which likely happens before the client's own join message is processed).  This event does not represent a safe-to-use state, and has been removed.  To detect when the `Container` is fully connected, the `"connected"` event should be used instead.
@@ -32,6 +33,14 @@ Please use `DriverErrorType.fileOverwrittenInStorage` instead of `OdspErrorType.
 
 ### absolutePath use in IFluidHandle is deprecated
 Rather than retrieving the absolute path, ostensibly to be stored, one should instead store the handle itself. To load, first retrieve the handle and then call `get` on it to get the actual object. Note that it is assumed that the container is responsible both for mapping an external URI to an internal object and for requesting resolved objects with any remaining tail of the external URI. For example, if a container has some map that maps `/a --> <some handle>`, then a request like `request(/a/b/c)` should flow like `request(/a/b/c) --> <some handle> --> <object> -->  request(/b/c)`.
+
+### ITelemetryBaseLogger.send signature change
+**A breaking change was made in @fluid-framework/common-definitions 0.20.1, compared to the initial 0.39 release**
+
+The signature of `ITelemetryBaseLogger.send` changed to a more inclusive type which needs to be accounted for in implementations.
+However, in 0.39, _no tagged events are sent to any ITelemetryBaseLogger by the Fluid Framework_, so tags can initially be ignored.
+See [UPCOMING.md in main](https://github.com/microsoft/FluidFramework/blob/be4f26d0ba9de18a69fa9d71a0cf8dc3e15e0452/UPCOMING.md) for
+more info on the transition plan.
 
 ## 0.38 Breaking changes
 - [IPersistedCache changes](#IPersistedCache-changes)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -37,7 +37,7 @@ Rather than retrieving the absolute path, ostensibly to be stored, one should in
 ### ITelemetryBaseLogger.send signature change
 **A breaking change was made in @fluid-framework/common-definitions 0.20.1, compared to the initial 0.39 release**
 
-The signature of `ITelemetryBaseLogger.send` changed to a more inclusive type which needs to be accounted for in implementations.
+The type of the `event` parameter of `ITelemetryBaseLogger.send` changed to a more inclusive type which needs to be accounted for in implementations.
 However, in 0.39, _no tagged events are sent to any ITelemetryBaseLogger by the Fluid Framework_, so tags can initially be ignored.
 See [UPCOMING.md in main](https://github.com/microsoft/FluidFramework/blob/4a5920457a1d867f3071a13bfd5a5fa8c2025ca9/UPCOMING.md) for
 more info on the transition plan.

--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -1,0 +1,10 @@
+## 0.20 Breaking changes
+
+__NOTE: Against semver guidelines, the following breaking change was introduced between 0.20 and 0.20.1__
+
+### ITelemetryBaseLogger.send signature change
+
+The type of the `event` parameter of `ITelemetryBaseLogger.send` changed to a more inclusive type which needs to be accounted for in implementations.
+However, in all current releases, _no tagged events are sent to any ITelemetryBaseLogger by the Fluid Framework_, so tags can initially be ignored.
+See [UPCOMING.md in main](https://github.com/microsoft/FluidFramework/blob/be4f26d0ba9de18a69fa9d71a0cf8dc3e15e0452/UPCOMING.md) for
+more info on the transition plan.

--- a/common/lib/common-definitions/BREAKING.md
+++ b/common/lib/common-definitions/BREAKING.md
@@ -6,5 +6,5 @@ __NOTE: Against semver guidelines, the following breaking change was introduced 
 
 The type of the `event` parameter of `ITelemetryBaseLogger.send` changed to a more inclusive type which needs to be accounted for in implementations.
 However, in all current releases, _no tagged events are sent to any ITelemetryBaseLogger by the Fluid Framework_, so tags can initially be ignored.
-See [UPCOMING.md in main](https://github.com/microsoft/FluidFramework/blob/be4f26d0ba9de18a69fa9d71a0cf8dc3e15e0452/UPCOMING.md) for
+See [UPCOMING.md in main](https://github.com/microsoft/FluidFramework/blob/4a5920457a1d867f3071a13bfd5a5fa8c2025ca9/UPCOMING.md) for
 more info on the transition plan.

--- a/common/lib/common-definitions/UPCOMING.md
+++ b/common/lib/common-definitions/UPCOMING.md
@@ -1,4 +1,4 @@
-## Upcoming Breaking changes being staged in this release
+## Breaking changes to expect in upcoming releases
 
 - [ITelemetryBaseLogger.supportsTags to be deleted](#ITelemetryBaseLogger.supportstags-to-be-deleted)
 

--- a/common/lib/common-definitions/UPCOMING.md
+++ b/common/lib/common-definitions/UPCOMING.md
@@ -6,4 +6,4 @@
 Proper support for tagged events will be assumed going forward.  Only at the loader-runtime boundary do we retain
 a concession for backwards compatibility, but that's done outside of this interface.
 
-This property has be __deprecated__ in 0.20.1, and will be __deleted__ in the 0.21 release
+This property will be __deprecated__ in 0.20.2, and will be __deleted__ in the 0.21 release

--- a/common/lib/common-definitions/UPCOMING.md
+++ b/common/lib/common-definitions/UPCOMING.md
@@ -1,0 +1,9 @@
+## Upcoming Breaking changes being staged in this release
+
+- [ITelemetryBaseLogger.supportsTags to be deleted](#ITelemetryBaseLogger.supportstags-to-be-deleted)
+
+### ITelemetryBaseLogger.supportsTags to be deleted
+Proper support for tagged events will be assumed going forward.  Only at the loader-runtime boundary do we retain
+a concession for backwards compatibility, but that's done outside of this interface.
+
+This property has be __deprecated__ in 0.20.1, and will be __deleted__ in the 0.21 release

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -41,6 +41,7 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
  */
 export interface ITelemetryBaseLogger {
     /**
+     * @deprecated - Tag support is assumed starting in an upcoming client release, likely 0.45
      * An optional boolean which indicates to the user of this interface that tags (i.e. `ITaggedTelemetryPropertyType`
      * objects) are in use. Eventually this will be a required property, but this is a stopgap that allows older hosts
      * to continue to pass through telemetry without trouble (this property will simply show up undefined), while our


### PR DESCRIPTION
It's deleted in 0.21, and shouldn't be used.  We simply assume tag support (but don't send tags yet, until an upcoming release, probably 0.45).

Part of #5560 