### PR TITLE
Improved messaging for getkeys

### DIFF
--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -64,8 +64,7 @@ function stdResponse(err, stdout, stderr) {
     try {
         // Key Vault with restricted access for the FF dev team only
         await getKeys(client, rc, "https://ff-internal-dev-secrets.vault.azure.net/");
-    } catch (e) {
-        console.log("Couldn't get secrets from FF internal keyvault. If you need access make sure you are in the relevant security group.")
-    }
+        console.log("Overriding defaults with values from the FF internal keyvault.")
+    } catch (e) {}
     await rcTools.saveRC(rc);
 })();


### PR DESCRIPTION
The existing way logs a scary message for almost everyone who uses getkeys.  Flip it to log a happy sounding message to those who are in the more restricted security group.