### PR TITLE
Throttler unit tests

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -102,7 +102,7 @@ import { ContainerFluidHandleContext } from "./containerHandleContext";
 import { FluidDataStoreRegistry } from "./dataStoreRegistry";
 import { debug } from "./debug";
 import { Summarizer } from "./summarizer";
-import { SummaryManager } from "./summaryManager";
+import { defaultStartThrottleConfig, SummaryManager } from "./summaryManager";
 import { DeltaScheduler } from "./deltaScheduler";
 import { ReportOpPerfTelemetry } from "./connectionTelemetry";
 import { IPendingLocalState, PendingStateManager } from "./pendingStateManager";
@@ -131,6 +131,7 @@ import {
     ISummarizerOptions,
     ISummarizerRuntime,
 } from "./summarizerTypes";
+import { Throttler } from "./throttler";
 
 export enum ContainerMessageType {
     // An op to be delivered to store
@@ -930,6 +931,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 this.summarizerClientElection,
                 this, // IConnectedState
                 this.logger,
+                new Throttler(
+                    defaultStartThrottleConfig.delayWindowMs,
+                    defaultStartThrottleConfig.maxDelayMs,
+                    defaultStartThrottleConfig.delayFn,
+                ),
                 this.runtimeOptions.summaryOptions.initialSummarizerDelayMs,
                 this.runtimeOptions.summaryOptions.summarizerOptions,
             );

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -201,7 +201,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
         }, (error) => {
             this.logger.sendErrorEvent({
                 eventName: "CreateSummarizerError",
-                attempt: this.startThrottler.attempts,
+                attempt: this.startThrottler.numAttempts,
             }, error);
             this.tryRestart();
         });
@@ -216,7 +216,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
 
         PerformanceEvent.timedExecAsync(
             this.logger,
-            { eventName: "RunningSummarizer", attempt: this.startThrottler.attempts },
+            { eventName: "RunningSummarizer", attempt: this.startThrottler.numAttempts },
             async () => summarizer.run(clientId, this.summarizerOptions),
         ).finally(() => {
             this.runningSummarizer = undefined;

--- a/packages/runtime/container-runtime/src/test/throttler.spec.ts
+++ b/packages/runtime/container-runtime/src/test/throttler.spec.ts
@@ -125,7 +125,7 @@ describe("Throttler", () => {
             }
         });
 
-        it.skip("State should be corrected if delay is bypassed", () => {
+        it("State should be corrected if delay is bypassed", () => {
             // First 2 attempts are allowed to be instant.
             assert.strictEqual(getDelayAndTick(), 0);
             assert.strictEqual(throttler.getDelay(), 20);

--- a/packages/runtime/container-runtime/src/test/throttler.spec.ts
+++ b/packages/runtime/container-runtime/src/test/throttler.spec.ts
@@ -1,0 +1,137 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import sinon from "sinon";
+import { Throttler } from "../throttler";
+
+describe("Throttler", () => {
+    let throttler: Throttler;
+    let clock: sinon.SinonFakeTimers;
+    before(() => clock = sinon.useFakeTimers());
+    after(() => clock.restore());
+    afterEach(() => clock.reset());
+
+    function assertAscending(array: readonly number[]) {
+        if (array.length < 1) {
+            return;
+        }
+        let prev = array[0];
+        for (const item of array) {
+            assert(item >= prev, "out of order");
+            prev = item;
+        }
+    }
+
+    function getDelayAndTick(): number {
+        const delay = throttler.getDelay();
+        clock.tick(delay);
+        assert.strictEqual(throttler.latestAttemptTime, Date.now(),
+            "getDelayAndTick should yield latestAttemptTime === now");
+        assertAscending(throttler.getAttempts());
+        return delay;
+    }
+
+    describe("Exponential Delay", () => {
+        // 60 second delay window. We ignore attempts that are more
+        // than 60 seconds ago. We are always subtracting the actual
+        // delay time for this window.
+        const delayWindowMs = 60 * 1000;
+
+        // 30 second maximum delay. After delays reach this length,
+        // subsequent attempts will also use the max delay, unless
+        // enough extra time passes between attempts for some of the
+        // previous start times to drop off out of the window.
+        const maxDelayMs = 30 * 1000;
+
+        // Exponential delay: [prev x 2 + 20] (0ms, 20ms, 60ms, 140ms, etc)
+        //  # | calculation                   |   delay   | cumulative delay
+        // ---|-------------------------------|-----------|-----------------
+        //  1 | (2^0  - 1) x 20 =    0 x 20 = |      0 ms |      0 ms
+        //  2 | (2^1  - 1) x 20 =    1 x 20 = |     20 ms |     20 ms
+        //  3 | (2^2  - 1) x 20 =    3 x 20 = |     60 ms |     80 ms
+        //  4 | (2^3  - 1) x 20 =    7 x 20 = |    140 ms |    220 ms
+        //  5 | (2^4  - 1) x 20 =   15 x 20 = |    300 ms |    520 ms
+        //  6 | (2^5  - 1) x 20 =   31 x 20 = |    620 ms |  1,140 ms
+        //  7 | (2^6  - 1) x 20 =   63 x 20 = |  1,260 ms |  2,400 ms
+        //  8 | (2^7  - 1) x 20 =  127 x 20 = |  2,540 ms |  4,940 ms
+        //  9 | (2^8  - 1) x 20 =  255 x 20 = |  5,100 ms | 10,040 ms
+        // 10 | (2^9  - 1) x 20 =  511 x 20 = | 10,220 ms | 20,260 ms
+        // 11 | (2^10 - 1) x 20 = 1023 x 20 = | 20,460 ms | 40,720 ms
+        // 12 | (2^11 - 1) x 20 = 2047 x 20 = | 30,000 ms | 70,720 ms (MAX)
+        // 13 | (2^11 - 1) x 20 = 2047 x 20 = | 30,000 ms | 70,720 ms (MAX)
+        const delayFn = (numAttempts: number) => 20 * (Math.pow(2, numAttempts) - 1);
+
+        beforeEach(() => throttler = new Throttler(delayWindowMs, maxDelayMs, delayFn));
+
+        it("Should initially have zero delay", () => {
+            assert.strictEqual(throttler.getDelay(), 0);
+        });
+
+        it("Should increase as expected with instant failures", () => {
+            const expectedDelays = [
+                0, 20, 60, 140, 300, 620, 1260,
+                2540, 5100, 10220, 20460, 30000, 30000,
+            ];
+            for (const expectedDelay of expectedDelays) {
+                assert.strictEqual(getDelayAndTick(), expectedDelay);
+            }
+        });
+
+        it("Should remain zero delay with long pauses between getDelay calls", () => {
+            for (let i = 0; i < 5; i++) {
+                assert.strictEqual(getDelayAndTick(), 0, `iteration ${i}`);
+                clock.tick(delayWindowMs);
+            }
+            assert.strictEqual(getDelayAndTick(), 0);
+
+            // This time barely keep it in the window, giving a delay.
+            clock.tick(delayWindowMs - 1);
+            assert.strictEqual(getDelayAndTick(), 20);
+        });
+
+        it("Should not increase with long pauses between getDelay calls", () => {
+            const oneThirdTicks = Math.floor(delayWindowMs / 3);
+            const remainingTicks = delayWindowMs - (2 * oneThirdTicks);
+
+            // Accumulate some attempts first.
+            assert.strictEqual(getDelayAndTick(), 0);
+            clock.tick(oneThirdTicks);
+            assert.strictEqual(getDelayAndTick(), 20);
+            clock.tick(oneThirdTicks);
+            assert.strictEqual(getDelayAndTick(), 60);
+            clock.tick(remainingTicks);
+
+            // Loop through attempts periodically dropping off.
+            for (let i = 0; i < 100; i++) {
+                assert.strictEqual(getDelayAndTick(), 60, `iteration ${i}`);
+                clock.tick(i % 3 === 2 ? remainingTicks : oneThirdTicks);
+            }
+            assert.strictEqual(getDelayAndTick(), 60);
+
+            // This time fail instantly, giving a later delay.
+            assert.strictEqual(getDelayAndTick(), 140);
+        });
+
+        it("Should stop increasing number of attempts after max", () => {
+            for (let i = 0; i < 11; i++) {
+                getDelayAndTick();
+                assert.strictEqual(throttler.numAttempts, i + 1, `loop 1; iteration ${i}`);
+            }
+            for (let i = 0; i < 100; i++) {
+                getDelayAndTick();
+                assert.strictEqual(throttler.numAttempts, 11, `loop 2; iteration ${i}`);
+            }
+        });
+
+        it.skip("State should be corrected if delay is bypassed", () => {
+            // First 2 attempts are allowed to be instant.
+            assert.strictEqual(getDelayAndTick(), 0);
+            assert.strictEqual(throttler.getDelay(), 20);
+
+            // This attempt is too soon, since we have not delayed 20ms.
+            assert.strictEqual(getDelayAndTick(), 60);
+        });
+    });
+});

--- a/packages/runtime/container-runtime/src/throttler.ts
+++ b/packages/runtime/container-runtime/src/throttler.ts
@@ -71,6 +71,16 @@ export class Throttler implements IThrottler {
     public getDelay() {
         const now = Date.now();
 
+        const latestAttemptTime = this.latestAttemptTime;
+        if (latestAttemptTime !== undefined) {
+            // If getDelay was called sooner than the most recent delay,
+            // subtract the remaining time, since we previously added it.
+            const earlyMs = latestAttemptTime - now;
+            if (earlyMs > 0) {
+                this.startTimes = this.startTimes.map((t) => t - earlyMs);
+            }
+        }
+
         // Remove all attempts that have already fallen out of the window.
         this.startTimes = this.startTimes.filter((t) => (now - t) < this.delayWindowMs);
 

--- a/packages/runtime/container-runtime/src/throttler.ts
+++ b/packages/runtime/container-runtime/src/throttler.ts
@@ -9,6 +9,23 @@ export interface IThrottler {
      * which will be used for calculating future attempt delays.
      */
     getDelay(): number;
+
+    /**
+     * Number of attempts that occurred within the sliding window as of
+     * the most recent delay computation.
+     */
+    readonly numAttempts: number;
+
+    /** Width of sliding delay window in milliseconds. */
+    readonly delayWindowMs: number;
+    /** Maximum delay allowed in milliseconds. */
+    readonly maxDelayMs: number;
+    /**
+     * Delay function used to calculate what the delay should be.
+     * The input is the number of attempts that occurred within the sliding window.
+     * The result is the calculated delay in milliseconds.
+     */
+    readonly delayFn: (numAttempts: number) => number;
 }
 
 /**
@@ -18,20 +35,16 @@ export interface IThrottler {
 export class Throttler implements IThrottler {
     private startTimes: number[] = [];
 
+    public get numAttempts() {
+        return this.startTimes.length;
+    }
+
     /**
      * Gets all attempt start times after compensating for the delay times
      * by adding the delay times to the actual times.
      */
     public getAttempts(): readonly number[] {
         return [ ...this.startTimes ];
-    }
-
-    /**
-     * Number of attempts that occurred within the sliding window as of
-     * the most recent delay computation.
-     */
-    public get numAttempts() {
-        return this.startTimes.length;
     }
 
     /**
@@ -44,15 +57,15 @@ export class Throttler implements IThrottler {
 
     constructor(
         /** Width of sliding delay window in milliseconds. */
-        private readonly delayWindowMs: number,
+        public readonly delayWindowMs: number,
         /** Maximum delay allowed in milliseconds. */
-        private readonly maxDelayMs: number,
+        public readonly maxDelayMs: number,
         /**
          * Delay function used to calculate what the delay should be.
          * The input is the number of attempts that occurred within the sliding window.
          * The result is the calculated delay in milliseconds.
          */
-        private readonly delayFn: (numAttempts: number) => number,
+        public readonly delayFn: (numAttempts: number) => number,
     ) { }
 
     public getDelay() {

--- a/packages/runtime/container-runtime/src/throttler.ts
+++ b/packages/runtime/container-runtime/src/throttler.ts
@@ -3,31 +3,76 @@
  * Licensed under the MIT License.
  */
 
+export interface IThrottler {
+    /**
+     * Computes what the throttle delay should be, and records an attempt
+     * which will be used for calculating future attempt delays.
+     */
+    getDelay(): number;
+}
+
 /**
  * Used to give increasing delay times for throttling a single functionality.
- * Delay is based on previous attempts within specified time window, ignoring actual delay time.
+ * Delay is based on previous attempts within specified time window, subtracting delay time.
  */
- export class Throttler {
+export class Throttler implements IThrottler {
     private startTimes: number[] = [];
-    constructor(
-        private readonly delayWindowMs: number,
-        private readonly maxDelayMs: number,
-        private readonly delayFunction: (n: number) => number,
-    ) { }
 
-    public get attempts() {
+    /**
+     * Gets all attempt start times after compensating for the delay times
+     * by adding the delay times to the actual times.
+     */
+    public getAttempts(): readonly number[] {
+        return [ ...this.startTimes ];
+    }
+
+    /**
+     * Number of attempts that occurred within the sliding window as of
+     * the most recent delay computation.
+     */
+    public get numAttempts() {
         return this.startTimes.length;
     }
 
+    /**
+     * Latest attempt time after compensating for the delay time itself
+     * by adding the delay time to the actual time.
+     */
+    public get latestAttemptTime() {
+        return this.startTimes.length > 0 ? this.startTimes[this.startTimes.length - 1] : undefined;
+    }
+
+    constructor(
+        /** Width of sliding delay window in milliseconds. */
+        private readonly delayWindowMs: number,
+        /** Maximum delay allowed in milliseconds. */
+        private readonly maxDelayMs: number,
+        /**
+         * Delay function used to calculate what the delay should be.
+         * The input is the number of attempts that occurred within the sliding window.
+         * The result is the calculated delay in milliseconds.
+         */
+        private readonly delayFn: (numAttempts: number) => number,
+    ) { }
+
     public getDelay() {
         const now = Date.now();
-        this.startTimes = this.startTimes.filter((t) => now - t < this.delayWindowMs);
-        const delayMs = Math.min(this.delayFunction(this.startTimes.length), this.maxDelayMs);
+
+        // Remove all attempts that have already fallen out of the window.
+        this.startTimes = this.startTimes.filter((t) => (now - t) < this.delayWindowMs);
+
+        // Compute delay, but do not exceed the specified max delay.
+        const delayMs = Math.min(this.delayFn(this.startTimes.length), this.maxDelayMs);
+
+        // Record this attempt start time.
         this.startTimes.push(now);
-        this.startTimes = this.startTimes.map((t) => t + delayMs); // account for delay time
+
+        // Account for the delay time, by effectively removing it from the delay window.
+        this.startTimes = this.startTimes.map((t) => t + delayMs);
+
         if (delayMs === this.maxDelayMs) {
-            // we hit max delay so adding more won't affect anything
-            // shift off oldest time to stop this array from growing forever
+            // We hit max delay, so adding more won't affect anything.
+            // Shift off oldest time to stop this array from growing forever.
             this.startTimes.shift();
         }
 


### PR DESCRIPTION
Fixes #6472.

1. First commit adds comments and tests to Throttler.
2. Second commit changes SummaryManager to depend on IThrottler to be passed in rather than creating locally.
3. Third commit "fixes" and enables a test to handle the case when subsequent getDelay() is called before the previous delay elapsed. Before the virtual times would keep increasing further into the future, but now they are capped at the real current time by subtracting them back down.