### PR TITLE
Expose R11s WholeSummaryUpload functionality in client

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -29,6 +29,7 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     maxConcurrentStorageRequests: 100,
     maxConcurrentOrdererRequests: 100,
     aggregateBlobsSmallerThanBytes: undefined,
+    enableWholeSummaryUpload: false,
 };
 
 /**

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -23,10 +23,16 @@ import {
     ITree,
     IVersion,
 } from "@fluidframework/protocol-definitions";
-import { GitManager, ISummaryUploadManager, SummaryTreeUploadManager } from "@fluidframework/server-services-client";
+import {
+    GitManager,
+    ISummaryUploadManager,
+    SummaryTreeUploadManager,
+    WholeSummaryUploadManager,
+} from "@fluidframework/server-services-client";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { DocumentStorageServiceProxy, PrefetchDocumentStorageService } from "@fluidframework/driver-utils";
 import { RetriableGitManager } from "./retriableGitManager";
+import { IRouterliciousDriverPolicies } from "./policies";
 
 /**
  * Document access to underlying storage for routerlicious driver.
@@ -45,12 +51,14 @@ class DocumentStorageServiceCore implements IDocumentStorageService {
         private readonly id: string,
         private readonly manager: GitManager,
         private readonly logger: ITelemetryLogger,
-        public readonly policies: IDocumentStorageServicePolicies = {}) {
-        this.summaryUploadManager = new SummaryTreeUploadManager(
-            new RetriableGitManager(this.manager, this.logger),
-            this.blobsShaCache,
-            this.getPreviousFullSnapshot.bind(this),
-        );
+        public readonly policies: IDocumentStorageServicePolicies = {},
+        driverPolicies?: IRouterliciousDriverPolicies) {
+        this.summaryUploadManager = driverPolicies?.enableWholeSummaryUpload
+            ? new WholeSummaryUploadManager(this.manager)
+            : new SummaryTreeUploadManager(
+                new RetriableGitManager(this.manager, this.logger),
+                this.blobsShaCache,
+                this.getPreviousFullSnapshot.bind(this));
     }
 
     public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTreeEx | null> {
@@ -191,8 +199,9 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
         id: string,
         manager: GitManager,
         logger: ITelemetryLogger,
-        policies: IDocumentStorageServicePolicies): IDocumentStorageService {
-        const storageService = new DocumentStorageServiceCore(id, manager, logger, policies);
+        policies: IDocumentStorageServicePolicies,
+        driverPolicies?: IRouterliciousDriverPolicies): IDocumentStorageService {
+        const storageService = new DocumentStorageServiceCore(id, manager, logger, policies, driverPolicies);
         if (policies.caching === LoaderCachingPolicy.Prefetch) {
             return new PrefetchDocumentStorageService(storageService);
         }
@@ -203,8 +212,9 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
         public readonly id: string,
         public manager: GitManager,
         logger: ITelemetryLogger,
-        policies: IDocumentStorageServicePolicies = {}) {
-        super(DocumentStorageService.loadInternalDocumentStorageService(id, manager, logger, policies));
+        policies: IDocumentStorageServicePolicies = {},
+        driverPolicies?: IRouterliciousDriverPolicies) {
+        super(DocumentStorageService.loadInternalDocumentStorageService(id, manager, logger, policies, driverPolicies));
     }
 
     public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTreeEx | null> {

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -27,4 +27,9 @@ export interface IRouterliciousDriverPolicies {
      * Default: undefined
      */
     aggregateBlobsSmallerThanBytes: number | undefined;
+    /**
+     * Enable uploading entire summary tree as a IWholeSummaryPayload to storage.
+     * Default: false
+     */
+    enableWholeSummaryUpload: boolean;
 }

--- a/packages/tools/webpack-fluid-loader/README.md
+++ b/packages/tools/webpack-fluid-loader/README.md
@@ -14,6 +14,7 @@ The following environment variables can be defined when running webpack-dev-serv
 | `tenantId` | Tenant ID for your host. If you supply this you must supply a tenant secret |
 | `tenantSecret` | Secret for your tenant |
 | `bearerSecret` | Secret for your bearer |
+| `enableWholeSummaryUpload` | Enables whole summary upload functionality when using routerlicious or docker mode |
 
 
 | modes | description |
@@ -49,6 +50,7 @@ npm run start -- --env.fluidHost https://fluidhost.com --env.tenantId my_tenant 
 - `fluid__webpack__tenantSecret`
 - `fluid__webpack__bearerSecret`
 - `fluid__webpack__npm`
+- `fluid__webpack__enableWholeSummaryUpload`
 
 ### config file:
 or in an optional `config.json` file in the `baseDir` passed into `webpack-fluid-loader.after()` that looks like this:
@@ -60,7 +62,8 @@ or in an optional `config.json` file in the `baseDir` passed into `webpack-fluid
             "tenantId": "my_tenant",
             "tenantSecret": "my_secret",
             "bearerSecret": "bear_secret",
-            "npm": "npm.com"
+            "npm": "npm.com",
+            "enableWholeSummaryUpload": false,
         }
     }
 }

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -52,6 +52,7 @@ export interface IDockerRouteOptions extends IBaseRouteOptions {
     tenantId?: string;
     tenantSecret?: string;
     bearerSecret?: string;
+    enableWholeSummaryUpload?: boolean;
 }
 
 export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
@@ -60,6 +61,7 @@ export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
     tenantId?: string;
     tenantSecret?: string;
     bearerSecret?: string;
+    enableWholeSummaryUpload?: boolean;
 }
 
 export interface ITinyliciousRouteOptions extends IBaseRouteOptions {

--- a/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/multiDocumentServiceFactory.ts
@@ -51,6 +51,12 @@ export function getDocumentServiceFactory(
             async () => options.mode === "spo" || options.mode === "spo-df" ? options.pushAccessToken : undefined,
             odspPersistantCache,
         ),
-        new RouterliciousDocumentServiceFactory(routerliciousTokenProvider),
+        new RouterliciousDocumentServiceFactory(
+            routerliciousTokenProvider,
+            {
+                enableWholeSummaryUpload: options.mode === "r11s" || options.mode === "docker"
+                    ? options.enableWholeSummaryUpload
+                    : undefined,
+            }),
     ]);
 }

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -35,7 +35,9 @@ export const before = async (app: express.Application) => {
 
 export const after = (app: express.Application, server: WebpackDevServer, baseDir: string, env: RouteOptions) => {
     const options: RouteOptions = { mode: "local", ...env, ...{ port: server.options.port } };
-    const config: nconf.Provider = nconf.env("__").file(path.join(baseDir, "config.json"));
+    const config: nconf.Provider = nconf
+        .env({ parseValules: true, inputSeparator: "__"})
+        .file(path.join(baseDir, "config.json"));
     const buildTokenConfig = (response, redirectUriCallback?): OdspTokenConfig => ({
         type: "browserLogin",
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -71,6 +73,11 @@ export const after = (app: express.Application, server: WebpackDevServer, baseDi
         options.bearerSecret = options.bearerSecret || config.get("fluid:webpack:bearerSecret");
         if (options.mode !== "tinylicious") {
             options.tenantId = options.tenantId || config.get("fluid:webpack:tenantId") || "fluid";
+            options.enableWholeSummaryUpload =
+                options.enableWholeSummaryUpload ?? config.get("fluid:webpack:enableWholeSummaryUpload") ?? false;
+            if (typeof options.enableWholeSummaryUpload === "string") {
+                options.enableWholeSummaryUpload = options.enableWholeSummaryUpload === "true";
+            }
             if (options.mode === "docker") {
                 options.tenantSecret = options.tenantSecret
                     || config.get("fluid:webpack:docker:tenantSecret")


### PR DESCRIPTION
For context, FRS will be adding and requiring a single-call summary upload API. #6291 added the necessary logic to do this in services-client. This PR exposes that new "WholeSummaryUpload" functionality in the driver behind a policy flag called "enableWholeSummaryUpload" which defaults to false.

The second part of this PR is to expose this new option in the Webpack Fluid Loader so that example apps like Clicker can continue to easily run against FRS after WholeSummaryUpload is required (and during testing).

Everything is safely behind an optional flag. Existing R11s flow does not change.