### PR TITLE
Add explicit types for some public APIs

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): GenericNetworkError | ThrottlingError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -130,7 +130,7 @@ export function createGenericNetworkError(
     errorMessage: string,
     canRetry: boolean,
     retryAfterMs?: number,
-    props?: ITelemetryProperties) {
+    props?: ITelemetryProperties): ThrottlingError | GenericNetworkError {
     if (retryAfterMs !== undefined && canRetry) {
         return new ThrottlingError(errorMessage, retryAfterMs / 1000, props);
     }

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -130,7 +130,8 @@ export function createGenericNetworkError(
     errorMessage: string,
     canRetry: boolean,
     retryAfterMs?: number,
-    props?: ITelemetryProperties): ThrottlingError | GenericNetworkError {
+    props?: ITelemetryProperties,
+): ThrottlingError | GenericNetworkError {
     if (retryAfterMs !== undefined && canRetry) {
         return new ThrottlingError(errorMessage, retryAfterMs / 1000, props);
     }

--- a/packages/test/test-drivers/src/factory.ts
+++ b/packages/test/test-drivers/src/factory.ts
@@ -53,7 +53,7 @@ export async function createFluidTestDriver(
     fluidTestDriverType: TestDriverTypes = "local",
     config?: FluidTestDriverConfig,
     api: DriverApiType = DriverApi,
-) {
+): Promise<LocalServerTestDriver | TinyliciousTestDriver | RouterliciousTestDriver | OdspTestDriver> {
     switch (fluidTestDriverType) {
         case "local":
             return new LocalServerTestDriver(api.LocalDriverApi);


### PR DESCRIPTION
This change will help address #6158. Long term we can add some linting rules to help enforce explicit typing for public APIs, but this will address a couple of places that have caused build problems in the past.