### PR TITLE
Hedasilv/hotfix for scribe restart loop

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -88,6 +88,11 @@ export class DocumentPartition {
                 this.q.resume();
             },
             (error) => {
+                // There is no need to pass the message to be checkpointed to markAsCorrupt().
+                // The message, in this case, would be the head in the DocumentContext (the DocumentLambda
+                // that creates this DocumentPartition will also put the same message in the queue.
+                // So the DocumentPartition will see that message in the queue above, and checkpoint it
+                // since the document was marked as corrupted.
                 this.markAsCorrupt(error);
                 context.error(error, { restart: false, tenantId, documentId });
                 this.q.resume();

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -90,7 +90,7 @@ export class DocumentPartition {
             (error) => {
                 // There is no need to pass the message to be checkpointed to markAsCorrupt().
                 // The message, in this case, would be the head in the DocumentContext (the DocumentLambda
-                // that creates this DocumentPartition will also put the same message in the queue.
+                // that creates this DocumentPartition will also put the same message in the queue).
                 // So the DocumentPartition will see that message in the queue above, and checkpoint it
                 // since the document was marked as corrupted.
                 this.markAsCorrupt(error);

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -51,7 +51,7 @@ export class DocumentPartition {
                             optionalPromise
                                 .then(callback as any)
                                 .catch((error) => {
-                                    this.markAsCorrupt(message, error);
+                                    this.markAsCorrupt(error, message);
                                     callback();
                                 });
                             return;
@@ -63,7 +63,7 @@ export class DocumentPartition {
                 } catch (error) {
                     // TODO dead letter queue for bad messages, etc... when the lambda is throwing an exception
                     // for now we will simply continue on to keep the queue flowing
-                    this.markAsCorrupt(message, error);
+                    this.markAsCorrupt(error, message);
                 }
 
                 // Handle the next message
@@ -88,8 +88,9 @@ export class DocumentPartition {
                 this.q.resume();
             },
             (error) => {
-                context.error(error, { restart: true, tenantId, documentId });
-                this.q.kill();
+                this.markAsCorrupt(error);
+                context.error(error, { restart: false, tenantId, documentId });
+                this.q.resume();
             });
     }
 
@@ -133,7 +134,7 @@ export class DocumentPartition {
      * Marks this document partition as corrupt
      * Future messages will be checkpointed but no real processing will happen
      */
-    private markAsCorrupt(message: IQueuedMessage, error: any) {
+    private markAsCorrupt(error: any, message?: IQueuedMessage) {
         this.corrupt = true;
         this.context.log?.error(
             `Marking document as corrupted due to error: ${inspect(error)}`,
@@ -144,7 +145,9 @@ export class DocumentPartition {
                 },
             });
         this.context.error(error, { restart: false, tenantId: this.tenantId, documentId: this.documentId });
-        this.context.checkpoint(message);
+        if (message) {
+            this.context.checkpoint(message);
+        }
     }
 
     private updateActivityTime() {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -94,7 +94,6 @@ export class DocumentPartition {
                 // So the DocumentPartition will see that message in the queue above, and checkpoint it
                 // since the document was marked as corrupted.
                 this.markAsCorrupt(error);
-                context.error(error, { restart: false, tenantId, documentId });
                 this.q.resume();
             });
     }

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
@@ -155,7 +155,7 @@ describe("document-router", () => {
 
                     context.on("error", (error, errorData: IContextErrorData) => {
                         assert.ok(error);
-                        assert.ok(errorData.restart);
+                        assert.ok(!errorData.restart);
                         resolve();
                     });
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -368,6 +368,7 @@ export class ScribeLambda implements IPartitionLambda {
                             tenantId: this.tenantId,
                         },
                     });
+                throw new Error(`Protocol error ${error} for ${this.documentId} ${this.tenantId}`);
             }
         }
     }


### PR DESCRIPTION
Following up on #6862 as I missed updating a unit test that is making the build break (test pipelines do not run the build pipeline yet so I missed that, unfortunately). Here is my comment on the previous PR:

In #5911, a metthod called markAsCorrupt() was added to the DocumentPartition so that if the lambda's handler() throws an exception, we mark the document as corrupted and keep just checkpointing the messages in Kafka, to keep the queue moving. The idea behind that is preventing that the whole pod (for example, Scribe) restarts because of a single corrupted document - that was the behavior before: in case the Scribe lambda had an exception for document X, the whole pod would crash and restart, affecting documents Y and Z as well.

There is another situation that can cause similar behavior: Scribe's LambdaFactory. As part of the flow to create the Scribe lambda, the lambda factory will check if the pending op messages since last summary (persisted in the DB) are compatible with last checkpoint's protocol state. In case there is an issue with the ops stored in the DB, the check will fail, and an exception will be thrown.
FluidFramework/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts

Line 118 in f98fced

 throw new Error(`Invalid message sequence from checkpoint/summary.` 
The exception would be caught in the DocumentPartition, which would use the context to signal that the pod needs to restart. Even though only the lambda factory creating the lambda for a single document had issues, it would affect the whole pod and all other documents in there. Also, since the message that triggered the Scribe lambda to be created for that document would never be checkpointed from Kafka, it would cause Scribe to keep in a crash/restart loop until the message expires from Kafka.

In this hotfix PR, I am fixing that by also marking the document as corrupted in the DocumentPartition level when the lambda factory throws the exception. Since this branch is a hotfix and is pointing to what we currently have in the cluster, I am also adding the changes from #6846, which address a possibly related issue.

This is a short-term fix, or at least not the final state - we must later revisit out lambdas and lambda factories and determine when it is appropriate to mark the document as corrupted, and when we don't need to because it is possible to recover.

Test strategy: I tested these changes in my local setup, where I forced Scribe's lambda factory to randomly throw exceptions depending on the document's name. The documents that had exceptions were marked as corrupted, and no pod restart happened - other documents were able to continue working as expected.