### PR TITLE
Better telemetry for fetching ops

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;
@@ -246,6 +246,8 @@ export class ParallelRequests<T> {
     }>, responseCallback: (payload: T[]) => void);
     // (undocumented)
     cancel(): void;
+    // (undocumented)
+    get canceled(): boolean;
     // (undocumented)
     run(concurrency: number): Promise<void>;
     }

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -149,13 +149,15 @@ export class OpsCache {
 
             batchNumber++;
         }
-        if (messages.length > 0) {
+
+        const duration = performance.now() - start;
+        if (messages.length > 0 || duration > 1000) {
             this.logger.sendPerformanceEvent({
                 eventName: "CacheOpsUsed",
                 from,
                 to,
                 length: messages.length,
-                duration: performance.now() - start,
+                duration,
             });
         }
         return messages;

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -871,13 +871,6 @@ export class DeltaManager
                 // connection and reconnected (likely to another box), and new socket's initial ops contains these ops.
                 assert(op.sequenceNumber === this.lastQueuedSequenceNumber, "seq#'s");
                 if (this.lastQueuedSequenceNumber >= lastExpectedOp) {
-                    this.logger.sendPerformanceEvent({
-                        reason: this.fetchReason,
-                        eventName: "ExtraStorageCall",
-                        from,
-                        to,
-                        ...this.connectionStateProps,
-                    });
                     controller.abort();
                     this._inbound.off("push", listener);
                 }

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -507,7 +507,7 @@ export function requestOps(
                 requests,
             };
             if (manager.canceled) {
-                telemetryEvent.cancel({ ...props });
+                telemetryEvent.cancel(props);
             } else {
                 telemetryEvent.end(props);
             }


### PR DESCRIPTION
**Problem statement:**

Newly added NoJoinOp telemetry event points out to a condition where ops are not processed for very long time.
Examining telemetry shows that all such cases have one thing in common - there is outstanding ops request to service that takes a long time. And in pretty much all the cases actual network request (as indicated by OpsFetch event) takes relatively short time, but overall process (GetDeltas_end) takes long time, occasionally minutes.

I believe in all these cases ops never get to storage (in reasonable time), but in majority cases client actually receives missing ops through websocket (though in all cases, read on). DeltaManager does cancel request in such case (see ExtraStorageCall event), but request is not immediately cancelled, blocking future requests (see fetchMissingDeltasCore - it allows only one outstanding call). As result, whole process does not more forward for the long time.

I do not have in-depth understanding where we get stuck in the process, but one such case is obvious waitForConnectedState() - it's possible that browser lies to us or does not quickly reacts to online/offline, which may cause process to get stuck for up to 30 seconds.

The other one more likely reason - 429s returned from SPO for fetching ops. We do not have logging for individual retryable attempts, so this goes unnoticed today.

**Fix:**
1. Make op fetching process return on cancellation immediately by listening for cancelation event.
2. Add telemetry for some sub-processes, like fetching ops from cache, if it takes longer than 1 second.
3. Remove ExtraStorageCall event as it fires on all successful fetches, and instead make core op fetching logic raise GetDeltas_cancel event instead if cancel was processed before all ops were fetched.
4. Add telemetry (logNetworkFailure in getSingleOpBatch) for individual failed fetched, such that we get insights for things like 429 that may block fetching process (but currently not visible in telemetry).

**Outcome:**
This does address many, but not all NoJoinOp issues (remaining needs to be looked deeper).
But this in turn brings back "too many retries" errors, indicating that one of the reasons we run into initial problem is due to client not being able to find relevant ops (and on top of it - not failing sooner, but hanging). These errors needs to also be looked deeper to understand if bugs are on client or server side.