### PR TITLE
Remove stop() from IRuntime

### DIFF
--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -435,11 +435,6 @@ export interface IRuntime extends IDisposable {
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
     setConnectionState(connected: boolean, clientId?: string): any;
     snapshot(tagMessage: string, fullTree?: boolean): Promise<ITree | null>;
-    // @deprecated (undocumented)
-    stop(): Promise<{
-        snapshot?: never;
-        state?: never;
-    }>;
 }
 
 // @public (undocumented)

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -64,15 +64,6 @@ export interface IRuntime extends IDisposable {
     setConnectionState(connected: boolean, clientId?: string);
 
     /**
-     * @deprecated in 0.14 async stop()
-     * Use snapshot to get a snapshot for an IRuntimeState as needed, followed by dispose
-     *
-     * Stops the runtime. Once stopped no more messages will be delivered and the context passed to the runtime
-     * on creation will no longer be active
-     */
-    stop(): Promise<{snapshot?: never, state?: never}>;
-
-    /**
      * Processes the given op (message)
      */
     process(message: ISequencedDocumentMessage, local: boolean, context: any);

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -81,6 +81,10 @@ class ProxyRuntime implements IRuntime {
     }
     async setConnectionState(connected: boolean, clientId?: string) {
     }
+    /**
+     * @deprecated in 0.14, use dispose() to stop the runtime.
+     * Remove after IRuntime definition no longer includes it.
+     */
     async stop(): Promise<{snapshot?: never, state?: never}> {
         throw new Error("Method not implemented.");
     }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1196,20 +1196,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    public async stop() {
-        this.verifyNotClosed();
-
-        // Reload would not work properly with local changes.
-        // First, summarizing code likely does not work (i.e. read - produced unknown result)
-        // in presence of local changes.
-        // On top of that newly reloaded runtime likely would not be dirty, while it has some changes.
-        // And container would assume it's dirty (as there was no notification changing state)
-        if (this.dirtyContainer) {
-            this.logger.sendErrorEvent({ eventName: "DirtyContainerReloadRuntime"});
-        }
-
+    /**
+     * @deprecated in 0.14, use dispose() to stop the runtime.
+     * Remove after IRuntime definition no longer includes it.
+     */
+    public async stop(): Promise<{snapshot?: never, state?: never}> {
         this.dispose(new Error("ContainerRuntimeStopped"));
-        return { };
+        throw new Error("Stop is no longer supported, use dispose to stop the runtime");
     }
 
     private replayPendingStates() {


### PR DESCRIPTION
Definition was deprecated over a year ago, and both the definition and implementation were made unusable about 4 months ago.  Not seeing any relevant telemetry hits either, seems safe to drop the definition.  Adding a thrown error to be a little more aggressive in discouraging usage until we release a new version of the definitions.