### PR TITLE
Fix naming on returned objects in docs

### DIFF
--- a/docs/content/docs/build/audience.md
+++ b/docs/content/docs/build/audience.md
@@ -15,7 +15,7 @@ This document will explain how to use the audience APIs and then provide example
 When creating a container, you are also provided a container services object which holds the audience.  This audience is backed by that same container.
 
 ```js
-const { container, containerServices } =
+const { fluidContainer, containerServices } =
     await tinyliciousClient.createContainer(serviceConfig, containerSchema);
 const audience = containerServices.audience;
 ```

--- a/docs/content/docs/build/data-modeling.md
+++ b/docs/content/docs/build/data-modeling.md
@@ -30,11 +30,11 @@ const schema = {
     }
 }
 
-const { container, containerServices } = await client.createContainer(/*service config*/, schema);
+const { fluidContainer, containerServices } = await client.createContainer(/*service config*/, schema);
 
-const initialObjects = container.initialObjects;
-const map = container.initialObjects.customMap;
-const cell = container.initialObjects["custom-cell"];
+const initialObjects = fluidContainer.initialObjects;
+const map = fluidContainer.initialObjects.customMap;
+const cell = fluidContainer.initialObjects["custom-cell"];
 ```
 
 ## Dynamic objects
@@ -53,10 +53,10 @@ const schema = {
     dynamicObjectTypes: [ SharedCell, SharedMap ],
 }
 
-const { container, containerServices } = await client.getContainer(/*service config*/, schema);
+const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
 
-const newCell = await container.create(SharedCell); // Create a new SharedCell
-const newMap = await container.create(SharedMap); // Create a new SharedMap
+const newCell = await fluidContainer.create(SharedCell); // Create a new SharedCell
+const newMap = await fluidContainer.create(SharedMap); // Create a new SharedMap
 ```
 
 ### Using handles to store and retrieve Fluid objects
@@ -78,10 +78,10 @@ const schema = {
     dynamicObjectTypes: [ SharedCell ],
 }
 
-const { container, containerServices } = await client.getContainer(/*service config*/, schema);
-const map = container.initialObjects.map;
+const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
+const map = fluidContainer.initialObjects.map;
 
-const newCell = await container.create(SharedCell); // Create a new SharedCell
+const newCell = await fluidContainer.create(SharedCell); // Create a new SharedCell
 map.set("cell-id", newCell.handle); // Attach the new SharedCell
 
 // ...


### PR DESCRIPTION
Updates the `container` naming of the returned object from create/getContainer to be `fluidContainer` to match the code