### PR TITLE
Move submitSignal() to IContainerRuntime

### DIFF
--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -137,4 +137,11 @@ export interface IContainerRuntime extends
      * @param request - request to resolve
      */
     resolveHandle(request: IRequest): Promise<IResponse>;
+
+    /**
+     * Submits a container runtime level signal to be sent to other clients.
+     * @param type - Type of the signal.
+     * @param content - Content of the signal.
+     */
+     submitSignal(type: string, content: any): void;
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -88,13 +88,6 @@ export interface IContainerRuntimeBase extends
     request(request: IRequest): Promise<IResponse>;
 
     /**
-     * Submits a container runtime level signal to be sent to other clients.
-     * @param type - Type of the signal.
-     * @param content - Content of the signal.
-     */
-    submitSignal(type: string, content: any): void;
-
-    /**
      * @deprecated 0.16 Issue #1537, #3631
      * @internal
      */

--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -116,8 +116,8 @@ describeFullCompat("TestSignals", (getTestObjectProvider) => {
         let user2HostSignalReceivedCount = 0;
         let user1CompSignalReceivedCount = 0;
         let user2CompSignalReceivedCount = 0;
-        const user1ContainerRuntime = dataObject1.context.containerRuntime;
-        const user2ContainerRuntime = dataObject2.context.containerRuntime;
+        const user1ContainerRuntime = dataObject1.context;
+        const user2ContainerRuntime = dataObject2.context;
         const user1DtaStoreRuntime = dataObject1.runtime;
         const user2DataStoreRuntime = dataObject2.runtime;
 
@@ -133,20 +133,20 @@ describeFullCompat("TestSignals", (getTestObjectProvider) => {
             }
         });
 
-        user1ContainerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
+        user1ContainerRuntime.containerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
             if (message.type === "TestSignal") {
                 user1HostSignalReceivedCount += 1;
             }
         });
 
-        user2ContainerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
+        user2ContainerRuntime.containerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
             if (message.type === "TestSignal") {
                 user2HostSignalReceivedCount += 1;
             }
         });
 
         user1ContainerRuntime.submitSignal("TestSignal", true);
-        await waitForSignal(user1ContainerRuntime, user2ContainerRuntime);
+        await waitForSignal(user1ContainerRuntime.containerRuntime, user2ContainerRuntime.containerRuntime);
         assert.equal(user1HostSignalReceivedCount, 1, "client 1 did not receive signal on host runtime");
         assert.equal(user2HostSignalReceivedCount, 1, "client 2 did not receive signal on host runtime");
         assert.equal(user1CompSignalReceivedCount, 0, "client 1 should not receive signal on data store runtime");

--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -87,25 +87,25 @@ describeFullCompat("TestSignals", (getTestObjectProvider) => {
             const user1ContainerRuntime = dataObject1.context;
             const user2ContainerRuntime = dataObject2.context;
 
-            user1ContainerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
+            user1ContainerRuntime.containerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
                 if (message.type === "TestSignal") {
                     user1SignalReceivedCount += 1;
                 }
             });
 
-            user2ContainerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
+            user2ContainerRuntime.containerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
                 if (message.type === "TestSignal") {
                     user2SignalReceivedCount += 1;
                 }
             });
 
             user1ContainerRuntime.submitSignal("TestSignal", true);
-            await waitForSignal(user1ContainerRuntime, user2ContainerRuntime);
+            await waitForSignal(user1ContainerRuntime.containerRuntime, user2ContainerRuntime.containerRuntime);
             assert.equal(user1SignalReceivedCount, 1, "client 1 did not receive signal");
             assert.equal(user2SignalReceivedCount, 1, "client 2 did not receive signal");
 
             user2ContainerRuntime.submitSignal("TestSignal", true);
-            await waitForSignal(user1ContainerRuntime, user2ContainerRuntime);
+            await waitForSignal(user1ContainerRuntime.containerRuntime, user2ContainerRuntime.containerRuntime);
             assert.equal(user1SignalReceivedCount, 2, "client 1 did not receive signal");
             assert.equal(user2SignalReceivedCount, 2, "client 2 did not receive signal");
         });

--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -84,8 +84,8 @@ describeFullCompat("TestSignals", (getTestObjectProvider) => {
         it("Validate host runtime signals", async () => {
             let user1SignalReceivedCount = 0;
             let user2SignalReceivedCount = 0;
-            const user1ContainerRuntime = dataObject1.context.containerRuntime;
-            const user2ContainerRuntime = dataObject2.context.containerRuntime;
+            const user1ContainerRuntime = dataObject1.context;
+            const user2ContainerRuntime = dataObject2.context;
 
             user1ContainerRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
                 if (message.type === "TestSignal") {


### PR DESCRIPTION
This PR has moved the IContainerRuntimeBase.submitSignal() to IContainerRuntime

Relate issue: #4223