### PR TITLE
Fixed: loader.request not passing headers to the container

### DIFF
--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -366,7 +366,10 @@ export class Loader implements IHostLoader {
     public async request(request: IRequest): Promise<IResponse> {
         return PerformanceEvent.timedExecAsync(this.logger, { eventName: "Request" }, async () => {
             const resolved = await this.resolveCore(request);
-            return resolved.container.request({ url: `${resolved.parsed.path}${resolved.parsed.query}` });
+            return resolved.container.request({
+                ...request,
+                url: `${resolved.parsed.path}${resolved.parsed.query}`,
+            });
         });
     }
 

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -13,7 +13,7 @@ import {
 import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
 import { IRequest, IResponse, IRequestHeader } from "@fluidframework/core-interfaces";
-import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { createAndAttachContainer, ITestObjectProvider } from "@fluidframework/test-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 
@@ -74,6 +74,21 @@ class TestSharedDataObject2 extends DataObject {
     }
 }
 
+/**
+ * Data object that handles requests that have headers. It returns the headers in the request. This is
+ * used to validate that headers are correctly propagated all the way in the stack.
+ */
+class TestDataObjectWithRequestHeaders extends DataObject {
+    public async request(request: IRequest): Promise<IResponse> {
+        // If the request has headers, return a specialized response with the headers in the request.
+        if (request.headers !== undefined) {
+            return { value: request.headers, status: 200, mimeType: "request/headers" };
+        } else {
+            return super.request(request);
+        }
+    }
+}
+
 const testSharedDataObjectFactory1 = new DataObjectFactory(
     "TestSharedDataObject1",
     TestSharedDataObject1,
@@ -86,6 +101,12 @@ const testSharedDataObjectFactory2 = new DataObjectFactory(
     [],
     []);
 
+const testFactoryWithRequestHeaders = new DataObjectFactory(
+    "TestDataObjectWithRequestHeaders",
+    TestDataObjectWithRequestHeaders,
+    [],
+    []);
+
 // REVIEW: enable compat testing?
 describeNoCompat("Loader.request", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
@@ -93,6 +114,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
     let dataStore1: TestSharedDataObject1;
     let dataStore2: TestSharedDataObject2;
     let loader: IHostLoader;
+    let container: IContainer;
 
     const runtimeFactory =
         new ContainerRuntimeFactoryWithDefaultDataStore(
@@ -100,20 +122,26 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
             [
                 [testSharedDataObjectFactory1.type, Promise.resolve(testSharedDataObjectFactory1)],
                 [testSharedDataObjectFactory2.type, Promise.resolve(testSharedDataObjectFactory2)],
+                [testFactoryWithRequestHeaders.type, Promise.resolve(testFactoryWithRequestHeaders)],
             ],
         );
-    const createContainer = async (): Promise<IContainer> => provider.createContainer(runtimeFactory);
-    let container: IContainer;
+
     beforeEach(async () => {
         provider = getTestObjectProvider();
-        container = await createContainer();
         loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]]);
+        container = await createAndAttachContainer(
+            provider.defaultCodeDetails,
+            loader,
+            provider.driver.createCreateNewRequest(provider.documentId),
+        );
         dataStore1 = await requestFluidObject(container, "default");
 
         dataStore2 = await testSharedDataObjectFactory2.createInstance(dataStore1._context.containerRuntime);
 
         // this binds dataStore2 to dataStore1
         dataStore1._root.set("key", dataStore2.handle);
+
+        await provider.ensureSynchronized();
     });
 
     it("can create the data objects with correct types", async () => {
@@ -227,5 +255,25 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
         const searchParams = new URLSearchParams(response.value);
         assert.strictEqual(searchParams.get("query1"), "1", "request did not pass the right query to the data store");
         assert.strictEqual(searchParams.get("query2"), "2", "request did not pass the right query to the data store");
+    });
+
+    it("can handle requests with headers", async () => {
+        const dataStoreWithRequestHeaders =
+            await testFactoryWithRequestHeaders.createInstance(dataStore1._context.containerRuntime);
+        dataStore1._root.set("key", dataStoreWithRequestHeaders.handle);
+
+        // Flush all the ops
+        await provider.ensureSynchronized();
+
+        const url = await container.getAbsoluteUrl(dataStoreWithRequestHeaders.id);
+        assert(url, "Container should return absolute url");
+
+        const headers = { wait: false, externalRequest: true };
+        // Request to the newly created data store with headers.
+        const response = await loader.request({ url, headers });
+
+        assert.strictEqual(response.status, 200, "Did not return the correct status");
+        assert.strictEqual(response.mimeType, "request/headers", "Did not get the correct mimeType");
+        assert.deepStrictEqual(response.value, headers, "Did not get the correct headers in the response");
     });
 });


### PR DESCRIPTION
Fixes #6806
In loader.request, passed the original request with only the url modified to container.request. Added tests.