### PR TITLE
Fetching ops from PUSH

### DIFF
--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -34,6 +34,7 @@
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/telemetry-utils": "^0.45.0",
     "debug": "^4.1.1"
   },
   "devDependencies": {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -23,6 +23,7 @@ import {
     ScopeType,
 } from "@fluidframework/protocol-definitions";
 import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { debug } from "./debug";
 
 /**
@@ -71,6 +72,7 @@ export class DocumentDeltaConnection
      * After disconnection, we flip this to prevent any stale messages from being emitted.
      */
     protected _disposed: boolean = false;
+    protected readonly logger: ITelemetryLogger;
 
     public get details(): IConnected {
         if (!this._details) {
@@ -86,9 +88,11 @@ export class DocumentDeltaConnection
     protected constructor(
         protected readonly socket: SocketIOClient.Socket,
         public documentId: string,
-        protected readonly logger: ITelemetryLogger,
+        logger: ITelemetryLogger,
     ) {
         super();
+
+        this.logger = ChildLogger.create(logger, "DeltaConnection");
 
         this.submitManager = new BatchManager<IDocumentMessage[]>(
             (submitType, work) => {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -88,7 +88,7 @@ export class OdspDocumentService implements IDocumentService {
 
     private _opsCache?: OpsCache;
 
-    private currentConnection?: OdspDocumentDeltaConnection = undefined;
+    private currentConnection?: OdspDocumentDeltaConnection;
 
     /**
      * @param odspResolvedUrl - resolved url identifying document that will be managed by this service instance.


### PR DESCRIPTION
Implementing solution described in https://github.com/microsoft/FluidFramework/issues/6685.

After implementing https://github.com/microsoft/FluidFramework/pull/6947, the client hits again "too many retries" issue (critical failure due to client not being able to get ops within 30 seconds).
With this PR, client always asks PUSH for any missing ops in parallel to fetching same ops from storage and/or local cache.
This reduces number of cases when we get "too many retries", but does not eliminate it.

I've added minimum telemetry, but most request can be tracked by tracking storage request telemetry, as every call will be duplicated to PUSH if there is active connection.

Flow can be optimized further by
1. Not asking PUSH for ops ranges that are preceding first op on socket
2. Ask for ops in sequence (not in parallel), in order of local cache / PUSH / storage.

This PR (in current form) should unblock further investigations and understanding of "too many retries" problem, but also allow PUSH to be simpler (if needed / desired) by eliminating various work arounds, if we chose to go that route.
Or, if we chose for PUSH to provide stronger guarantees and ensure ops are always coming in order, than lack of hits for newly added telemetry will allow us to remove this code and have confidence it's not needed.