### PR TITLE
[0.39 release] Mark IErrorBase.sequenceNumber as deprecated

### DIFF
--- a/packages/loader/container-definitions/src/UPCOMING.md
+++ b/packages/loader/container-definitions/src/UPCOMING.md
@@ -1,0 +1,10 @@
+## Breaking changes to expect in upcoming releases
+
+- [IErrorBase.sequenceNumber to be removed](#IErrorBase.sequenceNumber-to-be-removed)
+
+### IErrorBase.sequenceNumber to be removed
+This field was used for logging and this was probably not the right abstraction for it to live in.
+But practically speaking, the only places it was set have been updated to log not just sequenceNumber
+but a large number of useful properties off the offending message, via `CreateProcessingError`.
+
+This property will be __deprecated__ in 0.39.7, and will be __deleted__ in the 0.40 release

--- a/packages/loader/container-definitions/src/error.ts
+++ b/packages/loader/container-definitions/src/error.ts
@@ -39,7 +39,10 @@ export interface IErrorBase {
      */
     readonly errorType: string;
     readonly message: string;
-    /** Sequence number when error happened */
+    /**
+     * @deprecated - This info is logged by other means, when applicable, so this is no longer needed
+     * Sequence number when error happened
+     */
     sequenceNumber?: number;
 }
 


### PR DESCRIPTION
This is removed altogether in main, see #6639