### PR TITLE
Move webpack-fluid-loader to @fluid-tools scope

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,7 @@
 - [Changes to PureDataObject](#changes-to-PureDataObject)
 - [Changes to DataObject](#changes-to-DataObject)
 - [Changes to PureDataObjectFactory](#changes-to-PureDataObjectFactory)
+- [webpack-fluid-loader package name changed](#webpack-fluid-loader-package-name-changed)
 
 ### Changes to local testing in insecure environments
 Previously the `@fluidframework/common-utils` package exposed a `setInsecureContextHashFn` function so users could set an override when testing locally in insecure environments because the `crypto.subtle` library is not available.  This is now done automatically as a fallback and the function is removed.
@@ -23,6 +24,9 @@ Previously the `@fluidframework/common-utils` package exposed a `setInsecureCont
 
 ### Changes to PureDataObjectFactory
 - The `createDataObject` in `PureDataObjectFactory` has a mandatory `existing` parameter to differentiate creating vs loading.
+
+### `webpack-fluid-loader` package name changed
+The `webpack-fluid-loader` utility was previously available from a package named `@fluidframework/webpack-fluid-loader`.  However, since it is intended as an example tool not for use in production, it is now available under the tools scope `@fluid-tools/webpack-fluid-loader`.
 
 ## 0.44 Breaking changes
 - [Property removed from ContainerRuntime class](#Property-removed-from-the-ContainerRuntime-class)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -26,7 +26,7 @@ Previously the `@fluidframework/common-utils` package exposed a `setInsecureCont
 - The `createDataObject` in `PureDataObjectFactory` has a mandatory `existing` parameter to differentiate creating vs loading.
 
 ### `webpack-fluid-loader` package name changed
-The `webpack-fluid-loader` utility was previously available from a package named `@fluidframework/webpack-fluid-loader`.  However, since it is intended as an example tool not for use in production, it is now available under the tools scope `@fluid-tools/webpack-fluid-loader`.
+The `webpack-fluid-loader` utility was previously available from a package named `@fluidframework/webpack-fluid-loader`.  However, since it is a tool and should not be used in production, it is now available under the tools scope `@fluid-tools/webpack-fluid-loader`.
 
 ## 0.44 Breaking changes
 - [Property removed from ContainerRuntime class](#Property-removed-from-the-ContainerRuntime-class)

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -46,10 +46,10 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/collaborative-textarea/webpack.config.js
+++ b/examples/apps/collaborative-textarea/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -47,9 +47,9 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/badge/webpack.config.js
+++ b/examples/data-objects/badge/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -44,10 +44,10 @@
     "@fluidframework/view-interfaces": "^0.45.0"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/canvas/webpack.config.js
+++ b/examples/data-objects/canvas/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -43,10 +43,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-context/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-context/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -43,10 +43,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-function/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-function/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -45,10 +45,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-react/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-react/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -44,10 +44,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-reducer/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-reducer/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -44,10 +44,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker-react/clicker-with-hook/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-with-hook/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -47,10 +47,10 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker/webpack.config.js
+++ b/examples/data-objects/clicker/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -52,9 +52,9 @@
     "codemirror": "^5.48.4"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/codemirror/webpack.config.js
+++ b/examples/data-objects/codemirror/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -45,10 +45,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/diceroller/webpack.config.js
+++ b/examples/data-objects/diceroller/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -41,8 +41,8 @@
     "react-image-gallery": "^0.9.1"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluid-tools/webpack-fluid-loader": "^0.45.0",
+    "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/image-gallery/webpack.config.js
+++ b/examples/data-objects/image-gallery/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -46,9 +46,9 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/key-value-cache/webpack.config.js
+++ b/examples/data-objects/key-value-cache/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -46,9 +46,9 @@
     "monaco-editor": "^0.15.6"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/monaco/webpack.config.js
+++ b/examples/data-objects/monaco/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require('path');
 const merge = require('webpack-merge');
 // const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -44,10 +44,10 @@
     "@fluidframework/map": "^0.45.0"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/constellation-model/webpack.config.js
+++ b/examples/data-objects/multiview/constellation-model/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -42,10 +42,10 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/constellation-view/webpack.config.js
+++ b/examples/data-objects/multiview/constellation-view/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -53,10 +53,10 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/container/webpack.config.js
+++ b/examples/data-objects/multiview/container/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -42,10 +42,10 @@
     "@fluidframework/map": "^0.45.0"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/coordinate-model/webpack.config.js
+++ b/examples/data-objects/multiview/coordinate-model/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -41,10 +41,10 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/webpack.config.js
+++ b/examples/data-objects/multiview/plot-coordinate-view/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -41,10 +41,10 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/slider-coordinate-view/webpack.config.js
+++ b/examples/data-objects/multiview/slider-coordinate-view/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -41,10 +41,10 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/triangle-view/webpack.config.js
+++ b/examples/data-objects/multiview/triangle-view/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -47,7 +47,7 @@
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/babel__core": "^7",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -45,9 +45,9 @@
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/babel__core": "^7",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/musica/webpack.config.js
+++ b/examples/data-objects/musica/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require('path');
 const merge = require('webpack-merge');
 

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -51,10 +51,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/pond/webpack.config.js
+++ b/examples/data-objects/pond/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -42,9 +42,9 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/primitives/webpack.config.js
+++ b/examples/data-objects/primitives/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/orderedmap": "^1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -66,9 +66,9 @@
     "prosemirror-view": "^1.10.3"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/orderedmap": "^1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/prosemirror/webpack.config.js
+++ b/examples/data-objects/prosemirror/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/async": "^3.2.6",
     "@types/lodash": "^4.14.118",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -59,9 +59,9 @@
     "url-loader": "^2.1.0"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/async": "^3.2.6",
     "@types/lodash": "^4.14.118",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/scribe/webpack.config.js
+++ b/examples/data-objects/scribe/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -78,9 +78,9 @@
     "url-loader": "^2.1.0"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/shared-text/webpack.config.js
+++ b/examples/data-objects/shared-text/webpack.config.js
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 const pkg = require("./package.json");

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -41,8 +41,8 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluid-tools/webpack-fluid-loader": "^0.45.0",
+    "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/simple-fluidobject-embed/webpack.config.js
+++ b/examples/data-objects/simple-fluidobject-embed/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -51,9 +51,9 @@
     "simplemde": "^1.11.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/marked": "^2.0.2",
     "@types/node": "^12.19.0",
     "@types/simplemde": "^1.11.7",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/marked": "^2.0.2",
     "@types/node": "^12.19.0",
     "@types/simplemde": "^1.11.7",

--- a/examples/data-objects/smde/webpack.config.js
+++ b/examples/data-objects/smde/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -50,9 +50,9 @@
     "url-loader": "^2.1.0"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/table-view/webpack.config.js
+++ b/examples/data-objects/table-view/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -53,10 +53,10 @@
     "source-map-loader": "^0.2.4"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/todo/webpack.config.js
+++ b/examples/data-objects/todo/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -60,10 +60,10 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",

--- a/examples/data-objects/vltava/webpack.config.js
+++ b/examples/data-objects/vltava/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -88,7 +88,7 @@
     "@fluidframework/runtime-utils": "^0.45.0",
     "@fluidframework/test-utils": "^0.45.0",
     "@fluidframework/test-version-utils": "^0.45.0",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -82,13 +82,13 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.45.0",
     "@fluidframework/runtime-utils": "^0.45.0",
     "@fluidframework/test-utils": "^0.45.0",
     "@fluidframework/test-version-utils": "^0.45.0",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",

--- a/examples/data-objects/webflow/webpack.config.js
+++ b/examples/data-objects/webflow/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -49,10 +49,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/experimental/examples/bubblebench/baseline/webpack.config.js
+++ b/experimental/examples/bubblebench/baseline/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -51,10 +51,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/experimental/examples/bubblebench/ot/webpack.config.js
+++ b/experimental/examples/bubblebench/ot/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -53,7 +53,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/webpack-fluid-loader": "^0.45.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -50,10 +50,10 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
+    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluid-tools/webpack-fluid-loader": "^0.45.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/experimental/examples/bubblebench/sharedtree/webpack.config.js
+++ b/experimental/examples/bubblebench/sharedtree/webpack.config.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const merge = require("webpack-merge");
 

--- a/packages/tools/webpack-fluid-loader/README.md
+++ b/packages/tools/webpack-fluid-loader/README.md
@@ -1,4 +1,4 @@
-# @fluidframework/webpack-fluid-loader
+# @fluid-tools/webpack-fluid-loader
 
 This folder contains the webpack-fluid-loader. This package is meant to be used with the webpack-dev-server and is used by yo Fluid as the default `start` option.
 

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fluidframework/webpack-fluid-loader",
+  "name": "@fluid-tools/webpack-fluid-loader",
   "version": "0.45.0",
   "description": "Fluid object loader for webpack-dev-server",
   "homepage": "https://fluidframework.com",

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -282,7 +282,7 @@ const fluid = (req: express.Request, res: express.Response, baseDir: string, opt
     <div id="content" style="min-height: 100%;">
     </div>
 
-    <script src="/node_modules/@fluidframework/webpack-fluid-loader/dist/fluid-loader.bundle.js"></script>
+    <script src="/node_modules/@fluid-tools/webpack-fluid-loader/dist/fluid-loader.bundle.js"></script>
     ${packageJson.fluid.browser.umd.files.map((file) => `<script src="/${file}"></script>\n`)}
     <script>
         var pkgJson = ${JSON.stringify(packageJson)};

--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -241,7 +241,7 @@
                     "@fluid-internal/test-dds-utils",
                     "@fluidframework/local-driver",
                     "@fluidframework/test-runtime-utils",
-                    "@fluidframework/webpack-fluid-loader"
+                    "@fluid-tools/webpack-fluid-loader"
                 ],
                 "dirs": [
                     "packages/test/"

--- a/tools/generator-fluid/app/templates/package.json
+++ b/tools/generator-fluid/app/templates/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^16.8.3"
   },
   "devDependencies": {
-    "@fluid-tools/webpack-fluid-loader": "^0.26.0",
+    "@fluidframework/webpack-fluid-loader": "^0.26.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/tools/generator-fluid/app/templates/package.json
+++ b/tools/generator-fluid/app/templates/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^16.8.3"
   },
   "devDependencies": {
-    "@fluidframework/webpack-fluid-loader": "^0.26.0",
+    "@fluid-tools/webpack-fluid-loader": "^0.26.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",
     "@types/jest-environment-puppeteer": "2.2.0",

--- a/tools/generator-fluid/app/templates/webpack.config.js
+++ b/tools/generator-fluid/app/templates/webpack.config.js
@@ -1,4 +1,4 @@
-const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
+const fluidRoute = require("@fluidframework/webpack-fluid-loader");
 const path = require("path");
 
 const pkg = require("./package.json");

--- a/tools/generator-fluid/app/templates/webpack.config.js
+++ b/tools/generator-fluid/app/templates/webpack.config.js
@@ -1,4 +1,4 @@
-const fluidRoute = require("@fluidframework/webpack-fluid-loader");
+const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 
 const pkg = require("./package.json");


### PR DESCRIPTION
Fixes #6914

This change moves webpack-fluid-loader under the @fluid-tools scope (as it is only intended for use in internal examples).