### PR TITLE
Remove audience error logging in container

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1798,9 +1798,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 this._audience.addMember(newClient.clientId, newClient.client);
             } else if (innerContent.type === MessageType.ClientLeave) {
                 const leftClientId = innerContent.content as string;
-                if (!this._audience.removeMember(leftClientId) && this.connected) {
-                    this.logger.sendErrorEvent({ eventName: "MissingAudienceMember", clientId: leftClientId });
-                }
+                this._audience.removeMember(leftClientId);
             }
         } else {
             const local = this.clientId === message.clientId;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1798,7 +1798,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 this._audience.addMember(newClient.clientId, newClient.client);
             } else if (innerContent.type === MessageType.ClientLeave) {
                 const leftClientId = innerContent.content as string;
-                if (!this._audience.removeMember(leftClientId)) {
+                if (!this._audience.removeMember(leftClientId) && this.connected) {
                     this.logger.sendErrorEvent({ eventName: "MissingAudienceMember", clientId: leftClientId });
                 }
             }


### PR DESCRIPTION
Fixes #6910 
We're frequently hitting the race condition on initial connection (such as with transition from read to write client) where a client disconnects very close to when another client connects, and the disconnect audience signal is sent to the connecting client that never knew about the disconnecting client.  This is obfuscating what we really want to check (mismatched audience join/leaves e.g. legitimately lost signals), so just remove it because it's nbd(TM)