### PR TITLE
Container.close() to be more robust

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -569,7 +569,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         private readonly loader: Loader,
         config: IContainerConfig,
     ) {
-        super();
+        super((name, error) => {
+            this.logger.sendErrorEvent(
+                {
+                    eventName: "ContainerError",
+                    name: typeof name === "string" ? name : undefined,
+                },
+                error);
+            });
         this._audience = new Audience();
 
         this.clientDetailsOverride = config.clientDetailsOverride;
@@ -715,34 +722,35 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         }
         this._closed = true;
 
-        this.collabWindowTracker.stopSequenceNumberUpdate();
-        this._deltaManager.close(error);
+        // Ensure that we raise all key events even if one of these throws
+        try {
+            this.collabWindowTracker.stopSequenceNumberUpdate();
+            this._deltaManager.close(error);
 
-        this._protocolHandler?.close();
+            this._protocolHandler?.close();
 
-        this._context?.dispose(error !== undefined ? new Error(error.message) : undefined);
+            this._context?.dispose(error !== undefined ? new Error(error.message) : undefined);
 
-        assert(this.connectionState === ConnectionState.Disconnected, 0x0cf /* "disconnect event was not raised!" */);
+            assert(this.connectionState === ConnectionState.Disconnected,
+                0x0cf /* "disconnect event was not raised!" */);
 
-        this._storageService?.dispose();
+            this._storageService?.dispose();
 
-        // Notify storage about critical errors. They may be due to disconnect between client & server knowledge about
-        // file, like file being overwritten in storage, but client having stale local cache.
-        // Driver need to ensure all caches are cleared on critical errors
-        this.service?.dispose(error);
-
-        if (error !== undefined) {
-            this.logger.sendErrorEvent(
-                {
-                    eventName: "ContainerClose",
-                    lastSequenceNumber: this._deltaManager.lastSequenceNumber,
-                },
-                error,
-            );
-        } else {
-            assert(this.loaded, 0x0d0 /* "Container in non-loaded state before close!" */);
-            this.logger.sendTelemetryEvent({ eventName: "ContainerClose" });
+            // Notify storage about critical errors. They may be due to disconnect between client & server knowledge
+            // about file, like file being overwritten in storage, but client having stale local cache.
+            // Driver need to ensure all caches are cleared on critical errors
+            this.service?.dispose(error);
+        } catch (exception) {
+            this.logger.sendErrorEvent({ eventName: "ContainerCloseException"}, exception);
         }
+
+        this.logger.sendErrorEvent(
+            {
+                eventName: "ContainerClose",
+                lastSequenceNumber: this._deltaManager.lastSequenceNumber,
+            },
+            error,
+        );
 
         this.emit("closed", error);
 
@@ -1257,7 +1265,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             }
         }
 
-        // Safety net: static version of Container.load() should have got this message through "closed" handler.
+        // Safety net: static version of Container.load() should have learned about it through "closed" handler.
         // But if that did not happen for some reason, fail load for sure.
         // Otherwise we can get into situations where container is closed and does not try to connect to ordering
         // service, but caller does not know that (callers do expect container to be not closed on successful path

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -572,7 +572,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         super((name, error) => {
             this.logger.sendErrorEvent(
                 {
-                    eventName: "ContainerError",
+                    eventName: "ContainerEventHandlerException",
                     name: typeof name === "string" ? name : undefined,
                 },
                 error);
@@ -744,10 +744,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.logger.sendErrorEvent({ eventName: "ContainerCloseException"}, exception);
         }
 
-        this.logger.sendErrorEvent(
+        this.logger.sendTelemetryEvent(
             {
                 eventName: "ContainerClose",
-                lastSequenceNumber: this._deltaManager.lastSequenceNumber,
+                loaded: this.loaded,
             },
             error,
         );

--- a/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
+++ b/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
@@ -11,11 +11,11 @@ import { TypedEventEmitter, EventEmitterEventType } from "@fluidframework/common
  * Any exception thrown by "error" listeners will propagate to the caller.
  */
 export class EventEmitterWithErrorHandling<TEvent extends IEvent = IEvent> extends TypedEventEmitter<TEvent> {
-    constructor(private readonly errorListener?: (eventName: EventEmitterEventType, error: any) => void) {
+    private readonly errorHandler: (eventName: EventEmitterEventType, error: any) => void;
+
+    constructor(errorHandler?: (eventName: EventEmitterEventType, error: any) => void) {
         super();
-        if (this.errorListener === undefined) {
-            this.errorListener = this.defaultErrorHandler.bind(this);
-        }
+        this.errorHandler = errorHandler ?? this.defaultErrorHandler.bind(this);
     }
 
     private defaultErrorHandler(event, error) {
@@ -33,7 +33,7 @@ export class EventEmitterWithErrorHandling<TEvent extends IEvent = IEvent> exten
         try {
             return super.emit(event, ...args);
         } catch (error) {
-            this.errorListener!(event, error);
+            this.errorHandler(event, error);
             return true;
         }
     }

--- a/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
+++ b/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
@@ -11,18 +11,30 @@ import { TypedEventEmitter, EventEmitterEventType } from "@fluidframework/common
  * Any exception thrown by "error" listeners will propagate to the caller.
  */
 export class EventEmitterWithErrorHandling<TEvent extends IEvent = IEvent> extends TypedEventEmitter<TEvent> {
+    constructor(private readonly errorListener?: (eventName: EventEmitterEventType, error: any) => void) {
+        super();
+        if (this.errorListener === undefined) {
+            this.errorListener = this.defaultErrorHandler.bind(this);
+        }
+    }
+
+    private defaultErrorHandler(event, error) {
+        // Some listener threw an error, we'll try emitting that error via the error event
+        // But not if we're already dealing with the error event, in that case just let the error be thrown
+        if (event === "error") {
+            throw error;
+        }
+
+        // Note: This will throw if no listeners are registered for the error event
+        super.emit("error", error);
+    }
+
     public emit(event: EventEmitterEventType, ...args: any[]): boolean {
         try {
             return super.emit(event, ...args);
         } catch (error) {
-            // Some listener threw an error, we'll try emitting that error via the error event
-            // But not if we're already dealing with the error event, in that case just let the error be thrown
-            if (event === "error") {
-                throw error;
-            }
-
-            // Note: This will throw if no listeners are registered for the error event
-            return super.emit("error", error);
+            this.errorListener!(event, error);
+            return true;
         }
     }
 }


### PR DESCRIPTION
Addresses issue #6690.
Ensure that failures on container closure path are properly logged into telemetry and that proper events are raised in all cases.
