### PR TITLE
Fix ordered client election loggers

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -896,13 +896,14 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.IFluidHandleContext,
             this.summaryCollection);
 
+        const orderedClientLogger = ChildLogger.create(this.logger, "OrderedClientElection");
         const orderedClientCollection = new OrderedClientCollection(
-            this.logger,
+            orderedClientLogger,
             this.context.deltaManager,
             this.context.quorum,
         );
         const orderedClientElectionForSummarizer = new OrderedClientElection(
-            this.logger,
+            orderedClientLogger,
             orderedClientCollection,
             electedSummarizerData ?? this.context.deltaManager.lastSequenceNumber,
             SummarizerClientElection.isClientEligible,
@@ -910,7 +911,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const summarizerClientElectionEnabled = getLocalStorageFeatureGate("summarizerClientElection") ??
             this.runtimeOptions.summaryOptions?.summarizerClientElection === true;
         this.summarizerClientElection = new SummarizerClientElection(
-            this.logger,
+            orderedClientLogger,
             this.summaryCollection,
             orderedClientElectionForSummarizer,
             maxOpsSinceLastSummary,
@@ -918,7 +919,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         );
         // Only create a SummaryManager if summaries are enabled and we are not the summarizer client
         if (this.runtimeOptions.summaryOptions.generateSummaries === false) {
-            this.logger.sendTelemetryEvent({ eventName: "SummariesDisabled" });
+            this._logger.sendTelemetryEvent({ eventName: "SummariesDisabled" });
         }
         if (
             this.runtimeOptions.summaryOptions.generateSummaries !== false

--- a/packages/runtime/container-runtime/src/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/orderedClientElection.ts
@@ -281,14 +281,18 @@ export class OrderedClientElection
                 // Cannot find initially elected client, so elect undefined.
                 logger.sendErrorEvent({
                     eventName: "InitialElectedClientNotFound",
-                    clientId: initialState.electedClientId,
+                    electionSequenceNumber: initialState.electionSequenceNumber,
+                    expectedClientId: initialState.electedClientId,
+                    electedClientId: initialClient?.clientId,
+                    clientCount: orderedClientCollection.count,
                 });
             } else if (initialClient !== undefined && !isEligibleFn(initialClient)) {
                 // Initially elected client is ineligible, so elect next eligible client.
                 initialClient = this.findFirstEligibleClient(initialClient);
                 logger.sendErrorEvent({
                     eventName: "InitialElectedClientIneligible",
-                    clientId: initialState.electedClientId,
+                    electionSequenceNumber: initialState.electionSequenceNumber,
+                    expectedClientId: initialState.electedClientId,
                     electedClientId: initialClient?.clientId,
                 });
             }


### PR DESCRIPTION
As part of #6948

Use a new "OrderedClientElection" child logger for OrderedClientCollection, OrderedClientElection, and SummarizerClientElection instances.

Add several properties to help troubleshoot "InitialElectedClientNotFound" and "InitialElectedClientIneligible" events.

Also fix recently moved "SummariesDisabled" event to use the ContainerRuntime _logger instead of the base logger, so the event should shift from:
"fluid:telemetry:SummariesDisabled" to "fluid:telemetry:ContainerRuntime:SummariesDisabled".