### PR TITLE
Copyprops precedence

### DIFF
--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -61,7 +61,7 @@ export function extractLogSafeErrorProperties(error: any, sanitizeStack: boolean
 export const isILoggingError = (x: any): x is ILoggingError => typeof x?.getTelemetryProperties === "function";
 
 /** Copy props from source onto target, but do not overwrite an existing prop that matches */
-function copyProps(source: ITelemetryProperties, target: ITelemetryProperties | LoggingError) {
+function copyProps(target: ITelemetryProperties | LoggingError, source: ITelemetryProperties) {
     for (const key of Object.keys(source)) {
         if (target[key] === undefined) {
             target[key] = source[key];
@@ -94,7 +94,6 @@ class SimpleFluidError implements IFluidErrorBase {
         this.stack = errorProps.stack;
         this.name = errorProps.name;
 
-        //* PR: Do I need to avoid adding optional ones, or is it ok to add an explicit undefined value?
         // (like I wonder if it will show up in Kusto as "undefined" -- Oh I think not, recalling the Bohemia code)
         this.addTelemetryProperties(errorProps);
     }
@@ -104,7 +103,7 @@ class SimpleFluidError implements IFluidErrorBase {
     }
 
     addTelemetryProperties(props: ITelemetryProperties) {
-        copyProps(props, this.telemetryProps);
+        copyProps(this.telemetryProps, props);
     }
 }
 
@@ -245,8 +244,7 @@ export class LoggingError extends Error implements ILoggingError {
      * Add additional properties to be logged
      */
     public addTelemetryProperties(props: ITelemetryProperties) {
-        //* PR:  Test case to remember - ensure stack/message can't be overwritten via ATP
-        copyProps(props, this);
+        copyProps(this, props);
     }
 
     /**

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -94,7 +94,6 @@ class SimpleFluidError implements IFluidErrorBase {
         this.stack = errorProps.stack;
         this.name = errorProps.name;
 
-        // (like I wonder if it will show up in Kusto as "undefined" -- Oh I think not, recalling the Bohemia code)
         this.addTelemetryProperties(errorProps);
     }
 

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -60,9 +60,13 @@ export function extractLogSafeErrorProperties(error: any, sanitizeStack: boolean
 /** type guard for ILoggingError interface */
 export const isILoggingError = (x: any): x is ILoggingError => typeof x?.getTelemetryProperties === "function";
 
-/** Copy props from source onto target, overwriting any keys that are already set on target */
-function copyProps(target: unknown, source: ITelemetryProperties) {
-    Object.assign(target, source);
+/** Copy props from source onto target, but do not overwrite an existing prop that matches */
+function copyProps(source: ITelemetryProperties, target: ITelemetryProperties | LoggingError) {
+    for (const key of Object.keys(source)) {
+        if (target[key] === undefined) {
+            target[key] = source[key];
+        }
+    }
 }
 
 /** Metadata to annotate an error object when annotating or normalizing it */
@@ -108,7 +112,7 @@ class SimpleFluidError implements IFluidErrorBase {
     }
 
     addTelemetryProperties(props: ITelemetryProperties) {
-        copyProps(this.telemetryProps, props);
+        copyProps(props, this.telemetryProps);
     }
 }
 
@@ -249,7 +253,7 @@ export class LoggingError extends Error implements ILoggingError {
      * Add additional properties to be logged
      */
     public addTelemetryProperties(props: ITelemetryProperties) {
-        copyProps(this, props);
+        copyProps(props, this);
     }
 
     /**

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -219,15 +219,15 @@ describe("Error Logging", () => {
         });
         it("addTelemetryProperties - adds to object, returned from getTelemetryProperties, overwrites", () => {
             const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true});
-            (loggingError as any).p1 = "should be overwritten";
+            (loggingError as any).p1 = "should not be overwritten";
             loggingError.addTelemetryProperties(
-                {p1: "one", p4: 4, p5: { value: 5, tag: "PackageData" }});
+                {p1: "ignored", p4: 4, p5: { value: 5, tag: "PackageData" }});
             const props = loggingError.getTelemetryProperties();
-            assert.strictEqual(props.p1, "one");
+            assert.strictEqual(props.p1, "should not be overwritten");
             assert.strictEqual(props.p4, 4);
             assert.deepStrictEqual(props.p5, { value: 5, tag: "PackageData" });
             const errorAsAny = loggingError as any;
-            assert.strictEqual(errorAsAny.p1, "one");
+            assert.strictEqual(errorAsAny.p1, "should not be overwritten");
             assert.strictEqual(errorAsAny.p4, 4);
             assert.deepStrictEqual(errorAsAny.p5, { value: 5, tag: "PackageData" });
         });
@@ -256,29 +256,31 @@ describe("Error Logging", () => {
             assert.strictEqual(props.p4, "REDACTED (arbitrary object)");
             assert.strictEqual(props.p5, "REDACTED (arbitrary object)");
         });
-        it("addTelemetryProperties - overwrites base class Error fields (untagged)", () => {
+        it("addTelemetryProperties - Does not overwrite base class Error fields (untagged)", () => {
             const loggingError = new LoggingError("myMessage");
-            const overwritingProps = { message: "surprise1", stack: "surprise2" };
-            loggingError.addTelemetryProperties(overwritingProps);
+            const propsWillBeIgnored = { message: "surprise1", stack: "surprise2" };
+            loggingError.addTelemetryProperties(propsWillBeIgnored);
             const props = loggingError.getTelemetryProperties();
-            assert.deepStrictEqual(props, overwritingProps);
+            const { message, stack } = loggingError;
+            assert.deepStrictEqual(props, { message, stack }, "addTelemetryProperties should not overwrite existing props");
         });
-        it("addTelemetryProperties - overwrites base class Error fields (tagged)", () => {
-            const overwritingProps = new LoggingError("myMessage");
-            const expectedProps = {
-                message: { value: "Mark Fields", tag: "UserData" }, // hopefully no one does this!
+        it("addTelemetryProperties - Does not overwrite base class Error fields (tagged)", () => {
+            const loggingError = new LoggingError("myMessage");
+            const propsWillBeIgnored = {
+                message: { value: "Mark Fields", tag: "UserData" },
                 stack: { value: "surprise2", tag: "PackageData" },
             };
-            overwritingProps.addTelemetryProperties(expectedProps);
-            const props = overwritingProps.getTelemetryProperties();
-            assert.deepStrictEqual(props, expectedProps);
+            loggingError.addTelemetryProperties(propsWillBeIgnored);
+            const props = loggingError.getTelemetryProperties();
+            const { message, stack } = loggingError;
+            assert.deepStrictEqual(props, { message, stack }, "addTelemetryProperties should not overwrite existing props");
         });
-        it("addTelemetryProperties - overwrites existing telemetry props", () => {
+        it("addTelemetryProperties - Does not overwrite existing telemetry props", () => {
             const loggingError = new LoggingError("myMessage", { p1: 1 });
             loggingError.addTelemetryProperties({ p1: "one" });
-            assert(loggingError.getTelemetryProperties().p1 === "one");
+            assert(loggingError.getTelemetryProperties().p1 === 1);
             loggingError.addTelemetryProperties({ p1: "uno" });
-            assert(loggingError.getTelemetryProperties().p1 === "uno");
+            assert(loggingError.getTelemetryProperties().p1 === 1);
         });
     });
 });
@@ -518,11 +520,11 @@ describe("normalizeError", () => {
             assert(actualStack !== undefined, "stack should be present as a string");
             if (actualStack.indexOf("<<generated stack>>") >= 0) {
                 assert.equal(expected.stack, "<<generated stack>>", "<<generated stack>> hint should be used if generated");
-                Object.assign(actual, { stack: "<<generated stack>>" }); // for telemetry props to match below
+                expected.withExpectedTelemetryProps({ stack: actualStack });
             } else {
                 assert.equal(actualStack, inputStack, "If stack wasn't generated, it should match input stack");
                 assert.equal(expected.stack, "<<stack from input>>", "<<stack from input>> hint should be used if not generated");
-                Object.assign(actual, { stack: "<<stack from input>>" }); // for telemetry props to match below
+                expected.withExpectedTelemetryProps({ stack: inputStack });
             }
 
             assert.deepStrictEqual(actual.getTelemetryProperties(), expected.expectedTelemetryProps, "telemetry props should match");


### PR DESCRIPTION
Fixes #6758.

As an error flows through FF, we may add telemetry properties at various points.  The closer to the source that a prop is added, the more authoritative it is, so when adding subsequent properties, do not overwrite.