### PR TITLE
[bump] package version for common-definitions (patch)

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-definitions",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-definitions",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Fluid common definitions",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",


### PR DESCRIPTION
            @fluidframework/build-common:     0.22.1 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.0 (unchanged)
      @fluidframework/common-definitions:     0.20.1 -> 0.20.2
            @fluidframework/common-utils:     0.30.1 (unchanged)
                                  Server:   0.1024.1 (unchanged)
                                  Client:     0.39.5 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)