### PR TITLE
Update base64-js version in common-utils

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -2292,9 +2292,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@types/events": "^3.0.0",
-    "base64-js": "^1.3.1",
+    "base64-js": "^1.5.1",
     "events": "^3.1.0",
     "lodash": "^4.17.21",
     "sha.js": "^2.4.11"


### PR DESCRIPTION
As part of bumping the common-utils version.  Client build is complaining there are multiple versions of base64-js, so bump the version in common-utils to latest to match the duplicate.