### PR TITLE
Try to read from new format while summarizing in detached container

### DIFF
--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -266,14 +266,14 @@ export function convertSnapshotTreeToSummaryTree(
 
     const builder = new SummaryTreeBuilder();
     for (const [path, id] of Object.entries(snapshot.blobs)) {
-        // 0.44 back-compat We still put contents in same blob for back-compat so need to add blob
-        // only for blobPath -> blobId mapping and not for blobId -> blob value contents.
         let decoded: string | Uint8Array | undefined;
         if ((snapshot as any).blobsContents !== undefined) {
             const content: ArrayBufferLike = (snapshot as any).blobsContents[id];
             if (content !== undefined) {
                 decoded = new Uint8Array(content);
             }
+        // 0.44 back-compat We still put contents in same blob for back-compat so need to add blob
+        // only for blobPath -> blobId mapping and not for blobId -> blob value contents.
         } else if (snapshot.blobs[id] !== undefined) {
             decoded = fromBase64ToUtf8(snapshot.blobs[id]);
         }

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -5,6 +5,7 @@
 
 import {
     assert,
+    bufferToString,
     fromBase64ToUtf8,
     IsoBuffer,
     Uint8ArrayToString,
@@ -265,12 +266,17 @@ export function convertSnapshotTreeToSummaryTree(
         0x19e /* "There should not be commit tree entries in snapshot" */);
 
     const builder = new SummaryTreeBuilder();
-    for (const [key, value] of Object.entries(snapshot.blobs)) {
-        // The entries in blobs are supposed to be blobPath -> blobId and blobId -> blobValue
-        // and we want to push blobPath to blobValue in tree entries.
-        if (snapshot.blobs[value] !== undefined) {
-            const decoded = fromBase64ToUtf8(snapshot.blobs[value]);
-            builder.addBlob(key, decoded);
+    for (const [path, id] of Object.entries(snapshot.blobs)) {
+        // 0.44 back-compat We still put contents in same blob for back-compat so need to add blob
+        // only for blobPath -> blobId mapping and not for blobId -> blob value contents.
+        if (snapshot.blobs[id] !== undefined) {
+            let decoded: string;
+            if ((snapshot as any).blobsContents !== undefined) {
+                decoded = bufferToString((snapshot as any).blobsContents[id], "utf8");
+            } else {
+                decoded = fromBase64ToUtf8(snapshot.blobs[id]);
+            }
+            builder.addBlob(path, decoded);
         }
     }
 


### PR DESCRIPTION
Refer: #4746
This is 4th part of above issue and part of draft PR: #6608

Since we don't put the blobContents in same ISnapshotTree.blobs anymore when rehydrating from snapshot in detached container, read from the .blobContents if present in the snapshot.