### PR TITLE
Add disposed method to IDocumentDeltaConnection

### DIFF
--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IEventProvider, IErrorEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { IDisposable, IEventProvider, IErrorEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import {
     ConnectionMode,
     IClient,
@@ -148,7 +148,7 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
     (event: "error", listener: (error: any) => void);
 }
 
-export interface IDocumentDeltaConnection extends IEventProvider<IDocumentDeltaConnectionEvents> {
+export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<IDocumentDeltaConnectionEvents> {
     /**
      * ClientID for the connection
      */
@@ -220,6 +220,7 @@ export interface IDocumentDeltaConnection extends IEventProvider<IDocumentDeltaC
 
     /**
      * Disconnects the given delta connection
+     * @deprecated, please use dispose()
      */
     close(): void;
 }


### PR DESCRIPTION
Per https://onedrive.visualstudio.com/SPIN/_workitems/edit/1167551/?triage=true, it looks like there might be a case where newly established connection is closed before it arrives to setupNewSuccessfulConnection().
And that manifests into client thinking that connection is alive, but no ops are propagated to client.
Adding IDisposable to be able to test this condition in DeltaManager.
