### PR TITLE
Add more context to container warning

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1872,6 +1872,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     // Please avoid calling it directly.
     // raiseContainerWarning() is the right flow for most cases
     private logContainerError(warning: ContainerWarning) {
-        this.logger.sendErrorEvent({ eventName: "ContainerWarning" }, warning);
+        this.logger.sendErrorEvent({ eventName: "ContainerWarning", runtimeVersion: pkgVersion }, warning);
     }
 }


### PR DESCRIPTION
Add  runtime version to raiseContainerWarning on the container runtime we proxy errors to the loader layer

Related issue: #6850