### PR TITLE
Add logic to track speed of receiving join ops and reset connection on timeout

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -7,7 +7,6 @@
 import { AttachState } from '@fluidframework/container-definitions';
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
-import { EventEmitter } from 'events';
 import { EventEmitterWithErrorHandling } from '@fluidframework/telemetry-utils';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IClient } from '@fluidframework/protocol-definitions';
@@ -18,18 +17,15 @@ import { IConnectionDetails } from '@fluidframework/container-definitions';
 import { IContainer } from '@fluidframework/container-definitions';
 import { IContainerEvents } from '@fluidframework/container-definitions';
 import { IContainerLoadMode } from '@fluidframework/container-definitions';
-import { ICreateBlobResponse } from '@fluidframework/protocol-definitions';
 import { ICriticalContainerError } from '@fluidframework/container-definitions';
 import { IDeltaHandlerStrategy } from '@fluidframework/container-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
 import { IDeltaManagerEvents } from '@fluidframework/container-definitions';
 import { IDeltaQueue } from '@fluidframework/container-definitions';
-import { IDisposable } from '@fluidframework/common-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentService } from '@fluidframework/driver-definitions';
 import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
-import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidCodeDetails } from '@fluidframework/core-interfaces';
 import { IFluidModule } from '@fluidframework/container-definitions';
@@ -47,31 +43,15 @@ import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
-import { ISnapshotTree } from '@fluidframework/protocol-definitions';
-import { ISummaryContext } from '@fluidframework/driver-definitions';
-import { ISummaryHandle } from '@fluidframework/protocol-definitions';
-import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { IThrottlingWarning } from '@fluidframework/container-definitions';
-import { ITree } from '@fluidframework/protocol-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { IVersion } from '@fluidframework/protocol-definitions';
 import { MessageType } from '@fluidframework/protocol-definitions';
 import { ReadOnlyInfo } from '@fluidframework/container-definitions';
 import { TelemetryLogger } from '@fluidframework/telemetry-utils';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
-
-// @public
-export class Audience extends EventEmitter implements IAudience {
-    addMember(clientId: string, details: IClient): void;
-    clear(): void;
-    getMember(clientId: string): IClient | undefined;
-    getMembers(): Map<string, IClient>;
-    // (undocumented)
-    on(event: "addMember" | "removeMember", listener: (clientId: string, client: IClient) => void): this;
-    removeMember(clientId: string): boolean;
-}
 
 // @public (undocumented)
 export class CollabWindowTracker {
@@ -231,6 +211,8 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     // (undocumented)
     submitSignal(content: any): void;
     // (undocumented)
+    triggerReconnect(reason: string): void;
+    // (undocumented)
     get version(): string;
 }
 
@@ -360,33 +342,6 @@ export class RelativeLoader implements ILoader {
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
     resolve(request: IRequest): Promise<IContainer>;
-}
-
-// @public (undocumented)
-export class RetriableDocumentStorageService implements IDocumentStorageService, IDisposable {
-    constructor(internalStorageService: IDocumentStorageService, deltaManager: Pick<DeltaManager, "emitDelayInfo" | "refreshDelayInfo">, logger: ITelemetryLogger);
-    // (undocumented)
-    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
-    // (undocumented)
-    dispose(): void;
-    // (undocumented)
-    get disposed(): boolean;
-    // (undocumented)
-    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
-    // (undocumented)
-    getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null>;
-    // (undocumented)
-    getVersions(versionId: string, count: number): Promise<IVersion[]>;
-    // (undocumented)
-    get policies(): IDocumentStorageServicePolicies | undefined;
-    // (undocumented)
-    readBlob(id: string): Promise<ArrayBufferLike>;
-    // (undocumented)
-    get repositoryUrl(): string;
-    // (undocumented)
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
-    // (undocumented)
-    write(tree: ITree, parents: string[], message: string, ref: string): Promise<IVersion>;
 }
 
 // @public

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -69,10 +69,10 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         );
 
         this.joinOpTimer = new Timer(
-            15000,
+            30000,
             () => {
-                // If this event fires too often, then we should look into one of the options:
-                // 1. It happens because it takes client too long to catch up, then we should consider why
+                // If this event fires too often, then we should look into potential reasons why:
+                // 1. It may happen because it takes client too long to catch up, then we should consider why
                 //    and how to address it. It blocks collab window moving forward. One reason might be -
                 //    we raised "connected" event to runtime right away on establishing "read" connection, allowing
                 //    it to send op and switch to "write" mode too early. We should consider waiting with delivery

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -73,15 +73,14 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
             () => {
                 // If this event fires too often, then we should look into one of the options:
                 // 1. If it happens because it takes client too long to catch up, then we should consider why
-                //    and how to add address it. It blocks collab window moving forward. One reason might be -
-                //    we raised "connected" event to runtime right away on "read" connection allowing it to send op
-                //    and switch to "write" too early, maybe we should wait with initial signal until client is
-                //    mostly caught (see waitContainerToCatchUp())
+                //    and how to address it. It blocks collab window moving forward. One reason might be -
+                //    we raised "connected" event to runtime right away on establishing "read" connection, allowing
+                //    it to send op and switch to "write" mode too early. We should consider waiting with delivery
+                //    of initial "connected" signal until client is mostly caught (see waitContainerToCatchUp())
                 // 2. It's possible that client does not receiving any ops at all on this connection, either due
-                //    to client bug or server bug. We should instrument more, by adding number of ops delivered
-                //    on this connection (excluding initial ops) up until this moment.
-                // So adding telemetry on how far client is behind (from last known seq number) and how many ops it
-                // received would help here.
+                //    to client bug or server bug. We should instrument more to understand this problem better.
+                // Adding telemetry on how far client is behind (from last known seq number) at the time of
+                // connection/failure and how many ops it received on given connection would help here.
                 this.logger.sendErrorEvent({ eventName: "NoJoinOp" });
                 this.handler.triggerReconnect("NoJoinOp");
             },

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -72,12 +72,12 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
             15000,
             () => {
                 // If this event fires too often, then we should look into one of the options:
-                // 1. If it happens because it takes client too long to catch up, then we should consider why
+                // 1. It happens because it takes client too long to catch up, then we should consider why
                 //    and how to address it. It blocks collab window moving forward. One reason might be -
                 //    we raised "connected" event to runtime right away on establishing "read" connection, allowing
                 //    it to send op and switch to "write" mode too early. We should consider waiting with delivery
                 //    of initial "connected" signal until client is mostly caught (see waitContainerToCatchUp())
-                // 2. It's possible that client does not receiving any ops at all on this connection, either due
+                // 2. It's possible that client does not receive any ops at all on this connection, either due
                 //    to client bug or server bug. We should instrument more to understand this problem better.
                 // Adding telemetry on how far client is behind (from last known seq number) at the time of
                 // connection/failure and how many ops it received on given connection would help here.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -630,6 +630,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
                 shouldClientJoinWrite: () => this._deltaManager.shouldJoinWrite(),
                 maxClientLeaveWaitTime: this.loader.services.options.maxClientLeaveWaitTime,
+                triggerReconnect: (reason: string) => this._deltaManager.triggerReconnect(reason),
             },
             this.logger,
         );

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -422,7 +422,7 @@ export class DeltaManager
     }
 
     public triggerReconnect(reason: string) {
-            assert(this.connection !== undefined, "called only in connected state")
+            assert(this.connection !== undefined, "called only in connected state");
             this.disconnectFromDeltaStream(reason);
             this.triggerConnect({ reason, mode: "read", fetchOpsFromStorage: false });
     }
@@ -562,7 +562,7 @@ export class DeltaManager
      * @param args - The connection arguments
      */
     private triggerConnect(args: IConnectionArgs) {
-        assert(this.connection === undefined, "called only in disconnected state")
+        assert(this.connection === undefined, "called only in disconnected state");
         if (this.reconnectMode !== ReconnectMode.Enabled) {
             return;
         }

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./audience";
 export * from "./container";
 export * from "./deltaManager";
 export * from "./loader";
-export * from "./retriableDocumentStorageService";

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -75,6 +75,7 @@ describe("ConnectionStateHandler Tests", () => {
                 maxClientLeaveWaitTime: expectedTimeout,
                 protocolHandler: () => protocolHandler,
                 shouldClientJoinWrite: () => shouldClientJoinWrite,
+                triggerReconnect: (reason: string) => { throw new Error("triggerReconnect"); },
             },
             new TelemetryNullLogger(),
         );


### PR DESCRIPTION
Add logic to track speed of receiving join ops.
This is related to https://onedrive.visualstudio.com/SPIN/_queries/edit/1156694/?triage=true
Related PR: https://github.com/microsoft/FluidFramework/pull/6928/