### PR TITLE
Add more logging and recovery attempts for stalled connection

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -191,7 +191,7 @@ export class DocumentDeltaConnection
     }
 
     private checkNotClosed() {
-        assert(!this.disposed, "not disposed");
+        assert(!this.disposed, "connection disposed");
     }
 
     /**

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -190,12 +190,18 @@ export class DocumentDeltaConnection
         return this.details.serviceConfiguration;
     }
 
+    private checkNotClosed() {
+        assert(!this.disposed, "not disposed");
+    }
+
     /**
      * Get messages sent during the connection
      *
      * @returns messages sent during the connection
      */
     public get initialMessages(): ISequencedDocumentMessage[] {
+        this.checkNotClosed();
+
         // If we call this when the earlyOpHandler is not attached, then the queuedMessages may not include the
         // latest ops.  This could possibly indicate that initialMessages was called twice.
         assert(this.earlyOpHandlerAttached, 0x08e /* "Potentially missed initial messages" */);
@@ -220,6 +226,7 @@ export class DocumentDeltaConnection
      * @returns initial signals returned by ordering service
      */
     public get initialSignals(): ISignalMessage[] {
+        this.checkNotClosed();
         return this.details.initialSignals;
     }
 
@@ -229,6 +236,7 @@ export class DocumentDeltaConnection
      * @returns initial client list sent during the connection
      */
     public get initialClients(): ISignalClient[] {
+        this.checkNotClosed();
         return this.details.initialClients;
     }
 
@@ -238,6 +246,7 @@ export class DocumentDeltaConnection
      * @param message - delta operation to submit
      */
     public submit(messages: IDocumentMessage[]): void {
+        this.checkNotClosed();
         this.submitManager.add("submitOp", messages);
     }
 
@@ -247,6 +256,7 @@ export class DocumentDeltaConnection
      * @param message - signal to submit
      */
     public submitSignal(message: IDocumentMessage): void {
+        this.checkNotClosed();
         this.submitManager.add("submitSignal", [message]);
     }
 

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -73,10 +73,8 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
             },
         );
 
-        const timerGranularity = 10000;
-
         this.joinOpTimer = new Timer(
-            timerGranularity,
+            10000,
             () => {
                 this.joinOpTimerRetry++;
 
@@ -93,6 +91,8 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
     }
 
     private startJoinOpTimer() {
+        assert(!this.joinOpTimer.hasTimer, "has joinOpTimer");
+        assert(this.joinOpEvent === undefined, "has joinOpEvent");
         this.joinOpTimerRetry = ConnectionStateHandler.joinOpTimerRetryInitialValue;
         this.joinOpEvent = PerformanceEvent.start(
             this.logger,
@@ -203,7 +203,6 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         ) {
             this.setConnectionState(ConnectionState.Connected);
         } else if (connectionMode === "write") {
-            this.joinOpTimerRetry = ConnectionStateHandler.joinOpTimerRetryInitialValue;
             this.startJoinOpTimer();
         }
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -630,7 +630,16 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
                 shouldClientJoinWrite: () => this._deltaManager.shouldJoinWrite(),
                 maxClientLeaveWaitTime: this.loader.services.options.maxClientLeaveWaitTime,
-                triggerReconnect: (reason: string) => this._deltaManager.triggerReconnect(reason),
+                triggerConnectionRecovery: (reason: string, retryCount: number, duration: number) => {
+                    // We get here when socket does not receive any ops on "write" connection, including
+                    // its own join op. Attempt some recovery options. Need to collect more data to see
+                    // If they actually do anything good.
+                    if (retryCount <= 10) {
+                        this._deltaManager.submit(MessageType.NoOp, null);
+                    } else {
+                        this._deltaManager.triggerReconnect(reason);
+                    }
+                },
             },
             this.logger,
         );

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -630,7 +630,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
                 shouldClientJoinWrite: () => this._deltaManager.shouldJoinWrite(),
                 maxClientLeaveWaitTime: this.loader.services.options.maxClientLeaveWaitTime,
-                triggerConnectionRecovery: (reason: string, retryCount: number, duration: number) => {
+                triggerConnectionRecovery: (reason: string, retryCount: number) => {
                     // We get here when socket does not receive any ops on "write" connection, including
                     // its own join op. Attempt some recovery options. Need to collect more data to see
                     // If they actually do anything good.

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -75,7 +75,7 @@ describe("ConnectionStateHandler Tests", () => {
                 maxClientLeaveWaitTime: expectedTimeout,
                 protocolHandler: () => protocolHandler,
                 shouldClientJoinWrite: () => shouldClientJoinWrite,
-                triggerReconnect: (reason: string) => { throw new Error("triggerReconnect"); },
+                triggerConnectionRecovery: (reason: string) => { throw new Error("triggerConnectionRecovery"); },
             },
             new TelemetryNullLogger(),
         );


### PR DESCRIPTION
1. Added NoJoinOpRecovered to see if connection ever recovers
2. Converted NoJoinOp to heartbeat instead of single event. Likely will undo that in future when we have more data here, but currently it will help understand how long connection existed in cases where currently NoJoinOp is the last  event in whole trace (not clear if that's because process dies, or some other reasons).
3. Added noop pings and reconnects as recovery options taking on broken connection. Telemetry around if it helps will point us to next steps to take in this area.
4. Validate that we somehow did not miss "disconnect" event - all key methods on connection to assert it's not used in disconnected state.
