### PR TITLE
Image gallery example view/model separation

### DIFF
--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/map": "^0.45.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "react-image-gallery": "^0.9.1"
+    "react-image-gallery": "^1.2.6"
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.45.0",
@@ -47,7 +47,7 @@
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
-    "@types/react-image-gallery": "^0.8.4",
+    "@types/react-image-gallery": "^1.0.4",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -25,6 +25,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --package package.json --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --package package.json --env.mode spo-df",
+    "start:tinylicious": "webpack-dev-server --config webpack.config.js --package package.json --env.mode tinylicious",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace",
@@ -32,10 +33,10 @@
     "webpack:dev": "webpack --env.development"
   },
   "dependencies": {
+    "@fluid-example/example-utils": "^0.45.0",
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/map": "^0.45.0",
-    "@fluidframework/view-interfaces": "^0.45.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-image-gallery": "^0.9.1"

--- a/examples/data-objects/image-gallery/src/index.ts
+++ b/examples/data-objects/image-gallery/src/index.ts
@@ -13,7 +13,7 @@ import { ImageGalleryInstantiationFactory, ImageGalleryModel } from "./model";
 import { ImageGalleryView } from "./view";
 
 const imageGalleryViewCallback = (imageGalleryModel: ImageGalleryModel) =>
-    <ImageGalleryView imageGalleryModel={ imageGalleryModel } />;
+    React.createElement(ImageGalleryView, { imageGalleryModel });
 
 export const fluidExport =
     new ContainerViewRuntimeFactory<ImageGalleryModel>(ImageGalleryInstantiationFactory, imageGalleryViewCallback);

--- a/examples/data-objects/image-gallery/src/index.tsx
+++ b/examples/data-objects/image-gallery/src/index.tsx
@@ -9,11 +9,11 @@ import {
 
 import React from "react";
 
-import { ImageGalleryInstantiationFactory, ImageGalleryObject } from "./model";
+import { ImageGalleryInstantiationFactory, ImageGalleryModel } from "./model";
 import { ImageGalleryView } from "./view";
 
-const imageGalleryViewCallback = (imageGalleryObject: ImageGalleryObject) =>
-    <ImageGalleryView imageGalleryObject={ imageGalleryObject } />;
+const imageGalleryViewCallback = (imageGalleryModel: ImageGalleryModel) =>
+    <ImageGalleryView imageGalleryModel={ imageGalleryModel } />;
 
 export const fluidExport =
-    new ContainerViewRuntimeFactory<ImageGalleryObject>(ImageGalleryInstantiationFactory, imageGalleryViewCallback);
+    new ContainerViewRuntimeFactory<ImageGalleryModel>(ImageGalleryInstantiationFactory, imageGalleryViewCallback);

--- a/examples/data-objects/image-gallery/src/index.tsx
+++ b/examples/data-objects/image-gallery/src/index.tsx
@@ -4,114 +4,16 @@
  */
 
 import {
-    ContainerRuntimeFactoryWithDefaultDataStore,
-    DataObject,
-    DataObjectFactory,
-} from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
-import { IFluidHTMLView } from "@fluidframework/view-interfaces";
+    ContainerViewRuntimeFactory,
+} from "@fluid-example/example-utils";
+
 import React from "react";
-import ReactDOM from "react-dom";
-import ImageGallery from "react-image-gallery";
-// eslint-disable-next-line import/no-internal-modules, import/no-unassigned-import
-import "react-image-gallery/styles/css/image-gallery.css";
-// eslint-disable-next-line import/no-unassigned-import
-import "./Styles.css";
 
-const imageGalleryName = "@fluid-example/image-gallery";
+import { ImageGalleryInstantiationFactory, ImageGalleryObject } from "./model";
+import { ImageGalleryView } from "./view";
 
-export class ImageGalleryObject extends DataObject implements IFluidHTMLView {
-    public get IFluidHTMLView() { return this; }
+const imageGalleryViewCallback = (imageGalleryObject: ImageGalleryObject) =>
+    <ImageGalleryView imageGalleryObject={ imageGalleryObject } />;
 
-    imageList = [
-        {
-            original: "https://picsum.photos/800/800/?image=400",
-            thumbnail: "https://picsum.photos/100/100/?image=400",
-        },
-        {
-            original: "https://picsum.photos/800/800/?image=430",
-            thumbnail: "https://picsum.photos/100/100/?image=430",
-        },
-        {
-            original: "https://picsum.photos/800/800/?image=490",
-            thumbnail: "https://picsum.photos/100/100/?image=490",
-        },
-        {
-            original: "https://picsum.photos/800/800/?image=580",
-            thumbnail: "https://picsum.photos/100/100/?image=580",
-        },
-        {
-            original: "https://picsum.photos/800/800/?image=700",
-            thumbnail: "https://picsum.photos/100/100/?image=700",
-        },
-    ];
-
-    defaultProps = {
-        items: [],
-        showNav: true,
-        autoPlay: false,
-        lazyLoad: false,
-    };
-
-    imageGallery: ImageGallery | undefined;
-
-    private readonly onSlide = (index) => {
-        this.root.set("position", index);
-    };
-
-    private readonly reactRender = (div, onSlide = this.onSlide) => {
-        ReactDOM.render(
-            <ImageGallery
-                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                ref={(gallery) => (this.imageGallery = gallery ?? undefined)}
-                items={this.imageList}
-                onSlide={onSlide}
-                slideDuration={10}
-            />,
-            div,
-        );
-    };
-    protected async initializingFirstTime() {
-        this.root.set("position", 0);
-    }
-
-    public render(div: HTMLDivElement) {
-        div.className = "app-sandbox";
-
-        this.reactRender(div);
-        if (this.imageGallery !== undefined) {
-            this.imageGallery.slideToIndex(this.getPosition());
-        }
-
-        this.root.on("valueChanged", (_, local) => {
-            if (local) {
-                return;
-            }
-
-            if (this.imageGallery !== undefined) {
-                // This is a result of a remote slide, don't trigger onSlide for this slide
-                this.reactRender(div, () => this.reactRender(div));
-                this.imageGallery.slideToIndex(this.getPosition());
-            }
-        });
-    }
-
-    private getPosition() {
-        return this.root.get<number>("position") ?? 0;
-    }
-}
-
-export const ImageGalleryInstantiationFactory = new DataObjectFactory<ImageGalleryObject, undefined, undefined, IEvent>
-(
-    imageGalleryName,
-    ImageGalleryObject,
-    [],
-    {},
-);
-
-export const fluidExport = new ContainerRuntimeFactoryWithDefaultDataStore(
-    ImageGalleryInstantiationFactory,
-    new Map([
-        [imageGalleryName, Promise.resolve(ImageGalleryInstantiationFactory)],
-    ]),
-);
+export const fluidExport =
+    new ContainerViewRuntimeFactory<ImageGalleryObject>(ImageGalleryInstantiationFactory, imageGalleryViewCallback);

--- a/examples/data-objects/image-gallery/src/model.ts
+++ b/examples/data-objects/image-gallery/src/model.ts
@@ -11,6 +11,8 @@ import { IEvent } from "@fluidframework/common-definitions";
 
 const imageGalleryName = "@fluid-example/image-gallery";
 
+const indexKey = "index";
+
 export class ImageGalleryModel extends DataObject {
     public get imageList() {
         return [
@@ -37,29 +39,29 @@ export class ImageGalleryModel extends DataObject {
         ];
     }
 
-    public readonly setPosition = (index: number) => {
+    public readonly setIndex = (index: number) => {
         if (typeof index !== "number") {
             throw new Error("Index is not a number");
         }
-        this.root.set("position", index);
+        this.root.set(indexKey, index);
     };
 
-    public readonly getPosition = () => {
-        const position = this.root.get<number>("position");
-        if (typeof position !== "number") {
-            throw new Error("Position is not a number");
+    public readonly getIndex = () => {
+        const index = this.root.get<number>(indexKey);
+        if (typeof index !== "number") {
+            throw new Error("Index is not a number");
         }
-        return position;
+        return index;
     };
 
     protected async initializingFirstTime() {
-        this.root.set("position", 0);
+        this.root.set(indexKey, 0);
     }
 
     protected async hasInitialized() {
         this.root.on("valueChanged", (changed, local) => {
-            if (changed.key === "position") {
-                this.emit("slideChanged", local);
+            if (changed.key === indexKey) {
+                this.emit("slideChanged");
             }
         });
     }

--- a/examples/data-objects/image-gallery/src/model.ts
+++ b/examples/data-objects/image-gallery/src/model.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    DataObject,
+    DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { IEvent } from "@fluidframework/common-definitions";
+
+const imageGalleryName = "@fluid-example/image-gallery";
+
+export class ImageGalleryObject extends DataObject {
+    public get imageList() {
+        return [
+            {
+                original: "https://picsum.photos/800/800/?image=400",
+                thumbnail: "https://picsum.photos/100/100/?image=400",
+            },
+            {
+                original: "https://picsum.photos/800/800/?image=430",
+                thumbnail: "https://picsum.photos/100/100/?image=430",
+            },
+            {
+                original: "https://picsum.photos/800/800/?image=490",
+                thumbnail: "https://picsum.photos/100/100/?image=490",
+            },
+            {
+                original: "https://picsum.photos/800/800/?image=580",
+                thumbnail: "https://picsum.photos/100/100/?image=580",
+            },
+            {
+                original: "https://picsum.photos/800/800/?image=700",
+                thumbnail: "https://picsum.photos/100/100/?image=700",
+            },
+        ];
+    }
+
+    public readonly setPosition = (index: number) => {
+        console.log("setting", index);
+        this.root.set("position", index);
+    };
+
+    public readonly getPosition = () => {
+        return this.root.get<number>("position") ?? 0;
+    };
+
+    protected async initializingFirstTime() {
+        this.root.set("position", 0);
+    }
+
+    protected async hasInitialized() {
+        this.root.on("valueChanged", (changed, local) => {
+            if (changed.key === "position") {
+                this.emit("slideChanged", local);
+            }
+        });
+    }
+}
+
+export const ImageGalleryInstantiationFactory = new DataObjectFactory<ImageGalleryObject, undefined, undefined, IEvent>
+(
+    imageGalleryName,
+    ImageGalleryObject,
+    [],
+    {},
+);

--- a/examples/data-objects/image-gallery/src/model.ts
+++ b/examples/data-objects/image-gallery/src/model.ts
@@ -11,7 +11,7 @@ import { IEvent } from "@fluidframework/common-definitions";
 
 const imageGalleryName = "@fluid-example/image-gallery";
 
-export class ImageGalleryObject extends DataObject {
+export class ImageGalleryModel extends DataObject {
     public get imageList() {
         return [
             {
@@ -38,12 +38,18 @@ export class ImageGalleryObject extends DataObject {
     }
 
     public readonly setPosition = (index: number) => {
-        console.log("setting", index);
+        if (typeof index !== "number") {
+            throw new Error("Index is not a number");
+        }
         this.root.set("position", index);
     };
 
     public readonly getPosition = () => {
-        return this.root.get<number>("position") ?? 0;
+        const position = this.root.get<number>("position");
+        if (typeof position !== "number") {
+            throw new Error("Position is not a number");
+        }
+        return position;
     };
 
     protected async initializingFirstTime() {
@@ -59,10 +65,10 @@ export class ImageGalleryObject extends DataObject {
     }
 }
 
-export const ImageGalleryInstantiationFactory = new DataObjectFactory<ImageGalleryObject, undefined, undefined, IEvent>
+export const ImageGalleryInstantiationFactory = new DataObjectFactory<ImageGalleryModel, undefined, undefined, IEvent>
 (
     imageGalleryName,
-    ImageGalleryObject,
+    ImageGalleryModel,
     [],
     {},
 );

--- a/examples/data-objects/image-gallery/src/view.tsx
+++ b/examples/data-objects/image-gallery/src/view.tsx
@@ -1,0 +1,76 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import ImageGallery from "react-image-gallery";
+import { ImageGalleryObject } from "./model";
+// eslint-disable-next-line import/no-internal-modules, import/no-unassigned-import
+import "react-image-gallery/styles/css/image-gallery.css";
+// eslint-disable-next-line import/no-unassigned-import
+import "./Styles.css";
+
+export interface IImageGalleryViewProps {
+    imageGalleryObject: ImageGalleryObject;
+}
+
+export const ImageGalleryView: React.FC<IImageGalleryViewProps> = (props: IImageGalleryViewProps) => {
+    const { imageGalleryObject } = props;
+
+    // By default, we're waiting for the local user to manipulate the slides.  If they do, then we'll set
+    // the new slide index into the Fluid data object to transmit to remote clients.
+    // When we hear a remote transmission come in, we want to programmatically slide to the new value but
+    // we don't want to retrigger this logic and rebroadcast that same value back out.  To achieve this,
+    // we will temporarily disable modification of the Fluid data object in response to the slide and
+    // only resume it after a single onSlide callback (the onSlide that was triggered by our programmatic
+    // slide).
+    const handleLocalSlide = (index: number | undefined) => {
+        console.log("handlelocal", index);
+        if (index !== undefined) {
+            imageGalleryObject.setPosition(index);
+        }
+    };
+    const [onSlideCallback, setOnSlideCallback] = useState<(index: number | undefined) => void>(handleLocalSlide);
+    const resumeHandlingLocalSlide = () => {
+        console.log("setting to local");
+        setOnSlideCallback(handleLocalSlide);
+    };
+
+    // eslint-disable-next-line no-null/no-null
+    const imageGalleryRef = useRef<ImageGallery>(null);
+
+    useEffect(() => {
+        const handleSlideChanged = () => {
+            // eslint-disable-next-line no-null/no-null
+            if (imageGalleryRef.current !== null) {
+                const index = imageGalleryObject.getPosition();
+                console.log("current", imageGalleryRef.current.getCurrentIndex());
+                if (imageGalleryRef.current.getCurrentIndex() === index) {
+                    return;
+                }
+                // We're about to induce a slide from the remote change -- disable onSlide handling for a
+                // single callback and then resume.
+                console.log("setting to resume after 1");
+                setOnSlideCallback(resumeHandlingLocalSlide);
+                console.log("handling", index);
+                imageGalleryRef.current.slideToIndex(index);
+            }
+        };
+        // Run once to set the initial slide on load
+        handleSlideChanged();
+        imageGalleryObject.on("slideChanged", handleSlideChanged);
+        return () => {
+            imageGalleryObject.off("slideChanged", handleSlideChanged);
+        };
+    }, [ imageGalleryObject ]);
+
+    return (
+        <ImageGallery
+            ref={ imageGalleryRef }
+            items={ imageGalleryObject.imageList }
+            onSlide={ onSlideCallback }
+            slideDuration={ 10 }
+        />
+    );
+};

--- a/examples/data-objects/image-gallery/src/view.tsx
+++ b/examples/data-objects/image-gallery/src/view.tsx
@@ -40,10 +40,10 @@ export const ImageGalleryView: React.FC<IImageGalleryViewProps> = (props: IImage
 
     useEffect(() => {
         const slideToCurrentSlide = () => {
-            const index = imageGalleryModel.getIndex();
             // eslint-disable-next-line no-null/no-null
             if (imageGalleryRef.current !== null) {
-                imageGalleryRef.current.slideToIndex(index);
+                const currentIndex = imageGalleryModel.getIndex();
+                imageGalleryRef.current.slideToIndex(currentIndex);
             }
         };
         // Update at least once, on load.

--- a/examples/data-objects/image-gallery/src/view.tsx
+++ b/examples/data-objects/image-gallery/src/view.tsx
@@ -29,9 +29,9 @@ export const ImageGalleryView: React.FC<IImageGalleryViewProps> = (props: IImage
     // detect whether the slide is user-initiated or programmatic, and also the programmatic invocation would
     // interrupt/restart the slide rather than be dropped entirely.
     const onBeforeSlideHandler = (index: number) => {
-        const currentIndex = imageGalleryModel.getPosition();
+        const currentIndex = imageGalleryModel.getIndex();
         if (index !== currentIndex) {
-            imageGalleryModel.setPosition(index);
+            imageGalleryModel.setIndex(index);
         }
     };
 
@@ -40,7 +40,7 @@ export const ImageGalleryView: React.FC<IImageGalleryViewProps> = (props: IImage
 
     useEffect(() => {
         const slideToCurrentSlide = () => {
-            const index = imageGalleryModel.getPosition();
+            const index = imageGalleryModel.getIndex();
             // eslint-disable-next-line no-null/no-null
             if (imageGalleryRef.current !== null) {
                 imageGalleryRef.current.slideToIndex(index);

--- a/examples/data-objects/image-gallery/webpack.config.js
+++ b/examples/data-objects/image-gallery/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = env => {
 
     return merge({
         entry: {
-            main: "./src/index.tsx"
+            main: "./src/index.ts"
         },
         resolve: {
             extensions: [".ts", ".tsx", ".js"],

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -15544,9 +15544,9 @@
 			}
 		},
 		"@types/react-image-gallery": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/@types/react-image-gallery/-/react-image-gallery-0.8.4.tgz",
-			"integrity": "sha512-/C/XtlXiE8sdVCT7MuGuxw5JmMXCWLC6vgirefv+5q22KPdW4dS+GskywigJYZjgCF4GcXPxZzwlnICOOPglSw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@types/react-image-gallery/-/react-image-gallery-1.0.4.tgz",
+			"integrity": "sha512-BirrX9wEPIH/6XhScYNyQywxBaVmkO9EJPpjJP0l971k81gE/81tZJnxQcZ8O0zfSGGh0frx3PT62A1aX/W7gQ==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -34486,11 +34486,6 @@
 				"lodash._reinterpolate": "^3.0.0"
 			}
 		},
-		"lodash.throttle": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -44113,16 +44108,9 @@
 			}
 		},
 		"react-image-gallery": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/react-image-gallery/-/react-image-gallery-0.9.1.tgz",
-			"integrity": "sha512-J0ZDp12QwcHxK/De//Cx0lXvkPk2bL2voNm6xmZItCZ5TWTKJyNAa9U/iOtfi/RKJEpSLsTb2kP/4Lr5wgkJZA==",
-			"requires": {
-				"lodash.debounce": "^4.0.8",
-				"lodash.throttle": "^4.1.1",
-				"prop-types": "^15.5.8",
-				"react-swipeable": "^5.2.0",
-				"resize-observer-polyfill": "^1.5.0"
-			}
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/react-image-gallery/-/react-image-gallery-1.2.6.tgz",
+			"integrity": "sha512-+uL8RB3YrsXOtL95KY9oLWup2jww95qvvwsHOkRdV1SOImUO4qGuYh/0+M+vuqzBy7AB7G19+KhgucOPetn6+Q=="
 		},
 		"react-input-autosize": {
 			"version": "2.2.2",
@@ -45671,14 +45659,6 @@
 				"invariant": "^2.2.4",
 				"shallowequal": "^1.1.0",
 				"throttle-debounce": "^3.0.1"
-			}
-		},
-		"react-swipeable": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-5.5.1.tgz",
-			"integrity": "sha512-EQObuU3Qg3JdX3WxOn5reZvOSCpU4fwpUAs+NlXSN3y+qtsO2r8VGkVnOQzmByt3BSYj9EWYdUOUfi7vaMdZZw==",
-			"requires": {
-				"prop-types": "^15.6.2"
 			}
 		},
 		"react-syntax-highlighter": {


### PR DESCRIPTION
Last view/model separation change I had hanging over from last week.  This one also redoes the rendering approach (current implementation blows away the slider component on every change via repeated `ReactDOM.render()` calls which isn't ideal).

I took the opportunity to update the libraries used to their latest versions as well.