### PR TITLE
Add a hook for an event that will fire on changes to Interval properties

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -7,11 +7,11 @@
 import { BaseSegment } from '@fluidframework/merge-tree';
 import { Client } from '@fluidframework/merge-tree';
 import { Deferred } from '@fluidframework/common-utils';
-import { EventEmitter } from 'events';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
 import { IChannelStorageService } from '@fluidframework/datastore-definitions';
+import { IEvent } from '@fluidframework/common-definitions';
 import { IEventThisPlaceHolder } from '@fluidframework/common-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
@@ -36,6 +36,7 @@ import { MergeTreeMaintenanceType } from '@fluidframework/merge-tree';
 import { PropertySet } from '@fluidframework/merge-tree';
 import { Serializable } from '@fluidframework/datastore-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
+import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public (undocumented)
 export type DeserializeCallback = (properties: MergeTree.PropertySet) => void;
@@ -58,7 +59,7 @@ export interface IJSONRunSegment<T> extends IJSONSegment {
 export class Interval implements ISerializableInterval {
     constructor(start: number, end: number, props?: MergeTree.PropertySet);
     // (undocumented)
-    addProperties(newProps: MergeTree.PropertySet, collaborating?: boolean, seq?: number, op?: MergeTree.ICombiningOp): void;
+    addProperties(newProps: MergeTree.PropertySet, collaborating?: boolean, seq?: number, op?: MergeTree.ICombiningOp): MergeTree.PropertySet | undefined;
     // (undocumented)
     addPropertySet(props: MergeTree.PropertySet): void;
     // (undocumented)
@@ -95,8 +96,10 @@ export class Interval implements ISerializableInterval {
     union(b: Interval): Interval;
 }
 
+// Warning: (ae-forgotten-export) The symbol "IIntervalCollectionEvent" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export class IntervalCollection<TInterval extends ISerializableInterval> extends EventEmitter {
+export class IntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
     // (undocumented)
     [Symbol.iterator](): IntervalCollectionIterator<TInterval>;
     constructor(helpers: IIntervalHelpers<TInterval>, requiresClient: boolean, emitter: IValueOpEmitter, serializedIntervals: ISerializedInterval[]);
@@ -143,8 +146,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     // (undocumented)
     nextInterval(pos: number): TInterval;
     // (undocumented)
-    on(event: "addInterval" | "deleteInterval", listener: (interval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) => void): this;
-    // (undocumented)
     previousInterval(pos: number): TInterval;
     // (undocumented)
     removeIntervalById(id: string): TInterval;
@@ -177,7 +178,7 @@ export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationT
 // @public (undocumented)
 export interface ISerializableInterval extends MergeTree.IInterval {
     // (undocumented)
-    addProperties(props: MergeTree.PropertySet, collaborating?: boolean, seq?: number): any;
+    addProperties(props: MergeTree.PropertySet, collaborating?: boolean, seq?: number): MergeTree.PropertySet | undefined;
     // (undocumented)
     getIntervalId(): string | undefined;
     // (undocumented)
@@ -348,7 +349,7 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
 export class SequenceInterval implements ISerializableInterval {
     constructor(start: MergeTree.LocalReference, end: MergeTree.LocalReference, intervalType: MergeTree.IntervalType, props?: MergeTree.PropertySet);
     // (undocumented)
-    addProperties(newProps: MergeTree.PropertySet, collab?: boolean, seq?: number, op?: MergeTree.ICombiningOp): void;
+    addProperties(newProps: MergeTree.PropertySet, collab?: boolean, seq?: number, op?: MergeTree.ICombiningOp): MergeTree.PropertySet | undefined;
     // (undocumented)
     clone(): SequenceInterval;
     // (undocumented)

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -585,9 +585,6 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
             if (props) {
                 interval.addProperties(props);
             }
-            if (this.label && (this.label.length > 0)) {
-                interval.properties[MergeTree.reservedRangeLabelsKey] = [this.label];
-            }
             if (interval.properties[reservedIntervalIdKey] === undefined) {
                 // Create a new ID.
                 interval.properties[reservedIntervalIdKey] = uuid();

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -6,7 +6,7 @@
 /* eslint-disable no-bitwise */
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { ISharedObjectEvents } from "@fluidframework/shared-object-base";
+import { IEvent } from "@fluidframework/common-definitions";
 import * as MergeTree from "@fluidframework/merge-tree";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { v4 as uuid } from "uuid";
@@ -852,11 +852,12 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
     }
 }
 
-export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends ISharedObjectEvents {
+export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
     (event: "addInterval" | "deleteInterval",
-        listener: (interval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage) => void);
+        listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage) => void);
     (event: "propertyChanged", listener: (interval: TInterval, propertyArgs: MergeTree.PropertySet) => void);
 }
+
 export class IntervalCollection<TInterval extends ISerializableInterval>
     extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
     private savedSerializedIntervals?: ISerializedInterval[];

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { IntervalType, LocalReference } from "@fluidframework/merge-tree";
+import { IntervalType, LocalReference, PropertySet } from "@fluidframework/merge-tree";
 import { ISummaryBlob } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
@@ -23,6 +23,7 @@ import {
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
+import { TypedEventEmitter } from "@fluidframework/common-utils";
 
 const assertIntervalsHelper = (
     sharedString: SharedString,
@@ -656,11 +657,35 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
 
                 if (typeof(intervals1.changeProperties) === "function" &&
                     typeof(intervals2.changeProperties) === "function") {
+                    const assertPropertyChangedArg = (p: any, v: any, m: string) => {
+                        // Check expected values of args passed to the propertyChanged event only if IntervalCollection
+                        // is a TypedEventEmitter. (This is not true of earlier versions,
+                        // which will not capture the values.)
+                        if (intervals1 instanceof TypedEventEmitter && intervals2 instanceof TypedEventEmitter) {
+                            assert.strictEqual(p, v, m);
+                        }
+                    };
+                    let deltaArgs1: PropertySet = {};
+                    let deltaArgs2: PropertySet = {};
+                    intervals1.on("propertyChanged", (interval: SequenceInterval, propertyDeltas: PropertySet) => {
+                        deltaArgs1 = propertyDeltas;
+                    });
+                    intervals2.on("propertyChanged", (interval: SequenceInterval, propertyDeltas: PropertySet) => {
+                        deltaArgs2 = propertyDeltas;
+                    });
                     intervals1.changeProperties(id1, { prop1: "prop1" });
+                    // eslint-disable-next-line no-null/no-null
+                    assertPropertyChangedArg(deltaArgs1.prop1, null, "Mismatch in property-changed event arg 1");
                     await provider.opProcessingController.processOutgoing();
                     intervals2.changeProperties(id1, { prop2: "prop2" });
+                    // eslint-disable-next-line no-null/no-null
+                    assertPropertyChangedArg(deltaArgs2.prop2, null, "Mismatch in property-changed event arg 2");
 
                     await provider.ensureSynchronized();
+                    // eslint-disable-next-line no-null/no-null
+                    assertPropertyChangedArg(deltaArgs1.prop2, null, "Mismatch in property-changed event arg 3");
+                    // eslint-disable-next-line no-null/no-null
+                    assertPropertyChangedArg(deltaArgs2.prop1, null, "Mismatch in property-changed event arg 4");
 
                     interval1 = intervals1.getIntervalById(id1);
                     assert.strictEqual(interval1.properties.prop1, "prop1", "Mismatch in changed properties 1");
@@ -670,10 +695,15 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
                     assert.strictEqual(interval2.properties.prop2, "prop2", "Mismatch in changed properties 4");
 
                     intervals1.changeProperties(id1, { prop1: "no" });
+                    assertPropertyChangedArg(deltaArgs1.prop1, "prop1", "Mismatch in property-changed event arg 5");
                     await provider.opProcessingController.processOutgoing();
                     intervals2.changeProperties(id1, { prop1: "yes" });
+                    assertPropertyChangedArg(deltaArgs2.prop1, "prop1", "Mismatch in property-changed event arg 6");
 
                     await provider.ensureSynchronized();
+                    assertPropertyChangedArg(deltaArgs1.prop1, "no", "Mismatch in property-changed event arg 7");
+                    assertPropertyChangedArg(Object.hasOwnProperty.call(deltaArgs2, "prop1"), false,
+                        "Mismatch in property-changed event arg 8");
 
                     assert.strictEqual(interval1.properties.prop1, "yes", "Mismatch in changed properties 5");
                     assert.strictEqual(interval1.properties.prop2, "prop2", "Mismatch in changed properties 6");
@@ -681,11 +711,17 @@ describeFullCompat("SharedInterval", (getTestObjectProvider) => {
                     assert.strictEqual(interval2.properties.prop2, "prop2", "Mismatch in changed properties 8");
 
                     intervals1.changeProperties(id1, { prop1: "maybe" });
+                    assertPropertyChangedArg(deltaArgs1.prop1, "yes", "Mismatch in property-changed event arg 9");
                     await provider.opProcessingController.processOutgoing();
                     // eslint-disable-next-line no-null/no-null
                     intervals2.changeProperties(id1, { prop1: null });
+                    assertPropertyChangedArg(deltaArgs2.prop1, "yes", "Mismatch in property-changed event arg 10");
 
                     await provider.ensureSynchronized();
+
+                    assertPropertyChangedArg(deltaArgs1.prop1, "maybe", "Mismatch in property-changed event arg 11");
+                    assertPropertyChangedArg(Object.hasOwnProperty.call(deltaArgs2, "prop1"), false,
+                        "Mismatch in property-changed event arg 12");
 
                     assert.strictEqual(Object.prototype.hasOwnProperty.call(interval1.properties, "prop1"), false,
                         "Property not deleted 1");


### PR DESCRIPTION
The event will receive the current state of the changed Interval and a PropertySet containing the previous values of the changed properties.