### PR TITLE
Add ability to disable summarizer heuristics

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -132,6 +132,7 @@ import {
     IGenerateSummaryOptions,
     ISummarizer,
     ISummarizerInternalsProvider,
+    ISummarizerOptions,
     ISummarizerRuntime,
 } from "./summarizerTypes";
 
@@ -246,6 +247,9 @@ export interface ISummaryRuntimeOptions {
      * THis defaults to false (disabled) and must be explicitly set to true to enable.
      */
     summarizerClientElection?: boolean;
+
+    /** Options that control the running summarizer behavior. */
+    summarizerOptions?: Readonly<Partial<ISummarizerOptions>>;
 }
 
 /**
@@ -925,6 +929,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.runtimeOptions.summaryOptions.generateSummaries !== false,
             this.logger,
             this.runtimeOptions.summaryOptions.initialSummarizerDelayMs,
+            this.runtimeOptions.summaryOptions.summarizerOptions,
         );
 
         if (this.connected) {

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -28,6 +28,7 @@ import {
     IGenerateSummaryOptions,
     ISummarizer,
     ISummarizerInternalsProvider,
+    ISummarizerOptions,
     ISummarizerRuntime,
     ISummarizingWarning,
     OnDemandSummarizeResult,
@@ -91,9 +92,9 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         this.innerHandle = new SummarizerHandle(this, url, handleContext);
     }
 
-    public async run(onBehalfOf: string): Promise<void> {
+    public async run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<void> {
         try {
-            await this.runCore(onBehalfOf);
+            await this.runCore(onBehalfOf, options);
         } catch (error) {
             this.emit("summarizingError", SummarizingWarning.wrap(error, false /* logged */));
             throw error;
@@ -144,7 +145,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         return create404Response(request);
     }
 
-    private async runCore(onBehalfOf: string): Promise<void> {
+    private async runCore(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<void> {
         this.onBehalfOfClientId = onBehalfOf;
 
         const startResult = await this.runCoordinator.waitStart();
@@ -210,6 +211,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
                 }
             },
             this.summaryCollection,
+            options,
         );
         this.runningSummarizer = runningSummarizer;
 

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -203,7 +203,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             this /* Pick<ISummarizerInternalsProvider, "submitSummary"> */,
             new SummarizeHeuristicData(
                 this.runtime.deltaManager.lastSequenceNumber,
-                { /** Initial summary attempt */
+                { /** summary attempt baseline for heuristics */
                     refSequenceNumber: this.runtime.deltaManager.initialSequenceNumber,
                     summaryTime: Date.now(),
                 } as const,

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -34,6 +34,7 @@ import {
     OnDemandSummarizeResult,
     SummarizerStopReason,
 } from "./summarizerTypes";
+import { SummarizeHeuristicData } from "./summarizerHeuristics";
 
 const summarizingError = "summarizingError";
 
@@ -200,11 +201,13 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             this.summaryCollection.createWatcher(startResult.clientId),
             this.configurationGetter(),
             this /* Pick<ISummarizerInternalsProvider, "submitSummary"> */,
-            this.runtime.deltaManager.lastSequenceNumber,
-            { /** Initial summary attempt */
-                refSequenceNumber: this.runtime.deltaManager.initialSequenceNumber,
-                summaryTime: Date.now(),
-            } as const,
+            new SummarizeHeuristicData(
+                this.runtime.deltaManager.lastSequenceNumber,
+                { /** Initial summary attempt */
+                    refSequenceNumber: this.runtime.deltaManager.initialSequenceNumber,
+                    summaryTime: Date.now(),
+                } as const,
+            ),
             (description: string) => {
                 if (!this._disposed) {
                     this.emit("summarizingError", createSummarizingWarning(`Summarizer: ${description}`, true));

--- a/packages/runtime/container-runtime/src/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summarizerHeuristics.ts
@@ -5,31 +5,31 @@
 
 import { Timer } from "@fluidframework/common-utils";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
-import { ISummarizeHeuristicData, ISummarizeHeuristicRunner, ISummaryAttempt } from "./summarizerTypes";
+import { ISummarizeHeuristicData, ISummarizeHeuristicRunner, ISummarizeAttempt } from "./summarizerTypes";
 import { SummarizeReason } from "./summaryGenerator";
 
 /** Simple implementation of class for tracking summarize heuristic data. */
 export class SummarizeHeuristicData implements ISummarizeHeuristicData {
-    protected _lastAttempt: ISummaryAttempt;
-    public get lastAttempt(): ISummaryAttempt {
+    protected _lastAttempt: ISummarizeAttempt;
+    public get lastAttempt(): ISummarizeAttempt {
         return this._lastAttempt;
     }
 
-    protected _lastSuccessfulSummary: Readonly<ISummaryAttempt>;
-    public get lastSuccessfulSummary(): Readonly<ISummaryAttempt> {
+    protected _lastSuccessfulSummary: Readonly<ISummarizeAttempt>;
+    public get lastSuccessfulSummary(): Readonly<ISummarizeAttempt> {
         return this._lastSuccessfulSummary;
     }
 
     constructor(
         public lastOpSequenceNumber: number,
         /** Baseline attempt data used for comparisons with subsequent attempts/calculations. */
-        attemptBaseline: ISummaryAttempt,
+        attemptBaseline: ISummarizeAttempt,
     ) {
         this._lastAttempt = attemptBaseline;
         this._lastSuccessfulSummary = { ...attemptBaseline };
     }
 
-    public initialize(lastSummary: Readonly<ISummaryAttempt>) {
+    public initialize(lastSummary: Readonly<ISummarizeAttempt>) {
         this._lastAttempt = lastSummary;
         this._lastSuccessfulSummary = { ...lastSummary };
     }

--- a/packages/runtime/container-runtime/src/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summarizerHeuristics.ts
@@ -1,0 +1,108 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Timer } from "@fluidframework/common-utils";
+import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
+import { ISummarizerHeuristics, ISummaryAttempt } from "./summarizerTypes";
+import { SummarizeReason } from "./summaryGenerator";
+
+const minOpsForLastSummary = 50;
+
+class BaseSummarizerHeuristics {
+    protected _lastAttempt: ISummaryAttempt;
+    public get lastAttempt(): ISummaryAttempt {
+        return this._lastAttempt;
+    }
+
+    protected _lastAck: ISummaryAttempt;
+    public get lastAck(): ISummaryAttempt {
+        return this._lastAck;
+    }
+
+    constructor(
+        public lastOpSequenceNumber: number,
+        firstAck: ISummaryAttempt,
+    ) {
+        this._lastAttempt = firstAck;
+        this._lastAck = firstAck;
+    }
+
+    public initialize(lastSummary: ISummaryAttempt) {
+        this._lastAttempt = lastSummary;
+        this._lastAck = lastSummary;
+    }
+
+    public recordAttempt(refSequenceNumber?: number) {
+        this._lastAttempt = {
+            refSequenceNumber: refSequenceNumber ?? this.lastOpSequenceNumber,
+            summaryTime: Date.now(),
+        };
+    }
+
+    public ackLastSent() {
+        this._lastAck = this.lastAttempt;
+    }
+}
+
+/**
+ * This class contains the heuristics for when to summarize.
+ */
+export class DefaultSummarizerHeuristics extends BaseSummarizerHeuristics implements ISummarizerHeuristics {
+    private readonly idleTimer: Timer;
+
+    public constructor(
+        private readonly configuration: ISummaryConfiguration,
+        private readonly trySummarize: (reason: SummarizeReason) => void,
+        lastOpSequenceNumber: number,
+        firstAck: ISummaryAttempt,
+    ) {
+        super(lastOpSequenceNumber, firstAck);
+        this.idleTimer = new Timer(
+            this.configuration.idleTime,
+            () => this.trySummarize("idle"));
+    }
+
+    public run() {
+        const timeSinceLastSummary = Date.now() - this.lastAck.summaryTime;
+        const opCountSinceLastSummary = this.lastOpSequenceNumber - this.lastAck.refSequenceNumber;
+        if (timeSinceLastSummary > this.configuration.maxTime) {
+            this.idleTimer.clear();
+            this.trySummarize("maxTime");
+        } else if (opCountSinceLastSummary > this.configuration.maxOps) {
+            this.idleTimer.clear();
+            this.trySummarize("maxOps");
+        } else {
+            this.idleTimer.restart();
+        }
+    }
+
+    public runOnClose(): boolean {
+        const outstandingOps = this.lastOpSequenceNumber - this.lastAck.refSequenceNumber;
+        if (outstandingOps > minOpsForLastSummary) {
+            this.trySummarize("lastSummary");
+            return true;
+        }
+        return false;
+    }
+
+    public dispose() {
+        this.idleTimer.clear();
+    }
+}
+
+export class DisabledSummarizerHeuristics extends BaseSummarizerHeuristics implements ISummarizerHeuristics {
+    public run() {
+        // Intentionally do nothing; heuristics are disabled.
+    }
+
+    public dispose() {
+        // Intentionally do nothing; no resources to dispose.
+    }
+
+    public runOnClose() {
+        // Intentionally do nothing; heuristics are disabled.
+        return false;
+    }
+}

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -227,7 +227,7 @@ export interface ISummarizer
 }
 
 /**
- * Data about a summary attempt
+ * Data about an attempt to summarize.
  */
  export interface ISummaryAttempt {
     /**
@@ -246,7 +246,8 @@ export interface ISummarizer
     summarySequenceNumber?: number;
 }
 
-export interface ISummarizerHeuristics {
+/** Data relevant for summary heuristics. */
+export interface ISummarizeHeuristicData {
     /** Last received op sequence number */
     lastOpSequenceNumber: number;
 
@@ -272,7 +273,10 @@ export interface ISummarizerHeuristics {
 
     /** Mark that the last sent summary attempt has received an ack */
     ackLastSent(): void;
+}
 
+/** Responsible for running heuristics determining when to summarize. */
+export interface ISummarizeHeuristicRunner {
     /** Runs the heuristic to determine if it should try to summarize */
     run(): void;
 

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -226,39 +226,31 @@ export interface ISummarizer
     ): OnDemandSummarizeResult;
 }
 
-/**
- * Data about an attempt to summarize.
- */
- export interface ISummaryAttempt {
-    /**
-     * Reference sequence number when summary was generated or attempted
-     */
+/** Data about an attempt to summarize. */
+export interface ISummaryAttempt {
+    /** Reference sequence number when summary was generated or attempted */
     readonly refSequenceNumber: number;
 
-    /**
-     * Time of summary attempt after it was sent or attempted
-     */
+    /** Time of summary attempt after it was sent or attempted */
     readonly summaryTime: number;
 
-    /**
-     * Sequence number of summary op
-     */
+    /** Sequence number of summary op */
     summarySequenceNumber?: number;
 }
 
 /** Data relevant for summary heuristics. */
 export interface ISummarizeHeuristicData {
-    /** Last received op sequence number */
+    /** Latest received op sequence number */
     lastOpSequenceNumber: number;
 
-    /** Last sent summary attempt */
+    /** Most recent summary attempt from this client */
     readonly lastAttempt: ISummaryAttempt;
 
-    /** Last summary attempt that received an ack */
-    readonly lastAck: ISummaryAttempt;
+    /** Most recent summary that received an ack */
+    readonly lastSuccessfulSummary: Readonly<ISummaryAttempt>;
 
     /**
-     * Initializes lastAttempt and lastAck based on the last summary.
+     * Initializes lastAttempt and lastSuccessfulAttempt based on the last summary.
      * @param lastSummary - last ack summary
      */
     initialize(lastSummary: ISummaryAttempt): void;
@@ -272,7 +264,7 @@ export interface ISummarizeHeuristicData {
     recordAttempt(referenceSequenceNumber?: number): void;
 
     /** Mark that the last sent summary attempt has received an ack */
-    ackLastSent(): void;
+    markLastAttemptAsSuccessful(): void;
 }
 
 /** Responsible for running heuristics determining when to summarize. */

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -47,7 +47,14 @@ export interface ISummarizerInternalsProvider {
     ): Promise<void>;
 }
 
+/** Options that control the behavior of a running summarizer. */
 export interface ISummarizerOptions {
+    /**
+     * Set to true to disable the default heuristics from running; false by default.
+     * This affects only the heuristics around when a summarizer should
+     * submit summaries. So when it is disabled, summarizer clients should
+     * not be expected to summarize unless an on-demand summary is requested.
+     */
     disableHeuristics: boolean;
 }
 

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -233,8 +233,8 @@ export interface ISummarizer
     ): OnDemandSummarizeResult;
 }
 
-/** Data about an attempt to summarize. */
-export interface ISummaryAttempt {
+/** Data about an attempt to summarize used for heuristics. */
+export interface ISummarizeAttempt {
     /** Reference sequence number when summary was generated or attempted */
     readonly refSequenceNumber: number;
 
@@ -251,16 +251,16 @@ export interface ISummarizeHeuristicData {
     lastOpSequenceNumber: number;
 
     /** Most recent summary attempt from this client */
-    readonly lastAttempt: ISummaryAttempt;
+    readonly lastAttempt: ISummarizeAttempt;
 
     /** Most recent summary that received an ack */
-    readonly lastSuccessfulSummary: Readonly<ISummaryAttempt>;
+    readonly lastSuccessfulSummary: Readonly<ISummarizeAttempt>;
 
     /**
      * Initializes lastAttempt and lastSuccessfulAttempt based on the last summary.
      * @param lastSummary - last ack summary
      */
-    initialize(lastSummary: ISummaryAttempt): void;
+    initialize(lastSummary: ISummarizeAttempt): void;
 
     /**
      * Records a summary attempt. If the attempt was successfully sent,

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -187,7 +187,7 @@ export class SummaryGenerator {
             refreshLatestAck,
             fullTree,
             timeSinceLastAttempt: Date.now() - this.heuristicData.lastAttempt.summaryTime,
-            timeSinceLastSummary: Date.now() - this.heuristicData.lastAck.summaryTime,
+            timeSinceLastSummary: Date.now() - this.heuristicData.lastSuccessfulSummary.summaryTime,
         });
         // Helper functions to report failures and return.
         const getFailMessage = (message: keyof typeof summarizeErrors) => `${message}: ${summarizeErrors[message]}`;
@@ -220,7 +220,7 @@ export class SummaryGenerator {
             generateTelemetryProps = {
                 refSequenceNumber,
                 opsSinceLastAttempt: refSequenceNumber - this.heuristicData.lastAttempt.refSequenceNumber,
-                opsSinceLastSummary: refSequenceNumber - this.heuristicData.lastAck.refSequenceNumber,
+                opsSinceLastSummary: refSequenceNumber - this.heuristicData.lastSuccessfulSummary.refSequenceNumber,
             };
             if (summaryData.stage !== "base") {
                 generateTelemetryProps = {
@@ -296,7 +296,7 @@ export class SummaryGenerator {
                 summarySequenceNumber: ackNack.contents.summaryProposal.summarySequenceNumber,
             };
             if (ackNack.type === MessageType.SummaryAck) {
-                this.heuristicData.ackLastSent();
+                this.heuristicData.markLastAttemptAsSuccessful();
                 summarizeEvent.end({ ...telemetryProps, handle: ackNack.contents.handle, message: "summaryAck" });
                 resultsBuilder.receivedSummaryAckOrNack.resolve({ success: true, data: {
                     summaryAckNackOp: ackNack,

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -14,7 +14,7 @@ import { DriverHeader } from "@fluidframework/driver-definitions";
 import { createSummarizingWarning } from "./summarizer";
 import { SummarizerClientElection, summarizerClientType } from "./summarizerClientElection";
 import { Throttler } from "./throttler";
-import { ISummarizer, ISummarizingWarning, SummarizerStopReason } from "./summarizerTypes";
+import { ISummarizer, ISummarizerOptions, ISummarizingWarning, SummarizerStopReason } from "./summarizerTypes";
 
 const defaultInitialDelayMs = 5000;
 const opsToBypassInitialDelay = 4000;
@@ -72,6 +72,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         private readonly summariesEnabled: boolean,
         parentLogger: ITelemetryLogger,
         initialDelayMs: number = defaultInitialDelayMs,
+        private readonly summarizerOptions?: Readonly<Partial<ISummarizerOptions>>,
     ) {
         super();
 
@@ -241,7 +242,7 @@ export class SummaryManager extends EventEmitter implements IDisposable {
         PerformanceEvent.timedExecAsync(
             this.logger,
             { eventName: "RunningSummarizer", attempt: this.startThrottler.attempts },
-            async () => summarizer.run(clientId),
+            async () => summarizer.run(clientId, this.summarizerOptions),
         ).finally(() => {
             this.runningSummarizer = undefined;
             this.tryRestart();

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { MockDeltaManager, MockLogger } from "@fluidframework/test-runtime-utils";
 import { RunningSummarizer } from "../runningSummarizer";
-import { SummarizerStopReason } from "../summarizerTypes";
+import { ISummarizerOptions, SummarizerStopReason } from "../summarizerTypes";
 import { SummaryCollection } from "../summaryCollection";
 
 describe("Runtime", () => {
@@ -123,7 +123,9 @@ describe("Runtime", () => {
                     `${errorPrefix}unexpected refreshLatestAck count`);
             }
 
-            const startRunningSummarizer = async (): Promise<void> => {
+            const startRunningSummarizer = async (
+                summarizerOptions?: Readonly<Partial<ISummarizerOptions>>,
+            ): Promise<void> => {
                 summarizer = await RunningSummarizer.start(
                     summarizerClientId,
                     onBehalfOfClientId,
@@ -178,6 +180,7 @@ describe("Runtime", () => {
                     { refSequenceNumber: 0, summaryTime: Date.now() },
                     () => { },
                     summaryCollection,
+                    summarizerOptions,
                 );
             };
 
@@ -352,6 +355,26 @@ describe("Runtime", () => {
                     await emitNextOp(summaryConfig.maxOps + 1);
                     assertRunCounts(2, 0, 0);
                     deferGenerateSummary.resolve();
+                });
+
+                it("Should summarize one last time before closing >50 ops", async () => {
+                    await emitNextOp(51); // hard-coded to 50 for now
+                    const stopP = summarizer.waitStop();
+                    await flushPromises();
+                    await emitAck();
+                    await stopP;
+
+                    assertRunCounts(1, 0, 0, "should perform lastSummary");
+                });
+
+                it("Should not summarize one last time before closing <=50 ops", async () => {
+                    await emitNextOp(50); // hard-coded to 50 for now
+                    const stopP = summarizer.waitStop();
+                    await flushPromises();
+                    await emitAck();
+                    await stopP;
+
+                    assertRunCounts(0, 0, 0, "should not perform lastSummary");
                 });
             });
 
@@ -604,7 +627,7 @@ describe("Runtime", () => {
             describe("Summary Start", () => {
                 it("Should summarize immediately if summary ack is missing at startup", async () => {
                     assertRunCounts(0, 0, 0);
-                    // Simulate as summary op was in opstream.
+                    // Simulate as summary op was in op stream.
                     const summaryTimestamp = Date.now();
                     emitBroadcast(summaryTimestamp);
 
@@ -645,6 +668,69 @@ describe("Runtime", () => {
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:Summarize_end", summaryGenTag: runCount, reason: "maxOps" },
                     ]), "unexpected log sequence 3");
+                });
+            });
+
+            describe("Disabled Heuristics", () => {
+                it("Should not summarize after time or ops", async () => {
+                    await startRunningSummarizer({ disableHeuristics: true });
+
+                    await emitNextOp(summaryConfig.maxOps + 1);
+                    assertRunCounts(0, 0, 0, "should not summarize after maxOps");
+
+                    await tickAndFlushPromises(summaryConfig.idleTime + 1);
+                    assertRunCounts(0, 0, 0, "should not summarize after idleTime");
+
+                    await tickAndFlushPromises(summaryConfig.maxTime + 1);
+                    assertRunCounts(0, 0, 0, "should not summarize after maxTime");
+
+                    await emitNextOp(summaryConfig.maxOps * 3 + 10000);
+                    await tickAndFlushPromises(summaryConfig.maxTime * 3 + summaryConfig.idleTime * 3 + 10000);
+                    assertRunCounts(0, 0, 0, "make extra sure");
+                });
+
+                it("Should not summarize before closing", async () => {
+                    await startRunningSummarizer({ disableHeuristics: true });
+
+                    await emitNextOp(51); // hard-coded to 50 for now
+                    const stopP = summarizer.waitStop();
+                    await flushPromises();
+                    await emitAck();
+                    await stopP;
+
+                    assertRunCounts(0, 0, 0, "should not perform lastSummary");
+                });
+
+                it("Should not summarize immediately if summary ack is missing at startup when disabled", async () => {
+                    assertRunCounts(0, 0, 0);
+                    // Simulate as summary op was in op stream.
+                    const summaryTimestamp = Date.now();
+                    emitBroadcast(summaryTimestamp);
+
+                    let startStatus: "starting" | "started" | "failed" = "starting";
+                    startRunningSummarizer({ disableHeuristics: true }).then(
+                        () => startStatus = "started", () => startStatus = "failed");
+                    await flushPromises();
+                    assert.strictEqual(startStatus, "starting",
+                        "RunningSummarizer should still be starting since outstanding summary op");
+
+                    // Still should be waiting
+                    await emitNextOp(1, summaryTimestamp + summaryConfig.maxAckWaitTime - 1);
+                    assert.strictEqual(startStatus, "starting",
+                        "RunningSummarizer should still be starting since timestamp is within maxAckWaitTime");
+
+                    // Emit next op after maxAckWaitTime
+                    // clock.tick(summaryConfig.maxAckWaitTime + 1000);
+                    await emitNextOp(1, summaryTimestamp + summaryConfig.maxAckWaitTime);
+                    assert(mockLogger.matchEvents([
+                        { eventName: "Running:MissingSummaryAckFoundByOps" },
+                    ]), "unexpected log sequence 1");
+
+                    assert.strictEqual(startStatus, "started",
+                        "RunningSummarizer should be started from the above op");
+
+                    await emitNextOp(summaryConfig.maxOps + 1);
+                    assertRunCounts(0, 0, 0, "Should not run summarizer");
                 });
             });
         });

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -19,9 +19,10 @@ import { MockDeltaManager, MockLogger } from "@fluidframework/test-runtime-utils
 import { RunningSummarizer } from "../runningSummarizer";
 import { ISummarizerOptions, SummarizerStopReason } from "../summarizerTypes";
 import { SummaryCollection } from "../summaryCollection";
+import { SummarizeHeuristicData } from "../summarizerHeuristics";
 
 describe("Runtime", () => {
-    describe("Container Runtime", () => {
+    describe("Summarization", () => {
         describe("RunningSummarizer", () => {
             let stopCall: number;
             let runCount: number;
@@ -176,8 +177,7 @@ describe("Runtime", () => {
                             stopCall++;
                         },
                     },
-                    0,
-                    { refSequenceNumber: 0, summaryTime: Date.now() },
+                    new SummarizeHeuristicData(0, { refSequenceNumber: 0, summaryTime: Date.now() }),
                     () => { },
                     summaryCollection,
                     summarizerOptions,

--- a/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import sinon from "sinon";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { SummarizeHeuristicData, SummarizeHeuristicRunner } from "../summarizerHeuristics";
-import { ISummarizeHeuristicData, ISummaryAttempt } from "../summarizerTypes";
+import { ISummarizeHeuristicData, ISummarizeAttempt } from "../summarizerTypes";
 import { SummarizeReason } from "../summaryGenerator";
 
 describe("Runtime", () => {
@@ -47,7 +47,7 @@ describe("Runtime", () => {
                 maxOps = defaultSummaryConfig.maxOps,
                 maxAckWaitTime = defaultSummaryConfig.maxAckWaitTime,
                 run = true,
-            }: Partial<ISummaryConfiguration & ISummaryAttempt & {
+            }: Partial<ISummaryConfiguration & ISummarizeAttempt & {
                 lastOpSequenceNumber: number;
                 minOpsForAttemptOnClose: number;
                 run: boolean;

--- a/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
@@ -1,0 +1,192 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import sinon from "sinon";
+import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
+import { SummarizeHeuristicData, SummarizeHeuristicRunner } from "../summarizerHeuristics";
+import { ISummarizeHeuristicData, ISummaryAttempt } from "../summarizerTypes";
+import { SummarizeReason } from "../summaryGenerator";
+
+describe("Runtime", () => {
+    describe("Summarization", () => {
+        describe("Summarize Heuristic Runner", () => {
+            let clock: sinon.SinonFakeTimers;
+            before(() => { clock = sinon.useFakeTimers(); });
+            after(() => { clock.restore(); });
+
+            const defaultSummaryConfig: ISummaryConfiguration = {
+                idleTime: 5000, // 5 sec (idle)
+                maxTime: 5000 * 12, // 1 min (active)
+                maxOps: 1000, // 1k ops (active)
+                maxAckWaitTime: 120000, // 2 min
+            };
+            let summaryConfig: Readonly<ISummaryConfiguration>;
+            let data: ISummarizeHeuristicData;
+            let runner: SummarizeHeuristicRunner;
+
+            let attempts: SummarizeReason[];
+            const trySummarize = (reason: SummarizeReason) => {
+                attempts.push(reason);
+            };
+            const getLastAttempt = () => attempts.length > 0 ? attempts[attempts.length - 1] : undefined;
+            function assertAttemptCount(count: number, message?: string) {
+                const fullMessage = `${attempts.length} !== ${count}; ${message || "unexpected attempt count"}`;
+                assert(attempts.length === count, fullMessage);
+            }
+
+            function initialize({
+                refSequenceNumber = 0,
+                lastOpSequenceNumber = refSequenceNumber,
+                summaryTime = Date.now(),
+                minOpsForAttemptOnClose = 50,
+                idleTime = defaultSummaryConfig.idleTime,
+                maxTime = defaultSummaryConfig.maxTime,
+                maxOps = defaultSummaryConfig.maxOps,
+                maxAckWaitTime = defaultSummaryConfig.maxAckWaitTime,
+                run = true,
+            }: Partial<ISummaryConfiguration & ISummaryAttempt & {
+                lastOpSequenceNumber: number;
+                minOpsForAttemptOnClose: number;
+                run: boolean;
+            }> = {}) {
+                data = new SummarizeHeuristicData(lastOpSequenceNumber, { refSequenceNumber, summaryTime });
+                summaryConfig = { idleTime, maxTime, maxOps, maxAckWaitTime } as const;
+                runner = new SummarizeHeuristicRunner(data, summaryConfig, trySummarize, minOpsForAttemptOnClose);
+                if (run) {
+                    runner.run();
+                }
+            }
+
+            beforeEach(() => { attempts = []; });
+            afterEach(() => { clock.reset(); });
+
+            it("Should summarize after maxOps with no prior summary", () => {
+                const maxOps = 100;
+                initialize({ maxOps });
+
+                data.lastOpSequenceNumber = maxOps;
+                runner.run();
+                assertAttemptCount(0, "should not run yet");
+
+                data.lastOpSequenceNumber++;
+                runner.run();
+                assertAttemptCount(1, "should run now");
+                assert(getLastAttempt() === "maxOps");
+            });
+
+            it("Should summarize after maxOps", () => {
+                const lastSummary = 1000;
+                const maxOps = 100;
+                initialize({ refSequenceNumber: lastSummary, maxOps });
+
+                data.lastOpSequenceNumber = lastSummary + maxOps;
+                runner.run();
+                assertAttemptCount(0, "should not run yet");
+
+                data.lastOpSequenceNumber++;
+                runner.run();
+                assertAttemptCount(1, "should run now");
+                assert(getLastAttempt() === "maxOps");
+            });
+
+            it("Should summarize after maxTime", () => {
+                const lastSummary = 1000;
+                const idleTime = 101;
+                const maxTime = 1000;
+                const idlesPerActive = Math.floor((maxTime + 1) / (idleTime - 1));
+                const remainingTime = (maxTime + 1) % (idleTime - 1);
+                initialize({ refSequenceNumber: lastSummary, idleTime, maxTime });
+
+                for (let i = 0; i < idlesPerActive; i++) {
+                    // Prevent idle timer from triggering with periodic "ops" (heuristic runs)
+                    clock.tick(idleTime - 1);
+                    runner.run();
+                }
+                clock.tick(remainingTime - 1);
+                runner.run();
+                assertAttemptCount(0, "should not run yet");
+
+                clock.tick(1);
+                runner.run();
+                assertAttemptCount(1, "should run now");
+                assert(getLastAttempt() === "maxTime");
+            });
+
+            it("Should summarize after idleTime", () => {
+                const lastSummary = 1000;
+                const idleTime = 101;
+                const maxTime = 1000;
+                initialize({ refSequenceNumber: lastSummary, idleTime, maxTime });
+
+                clock.tick(idleTime - 1);
+                assertAttemptCount(0, "should not run yet");
+
+                clock.tick(1);
+                assertAttemptCount(1, "should run now");
+                assert(getLastAttempt() === "idle");
+            });
+
+            it("Should summarize after idleTime after a few interruptions", () => {
+                const lastSummary = 1000;
+                const idleTime = 101;
+                const maxTime = 1000;
+                initialize({ refSequenceNumber: lastSummary, idleTime, maxTime });
+
+                clock.tick(idleTime - 1);
+                assertAttemptCount(0, "should not run yet");
+                runner.run(); // interrupts idle timer
+
+                clock.tick(idleTime - 1);
+                assertAttemptCount(0, "still should not run yet");
+                runner.run(); // interrupts idle timer
+
+                clock.tick(idleTime - 1);
+                assertAttemptCount(0, "still should not run yet again");
+
+                clock.tick(idleTime);
+                assertAttemptCount(1, "should run now");
+                assert(getLastAttempt() === "idle");
+            });
+
+            it("Should summarize on close if enough outstanding ops", () => {
+                const lastSummary = 1000;
+                const minOpsForAttemptOnClose = 10;
+                initialize({ refSequenceNumber: lastSummary, minOpsForAttemptOnClose });
+
+                data.lastOpSequenceNumber = lastSummary + minOpsForAttemptOnClose + 1;
+                assert(runner.runOnClose() === true, "should run on close");
+                assertAttemptCount(1, "should run");
+                assert(getLastAttempt() === "lastSummary");
+            });
+
+            it("Should not summarize on close if insufficient outstanding ops", () => {
+                const lastSummary = 1000;
+                const minOpsForAttemptOnClose = 10;
+                initialize({ refSequenceNumber: lastSummary, minOpsForAttemptOnClose });
+
+                data.lastOpSequenceNumber = lastSummary + minOpsForAttemptOnClose;
+                assert(runner.runOnClose() === false, "should not run on close");
+                assertAttemptCount(0, "should not run");
+            });
+
+            it("Should not run idle timer after dispose", () => {
+                const lastSummary = 1000;
+                const idleTime = 101;
+                const maxTime = 1000;
+                initialize({ refSequenceNumber: lastSummary, idleTime, maxTime });
+
+                clock.tick(idleTime - 1);
+                runner.run();
+                assertAttemptCount(0, "should not run yet");
+
+                runner.dispose();
+                clock.tick(1);
+                runner.run();
+                assertAttemptCount(0, "should still run since disposed");
+            });
+        });
+    });
+});

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -44,6 +44,7 @@ export function generateRuntimeOptions(seed: number) {
         summaryConfigOverrides: [undefined],
         maxOpsSinceLastSummary: numberCases,
         summarizerClientElection: booleanCases,
+        summarizerOptions: [undefined],
     };
 
     const runtimeOptionsMatrix: OptionsMatrix<IContainerRuntimeOptions> = {


### PR DESCRIPTION
Part of #6382 is to allow the Summarizer heuristics to be disabled.

This PR breaks out SummarizerHeuristics class into several parts. Now it uses new contracts `ISummarizeHeuristicData` and `ISummarizeHeuristicRunner` found in `summaryTypes.ts`, as well as corresponding new classes `SummarizeHeuristicData` and `SummarizeHeuristicRunner` found in the new `summarizerHeuristics.ts` file.

The old SummarizerHeuristics class is broken up into a separate data tracking class (which is used in SummaryGenerator), from the runner class. The heuristic runner will be undefined in RunningSummarizer when heuristics are disabled, and so all calls to it are now wrapped with an undefined check like: `this.heuristicRunner?.run()`, which will take no action if it's undefined.

A new set of options: ISummarizerOptions have been created and are passed via `ISummarizer.run()`. They are set in the parent client's runtimeOptions, and passed through the SummaryManager.

Future proofing here:
- Starting to further decouple heuristics as a contract from its implementation. Eventually perhaps we let these be passed in rather than only configuring the default rules.
- Add summarizer options which may be used whether we run the summarizer from the parent client's SummaryManager _OR_ by spawning it within a running client already.

Includes more tests around these disabled heuristics: in runningSummarizer.spec.ts.

Also adds **unit tests** for SummarizeHeuristicRunner, which more closely tests the actual heuristic functions.