### PR TITLE
Don't try to insert blob if already present

### DIFF
--- a/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
@@ -35,7 +35,7 @@ describe("Test for Historian", () => {
         assert.equal(getCommit.message, commitParams.message, "Message not equal of commits!!");
     });
 
-    it("Blob Test", async () => {
+    it("Blob Test for insertion of duplicate blobs", async () => {
         const historian = new TestHistorian();
         const gitManager = new GitManager(historian);
         const blob1: ICreateBlobParams = {
@@ -48,6 +48,7 @@ describe("Test for Historian", () => {
         };
         const createBlobResponse1 = await gitManager.createBlob(blob1.content, blob1.encoding);
         const createBlobResponse2 = await gitManager.createBlob(blob2.content, blob2.encoding);
-        assert.strictEqual(createBlobResponse1.sha, createBlobResponse2.sha, "Sha for both blobs should match");
+        assert.strictEqual(createBlobResponse1.sha, createBlobResponse2.sha,
+            "Sha for both blobs should match as only 1 blob is stored as contents of both are same");
     });
 });

--- a/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
@@ -6,12 +6,17 @@
 import { strict as assert } from "assert";
 import { TestHistorian } from "../testHistorian";
 import { GitManager } from "@fluidframework/server-services-client";
-import { ICreateCommitParams } from "@fluidframework/gitresources";
+import { ICreateBlobParams, ICreateCommitParams } from "@fluidframework/gitresources";
+import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 
-describe("Test for TestUtils", () => {
-    it("Historian", async () => {
+describe("Test for Historian", () => {
+    let gitManager: GitManager;
+    beforeEach(async () => {
         const historian = new TestHistorian();
-        const gitManager = new GitManager(historian);
+        gitManager = new GitManager(historian);
+    });
+
+    it("Commit Test", async () => {
         const documentId = "documentId";
         const commitParams: ICreateCommitParams = {
             author: {
@@ -28,5 +33,21 @@ describe("Test for TestUtils", () => {
         const getCommit = await gitManager.getCommit(documentId);
         assert.equal(getCommit.sha, putCommit.sha, "Sha not equal of commits!!");
         assert.equal(getCommit.message, commitParams.message, "Message not equal of commits!!");
+    });
+
+    it("Blob Test", async () => {
+        const historian = new TestHistorian();
+        const gitManager = new GitManager(historian);
+        const blob1: ICreateBlobParams = {
+            content: "content",
+            encoding: "utf8",
+        };
+        const blob2: ICreateBlobParams = {
+            content: fromUtf8ToBase64(blob1.content),
+            encoding: "base64",
+        };
+        const createBlobResponse1 = await gitManager.createBlob(blob1.content, blob1.encoding);
+        const createBlobResponse2 = await gitManager.createBlob(blob2.content, blob2.encoding);
+        assert.strictEqual(createBlobResponse1.sha, createBlobResponse2.sha, "Sha for both blobs should match");
     });
 });

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -74,7 +74,7 @@ export class TestHistorian implements IHistorian {
 
     public async createBlob(blob: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> {
         const _id = await gitHashFile(IsoBuffer.from(blob.content, blob.encoding));
-        await this.blobs.insertOne({
+        await this.blobs.findOrCreate({ _id }, {
             _id,
             ...blob,
             value: blob,


### PR DESCRIPTION
It should be bug which I identified with my recent change. The historian db throws when we insert but there is something already present at that id. So for blob create we don't want to throw if the already present blob is same as the one being inserted.
For blobs if we already have the blob with same contents, then don't try to insert always. So use findOrCreate instead of just inserting always.
