### PR TITLE
throw error in protocol handler upon exception

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -368,6 +368,7 @@ export class ScribeLambda implements IPartitionLambda {
                             tenantId: this.tenantId,
                         },
                     });
+                throw new Error(`Protocol error ${error} for ${this.documentId} ${this.tenantId}`);
             }
         }
     }


### PR DESCRIPTION
We are having an incident where our scribe pods are restarting endlessly. We think it is due to failing to mark the document as corrupted at the scribe lambda level when this protocol state error happens for e.g.:

"level":"error","message":"Protocol error Error: Protocol state is not moving sequentially. Current is 72. Next is 29"

In the scribe lambda, for the errors we explicitly throw, they will be caught in the DocumentPartition and marked as corrupted. But if the error is not explicitly thrown, then the document will not be marked corrupted. The protocol state error is thrown from the protocolHandler.processMessage method, which is called inside the scribe lambda here:

https://github.com/microsoft/FluidFramework/blob/3fab271b6a0c8c93f082dbdfac0f9ee60a6501d2/server/routerlicious/packages/lambdas/src/scribe/lambda.ts#L337.

If there is an exception with calling protocolHandler.processMessage, however, we do not throw the error back up, but instead simply log it.

https://github.com/microsoft/FluidFramework/blob/3fab271b6a0c8c93f082dbdfac0f9ee60a6501d2/server/routerlicious/packages/lambdas/src/scribe/lambda.ts#L353

There is even a comment at the top of the method saying that if there is an exception while running this code, the document is corrupted and it seemed the author intended to log it to see when it happens. The theory is that since we do not throw the error back up, the document is never marked as corrupted, and then the document ends up in a bad state, so the scribe pod restart keeps getting triggered.

This change is to throw the error up so that it will be caught in the DocumentPartition, and the document will be marked as corrupted if the protocol state error happens.