### PR TITLE
fix serialize/rehydrate detached container with attachment blobs

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -52,8 +52,9 @@ export class BlobManager {
     public static readonly basePath = "_blobs";
     private readonly pendingBlobIds: Map<string, Deferred<void>> = new Map();
     private readonly blobIds: Set<string> = new Set();
+    private readonly detachedBlobIds: Set<string> = new Set();
 
-    public get blobCount() { return this.blobIds.size; }
+    public get blobCount() { return this.blobIds.size + this.detachedBlobIds.size; }
 
     constructor(
         private readonly routeContext: IFluidHandleContext,
@@ -92,7 +93,7 @@ export class BlobManager {
         );
 
         if (this.runtime.attachState === AttachState.Detached) {
-            this.blobIds.add(response.id);
+            this.detachedBlobIds.add(response.id);
             return handle;
         }
 


### PR DESCRIPTION
close #6828
Don't add blob IDs to `BlobManager.blobIds` while detached so they are not included in snapshots returned for the purpose of serialization/rehydration of detached container.

(this is already fixed in main and 0.44 by #6630)