### PR TITLE
Extend CombinedProducer to support sequential sends

### DIFF
--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -77,7 +77,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
     const localContext = new LocalContext(winston);
 
     const localProducer = new LocalKafka();
-    const combinedProducer = new core.CombinedProducer([forwardProducer, localProducer]);
+    const combinedProducer = new core.CombinedProducer([forwardProducer, localProducer], true);
 
     const broadcasterLambda = new LocalLambdaController(
         localProducer,

--- a/server/routerlicious/packages/services-core/src/combinedProducer.ts
+++ b/server/routerlicious/packages/services-core/src/combinedProducer.ts
@@ -8,11 +8,18 @@ import { IProducer } from "./queue";
 
 /**
  * Combines multiple producers to one.
- * This produces messages to all the producers concurrently
- * and waits for all the sends to finish
+ * This produces messages to all the producers.
+ * It can produce the messages parallelly or sequentially.
+ *
+ * When producing parallelly, it will produce the messages to all the producers at once.
+ * It will wait for all the sends to complete before resolving.
+ *
+ * When producing sequentially, it will produce the messages to each producer one
+ * after another in order of the producers argument.
+ * It will wait for each send to complete before sending the message to the next producer.
  */
 export class CombinedProducer<T = ITicketedMessage> implements IProducer<T> {
-    constructor(private readonly producers: IProducer<T>[]) {
+    constructor(private readonly producers: IProducer<T>[], private readonly parallel: boolean) {
     }
 
     /**
@@ -23,11 +30,19 @@ export class CombinedProducer<T = ITicketedMessage> implements IProducer<T> {
     }
 
     public async send(messages: T[], tenantId: string, documentId: string): Promise<any> {
-        const sendP = [];
-        for (const producer of this.producers) {
-            sendP.push(producer.send(messages, tenantId, documentId));
+        if (this.parallel) {
+            // parallelly
+            const sendP = [];
+            for (const producer of this.producers) {
+                sendP.push(producer.send(messages, tenantId, documentId));
+            }
+            return Promise.all(sendP);
+        } else {
+            // sequentially
+            for (const producer of this.producers) {
+                await producer.send(messages, tenantId, documentId);
+            }
         }
-        return Promise.all(sendP);
     }
 
     public async close(): Promise<void> {


### PR DESCRIPTION
Today it sends to all producers concurrently (in parallel). I have a scenario where I may want to have messages sent to producers sequentially. This change adds support for that