### PR TITLE
Fixing a bug: always fetching ops from PUSH

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -106,6 +106,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
             to: number,
             telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>,
         private readonly getCached: (from: number, to: number) => Promise<ISequencedDocumentMessage[]>,
+        private readonly requestFromSocket: (from: number, to: number) => void,
         private readonly opsReceived: (ops: ISequencedDocumentMessage[]) => void,
     ) {
     }
@@ -138,6 +139,9 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
                     }
                     this.snapshotOps = undefined;
                 }
+
+                // Kick out request to PUSH for ops if it has them
+                this.requestFromSocket(from, to);
 
                 // Cache in normal flow is continuous. Once there is a miss, stop consulting cache.
                 // This saves a bit of processing time

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -186,11 +186,13 @@ export class OdspDocumentService implements IDocumentService {
             concurrency,
             async (from, to, telemetryProps) => service.get(from, to, telemetryProps),
             async (from, to) => {
+                const res = await this.opsCache?.get(from, to);
+                return res as ISequencedDocumentMessage[] ?? [];
+            },
+            (from, to) => {
                 if (this.currentConnection !== undefined && !this.currentConnection.disposed) {
                     this.currentConnection.requestOps(from, to);
                 }
-                const res = await this.opsCache?.get(from, to);
-                return res as ISequencedDocumentMessage[] ?? [];
             },
             (ops: ISequencedDocumentMessage[]) => this.opsReceived(ops),
         );

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -345,6 +345,8 @@ describe("OdspDeltaStorageWithCache", () => {
             },
             // getCached
             async (from: number, to: number) => filterOps(cachedOps, from, to),
+            // requestFromSocket
+            (from: number, to: number) => { },
             // opsReceived
             (ops: ISequencedDocumentMessage[]) => opsToCache.push(...ops),
         );


### PR DESCRIPTION
Fetching ops from push was under "if (from < this.firstCacheMiss)" check that resulted in not requesting ops from PUSH all the time.
Fixing it by making sure fetching from PUSH is unique callback that is always involved.

How found:

In case of customDimensions.containerId == "65f88376-9665-465b-bc79-ae18d0ea0647", forcing reconnect actually resolved an issue of stalled client, because initial ops resolved the op gap. Client was stalled prior to that for two reasons:

1. fetching ops was first not bringing any ops, and then it started timing out.
2. The fact that it was resolved on reconnect forced me to inspect code, and I see that we do not always request ops from PUSH when we are looking for ops. That's the bug
