### PR TITLE
Replace shared object with Fluid object and use it consistently

### DIFF
--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -7,7 +7,7 @@ editor: tylerbutler
 
 ## Overview
 
-The container is the primary unit of encapsulation in the Fluid Framework. A container is represented by the `FluidContainer` type and consists of a collection of shared objects and APIs to manage the lifecyle of those objects.
+The container is the primary unit of encapsulation in the Fluid Framework. A container is represented by the `FluidContainer` type and consists of a collection of Fluid objects and APIs to manage the lifecycle of those objects.
 
 This documentation will explain how to create and load containers, the APIs to interact with them, and the overall container lifecycle.
 
@@ -21,7 +21,7 @@ In the below scenarios, `client` represents the service-specific client. See the
 
 You must define a schema that represents the structure of the data within your container. A schema can include `initialObjects` that are always available and types that can be dynamically created by the container at runtime. The same schema definition must be provided for creation and subsequent loading of the container. For more information on `initialObjects` and dynamic object creation see [Data modeling](./data-modeling.md).
 
-This example schema defines two initial objects, and declares `SharedCell` and `SharedString` as shared object types that can be dynamically created at runtime.
+This example schema defines two initial objects, `layout` and `text`, and declares the DDSes `SharedCell` and `SharedString` as Fluid object types that can be dynamically created at runtime.
 
 ```typescript
 const schema = {
@@ -108,7 +108,8 @@ container.on("disposed", () => {
 
 ### initialObjects
 
-`initialObjects` are shared objects that you define in a container's schema and exist for the lifetime of the container. These shared objects are exposed via the `initialObjects` property on the container.
+`initialObjects` are Fluid objects that you define in a container's schema and exist for the lifetime of the container.
+These Fluid objects are exposed via the `initialObjects` property on the container.
 
 ```typescript
 const schema = {
@@ -129,7 +130,7 @@ For more information about `initialObjects` see [Data modeling](data-modeling.md
 
 ### create
 
-The container also exposes a create function that allows dynamic creation of shared objects. This enables containers to create Fluid objects dynamically at runtime.
+The container also exposes a create function that allows dynamic creation of Fluid objects. This enables containers to create Fluid objects dynamically at runtime.
 
 For more information about dynamic object creation see [Data modeling](data-modeling.md).
 

--- a/docs/content/docs/build/data-modeling.md
+++ b/docs/content/docs/build/data-modeling.md
@@ -5,17 +5,20 @@ author: skylerjokiel
 editor: tylerbutler
 ---
 
-Fluid offers flexible ways to model your collaborative data. Shared objects can be declaratively defined in the `initialObjects` or dynamically created at runtime.
+Fluid offers flexible ways to model your collaborative data. You can declaratively define a static set of Fluid objects
+using `initialObjects`, or, for more sophisticated scenarios, dynamically create Fluid objects at runtime.
 
 ## Defining `initialObjects`
 
-The most straightforward way to use Fluid is by defining initial shared objects that are created when the `FluidContainer` is created, and exist for the lifetime of the underlying container.
+The most straightforward way to use Fluid is by defining initial Fluid objects that are created when the
+`FluidContainer` is created, and exist for the lifetime of the underlying container. `initialObjects` serve as a base
+foundation for a Fluid *schema* -- a definition of the shape of your data.
 
-`initialObjects` are always *connected* -- that is, they are connected to the Fluid service and are fully collaborative. You can access initial objects via the `initialObjects` property on the `FluidContainer`. The `initialObjects` property has the same signature as defined in the schema.
+`initialObjects` are always *connected* -- that is, they are connected to the Fluid service and are fully distributed.
+You can access initial objects via the `initialObjects` property on the `FluidContainer`. The `initialObjects` property
+at runtime has the same signature as the one you define in your declaration of `initialObjects.`
 
-### When to use `initialObjects`
-
-`initialObjects` are the most straightforward way to use Fluid and serve as a base foundation for a Fluid schema. Your schema must include one initial object and in many cases `initialObjects` is sufficient to build a Fluid application.
+You must define at least one `initialObject`. In many cases `initialObjects` is sufficient to build a Fluid application.
 
 ### Example usage
 
@@ -39,15 +42,21 @@ const cell = container.initialObjects["custom-cell"];
 
 ## Dynamic objects
 
-A shared object can be created dynamically by the container at runtime. Dynamic objects are both created and loaded dynamically and are always stored as references within another shared object. In other words, a container can create an object dynamically, and you must store references to those objects within another shared object.
+A Fluid object can be created dynamically by the container at runtime. Dynamic objects are both created and loaded
+dynamically and are always stored as references within another Fluid object. In other words, a container can create an
+object dynamically, and you must store references to those objects within another Fluid object so that you can later
+retrieve them.
 
 ### Creating a dynamic object
 
-A `FluidContainer` object has a `create` function that takes a shared object type and will return a new shared object. The `FluidContainer` can only create types defined in the `dynamicObjectTypes` section of the container schema.
+A `FluidContainer` object has a `create` function that takes a Fluid object type (that is, a distributed data structure
+or `DataObject`) and will return a new Fluid object. The `FluidContainer` can only create types defined in the
+`dynamicObjectTypes` section of the container schema.
 
-Dynamically created objects are local only (in-memory) and need to be stored on a connected shared object before being collaborative.
+Dynamically created objects are local only (in-memory) and need to be stored on a connected Fluid object before they are
+shared with other clients.
 
-```typescript
+```js
 const schema = {
     /*...*/,
     dynamicObjectTypes: [ SharedCell, SharedMap ],
@@ -59,15 +68,32 @@ const newCell = await container.create(SharedCell); // Create a new SharedCell
 const newMap = await container.create(SharedMap); // Create a new SharedMap
 ```
 
+{{% callout tip %}}
+Another way to think about `initialObjects` and dynamic objects is as follows:
+
+With `initialObjects`, you're telling Fluid both the type of the object *and* the key you'll use to later retrieve the
+object. This is statically defined, so Fluid can create the object for you and ensure it's always available via the key
+you defined.
+
+On the other hand, with dynamic objects, you're telling Fluid what object types it can create as well as *how* to create
+objects of those types, but that's all. Once you create a dynamic object using `container.create`, that objects is
+in-memory only. If you want to load that Fluid object again later, you must store it within another Fluid object. In a
+sense, you're defining the "key" to access that data again later, just as you did with `initialObjects`, but you define
+it dynamically at runtime.
+
+{{% /callout %}}
+
 ### Using handles to store and retrieve Fluid objects
 
-All shared objects have a `handle` property that can be used to store and retrieve them from other shared objects. Objects created dynamically must be stored before they are collaborative. As you will see below, the act of storing a handle is what links the new dynamic object to the underlying data model and is how other clients learn that it exists.
+All Fluid objects have a `handle` property that can be used to store and retrieve them from other Fluid objects. Objects created dynamically must be stored before they are collaborative. As you will see below, the act of storing a handle is what links the new dynamic object to the underlying data model and is how other clients learn that it exists.
 
-Dynamically created objects need to be stored on an already connected shared object, so the most common case is to store them in an `initialObject`, because `initialObjects` are connected on creation. However, you can also store dynamic objects in other connected dynamic objects. In this sense shared objects are arbitrarily nestable.
+Dynamically created objects need to be stored on an already connected Fluid object, so the most common case is to store them in an `initialObject`, because `initialObjects` are connected on creation. However, you can also store dynamic objects in other connected dynamic objects. In this sense Fluid objects are arbitrarily nestable.
 
 When retrieving dynamically created objects you need to first get the object's handle then get the object from the handle. This reference based approach allows the Fluid Framework to virtualize the data underneath, only loading objects when they are requested.
 
-This example shows creating a new `SharedCell` and storing it in the `SharedMap` initial object using the handle. It also demonstrates retrieving the `SharedCell` object from the `SharedMap` and listening for the new `SharedCell` being added to the Map.
+The following example demonstrates dynamically creating a `SharedCell` and storing it in the `SharedMap` initial object
+using the handle. It also demonstrates retrieving the `SharedCell` object from the `SharedMap` and listening for the new
+`SharedCell` being added to the Map.
 
 ```typescript
 const schema = {
@@ -109,7 +135,7 @@ map.on("valueChanged", (changed) => {
 
 Dynamic objects are more difficult to work with than `initialObjects`, but are especially important for large data sets where portions of the data are virtualized. Because dynamic objects are loaded into memory on demand, using them can reduce boot time of your application by delaying when the objects are loaded. Dynamic objects are also not strictly defined in the container schema. This enables you to create containers with flexible, user-generated schemas.
 
-An example where this is useful is building a collaborative storyboarding application. In this scenario you can have a large number of individual boards that make up the storyboard. By using a dynamic shared object for each board you can load them on demand as the user accesses them, instead of having to load them all in memory at once.
+An example where this is useful is building a collaborative storyboarding application. In this scenario you can have a large number of individual boards that make up the storyboard. By using a dynamic Fluid object for each board you can load them on demand as the user accesses them, instead of having to load them all in memory at once.
 
 <!-- AUTO-GENERATED-CONTENT:START (INCLUDE:path=docs/_includes/links.md) -->
 <!-- Links -->

--- a/docs/content/docs/build/dds.md
+++ b/docs/content/docs/build/dds.md
@@ -7,12 +7,23 @@ author: tylerbutler
 editor: sambroner
 ---
 
-The Fluid Framework provides developers with *distributed data structures* (DDSes) that automatically ensure that each
-client has access to the same state. We call them *distributed data structures* because they are similar to data
-structures used commonly when programming, like strings, maps/dictionaries, and sequences/lists. The APIs provided by
-DDSes are designed to be familiar to programmers who've used these types of data structures before. For example, the
-[SharedMap][] DDS is used to store key/value pairs, like a typical map or dictionary data structure, and provides `get`
-and `set` methods to store and retrieve data in the map.
+The Fluid Framework provides developers with two types of Fluid objects: *distributed data structures* (DDSes) and
+`DataObjects`. DDSes are low-level data structures, while `DataObject`s are composed of DDSes and other Fluid objects.
+In other words, you can't have `DataObject`s without DDSes, because `DataObject`s are composed of DDSes. DataObjects are
+used to organize distributed data structures into semantically meaningful groupings for your scenario, as well as
+providing an API surface to your data. However, many Fluid applications will use only DDSes.
+
+{{% callout note "See also" %}}
+
+[Encapsulating data with DataObject]({{< relref "dataobject-aqueduct.md" >}})
+
+{{% /callout %}}
+
+DDSes automatically ensure that each client has access to the same state. They're called *distributed data structures*
+because they are similar to data structures used commonly when programming, like strings, maps/dictionaries, and
+sequences/lists. The APIs provided by DDSes are designed to be familiar to programmers who've used these types of data
+structures before. For example, the [SharedMap][] DDS is used to store key/value pairs, like a typical map or dictionary
+data structure, and provides `get` and `set` methods to store and retrieve data in the map.
 
 When using a DDS, you can largely treat it as a local object. You can add data to it, remove data, update it, etc.
 However, a DDS is not *just* a local object. A DDS can also be changed by other users that are editing.

--- a/docs/content/docs/build/overview.md
+++ b/docs/content/docs/build/overview.md
@@ -11,7 +11,7 @@ There are three primary concepts to understand when building an application with
 
 - Service
 - Container
-- Shared objects
+- Fluid objects
 
 ### Service
 
@@ -25,15 +25,17 @@ See [Supported service-specific client packages](#service-specific-client-packag
 
 ### Container
 
-The container is the primary unit of encapsulation in Fluid. It consists of a collection of shared objects and supporting APIs to manage the lifecycle of the container and the objects within it.
+The container is the primary unit of encapsulation in Fluid. It consists of a collection of Fluid objects and supporting APIs to manage the lifecycle of the container and the objects within it.
 
 New containers require a client-driven action and container lifetimes are bound to the data stored on the supporting server. When getting existing containers it's important to consider the previous state of the container.
 
 For more about containers see [Containers](./containers.md).
 
-### Shared objects
+### Fluid objects
 
-A shared object is an object type that powers collaborative data by exposing a specific API. Many shared objects can exist within the context of a container and they can be created either statically or dynamically. Distributed Data Structures(DDSes) and DataObjects are both types of shared objects.
+
+A *Fluid object* is any object type that supports collaboration (simultaneous editing). Fluid Framework contains two
+types of Fluid objects: distributed data structures (DDSes) and `DataObject`s.
 
 For more information see [Data modeling](./data-modeling.md).
 
@@ -44,7 +46,7 @@ and a service-specific client package like `tinylicious-client`.
 
 ### The `fluid-framework` package
 
-The `fluid-framework` package is a collection of core Fluid APIs that make it easy to build and use applications. This package contains all the common type definitions as well as all the primitive shared objects.
+The `fluid-framework` package is a collection of core Fluid APIs that make it easy to build and use applications. This package contains all the common type definitions as well as all the primitive Fluid objects.
 
 ### Service-specific client packages
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -65,7 +65,7 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 Calls to `createContainer` and `getContainer` return an `FrsResources` object that contains a `FluidContainer` -- described above -- and a `containerServices` object.
 
-The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the Fluid shared objects within the container can be reused when moving to using `FrsClient`.
+The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the Fluid objects within the container can be reused when moving to using `FrsClient`.
 
 The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 

--- a/docs/content/docs/glossary.md
+++ b/docs/content/docs/glossary.md
@@ -27,8 +27,9 @@ You'll write container code to define which Fluid objects your scenario uses and
 
 ## DataObject
 
-Aqueduct's implementation of a Fluid object. Designed to organize distributed data structures into
-semantically meaningful groupings for your scenario, as well as, providing an API surface to your data.
+DataObjects are higher-level Fluid objects, compared to distributed data structures, which are low-level Fluid objects.
+DataObjects are used to organize distributed data structures into semantically meaningful groupings for your scenario,
+as well as providing an API surface to your data.
 
 ## Distributed data structures (DDSes)
 
@@ -41,7 +42,8 @@ Responsible for connecting to a Fluid service and loading a Fluid container.
 
 ## Fluid object
 
-Any JavaScript object that implements Fluid feature interfaces.
+Any object type that supports collaboration (simultaneous editing). Fluid Framework contains two types of Fluid objects:
+distributed data structures (DDSes) and `DataObject`s.
 
 ## Fluid service
 
@@ -50,10 +52,6 @@ A service endpoint that is responsible for receiving, processing, storing, and b
 ## Fluid service driver
 
 Client code responsible for connecting to the Fluid service.
-
-## Shared object
-
-A distributed data structure (DDS) or `DataObject`.
 
 ## URL resolver
 


### PR DESCRIPTION
_We've decided to stick with shared object, and the other changes in this PR are superseded https://github.com/microsoft/FluidFramework/pull/7155._

---

This PR contains the following changes:

- Use the term "Fluid object" to mean "a DDS or DataObject". That's how the term was used elsewhere in our docs, and regardless of the history, I propose that we accept some retconning and snap to this definition of Fluid object.
- Clarified the wording around initial and dynamic objects.
- Clarify the relationship of DDSes, DataObjects, and Fluid objects in the DDS article (and link to the DO article).
- Update some term definitions.