### PR TITLE
Remove deprecated getSummarizer

### DIFF
--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -255,11 +255,6 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         }
     }
 
-    public async setSummarizer(): Promise<ISummarizer> {
-        this.runtime.nextSummarizerD = new Deferred<ISummarizer>();
-        return this.runtime.nextSummarizerD.promise;
-    }
-
     /** Implementation of SummarizerInternalsProvider.submitSummary */
     public async submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult> {
         const result = this.internalsProvider.submitSummary(options);

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -8,7 +8,6 @@ import {
     IEventProvider,
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
-import { Deferred } from "@fluidframework/common-utils";
 import {
     IFluidRouter,
     IFluidRunnable,
@@ -56,7 +55,6 @@ export interface ISummarizerRuntime extends IConnectableRuntime {
     readonly logger: ITelemetryLogger;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly summarizerClientId: string | undefined;
-    nextSummarizerD?: Deferred<ISummarizer>;
     closeFn(): void;
     on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;
     on(event: "disconnected", listener: () => void): this;
@@ -207,10 +205,6 @@ export interface ISummarizerEvents extends IEvent {
 
 export interface ISummarizer
     extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidRunnable, IFluidLoadable {
-    /**
-     * Returns a promise that will be resolved with the next Summarizer after context reload
-     */
-    setSummarizer(): Promise<ISummarizer>;
     stop(reason?: SummarizerStopReason): void;
     run(onBehalfOf: string): Promise<void>;
     updateOnBehalfOf(onBehalfOf: string): void;


### PR DESCRIPTION
This code was used when hot-swapping contexts was intended to be possible. It previously allowed the summarizer data to be copied over to the new context.

It has been deprecated for a while now; this PR removes the function from ISummarizer and Summarizer to help make ISummarizer contract more slim.