### PR TITLE
Stop putting the response text on the error object.

### DIFF
--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -170,7 +170,6 @@ export function enrichOdspError(
 
     const facetCodes = responseText !== undefined ? parseFacetCodes(responseText) : undefined;
     error.facetCodes = facetCodes;
-    (error as any).response = responseText; // Issue #6139: This shouldn't be logged - will be fixed with #6485
 
     props.innerMostErrorCode = facetCodes !== undefined ? facetCodes[0] : undefined;
     if (response) {

--- a/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
@@ -151,9 +151,7 @@ describe("OdspErrorUtils", () => {
             const error = new GenericNetworkError("Some message", false) as OdspError & IFacetCodes;
             enrichOdspError(error, { type: "fooType", headers: mockHeaders } as unknown as Response /* response */, "responseText");
 
-            assert.equal((error as any).response, "responseText");
             assert(isILoggingError(error));
-            assert.equal(error.getTelemetryProperties().response, "responseText"); // bug GH #6139
             assert.equal(error.getTelemetryProperties().responseType, "fooType");
             assert.equal(error.getTelemetryProperties().sprequestguid, "mock header sprequestguid");
             assert.equal(error.getTelemetryProperties().requestId, "mock header request-id");


### PR DESCRIPTION
Fixes #6139, even without #6485.

On two different occasions I did a full-text search on the code base (narrowed to relevant dirs, e.g. ignoring dirs like server or runtime), and this is no longer used.  As of Si's error facet work.
