### PR TITLE
Disable recovery for when client does not observe its own join op for 30 seconds

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -87,7 +87,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
                 });
 
                 // Data suggests we hit it too often. Disabling "fixup" for now
-                this.handler.triggerReconnect("NoJoinOp");
+                // this.handler.triggerReconnect("NoJoinOp");
             },
         );
     }

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -69,7 +69,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         );
 
         this.joinOpTimer = new Timer(
-            30000,
+            60000,
             () => {
                 // If this event fires too often, then we should look into potential reasons why:
                 // 1. It may happen because it takes client too long to catch up, then we should consider why
@@ -81,7 +81,12 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
                 //    to client bug or server bug. We should instrument more to understand this problem better.
                 // Adding telemetry on how far client is behind (from last known seq number) at the time of
                 // connection/failure and how many ops it received on given connection would help here.
-                this.logger.sendErrorEvent({ eventName: "NoJoinOp" });
+                this.logger.sendErrorEvent({
+                    eventName: "NoJoinOp",
+                    clientId: this.pendingClientId,
+                });
+
+                // Data suggests we hit it too often. Disabling "fixup" for now
                 this.handler.triggerReconnect("NoJoinOp");
             },
         );


### PR DESCRIPTION
Newly added telemetry / recovery happens too often in our own stress tests.
Based on telemetry, event and recovery happens correctly - only when only when client is in "connecting" state for 30 seconds with "write" connection mode and there is no transition to "connected state". I.e. indeed we have not observed our own join op.
And based on auxiliary telemetry (or rather lack of it) we are not processing ops, though we need to get better telemetry here to confirm that.

So all in all, the problem is rather easy to hit in stress tests, but I have no good theory. So disabling recovery path to keep code on par with previous behavior, but keep logging and increasing it to 60 seconds to get new data. This should allow ODSP tests to run tonight undisturbed, while I use local tests to get better sense of what's going on.