### PR TITLE
Handling document lambda factory errors in document partition

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentLambda.spec.ts
@@ -155,7 +155,9 @@ describe("document-router", () => {
 
                     context.on("error", (error, errorData: IContextErrorData) => {
                         assert.ok(error);
-                        assert.ok(errorData.restart);
+                        // We expect that lambda factory errors do not trigger restarts,
+                        // since they affect one document only.
+                        assert.ok(!errorData.restart);
                         resolve();
                     });
 


### PR DESCRIPTION
_Note: this is a follow up to #6863 where I implemented a similar change as a hotfix. We deployed the hotfix to fix our customer-facing cluster, which is running fine now. This PR is to persist the change for future deployments as well._

In #5911, a metthod called markAsCorrupt() was added to the DocumentPartition so that if the lambda's handler() throws an exception, we mark the document as corrupted and keep just checkpointing the messages in Kafka, to keep the queue moving. The idea behind that is preventing that the whole pod (for example, Scribe) restarts because of a single corrupted document - that was the behavior before: in case the Scribe lambda had an exception for document X, the whole pod would crash and restart, affecting documents Y and Z as well.

There is another situation that can cause similar behavior: Scribe's LambdaFactory. As part of the flow to create the Scribe lambda, the lambda factory will check if the pending op messages since last summary (persisted in the DB) are compatible with last checkpoint's protocol state. In case there is an issue with the ops stored in the DB, the check will fail, and an exception will be thrown.

https://github.com/microsoft/FluidFramework/blob/f98fced2d441befa8eafbd1218f416cef5d55c67/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts#L118

The exception would be caught in the DocumentPartition, which would use the context to signal that the pod needs to restart. Even though only the lambda factory creating the lambda for a single document had issues, it would affect the whole pod and all other documents in there. Also, since the message that triggered the Scribe lambda to be created for that document would never be checkpointed from Kafka, it would cause Scribe to keep in a crash/restart loop until the message expires from Kafka.

In this PR, I am fixing that by also marking the document as corrupted in the DocumentPartition level when the lambda factory throws the exception. This is not the final state we should aim for, though - we must later revisit out lambdas and lambda factories and determine when it is appropriate to mark the document as corrupted, and when we don't need to because it is possible to recover.


