### PR TITLE
Automatically put assert shortcodes into fluidErrorCode in normalizeError

### DIFF
--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -148,7 +148,7 @@ export function normalizeError(
     const { message, stack } = extractLogSafeErrorProperties(error, false /* sanitizeStack */);
     const fluidError: IFluidErrorBase = new SimpleFluidError({
         errorType: "genericError", // Match Container/Driver generic error type
-        fluidErrorCode: annotations.errorCodeIfNone ?? "none",
+        fluidErrorCode: computeNormalizedErrorCode(message, annotations.errorCodeIfNone),
         message,
         stack: stack ?? generateStack(),
     });
@@ -163,6 +163,13 @@ export function normalizeError(
         fluidError.addTelemetryProperties({ typeofError: typeof(error) });
     }
     return fluidError;
+}
+
+function computeNormalizedErrorCode(message: string, errorCodeIfNone: string | undefined) {
+    if (/^0x([\da-f])+$/i.exec(message) !== null) {
+        return message;
+    }
+    return errorCodeIfNone ?? "none";
 }
 
 export function generateStack(): string | undefined {

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -466,6 +466,20 @@ describe("normalizeError", () => {
                 input: undefined,
                 expectedOutput: typicalOutput("undefined", "<<generated stack>>").withExpectedTelemetryProps({ typeofError: "undefined" }),
             }),
+            "string": () => ({
+                input: "some string",
+                expectedOutput: typicalOutput("some string", "<<generated stack>>").withExpectedTelemetryProps({ typeofError: "string" }),
+            }),
+            "shortCode": () => ({
+                input: "0x123abc",
+                expectedOutput: Object.assign(
+                    typicalOutput("0x123abc", "<<generated stack>>").withExpectedTelemetryProps({ typeofError: "string" }),
+                    { fluidErrorCode: "0x123abc" }),
+            }),
+            "shortCode and other stuff": () => ({
+                input: "0x123abc plus some message",
+                expectedOutput: typicalOutput("0x123abc plus some message", "<<generated stack>>").withExpectedTelemetryProps({ typeofError: "string" }),
+            }),
             "false": () => ({
                 input: false,
                 expectedOutput: typicalOutput("false", "<<generated stack>>").withExpectedTelemetryProps({ typeofError: "boolean" }),


### PR DESCRIPTION
It will be nice to have assert shortcodes show up in the error code column in telemetry.  So when normalizing an error, if the message is exactly the format of a shortcode (with any number of digits) then copy it over.  This is safe from a privacy standpoint even if some other code is emitting error messages that are hex numbers.

Tony I know you are trying to downplay asserts, so I went with this super lightweight approach that doesn't modify the assert function.  Feels worth it to me and for minimal effort.