### PR TITLE
Lint for banned words in docs

### DIFF
--- a/docs/.markdownlint-cli2.js
+++ b/docs/.markdownlint-cli2.js
@@ -12,6 +12,10 @@ const excludedTypography = [
     ["–", "-"],
 ];
 
+const excludedWords = [
+    "FRS",
+]
+
 const clamp = (number, min, max) => {
     return Math.max(min, Math.min(number, max));
 };
@@ -25,6 +29,26 @@ module.exports = {
     "customRules": [
         "markdownlint-rule-emphasis-style",
         "markdownlint-rule-github-internal-links",
+        {
+            "names": ["ban-words"],
+            "description": "Using a banned word",
+            "tags": ["style"],
+            "function": (params, onError) => {
+                forEachLine(getLineMetadata(params), (line, lineIndex) => {
+                    for (const word of excludedWords) {
+                        const column = line.indexOf(word);
+                        if (column >= 0) {
+                            onError({
+                                "lineNumber": lineIndex + 1,
+                                "detail": `Found banned word "${word}" at column ${column}`,
+                                "context": extractContext(line, column),
+                                "range": [column + 1, 1],
+                            });
+                        }
+                    }
+                });
+            }
+        },
         {
             "names": ["proper-typography"],
             "description": "Using improper typography",

--- a/docs/content/docs/build/auth.md
+++ b/docs/content/docs/build/auth.md
@@ -14,7 +14,7 @@ services]({{< relref "service-options.md" >}}) for more information.
 
 {{< include file="_includes/frs-onboarding.html" safeHTML=true >}}
 
-Each FRS tenant you create is assigned a *tenant ID* and its own unique *tenant secret key*.
+Each Azure Fluid Relay service tenant you create is assigned a *tenant ID* and its own unique *tenant secret key*.
 
 The secret key is a *shared secret*. Your app/service knows it, and the Azure Fluid Relay service knows it. Since the
 tenant secret key is uniquely tied to your tenant, using it to sign requests guarantees to the Azure Fluid Relay service
@@ -44,10 +44,10 @@ JWT. The Azure Fluid Relay service uses signed JWTs for establishing trust with 
 
 The next question is: what data should you send?
 
-You need to send your *tenant ID* so that FRS can look up the right secret key to validate your request. You need to
-send the *container ID* (called `documentId` in the JWT) so FRS knows which container the request is about. Finally, you
-need to also set the *scopes (permissions)* that the request is permitted to use -- this allows you to establish your
-own user permissions model if you wish.
+You need to send your *tenant ID* so that Azure Fluid Relay service can look up the right secret key to validate your
+request. You need to send the *container ID* (called `documentId` in the JWT) so Azure Fluid Relay service knows which
+container the request is about. Finally, you need to also set the *scopes (permissions)* that the request is permitted
+to use -- this allows you to establish your own user permissions model if you wish.
 
 ```json {linenos=inline,hl_lines=["5-6",13]}
 {
@@ -94,10 +94,10 @@ sign the token][1]. Fluid delegates the responsibility of creating and signing t
 
 ## The token provider
 
-A token provider is responsible for creating and signing tokens that the `@fluid-experimental/frs-client` uses to make requests to the
-Azure Fluid Relay service. You are required to provide your own secure token provider implementation.
-However, Fluid provides an `InsecureTokenProvider` that accepts your FRS tenant secret and returns signed tokens. This
-token provider is useful for testing, but in production scenarios you must use a secure token provider.
+A token provider is responsible for creating and signing tokens that the `@fluid-experimental/frs-client` uses to make
+requests to the Azure Fluid Relay service. You are required to provide your own secure token provider implementation.
+However, Fluid provides an `InsecureTokenProvider` that accepts your tenant secret and returns signed tokens. This token
+provider is useful for testing, but in production scenarios you must use a secure token provider.
 
 ### A secure serverless token provider
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -3,7 +3,7 @@ title: Connect to an Azure Fluid Relay service
 menuPosition: 2
 ---
 
-Azure Fluid Relay service (FRS) is a cloud-hosted Fluid service. You can connect your Fluid application to an Azure Fluid Relay instance using the `FrsClient` in the `@fluid-experimental/frs-client` package. `FrsClient` handles the logic of connecting your [Fluid Container]({{< relref "containers.md" >}}) to the service while keeping the container object itself service-agnostic. You can use one instance of this client to manage multiple containers.
+Azure Fluid Relay service is a cloud-hosted Fluid service. You can connect your Fluid application to an Azure Fluid Relay instance using the `FrsClient` in the `@fluid-experimental/frs-client` package. `FrsClient` handles the logic of connecting your [Fluid Container]({{< relref "containers.md" >}}) to the service while keeping the container object itself service-agnostic. You can use one instance of this client to manage multiple containers.
 
 The sections below will explain how to use `FrsClient` in your own application.
 
@@ -124,4 +124,5 @@ Alongside the user ID and name, `FrsMember` objects also hold an array of `conne
 
 These functions and events can be combined to present a real-time view of the users in the current session.
 
-**Congratulations!** You have now successfully connected your Fluid container to the FRS service and fetched back user details for the members in your collaborative session!!
+**Congratulations!** You have now successfully connected your Fluid container to the Azure Fluid Relay service and
+fetched back user details for the members in your collaborative session!!

--- a/docs/content/docs/start/quick-start.md
+++ b/docs/content/docs/start/quick-start.md
@@ -68,8 +68,8 @@ To run against the Azure Fluid Relay service, you'll make a code change to ```ap
 local in-memory service called Tinylicious, which runs on port 7070 by default.
 
 To use an Azure Fluid Relay instance instead, replace the configuration values with your Azure Fluid Relay tenant ID,
-orderer, and storage URLs that were provided as part of the FRS onboarding process. Then pass that configuration object
-into the `FrsClient` constructor:
+orderer, and storage URLs that were provided as part of the onboarding process. Then pass that configuration object into
+the `FrsClient` constructor:
 
 ```typescript
 // This configures the FrsClient to use a remote Azure Fluid Service instance.
@@ -87,14 +87,14 @@ const client = new FrsClient(config);
 ### TokenProvider
 
 The Azure Fluid Relay onboarding process provides you with a secret key for your tenant. You can use
-InsecureTokenProvider to generate and sign auth tokens such that the FRS service will accept it. **To ensure that the
-secret doesn't get exposed, this should be replaced with another implementation of ITokenProvider that fetches the token
-from a secure, developer-provided backend service prior to releasing to production.**
+InsecureTokenProvider to generate and sign auth tokens such that the Azure Fluid Relay service service will accept it.
+**To ensure that the secret doesn't get exposed, this should be replaced with another implementation of ITokenProvider
+that fetches the token from a secure, developer-provided backend service prior to releasing to production.**
 
 ### Build and run the client only
 
 Now that you've updated the `FrsClient` configuration, now run just the client to test it. You no longer need to run a
-local service, because you're using the remote FRS instance!
+local service, because you're using the remote Azure Fluid Relay service instance!
 
 ```bash
 npm run start:client


### PR DESCRIPTION
This PR adds support for linting for banned words in markdown. Linting for markdown files is not yet enabled in CI, but you can run it locally in the docs folder using `npm run lint`.