### PR TITLE
Removing legacy container creation path from snapshot tests and `container.load()` - work in progress

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -262,8 +262,6 @@ export interface IContainerConfig {
 export interface IContainerLoadOptions {
     canReconnect?: boolean;
     clientDetailsOverride?: IClientDetails;
-    // @deprecated
-    createOnLoad?: boolean;
     loadMode?: IContainerLoadMode;
     // (undocumented)
     resolvedUrl: IFluidResolvedUrl;
@@ -318,9 +316,6 @@ export interface ILoaderServices {
     readonly subLogger: ITelemetryLogger;
     readonly urlResolver: IUrlResolver;
 }
-
-// @public @deprecated
-export const LegacyCreateOnLoadEnvironmentKey = "enable-legacy-create-on-load";
 
 // @public
 export class Loader implements IHostLoader {

--- a/packages/drivers/file-driver/src/fileDocumentService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentService.ts
@@ -3,7 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import * as api from "@fluidframework/driver-definitions";
+import {
+    IDocumentDeltaConnection,
+    IDocumentDeltaStorageService,
+    IDocumentService,
+    IDocumentStorageService,
+    IFluidResolvedUrl,
+} from "@fluidframework/driver-definitions";
 import { IClient } from "@fluidframework/protocol-definitions";
 import { FileDeltaStorageService } from "./fileDeltaStorageService";
 
@@ -11,25 +17,22 @@ import { FileDeltaStorageService } from "./fileDeltaStorageService";
  * The DocumentService manages the different endpoints for connecting to
  * underlying storage for file document service.
  */
-export class FileDocumentService implements api.IDocumentService {
+export class FileDocumentService implements IDocumentService {
     constructor(
-        private readonly storage: api.IDocumentStorageService,
+        private readonly storage: IDocumentStorageService,
         private readonly deltaStorage: FileDeltaStorageService,
-        private readonly deltaConnection: api.IDocumentDeltaConnection) {
+        private readonly deltaConnection: IDocumentDeltaConnection,
+        public readonly resolvedUrl: IFluidResolvedUrl,
+    ) {
     }
 
     public dispose() {}
 
-    // TODO: Issue-2109 Implement detach container api or put appropriate comment.
-    public get resolvedUrl(): api.IResolvedUrl {
-        throw new Error("Not implemented");
-    }
-
-    public async connectToStorage(): Promise<api.IDocumentStorageService> {
+    public async connectToStorage(): Promise<IDocumentStorageService> {
         return this.storage;
     }
 
-    public async connectToDeltaStorage(): Promise<api.IDocumentDeltaStorageService> {
+    public async connectToDeltaStorage(): Promise<IDocumentDeltaStorageService> {
         return this.deltaStorage;
     }
 
@@ -37,11 +40,10 @@ export class FileDocumentService implements api.IDocumentService {
      * Connects to a delta storage endpoint of provided documentService to get ops and then replaying
      * them so as to mimic a delta stream endpoint.
      *
-     * @param client - Client that connects to socket.
+     * @param _client - Client that connects to socket.
      * @returns returns the delta stream service.
      */
-    public async connectToDeltaStream(
-        client: IClient): Promise<api.IDocumentDeltaConnection> {
+    public async connectToDeltaStream(_client: IClient): Promise<IDocumentDeltaConnection> {
         return this.deltaConnection;
     }
 }

--- a/packages/drivers/file-driver/src/fileDocumentServiceFactory.ts
+++ b/packages/drivers/file-driver/src/fileDocumentServiceFactory.ts
@@ -8,10 +8,13 @@ import {
     IDocumentService,
     IDocumentServiceFactory,
     IDocumentStorageService,
+    IFluidResolvedUrl,
     IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import { assert } from "@fluidframework/common-utils";
+import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { FileDeltaStorageService } from "./fileDeltaStorageService";
 import { FileDocumentService } from "./fileDocumentService";
 
@@ -24,7 +27,9 @@ export class FileDocumentServiceFactory implements IDocumentServiceFactory {
     constructor(
         private readonly storage: IDocumentStorageService,
         private readonly deltaStorage: FileDeltaStorageService,
-        private readonly deltaConnection: IDocumentDeltaConnection) {
+        private readonly deltaConnection: IDocumentDeltaConnection,
+        private readonly resolvedUrl: IFluidResolvedUrl,
+    ) {
     }
 
     /**
@@ -37,15 +42,16 @@ export class FileDocumentServiceFactory implements IDocumentServiceFactory {
         fileURL: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService> {
-        return new FileDocumentService(this.storage, this.deltaStorage, this.deltaConnection);
+        return new FileDocumentService(this.storage, this.deltaStorage, this.deltaConnection, this.resolvedUrl);
     }
 
-    // TODO: Issue-2109 Implement detach container api or put appropriate comment.
     public async createContainer(
         createNewSummary: ISummaryTree,
         resolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService> {
-        throw new Error("Not implemented");
+        ensureFluidResolvedUrl(resolvedUrl);
+        assert(!!createNewSummary, "create empty file not supported");
+        return this.createDocumentService(resolvedUrl, logger);
     }
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -127,13 +127,6 @@ export interface IContainerLoadOptions {
      * Loads the Container in paused state if true, unpaused otherwise.
      */
     loadMode?: IContainerLoadMode;
-    /**
-     * Create the container on load, without an existing snapshot.
-     * Used only for supporting legacy scenarios.
-     *
-     * @deprecated - avoid using this flow, this property is only for temporarily supporting a legacy scenario.
-     */
-    createOnLoad?: boolean;
 }
 
 export interface IContainerConfig {
@@ -326,7 +319,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 };
                 container.on("closed", onClosed);
 
-                container.load(version, mode, pendingLocalState, loadOptions.createOnLoad)
+                container.load(version, mode, pendingLocalState)
                     .finally(() => {
                         container.removeListener("closed", onClosed);
                     })
@@ -1127,14 +1120,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * @param specifiedVersion - one of the following
      *   - undefined - fetch latest snapshot
      *   - otherwise, version sha to load snapshot
-     * @param createIfNotExisting - create the container when there is no container to load.
-     *        Avoid using this flag, its goal is temporarily supporting a legacy scenario.
      */
     private async load(
         specifiedVersion: string | undefined,
         loadMode: IContainerLoadMode,
         pendingLocalState?: unknown,
-        createIfNotExisting?: boolean,
     ) {
         if (this._resolvedUrl === undefined) {
             throw new Error("Attempting to load without a resolved url");
@@ -1166,6 +1156,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         // Fetch specified snapshot.
         const { snapshot, versionId } = await this.fetchSnapshotTree(specifiedVersion);
+        assert(snapshot !== undefined, "Snapshot should exist");
 
         const attributes = await this.getDocumentAttributes(this.storageService, snapshot);
 
@@ -1178,53 +1169,34 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.loadAndInitializeProtocolState(attributes, this.storageService, snapshot);
 
         let opsBeforeReturnP: Promise<void> | undefined;
-
-        // Initialize document details - if loading a snapshot use that - otherwise we need to wait on
-        // the initial details
-        let existing = true;
-        if (snapshot !== undefined) {
-            switch (loadMode.opsBeforeReturn) {
-                case undefined:
-                    if (loadMode.deltaConnection !== "none") {
-                        // Start prefetch, but not set opsBeforeReturnP - boot is not blocked by it!
-                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                        this._deltaManager.preFetchOps(false);
-                    }
-                    break;
-                case "cached":
-                    opsBeforeReturnP = this._deltaManager.preFetchOps(true);
-                    // Keep going with fetching ops from storage once we have all cached ops in.
-                    // Ops processing will start once cached ops are in and and will stop when queue is empty
-                    // (which in most cases will happen when we are done processing cached ops)
+        switch (loadMode.opsBeforeReturn) {
+            case undefined:
+                if (loadMode.deltaConnection !== "none") {
+                    // Start prefetch, but not set opsBeforeReturnP - boot is not blocked by it!
                     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    opsBeforeReturnP.then(async () => this._deltaManager.preFetchOps(false));
-                    break;
-                case "all":
-                    opsBeforeReturnP = this._deltaManager.preFetchOps(false);
-                    break;
-                default:
-                    unreachableCase(loadMode.opsBeforeReturn);
-            }
-        } else {
-            //
-            // THIS IS LEGACY PATH
-            // The code is maintained for the snapshot back compat tests
-            //
-            assert(createIfNotExisting === true, 0x1fb /* "Snapshot should already exist" */);
-
-            if (startConnectionP === undefined) {
-                startConnectionP = this.connectToDeltaStream(connectionArgs);
-            }
-            // Intentionally don't .catch on this promise - we'll let any error throw below in the await.
-            const details = await startConnectionP;
-            existing = details.existing;
+                    this._deltaManager.preFetchOps(false);
+                }
+                break;
+            case "cached":
+                opsBeforeReturnP = this._deltaManager.preFetchOps(true);
+                // Keep going with fetching ops from storage once we have all cached ops in.
+                // Ops processing will start once cached ops are in and and will stop when queue is empty
+                // (which in most cases will happen when we are done processing cached ops)
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                opsBeforeReturnP.then(async () => this._deltaManager.preFetchOps(false));
+                break;
+            case "all":
+                opsBeforeReturnP = this._deltaManager.preFetchOps(false);
+                break;
+            default:
+                unreachableCase(loadMode.opsBeforeReturn);
         }
 
         this._protocolHandler = await protocolHandlerP;
 
         const codeDetails = this.getCodeDetailsFromQuorum();
         await this.instantiateContext(
-            existing,
+            true, // existing
             codeDetails,
             snapshot,
             pendingLocalState,
@@ -1807,7 +1779,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         Promise<{snapshot?: ISnapshotTree; versionId?: string}>
     {
         const version = await this.getVersion(specifiedVersion ?? this.id);
-
         if (version === undefined && specifiedVersion !== undefined) {
             // We should have a defined version to load from if specified version requested
             this.logger.sendErrorEvent({ eventName: "NoVersionFoundWhenSpecified", id: specifiedVersion });

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -264,14 +264,6 @@ export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | 
     size: number;
  };
 
- /**
- * To be included in the `IClientDetails.environment` value for the `IRequest` header
- * if the client must be able to create a container at load when an existing container is not available.
- *
- * @deprecated - avoid using this flow, this key is only for temporarily supporting a legacy scenario.
- */
-export const LegacyCreateOnLoadEnvironmentKey = "enable-legacy-create-on-load";
-
 /**
  * Manages Fluid resource loading
  */
@@ -500,10 +492,6 @@ export class Loader implements IHostLoader {
                 resolvedUrl: resolved,
                 version: request.headers?.[LoaderHeader.version] ?? undefined,
                 loadMode: request.headers?.[LoaderHeader.loadMode],
-                createOnLoad: request.headers
-                    ?.[LoaderHeader.clientDetails]
-                    ?.environment
-                    ?.includes(LegacyCreateOnLoadEnvironmentKey),
             },
             pendingLocalState,
         );


### PR DESCRIPTION
See #3429