### PR TITLE
Introduce and propagate reason for closing container / DeltaManager.

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -82,7 +82,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     get clientDetails(): IClientDetails;
     get clientId(): string | undefined;
     // (undocumented)
-    close(error?: ICriticalContainerError): void;
+    close(error?: ICriticalContainerError, reason?: string): void;
     // (undocumented)
     closeAndGetPendingLocalState(): string;
     // (undocumented)
@@ -152,7 +152,7 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     attachOpHandler(minSequenceNumber: number, sequenceNumber: number, term: number, handler: IDeltaHandlerStrategy): void;
     // (undocumented)
     readonly clientDetails: IClientDetails;
-    close(error?: ICriticalContainerError): void;
+    close(reason?: string, error?: ICriticalContainerError): void;
     // (undocumented)
     connect(args: IConnectionArgs): Promise<IConnectionDetails>;
     get connectionMode(): ConnectionMode;
@@ -257,7 +257,7 @@ export interface IDeltaManagerInternalEvents extends IDeltaManagerEvents {
     // (undocumented)
     (event: "throttled", listener: (error: IThrottlingWarning) => void): any;
     // (undocumented)
-    (event: "closed", listener: (error?: ICriticalContainerError) => void): any;
+    (event: "closed", listener: (reason: string, error?: ICriticalContainerError) => void): any;
 }
 
 // @public

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError ;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -196,7 +196,7 @@ export interface IContainerEvents extends IEvent {
     // (undocumented)
     (event: "disconnected" | "attached", listener: () => void): any;
     // (undocumented)
-    (event: "closed", listener: (error?: ICriticalContainerError) => void): any;
+    (event: "closed", listener: (reason: string, error?: ICriticalContainerError) => void): any;
     // (undocumented)
     (event: "warning", listener: (error: ContainerWarning) => void): any;
     // (undocumented)

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -156,6 +156,8 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     readonly readOnlyInfo: ReadOnlyInfo;
 
     /** Terminate the connection to storage */
+    // @deprecated in 0.45.
+    // IContainerRuntime.closeFn() should be used to initiate container termination.
     close(): void;
 
     /** Submit a signal to the service to be broadcast to other connected clients, but not persisted */

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -87,7 +87,7 @@ export interface IContainerEvents extends IEvent {
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
     (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);
     (event: "disconnected" | "attached", listener: () => void);
-    (event: "closed", listener: (reason: string, error?: ICriticalContainerError) => void);
+    (event: "closed", listener: (error?: ICriticalContainerError, reason?: string) => void);
     (event: "warning", listener: (error: ContainerWarning) => void);
     (event: "op", listener: (message: ISequencedDocumentMessage) => void);
     (event: "dirty" | "saved", listener: (dirty: boolean) => void);

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -87,7 +87,7 @@ export interface IContainerEvents extends IEvent {
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
     (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);
     (event: "disconnected" | "attached", listener: () => void);
-    (event: "closed", listener: (error?: ICriticalContainerError) => void);
+    (event: "closed", listener: (reason: string, error?: ICriticalContainerError) => void);
     (event: "warning", listener: (error: ContainerWarning) => void);
     (event: "op", listener: (message: ISequencedDocumentMessage) => void);
     (event: "dirty" | "saved", listener: (dirty: boolean) => void);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -462,7 +462,7 @@ export class DeltaManager
             });
 
         this._inbound.on("error", (error) => {
-            this.close("SocketError", CreateProcessingError(error, this.lastMessage));
+            this.close("InboundSocketError", CreateProcessingError(error, this.lastMessage));
         });
 
         // Outbound message queue. The outbound queue is represented as a queue of an array of ops. Ops contained
@@ -476,7 +476,7 @@ export class DeltaManager
             });
 
         this._outbound.on("error", (error) => {
-            this.close("OutboundError", CreateContainerError(error));
+            this.close("OutboundSocketError", CreateContainerError(error));
         });
 
         // Inbound signal queue
@@ -945,7 +945,7 @@ export class DeltaManager
         // This needs to be the last thing we do (before removing listeners), as it causes
         // Container to dispose context and break ability of data stores / runtime to "hear"
         // from delta manager, including notification (above) about readonly state.
-        this.emit("closed", error, reason ?? "ReasonNotProvided");
+        this.emit("closed", error, reason);
 
         this.removeAllListeners();
     }
@@ -1548,7 +1548,7 @@ export class DeltaManager
         } catch (error) {
             const eventName = "GetDeltas_Exception";
             this.logger.sendErrorEvent({ eventName }, error);
-            this.close(eventName, CreateContainerError(eventName, error));
+            this.close(eventName, CreateContainerError(error));
         } finally {
             this.refreshDelayInfo(this.deltaStorageDelayId);
             this.fetchReason = undefined;

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -152,6 +152,8 @@ export class DeltaManagerProxy
         super.dispose();
     }
 
+    // @deprecated in 0.45.
+    // IContainerRuntime.closeFn() should be used to initiate container termination.
     public close(): void {
         return this.deltaManager.close();
     }


### PR DESCRIPTION
It's hard to investigate container close issues.
Please see https://github.com/microsoft/FluidFramework/issues/6911 for more details.

The idea is similar to Mark's errorCodes. We can later populate reason as errorCode if error exists, and keep it as is if it's not (that's the main case I'm after - container is closed because reconnects are not allowed, but it's not really an error that we want to log, but down the road it becomes an error and it's really hard to diagnose these issues).

I've left reason optional on container to not force hosts to provide one, but made it almost required on DeltaManager.
It's almost, because unfortunately close() event is on IDeltaManager where it should be deleted.
So it will take some number of iterations / releases to get there.

Please provide feedback if you see better ways to collect / convey similar information.