### PR TITLE
Adjustments based on latest scalability run

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -45,6 +45,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
+import { ITelemetryProperties } from '@fluidframework/common-definitions';
 import { IThrottlingWarning } from '@fluidframework/container-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { IVersion } from '@fluidframework/protocol-definitions';
@@ -211,7 +212,7 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     // (undocumented)
     submitSignal(content: any): void;
     // (undocumented)
-    triggerReconnect(reason: string): void;
+    triggerConnectionRecovery(reason: string, props: ITelemetryProperties): void;
     // (undocumented)
     get version(): string;
 }

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -173,7 +173,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
         );
 
         return streamObserver(stream, (result) => {
-            if (result.done) {
+            if (result.done && opsFromSnapshot + opsFromCache + opsFromStorage !== 0) {
                 this.logger.sendPerformanceEvent({
                     eventName: "CacheOpsRetrieved",
                     opsFromSnapshot,

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -94,6 +94,7 @@ class SocketReference {
 
     public constructor(public readonly key: string, socket: SocketIOClient.Socket) {
         this._socket = socket;
+        assert(!SocketReference.socketIoSockets.has(key), "socket key collision");
         SocketReference.socketIoSockets.set(key, this);
 
         // The server always closes the socket after sending this message

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -70,9 +70,10 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         );
 
         // Based on recent data, it looks like majority of cases where we get stuck are due to really slow or
-        // timing out ops fetches. So attempt recovery infrequently.
+        // timing out ops fetches. So attempt recovery infrequently. Also fetch uses 30 second timeout, so
+        // if retrying fixes the problem, we should not see these events.
         this.joinOpTimer = new Timer(
-            30000,
+            45000,
             () => {
                 // I've observed timer firing within couple ms from disconnect event, looks like
                 // queued timer callback is not cancelled if timer is cancelled while callback sits in the queue.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -633,7 +633,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 triggerConnectionRecovery: (reason: string) => {
                     // We get here when socket does not receive any ops on "write" connection, including
                     // its own join op. Attempt recovery option.
-                    this._deltaManager.triggerReconnect(reason);
+                    this._deltaManager.triggerConnectionRecovery(
+                        reason,
+                        {
+                            duration: performance.now() - this.connectionTransitionTimes[this.connectionState],
+                        },
+                    );
                 },
             },
             this.logger,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -630,15 +630,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
                 shouldClientJoinWrite: () => this._deltaManager.shouldJoinWrite(),
                 maxClientLeaveWaitTime: this.loader.services.options.maxClientLeaveWaitTime,
-                triggerConnectionRecovery: (reason: string, retryCount: number) => {
+                triggerConnectionRecovery: (reason: string) => {
                     // We get here when socket does not receive any ops on "write" connection, including
-                    // its own join op. Attempt some recovery options. Need to collect more data to see
-                    // If they actually do anything good.
-                    if (retryCount <= 10) {
-                        this._deltaManager.submit(MessageType.NoOp, null);
-                    } else {
-                        this._deltaManager.triggerReconnect(reason);
-                    }
+                    // its own join op. Attempt recovery option.
+                    this._deltaManager.triggerReconnect(reason);
                 },
             },
             this.logger,

--- a/packages/loader/driver-utils/src/networkUtils.ts
+++ b/packages/loader/driver-utils/src/networkUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryErrorEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
-import { isOnline, OnlineStatus } from "./network";
+import { isOnline, OnlineStatus, canRetryOnError } from "./network";
 
 export function logNetworkFailure(logger: ITelemetryLogger, event: ITelemetryErrorEvent, error?: any) {
     const newEvent = { ...event };
@@ -24,10 +24,10 @@ export function logNetworkFailure(logger: ITelemetryLogger, event: ITelemetryErr
     }
 
     // If we are online, log it as an error, such that we look at it ASAP.
-    // But if we  are offline, log non-error event - we will remove
+    // But if we are offline, log non-error event - we will remove
     // it in the future once confident it's right thing to do.
     // Note: Unfortunately false positives happen in here (i.e. cable disconnected, but it reports true)!
-    newEvent.category = newEvent.online === OnlineStatus.Online ? "error" : "generic";
+    newEvent.category = (newEvent.online === OnlineStatus.Online || !canRetryOnError(error)) ? "error" : "generic";
     logger.sendTelemetryEvent(newEvent, error);
 }
 

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -373,11 +373,9 @@ async function getSingleOpBatch(
     while (signal?.aborted !== true) {
         retry++;
         let delay = Math.min(MaxFetchDelayInMs, MissingFetchDelayInMs * Math.pow(2, retry));
-        let canRetry = false;
 
         try {
             // Issue async request for deltas - limit the number fetched to MaxBatchDeltas
-            canRetry = true;
             const deltasP = get({ ...props, retry } /* telemetry props */);
 
             const { messages, partialResult } = await deltasP;
@@ -411,7 +409,7 @@ async function getSingleOpBatch(
                 );
             }
         } catch (error) {
-            canRetry = canRetry && canRetryOnError(error);
+            const canRetry = canRetryOnError(error);
 
             lastSuccessTime = undefined;
 

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -147,7 +147,7 @@ export function createOdspNetworkError(
             error = new RetryableError(errorMessage, DriverErrorType.incorrectServerResponse, { statusCode });
             break;
         case fetchTimeoutStatusCode:
-            error = new NonRetryableError(errorMessage, OdspErrorType.fetchTimeout, { statusCode });
+            error = new RetryableError(errorMessage, OdspErrorType.fetchTimeout, { statusCode });
             break;
         case fetchTokenErrorCode:
             error = new NonRetryableError(errorMessage, OdspErrorType.fetchTokenError, { statusCode });


### PR DESCRIPTION
1. We incorrectly quantify fetch timeouts as non-recoverable errors - that's not the case.
2. sending noops on broken connection does not really make a difference (though these ops make it to server), so remove this code and switch to forcing reconnect on error
3. Non-recoverable errors do not register as errors. Fix it.
4. Assert is hit due to timer callback firing after timer was cancelled - looks like a race condition.