### PR TITLE
Snapshot tests: Enabled GC and added ability to test snapshots created via detached container

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1134,6 +1134,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * @deprecated - Use summarize to get summary of the container runtime.
      */
     public async snapshot(): Promise<ITree> {
+        if (this.shouldRunGC) {
+            await this.collectGarbage(this.logger, true /* fullGC */);
+        }
+
         const root: ITree = { entries: [] };
         const entries = await this.dataStores.snapshot();
 

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -32,6 +32,7 @@ const [fileLocation, workerLocation] = getFileLocations();
 
 const currentSnapshots = "current_snapshots";
 const srcSnapshots = "src_snapshots";
+const baseSnapshot = "base_snapshot";
 
 const numberOfThreads = 4;
 
@@ -168,8 +169,8 @@ export async function processContent(mode: Mode, concurrently = true) {
 
         // For snapshots for documents created via detached container flow, the baseSnapshot directory contains
         // the base snapshot from which the container is to be loaded.
-        if (fs.existsSync(`${folder}/base_snapshot`)) {
-            data.baseSnapshotDir = "base_snapshot";
+        if (fs.existsSync(`${folder}/${baseSnapshot}`)) {
+            data.baseSnapshotDir = baseSnapshot;
         }
 
         switch (mode) {

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -93,7 +93,7 @@ class ConcurrencyLimiter {
  * 3. srcSnapshots - This folder contains snapshots in older versions. There is one folder for each set of snapshots
  *    in a previous version. In Mode.Validate, a container is loaded from each of these older snapshot and validated
  *    that it loads successfully.
- * 4. base_snapshot - This folder is present for snapshots from newer documents that use detached container flow. It
+ * 4. baseSnapshot - This folder is present for snapshots from newer documents that use detached container flow. It
  *    contains the base snapshot to load the container with.
  */
 export async function processOneNode(args: IWorkerArgs) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/FluidFramework/issues/6812

- Enabled GC in the snapshot flow that is used by snapshot tests.
- Added "base_snapshot" directory to reference snapshots. This contains the snapshot from which the container should load. It's usually the one created while attaching the detached container.
- Added snapshots that were created via the detached container flow and have GC enabled: https://github.com/microsoft/FluidFrameworkTestData/pull/22
- Will add README for instructions on adding new snapshots once I understand how ODSP stores ops and snapshots.