### PR TITLE
Track serverMetadata per client in deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/clientSeqManager.ts
@@ -65,6 +65,7 @@ export class ClientSequenceNumberManager {
      * @param canEvict Flag indicating whether or not we can evict the client (branch clients cannot be evicted)
      * @param scopes scope of the client
      * @param nack Flag indicating whether we have nacked this client
+     * @param serverMetadata Optional server provided metadata to associate with the client
      * Returns false if the same client has been added earlier.
      */
     public upsertClient(
@@ -74,13 +75,20 @@ export class ClientSequenceNumberManager {
         timestamp: number,
         canEvict: boolean,
         scopes: string[] = [],
-        nack: boolean = false): boolean {
+        nack: boolean = false,
+        serverMetadata: any = undefined): boolean {
         const client = this.clientNodeMap.get(clientId);
         if (client) {
             client.value.referenceSequenceNumber = referenceSequenceNumber;
             client.value.clientSequenceNumber = clientSequenceNumber;
             client.value.lastUpdate = timestamp;
             client.value.nack = nack;
+
+            if (serverMetadata) {
+                // update serverMetadata if it's provided
+                client.value.serverMetadata = serverMetadata;
+            }
+
             this.clientSeqNumbers.update(client);
             return false;
         }
@@ -94,6 +102,7 @@ export class ClientSequenceNumberManager {
             nack,
             referenceSequenceNumber,
             scopes,
+            serverMetadata,
         });
         this.clientNodeMap.set(clientId, newNode);
         return true;

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -44,6 +44,7 @@ export interface IClientSequenceNumber {
     referenceSequenceNumber: number;
     clientSequenceNumber: number;
     scopes: string[];
+    serverMetadata?: any;
 }
 
 export interface IDeliState {


### PR DESCRIPTION
ODSP attaches user/audit information into `serverMetadata`. The frontend inserts join/leave ops with `serverMetadata` filled out.

Today the `leave` op that deli creates does not have the `serverMetadata` property.

This change makes deli save the join op `serverMetadata` for the client. Deli will add that `serverMetadata` to the leave op that it generates in the idle client timer logic.