### PR TITLE
Integrate new binary snapshot format in odsp driver

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -18,6 +18,7 @@ export interface HostStoragePolicy {
     concurrentSnapshotFetch?: boolean;
     // (undocumented)
     enableRedeemFallback?: boolean;
+    fetchBinarySnapshotFormat?: boolean;
     // (undocumented)
     opsBatchSize?: number;
     opsCaching?: IOpsCachingPolicy;

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -129,7 +129,7 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
 }
 
 // @public
-export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean): Promise<boolean>;
+export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, fetchBinarySnapshotFormat?: boolean): Promise<boolean>;
 
 // @public
 export interface ShareLinkFetcherProps {

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -93,5 +93,10 @@ export interface HostStoragePolicy {
     /**
      * Policy controlling if we will cache initial summary when we create a document
      */
-     cacheCreateNewSummary?: boolean;
+    cacheCreateNewSummary?: boolean;
+
+    /**
+     * Policy controlling if we want to fetch binary format snapshot.
+     */
+    fetchBinarySnapshotFormat?: boolean;
 }

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -4,8 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { ISequencedDeltaOpMessage } from "./contracts";
+import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { ISnapshotContents } from "./odspUtils";
 import { ReadBuffer } from "./ReadBufferUtils";
 import { BlobCore, getAndValidateNodeProps, NodeCore, TreeBuilder } from "./zipItDataRepresentationUtils";
@@ -84,7 +83,7 @@ function readBlobSection(node: NodeCore, dictionary: string[]) {
  * @param node - tree node to read ops section from
  */
 function readOpsSection(node: NodeCore) {
-    const ops: ISequencedDeltaOpMessage[] = [];
+    const ops: ISequencedDocumentMessage[] = [];
     for (let i = 0; i < node.length; ++i) {
         ops.push(JSON.parse(node.getString(i)));
     }
@@ -126,7 +125,7 @@ function readTreeSection(treeNode: NodeCore, dictionary: string[]) {
  */
 export function parseCompactSnapshotResponse(buffer: ReadBuffer): ISnapshotContents {
     const builder = TreeBuilder.load(buffer);
-    let ops: ISequencedDeltaOpMessage[] | undefined;
+    let ops: ISequencedDocumentMessage[] | undefined;
 
     assert(builder.length === 1, "1 root should be there");
     const root = builder.getNode(0);

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -6,7 +6,6 @@
 import { assert, stringToBuffer } from "@fluidframework/common-utils";
 import { IBlob, ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { snapshotMinReadVersion } from "./compactSnapshotParser";
-import { ISequencedDeltaOpMessage } from "./contracts";
 import { ISnapshotContents } from "./odspUtils";
 import { ReadBuffer } from "./ReadBufferUtils";
 import { TreeBuilderSerializer } from "./WriteBufferUtils";
@@ -84,7 +83,7 @@ function writeBlobsSection(node: NodeCore, blobs: Map<string, IBlob | ArrayBuffe
  * @param node - node to serialize to.
  * @param ops - ops that is being serialized
 */
-function writeOpsSection(node: NodeCore, ops: ISequencedDeltaOpMessage[] | ISequencedDocumentMessage[]) {
+function writeOpsSection(node: NodeCore, ops: ISequencedDocumentMessage[]) {
     ops.forEach((op) => {
         node.addString(JSON.stringify(op));
     });

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert, stringToBuffer } from "@fluidframework/common-utils";
-import { IBlob, ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { IBlob, ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { snapshotMinReadVersion } from "./compactSnapshotParser";
 import { ISequencedDeltaOpMessage } from "./contracts";
 import { ISnapshotContents } from "./odspUtils";
@@ -84,7 +84,7 @@ function writeBlobsSection(node: NodeCore, blobs: Map<string, IBlob | ArrayBuffe
  * @param node - node to serialize to.
  * @param ops - ops that is being serialized
 */
-function writeOpsSection(node: NodeCore, ops: ISequencedDeltaOpMessage[]) {
+function writeOpsSection(node: NodeCore, ops: ISequencedDeltaOpMessage[] | ISequencedDocumentMessage[]) {
     ops.forEach((op) => {
         node.addString(JSON.stringify(op));
     });

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -87,7 +87,6 @@ export async function fetchSnapshotWithRedeem(
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
     removeEntries: () => Promise<void>,
     enableRedeemFallback?: boolean,
-    fetchBinarySnapshotFormat?: boolean,
 ): Promise<ISnapshotContents> {
     return fetchLatestSnapshotCore(
         odspResolvedUrl,
@@ -96,7 +95,6 @@ export async function fetchSnapshotWithRedeem(
         logger,
         snapshotDownloader,
         putInCache,
-        fetchBinarySnapshotFormat,
     ).catch(async (error) => {
         if (enableRedeemFallback && isRedeemSharingLinkError(odspResolvedUrl, error)) {
             // Execute the redeem fallback
@@ -114,7 +112,6 @@ export async function fetchSnapshotWithRedeem(
                 logger,
                 snapshotDownloader,
                 putInCache,
-                fetchBinarySnapshotFormat,
             );
         } else {
             throw error;
@@ -165,7 +162,6 @@ async function fetchLatestSnapshotCore(
             controller?: AbortController,
         ) => Promise<ISnapshotRequestAndResponseOptions>,
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
-    fetchBinarySnapshotFormat?: boolean,
 ): Promise<ISnapshotContents> {
     return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
         if (tokenFetchOptions.refresh) {

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -15,6 +15,7 @@ import {
     TokenFetchOptions,
     OdspErrorType,
 } from "@fluidframework/odsp-driver-definitions";
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { IOdspSnapshot, IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
@@ -26,6 +27,8 @@ import {
     ISnapshotContents,
 } from "./odspUtils";
 import { convertOdspSnapshotToSnapsohtTreeAndBlobs } from "./odspSnapshotParser";
+import { parseCompactSnapshotResponse } from "./compactSnapshotParser";
+import { ReadBuffer } from "./ReadBufferUtils";
 
 /**
  * Fetches a snapshot from the server with a given version id.
@@ -77,6 +80,7 @@ export async function fetchSnapshotWithRedeem(
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
     removeEntries: () => Promise<void>,
     enableRedeemFallback?: boolean,
+    fetchBinarySnapshotFormat?: boolean,
 ): Promise<ISnapshotContents> {
     return fetchLatestSnapshotCore(
         odspResolvedUrl,
@@ -85,6 +89,7 @@ export async function fetchSnapshotWithRedeem(
         logger,
         snapshotDownloader,
         putInCache,
+        fetchBinarySnapshotFormat,
     ).catch(async (error) => {
         if (enableRedeemFallback && isRedeemSharingLinkError(odspResolvedUrl, error)) {
             // Execute the redeem fallback
@@ -102,6 +107,7 @@ export async function fetchSnapshotWithRedeem(
                 logger,
                 snapshotDownloader,
                 putInCache,
+                fetchBinarySnapshotFormat,
             );
         } else {
             throw error;
@@ -147,6 +153,7 @@ async function fetchLatestSnapshotCore(
     logger: ITelemetryLogger,
     snapshotDownloader: (url: string, fetchOptions: {[index: string]: any}) => Promise<IOdspResponse<unknown>>,
     putInCache: (valueWithEpoch: IVersionedValueWithEpoch) => Promise<void>,
+    fetchBinarySnapshotFormat?: boolean,
 ): Promise<ISnapshotContents> {
     return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
         if (tokenFetchOptions.refresh) {
@@ -161,33 +168,8 @@ async function fetchLatestSnapshotCore(
                 errorType: "access denied",
             }, tokenFetchOptions.previousError);
         }
-        const snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
-        const url = `${snapshotUrl}/trees/latest?ump=1`;
         const storageToken = await storageTokenFetcher(tokenFetchOptions, "TreesLatest");
         assert(storageToken !== null, 0x1e5 /* "Storage token should not be null" */);
-        const formBoundary = uuid();
-        const formParams: string[] = [];
-        formParams.push(`--${formBoundary}`);
-        formParams.push(`Authorization: Bearer ${storageToken}`);
-        formParams.push(`X-HTTP-Method-Override: GET`);
-        const logOptions = {};
-        if (snapshotOptions !== undefined) {
-            Object.entries(snapshotOptions).forEach(([key, value]) => {
-                if (value !== undefined) {
-                    formParams.push(`${key}: ${value}`);
-                    logOptions[`snapshotOption_${key}`] = value;
-                }
-            });
-        }
-        if (odspResolvedUrl.sharingLinkToRedeem) {
-            formParams.push(`sl: ${odspResolvedUrl.sharingLinkToRedeem}`);
-        }
-        formParams.push(`_post: 1`);
-        formParams.push(`\r\n--${formBoundary}--`);
-        const postBody = formParams.join("\r\n");
-        const headers: {[index: string]: any} = {
-            "Content-Type": `multipart/form-data;boundary=${formBoundary}`,
-        };
 
         let controller: AbortController | undefined;
         if (snapshotOptions?.timeout !== undefined) {
@@ -197,7 +179,14 @@ async function fetchLatestSnapshotCore(
                 snapshotOptions.timeout,
             );
         }
-
+        const logOptions = {};
+        if (snapshotOptions !== undefined) {
+            Object.entries(snapshotOptions).forEach(([key, value]) => {
+                if (value !== undefined) {
+                    logOptions[`snapshotOption_${key}`] = value;
+                }
+            });
+        }
         // This event measures only successful cases of getLatest call (no tokens, no retries).
         return PerformanceEvent.timedExecAsync(
             logger,
@@ -207,18 +196,22 @@ async function fetchLatestSnapshotCore(
             },
             async (event) => {
                 const startTime = performance.now();
-                const response = await snapshotDownloader(
-                    url,
-                    {
-                        body: postBody,
-                        headers,
-                        signal: controller?.signal,
-                        method: "POST",
-                    },
-                ) as IOdspResponse<IOdspSnapshot>;
+                const response = fetchBinarySnapshotFormat ? await fetchSnapshotContentsCoreV2(
+                    odspResolvedUrl,
+                    storageToken,
+                    snapshotOptions,
+                    snapshotDownloader,
+                    controller,
+                ) : await fetchSnapshotContentsCoreV1(
+                    odspResolvedUrl,
+                    storageToken,
+                    snapshotOptions,
+                    snapshotDownloader,
+                    controller,
+                );
                 const endTime = performance.now();
                 const overallTime = endTime - startTime;
-                const snapshot = convertOdspSnapshotToSnapsohtTreeAndBlobs(response.content);
+                const snapshot = response.response.content;
                 let dnstime: number | undefined; // domainLookupEnd - domainLookupStart
                 let redirectTime: number | undefined; // redirectEnd -redirectStart
                 let tcpHandshakeTime: number | undefined; // connectEnd  - connectStart
@@ -227,7 +220,7 @@ async function fetchLatestSnapshotCore(
                 let fetchStToRespEndTime: number | undefined; // responseEnd  - fetchStart
                 let reqStToRespEndTime: number | undefined; // responseEnd - requestStart
                 let networkTime: number | undefined; // responseEnd - startTime
-                const spReqDuration = response.headers.get("sprequestduration");
+                const spReqDuration = response.response.headers.get("sprequestduration");
 
                 // getEntriesByType is only available in browser performance object
                 const resources1 = performance.getEntriesByType?.("resource") ?? [];
@@ -237,7 +230,7 @@ async function fetchLatestSnapshotCore(
                     const resource_name = indResTime.name;
                     const resource_initiatortype = indResTime.initiatorType;
                     if ((resource_initiatortype.localeCompare("fetch") === 0)
-                        && (resource_name.localeCompare(url) === 0)) {
+                        && (resource_name.localeCompare(response.requestUrl) === 0)) {
                         redirectTime = indResTime.redirectEnd - indResTime.redirectStart;
                         dnstime = indResTime.domainLookupEnd - indResTime.domainLookupStart;
                         tcpHandshakeTime = indResTime.connectEnd - indResTime.connectStart;
@@ -256,13 +249,13 @@ async function fetchLatestSnapshotCore(
                     }
                 }
 
-                const { numTrees, numBlobs, encodedBlobsSize, decodedBlobsSize } =
-                    validateAndEvalBlobsAndTrees(response.content);
+                const { numTrees, numBlobs, encodedBlobsSize } =
+                    validateAndEvalBlobsAndTrees(response.response.content);
                 const clientTime = networkTime ? overallTime - networkTime : undefined;
 
                 // There are some scenarios in ODSP where we cannot cache, trees/latest will explicitly tell us when we
                 // cannot cache using an HTTP response header.
-                const canCache = response.headers.get("disablebrowsercachingofusercontent") !== "true";
+                const canCache = response.response.headers.get("disablebrowsercachingofusercontent") !== "true";
                 const sequenceNumber: number = snapshot.sequenceNumber ?? 0;
                 const seqNumberFromOps = snapshot.ops && snapshot.ops.length > 0 ?
                     snapshot.ops[0].sequenceNumber - 1 :
@@ -273,7 +266,7 @@ async function fetchLatestSnapshotCore(
                     logger.sendErrorEvent({ eventName: "fetchSnapshotError", sequenceNumber, seqNumberFromOps });
                     snapshot.sequenceNumber = undefined;
                 } else if (canCache) {
-                    const fluidEpoch = response.headers.get("x-fluid-epoch");
+                    const fluidEpoch = response.response.headers.get("x-fluid-epoch");
                     assert(fluidEpoch !== undefined, 0x1e6 /* "Epoch  should be present in response" */);
                     const valueWithEpoch: IVersionedValueWithEpoch = {
                         value: snapshot,
@@ -288,10 +281,9 @@ async function fetchLatestSnapshotCore(
                     blobs: snapshot.blobs?.size ?? 0,
                     leafNodes: numBlobs,
                     encodedBlobsSize,
-                    decodedBlobsSize,
                     sequenceNumber,
                     ops: snapshot.ops?.length ?? 0,
-                    headers: Object.keys(headers).length !== 0 ? true : undefined,
+                    headers: Object.keys(response.requestHeaders).length !== 0 ? true : undefined,
                     redirecttime: redirectTime,
                     dnsLookuptime: dnstime,
                     responsenetworkTime: responseTime,
@@ -305,9 +297,9 @@ async function fetchLatestSnapshotCore(
                     // Sharing link telemetry regarding sharing link redeem status and performance. Ex: FRL; dur=100,
                     // FRS; desc=S, FRP; desc=False. Here, FRL is the duration taken for redeem, FRS is the redeem
                     // status (S means success), and FRP is a flag to indicate if the permission has changed.
-                    sltelemetry: response.headers.get("x-fluid-sltelemetry"),
+                    sltelemetry: response.response.headers.get("x-fluid-sltelemetry"),
                     attempts: tokenFetchOptions.refresh ? 2 : 1,
-                    ...response.commonSpoHeaders,
+                    ...response.response.commonSpoHeaders,
                 });
                 return snapshot;
             },
@@ -325,29 +317,115 @@ async function fetchLatestSnapshotCore(
     });
 }
 
-function validateAndEvalBlobsAndTrees(snapshot: IOdspSnapshot) {
-    assert(Array.isArray(snapshot.trees) && snapshot.trees.length > 0,
-        0x200 /* "Returned odsp snapshot is malformed. No trees!" */);
-    assert(Array.isArray(snapshot.blobs) && snapshot.blobs.length > 0,
-        0x201 /* "Returned odsp snapshot is malformed. No blobs!" */);
-    let numTrees = 0;
-    let numBlobs = 0;
-    let encodedBlobsSize = 0;
-    let decodedBlobsSize = 0;
-    for (const tree of snapshot.trees) {
-        for (const treeEntry of tree.entries) {
-            if (treeEntry.type === "blob") {
-                numBlobs++;
-            } else if (treeEntry.type === "tree") {
-                numTrees++;
+interface ISnapshotRequestAndResponseOptions {
+    response: IOdspResponse<ISnapshotContents>,
+    requestUrl: string,
+    requestHeaders: {[index: string]: any},
+}
+
+async function fetchSnapshotContentsCoreV1(
+    odspResolvedUrl: IOdspResolvedUrl,
+    storageToken: string,
+    snapshotOptions: ISnapshotOptions | undefined,
+    snapshotDownloader: (url: string, fetchOptions: {[index: string]: any}) => Promise<IOdspResponse<unknown>>,
+    controller?: AbortController,
+): Promise<ISnapshotRequestAndResponseOptions> {
+    const snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
+    const url = `${snapshotUrl}/trees/latest?ump=1`;
+    const formBoundary = uuid();
+    const formParams: string[] = [];
+    formParams.push(`--${formBoundary}`);
+    formParams.push(`Authorization: Bearer ${storageToken}`);
+    formParams.push(`X-HTTP-Method-Override: GET`);
+    if (snapshotOptions !== undefined) {
+        Object.entries(snapshotOptions).forEach(([key, value]) => {
+            if (value !== undefined) {
+                formParams.push(`${key}: ${value}`);
             }
-        }
+        });
     }
-    for (const blob of snapshot.blobs) {
-        decodedBlobsSize += blob.size;
-        encodedBlobsSize += blob.content.length;
+    if (odspResolvedUrl.sharingLinkToRedeem) {
+        formParams.push(`sl: ${odspResolvedUrl.sharingLinkToRedeem}`);
     }
-    return { numTrees, numBlobs, encodedBlobsSize, decodedBlobsSize };
+    formParams.push(`_post: 1`);
+    formParams.push(`\r\n--${formBoundary}--`);
+    const postBody = formParams.join("\r\n");
+    const headers: {[index: string]: any} = {
+        "Content-Type": `multipart/form-data;boundary=${formBoundary}`,
+    };
+
+    const response = await snapshotDownloader(
+        url,
+        {
+            body: postBody,
+            headers,
+            signal: controller?.signal,
+            method: "POST",
+        },
+    ) as IOdspResponse<IOdspSnapshot>;
+    const snapshotContents: ISnapshotContents = convertOdspSnapshotToSnapsohtTreeAndBlobs(response.content);
+    const finalSnapshotContents: IOdspResponse<ISnapshotContents> = { ...response, content: snapshotContents };
+    return  {
+        response: finalSnapshotContents,
+        requestHeaders: headers,
+        requestUrl: url,
+    };
+}
+
+async function fetchSnapshotContentsCoreV2(
+    odspResolvedUrl: IOdspResolvedUrl,
+    storageToken: string,
+    snapshotOptions: ISnapshotOptions | undefined,
+    snapshotDownloader: (url: string, fetchOptions: {[index: string]: any}) => Promise<IOdspResponse<unknown>>,
+    controller?: AbortController,
+): Promise<ISnapshotRequestAndResponseOptions> {
+    const fullUrl = `${odspResolvedUrl.siteUrl}/_api/v2.1/drives/${odspResolvedUrl.driveId}/items/${
+        odspResolvedUrl.itemId}/opStream/attachments/latest/content`;
+    const queryParams = { ...snapshotOptions };
+    if (odspResolvedUrl.sharingLinkToRedeem) {
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        queryParams["sl"] = odspResolvedUrl.sharingLinkToRedeem;
+    }
+    const queryString = getQueryString(queryParams);
+    const { url, headers } = getUrlAndHeadersWithAuth(`${fullUrl}${queryString}`, storageToken);
+    const response = await snapshotDownloader(
+        url,
+        {
+            headers,
+            signal: controller?.signal,
+        },
+    ) as IOdspResponse<ArrayBuffer>;
+    const snapshotContents: ISnapshotContents = parseCompactSnapshotResponse(
+        new ReadBuffer(new Uint8Array(response.content)));
+    const finalSnapshotContents: IOdspResponse<ISnapshotContents> = { ...response, content: snapshotContents };
+    return  {
+        response: finalSnapshotContents,
+        requestHeaders: headers,
+        requestUrl: url,
+    };
+}
+
+function validateAndEvalBlobsAndTrees(snapshot: ISnapshotContents) {
+    assert(snapshot.snapshotTree !== undefined,
+        0x200 /* "Returned odsp snapshot is malformed. No trees!" */);
+    assert(snapshot.blobs !== undefined,
+        0x201 /* "Returned odsp snapshot is malformed. No blobs!" */);
+    const numTrees = countTreesInSnapshotTree(snapshot.snapshotTree);
+    const numBlobs = snapshot.blobs.size;
+    let encodedBlobsSize = 0;
+    for (const [_, blobContent] of snapshot.blobs) {
+        encodedBlobsSize += blobContent.byteLength;
+    }
+    return { numTrees, numBlobs, encodedBlobsSize };
+}
+
+function countTreesInSnapshotTree(snapshotTree: ISnapshotTree): number {
+    let numTrees = 0;
+    for (const [_, tree] of Object.entries(snapshotTree.trees)) {
+        numTrees += 1;
+        numTrees += countTreesInSnapshotTree(tree);
+    }
+    return numTrees;
 }
 
 function isRedeemSharingLinkError(odspResolvedUrl: IOdspResolvedUrl, error: any) {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -176,9 +176,12 @@ export class OdspDocumentService implements IDocumentService {
         // batch size, please see issue #5211 for data around batch sizing
         const batchSize = this.hostPolicy.opsBatchSize ?? 5000;
         const concurrency = this.hostPolicy.concurrentOpsBatches ?? 1;
-
+        const messages: ISequencedDocumentMessage[] = [];
+        for (const op of snapshotOps) {
+            messages.push((op as any).op ?? op);
+        }
         return new OdspDeltaStorageWithCache(
-            snapshotOps.map((op) => op.op),
+            messages,
             this.logger,
             batchSize,
             concurrency,

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -36,6 +36,19 @@ import { fetchJoinSession } from "./vroom";
 import { isOdcOrigin } from "./odspUrlHelper";
 import { EpochTracker } from "./epochTracker";
 import { OpsCache } from "./opsCaching";
+
+// Gate that when set to "1", instructs to fetch the binary format snapshot from the spo.
+function gatesBinaryFormatSnapshot() {
+    try {
+        if (typeof localStorage === "object" && localStorage !== null) {
+            if  (localStorage.binaryFormatSnapshot === "1") {
+                return true;
+            }
+        }
+    } catch (e) {}
+    return false;
+}
+
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
  * clients
@@ -126,6 +139,7 @@ export class OdspDocumentService implements IDocumentService {
             });
 
         this.hostPolicy = hostPolicy;
+        this.hostPolicy.fetchBinarySnapshotFormat ??= gatesBinaryFormatSnapshot();
         if (this.odspResolvedUrl.summarizer) {
             this.hostPolicy = { ...this.hostPolicy, summarizerClient: true };
         }
@@ -176,12 +190,8 @@ export class OdspDocumentService implements IDocumentService {
         // batch size, please see issue #5211 for data around batch sizing
         const batchSize = this.hostPolicy.opsBatchSize ?? 5000;
         const concurrency = this.hostPolicy.concurrentOpsBatches ?? 1;
-        const messages: ISequencedDocumentMessage[] = [];
-        for (const op of snapshotOps) {
-            messages.push((op as any).op ?? op);
-        }
         return new OdspDeltaStorageWithCache(
-            messages,
+            snapshotOps,
             this.logger,
             batchSize,
             concurrency,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -565,8 +565,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 snapshotDownloader,
                 putInCache,
                 removeEntries,
-                this.hostPolicy.enableRedeemFallback,
-                this.hostPolicy.fetchBinarySnapshotFormat);
+                this.hostPolicy.enableRedeemFallback);
             return odspSnapshot;
         } catch (error) {
             const errorType = error.errorType;
@@ -589,8 +588,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     snapshotDownloader,
                     putInCache,
                     removeEntries,
-                    this.hostPolicy.enableRedeemFallback,
-                    this.hostPolicy.fetchBinarySnapshotFormat);
+                    this.hostPolicy.enableRedeemFallback);
                 return odspSnapshot;
             }
             throw error;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -542,6 +542,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             return downloadSnapshot(
                 finalOdspResolvedUrl,
                 storageToken,
+                this.logger,
                 options,
                 this.hostPolicy.fetchBinarySnapshotFormat,
                 controller,

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -66,7 +66,7 @@ export function convertOdspSnapshotToSnapsohtTreeAndBlobs(
     }
     const val: ISnapshotContents = {
         blobs: blobsWithBufferContent,
-        ops: odspSnapshot.ops ?? [],
+        ops: odspSnapshot.ops?.map((op) => op.op) ?? [],
         sequenceNumber: odspSnapshot.trees && (odspSnapshot.trees[0]).sequenceNumber,
         snapshotTree: buildHierarchy(odspSnapshot.trees[0]),
     };

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -7,7 +7,7 @@ import { ITelemetryProperties, ITelemetryBaseLogger, ITelemetryLogger } from "@f
 import { IResolvedUrl, DriverErrorType } from "@fluidframework/driver-definitions";
 import { isOnline, OnlineStatus } from "@fluidframework/driver-utils";
 import { assert, performance } from "@fluidframework/common-utils";
-import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
     fetchIncorrectResponse,
@@ -41,7 +41,7 @@ export const getOrigin = (url: string) => new URL(url).origin;
 export interface ISnapshotContents {
     snapshotTree: ISnapshotTree,
     blobs: Map<string, ArrayBuffer>,
-    ops: ISequencedDeltaOpMessage[],
+    ops: ISequencedDeltaOpMessage[] | ISequencedDocumentMessage[],
     sequenceNumber: number | undefined,
 }
 

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -31,7 +31,7 @@ import {
 } from "@fluidframework/odsp-driver-definitions";
 import { fetch } from "./fetch";
 import { pkgVersion } from "./packageVersion";
-import { IOdspSnapshot, ISequencedDeltaOpMessage } from "./contracts";
+import { IOdspSnapshot } from "./contracts";
 
 export const getWithRetryForTokenRefreshRepeat = "getWithRetryForTokenRefreshRepeat";
 
@@ -41,7 +41,7 @@ export const getOrigin = (url: string) => new URL(url).origin;
 export interface ISnapshotContents {
     snapshotTree: ISnapshotTree,
     blobs: Map<string, ArrayBuffer>,
-    ops: ISequencedDeltaOpMessage[] | ISequencedDocumentMessage[],
+    ops: ISequencedDocumentMessage[],
     sequenceNumber: number | undefined,
 }
 

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -17,6 +17,7 @@ import {
     createCacheSnapshotKey,
     createOdspLogger,
     fetchAndParseAsJSONHelper,
+    fetchArray,
     getOdspResolvedUrl,
     toInstrumentedOdspTokenFetcher,
 } from "./odspUtils";
@@ -44,6 +45,7 @@ export async function prefetchLatestSnapshot(
     logger: ITelemetryBaseLogger,
     hostSnapshotFetchOptions: ISnapshotOptions | undefined,
     enableRedeemFallback?: boolean,
+    fetchBinarySnapshotFormat?: boolean,
 ): Promise<boolean> {
     const odspLogger = createOdspLogger(ChildLogger.create(logger, "PrefetchSnapshot"));
     const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
@@ -56,10 +58,17 @@ export async function prefetchLatestSnapshot(
     );
 
     const snapshotDownloader = async (url: string, fetchOptions: {[index: string]: any}) => {
-        return fetchAndParseAsJSONHelper(
-            url,
-            fetchOptions,
-        );
+        if (fetchBinarySnapshotFormat) {
+            return fetchArray(
+                url,
+                fetchOptions,
+            );
+        } else {
+            return fetchAndParseAsJSONHelper(
+                url,
+                fetchOptions,
+            );
+        }
     };
     const snapshotKey = createCacheSnapshotKey(odspResolvedUrl);
     let cacheP: Promise<void> | undefined;
@@ -84,6 +93,7 @@ export async function prefetchLatestSnapshot(
                     putInCache,
                     removeEntries,
                     enableRedeemFallback,
+                    fetchBinarySnapshotFormat,
                 );
             assert(cacheP !== undefined, 0x1e7 /* "caching was not performed!" */);
             await cacheP;

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -64,7 +64,7 @@ export async function prefetchLatestSnapshot(
         controller?: AbortController,
     ) => {
         return downloadSnapshot(
-            finalOdspResolvedUrl, storageToken, snapshotOptions, fetchBinarySnapshotFormat, controller);
+            finalOdspResolvedUrl, storageToken, odspLogger, snapshotOptions, fetchBinarySnapshotFormat, controller);
     };
     const snapshotKey = createCacheSnapshotKey(odspResolvedUrl);
     let cacheP: Promise<void> | undefined;

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -89,7 +89,6 @@ export async function prefetchLatestSnapshot(
                     putInCache,
                     removeEntries,
                     enableRedeemFallback,
-                    fetchBinarySnapshotFormat,
                 );
             assert(cacheP !== undefined, 0x1e7 /* "caching was not performed!" */);
             await cacheP;

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -6,9 +6,8 @@
 /* eslint-disable max-len */
 
 import { strict as assert } from "assert";
-import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { stringToBuffer } from "@fluidframework/common-utils";
-import { ISequencedDeltaOpMessage } from "../contracts";
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser";
 import { convertToCompactSnapshot } from "../compactSnapshotWriter";
 import { ISnapshotContents } from "../odspUtils";
@@ -72,10 +71,8 @@ const blobs = new Map<string, ArrayBuffer>(
     ],
 );
 
-const ops: ISequencedDeltaOpMessage[] = [
+const ops: ISequencedDocumentMessage[] = [
     {
-        sequenceNumber: 1,
-        op: {
         clientId: "X",
         clientSequenceNumber: -1,
         contents: null,
@@ -85,21 +82,17 @@ const ops: ISequencedDeltaOpMessage[] = [
         term: 1,
         timestamp: 1623883807452,
         type: "join",
-        },
     },
     {
+        clientId: "Y",
+        clientSequenceNumber: -1,
+        contents: null,
+        minimumSequenceNumber: 0,
+        referenceSequenceNumber: -1,
         sequenceNumber: 2,
-        op: {
-            clientId: "Y",
-            clientSequenceNumber: -1,
-            contents: null,
-            minimumSequenceNumber: 0,
-            referenceSequenceNumber: -1,
-            sequenceNumber: 2,
-            term: 1,
-            timestamp: 1623883811928,
-            type: "join",
-        },
+        term: 1,
+        timestamp: 1623883811928,
+        type: "join",
     },
 ];
 

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -61,6 +61,7 @@ export const generateOdspHostStoragePolicy = (seed: number)=> {
         sessionOptions: [undefined, ...generatePairwiseOptions(odspSessionOptions, seed)],
         enableRedeemFallback: booleanCases,
         cacheCreateNewSummary: booleanCases,
+        fetchBinarySnapshotFormat: booleanCases,
     };
     return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -16,7 +16,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import { prefetchLatestSnapshot } from "@fluidframework/odsp-driver";
-import { IPersistedCache } from "@fluidframework/odsp-driver-definitions";
+import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { IFluidMountableView } from "@fluidframework/view-interfaces";
@@ -159,8 +159,14 @@ async function createWebLoader(
     testOrderer: boolean = false,
     odspPersistantCache?: IPersistedCache,
 ): Promise<Loader> {
+    const odspHostStoragePolicy: HostStoragePolicy = {};
+    if (window.location.hash === "#binarySnapshot") {
+        assert(options.mode === "spo-df" || options.mode === "spo",
+            "Binary format snapshot only for odsp driver!!");
+        odspHostStoragePolicy.fetchBinarySnapshotFormat = true;
+    }
     let documentServiceFactory: IDocumentServiceFactory =
-        getDocumentServiceFactory(documentId, options, odspPersistantCache);
+        getDocumentServiceFactory(documentId, options, odspPersistantCache, odspHostStoragePolicy);
     // Create the inner document service which will be wrapped inside local driver. The inner document service
     // will be used for ops(like delta connection/delta ops) while for storage, local storage would be used.
     if (testOrderer) {

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -7,7 +7,7 @@ import { ILocalDeltaConnectionServer, LocalDeltaConnectionServer } from "@fluidf
 import { MultiDocumentServiceFactory } from "@fluidframework/driver-utils";
 import { LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
 import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
-import { IPersistedCache } from "@fluidframework/odsp-driver-definitions";
+import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { getRandomName } from "@fluidframework/server-services-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
@@ -20,6 +20,7 @@ export function getDocumentServiceFactory(
     documentId: string,
     options: RouteOptions,
     odspPersistantCache: IPersistedCache,
+    odspHostStoragePolicy?: HostStoragePolicy,
 ) {
     const deltaConn = deltaConns.get(documentId) ??
         LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory(documentId));
@@ -50,6 +51,7 @@ export function getDocumentServiceFactory(
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.odspAccessToken : undefined,
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.pushAccessToken : undefined,
             odspPersistantCache,
+            odspHostStoragePolicy,
         ),
         new RouterliciousDocumentServiceFactory(routerliciousTokenProvider),
     ]);


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/4589
This Pr Integrate new binary snapshot format in odsp driver behind feature gate which can be set either through local storage in browser or by setting hash in url in webpack fluid loader.