### PR TITLE
SharedMatrix: Fixed not serializing handles in toString

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -723,7 +723,7 @@ export class SharedMatrix<T = any>
                     s += ", ";
                 }
 
-                s += `${JSON.stringify(this.getCell(r, c))}`;
+                s += `${this.serializer.stringify(this.getCell(r, c), this.handle)}`;
             }
             s += "]\n";
         }


### PR DESCRIPTION
`SharedMatrix::toString` uses JSON.stringify to serialize the contents. However, this doesn't serialize handles stored in the matrix. Fixed this to use `this.serialize.stringify` instead that can serialize handles.