### PR TITLE
Optionally have Alfred generate a container id on creation

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -75,6 +75,7 @@
     "nconf": "^0.11.0",
     "request": "^2.88.0",
     "split": "^1.0.0",
+    "uuid": "^8.3.1",
     "winston": "^3.3.3",
     "ws": "^7.4.6"
   },
@@ -97,6 +98,7 @@
     "@types/request": "^2.47.1",
     "@types/split": "^0.3.28",
     "@types/supertest": "^2.0.5",
+    "@types/uuid": "^8.3.0",
     "@types/ws": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -14,6 +14,7 @@ import { Router } from "express";
 import winston from "winston";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { Provider } from "nconf";
+import { v4 as uuid } from "uuid";
 import { Constants, handleResponse } from "../../../utils";
 
 export function create(
@@ -56,7 +57,7 @@ export function create(
         (request, response, next) => {
             // Tenant and document
             const tenantId = getParam(request.params, "tenantId");
-            const id = request.body.id as string;
+            const id = request.body.id as string || uuid();
 
             // Summary information
             const summary = request.body.summary;


### PR DESCRIPTION
We are transitioning R11s to server-side generation of the document (or container) id. This is step 1.

This PR allows the client to pass a blank string for "id" when creating a document/container. When the id param is blank, Alfred will generate the docId using `uuid`. Supposedly UUID is insanely collision-safe, so we don't realistically have to worry about collisions.

Next step will be to make sure the driver handles blank doc ids. Eventually we will enforce it.