### PR TITLE
Clarify intent of new hash fallback chunk

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,5 +1,5 @@
 ## 0.45 Breaking changes
-- [Changes to local testing in insecure environments](#changes-to-local-testing-in-insecure-environments)
+- [Changes to local testing in insecure environments and associated bundle size increase](#changes-to-local-testing-in-insecure-environments-and-associated-bundle-size-increase)
 - [Property removed from IFluidDataStoreRuntime](#Property-removed-from-IFluidDataStoreRuntime)
 - [Changes to client-api Document](#changes-to-client-api-Document)
 - [Changes to PureDataObject](#changes-to-PureDataObject)
@@ -7,8 +7,8 @@
 - [Changes to PureDataObjectFactory](#changes-to-PureDataObjectFactory)
 - [webpack-fluid-loader package name changed](#webpack-fluid-loader-package-name-changed)
 
-### Changes to local testing in insecure environments
-Previously the `@fluidframework/common-utils` package exposed a `setInsecureContextHashFn` function so users could set an override when testing locally in insecure environments because the `crypto.subtle` library is not available.  This is now done automatically as a fallback and the function is removed.
+### Changes to local testing in insecure environments and associated bundle size increase
+Previously the `@fluidframework/common-utils` package exposed a `setInsecureContextHashFn` function so users could set an override when testing locally in insecure environments because the `crypto.subtle` library is not available.  This is now done automatically as a fallback and the function is removed.  The fallback exists as a dynamic import of our equivalent Node platform implementation, and will show as a chunk named "FluidFramework-HashFallback" and be up to ~25KB parsed in size.  It will not be served when running normally in a modern browser.
 
 ### Property removed from IFluidDataStoreRuntime
 - the `existing` property from `IFluidDataStoreRuntime` (and `FluidDataStoreRuntime`) has been removed. There is no need for this property in the class, as the flag can be supplied as a parameter to `FluidDataStoreRuntime.load` or to the constructor of `FluidDataStoreRuntime`. The `IFluidDataStoreFactory.instantiateDataStore` function has an `existing` parameter which can be supplied to the `FluidDataStoreRuntime` when the latter is created.

--- a/common/lib/common-utils/src/hashFileBrowser.ts
+++ b/common/lib/common-utils/src/hashFileBrowser.ts
@@ -17,8 +17,14 @@ import { IsoBuffer } from "./bufferBrowser";
 export async function hashFile(file: IsoBuffer): Promise<string> {
     // Handle insecure contexts (e.g. running with local services)
     // by deferring to Node version, which uses a hash polyfill
+    // When packed, this chunk will show as "FluidFramework-HashFallback" separately
+    // from the main chunk and will be of non-trivial size.  It will not be served
+    // under normal circumstances.
     if (crypto.subtle === undefined) {
-        return import("./hashFileNode").then(async (m) => m.hashFile(file));
+        return import(
+            /* webpackChunkName: "FluidFramework-HashFallback" */
+            "./hashFileNode"
+        ).then(async (m) => m.hashFile(file));
     }
 
     const hash = await crypto.subtle.digest("SHA-1", file);


### PR DESCRIPTION
Recent change to do automatic hash fallback when running in insecure contexts uses a dynamic import which webpack will create under all circumstances even if it is not expected to ever get served.  As is it receives anonymous naming ("1.js" in our local outputs), which is non-descriptive and can be confusing for those updating their fluid version and seeing a large bundle size increase.  This change adds additional notes around that increase and gives the chunk a more descriptive name matching its functionality.