### PR TITLE
QuorumProxy: move to client, adjust event lister warning limit

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -54,7 +54,6 @@ import {
 import {
     isSystemMessage,
     ProtocolOpHandler,
-    QuorumProxy,
 } from "@fluidframework/protocol-base";
 import {
     FileMode,
@@ -103,6 +102,7 @@ import { RetriableDocumentStorageService } from "./retriableDocumentStorageServi
 import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService";
 import { BlobOnlyStorage, ContainerStorageAdapter } from "./containerStorageAdapter";
 import { getSnapshotTreeFromSerializedContainer } from "./utils";
+import { QuorumProxy } from "./quorum";
 
 const detachedContainerRefSeqNumber = 0;
 

--- a/packages/loader/container-loader/src/quorum.ts
+++ b/packages/loader/container-loader/src/quorum.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { EventForwarder, doIfNotDisposed } from "@fluidframework/common-utils";
+import {
+    ICommittedProposal,
+    IQuorum,
+    IQuorumEvents,
+    ISequencedClient,
+} from "@fluidframework/protocol-definitions";
+
+/**
+ * Proxies Quorum events.
+ */
+export class QuorumProxy extends EventForwarder<IQuorumEvents> implements IQuorum {
+    public readonly propose: (key: string, value: any) => Promise<void>;
+    public readonly has: (key: string) => boolean;
+    public readonly get: (key: string) => any;
+    public readonly getApprovalData: (key: string) => ICommittedProposal | undefined;
+    public readonly getMembers: () => Map<string, ISequencedClient>;
+    public readonly getMember: (clientId: string) => ISequencedClient | undefined;
+
+    constructor(quorum: IQuorum) {
+        super(quorum);
+
+        // This is heavily used object, increase limit at which Node prints warnings.
+        super.setMaxListeners(50);
+
+        this.propose = doIfNotDisposed(this, quorum.propose.bind(quorum));
+        this.has = doIfNotDisposed(this, quorum.has.bind(quorum));
+        this.get = doIfNotDisposed(this, quorum.get.bind(quorum));
+        this.getApprovalData = doIfNotDisposed(this, quorum.getApprovalData.bind(quorum));
+        this.getMembers = doIfNotDisposed(this, quorum.getMembers.bind(quorum));
+        this.getMember = doIfNotDisposed(this, quorum.getMember.bind(quorum));
+    }
+}

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { EventForwarder } from '@fluidframework/common-utils';
 import * as git from '@fluidframework/gitresources';
 import { IAttachment } from '@fluidframework/protocol-definitions';
 import { IBlob } from '@fluidframework/protocol-definitions';
@@ -160,23 +159,6 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     snapshotValues(): IQuorumSnapshot["values"];
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
     }
-
-// @public
-export class QuorumProxy extends EventForwarder<IQuorumEvents> implements IQuorum {
-    constructor(quorum: IQuorum);
-    // (undocumented)
-    readonly get: (key: string) => any;
-    // (undocumented)
-    readonly getApprovalData: (key: string) => ICommittedProposal | undefined;
-    // (undocumented)
-    readonly getMember: (clientId: string) => ISequencedClient | undefined;
-    // (undocumented)
-    readonly getMembers: () => Map<string, ISequencedClient>;
-    // (undocumented)
-    readonly has: (key: string) => boolean;
-    // (undocumented)
-    readonly propose: (key: string, value: any) => Promise<void>;
-}
 
 // @public
 export class TreeTreeEntry {

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -6,7 +6,7 @@
 // eslint-disable-next-line import/no-internal-modules
 import cloneDeep from "lodash/cloneDeep";
 
-import { assert, Deferred, doIfNotDisposed, EventForwarder, TypedEventEmitter } from "@fluidframework/common-utils";
+import { assert, Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
     ICommittedProposal,
     IPendingProposal,
@@ -417,27 +417,5 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     public dispose(): void {
         throw new Error("Not implemented.");
         this.isDisposed = true;
-    }
-}
-
-/**
- * Proxies Quorum events.
- */
-export class QuorumProxy extends EventForwarder<IQuorumEvents> implements IQuorum {
-    public readonly propose: (key: string, value: any) => Promise<void>;
-    public readonly has: (key: string) => boolean;
-    public readonly get: (key: string) => any;
-    public readonly getApprovalData: (key: string) => ICommittedProposal | undefined;
-    public readonly getMembers: () => Map<string, ISequencedClient>;
-    public readonly getMember: (clientId: string) => ISequencedClient | undefined;
-
-    constructor(quorum: IQuorum) {
-        super(quorum);
-        this.propose = doIfNotDisposed(this, quorum.propose.bind(quorum));
-        this.has = doIfNotDisposed(this, quorum.has.bind(quorum));
-        this.get = doIfNotDisposed(this, quorum.get.bind(quorum));
-        this.getApprovalData = doIfNotDisposed(this, quorum.getApprovalData.bind(quorum));
-        this.getMembers = doIfNotDisposed(this, quorum.getMembers.bind(quorum));
-        this.getMember = doIfNotDisposed(this, quorum.getMember.bind(quorum));
     }
 }


### PR DESCRIPTION
QuorumProxy is heavily used object (as its exposed to all data stores / DDSs) and thus we do see Node warnings in various stress tests about exceeding event listener limit (of 10).

Raise this limit to 50 and move implementation to client as it does not belong on the server side.