### PR TITLE
[bump] package version for common-utils (patch)

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/common-utils",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Collection of utility functions for Fluid",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-utils/src/packageVersion.ts
+++ b/common/lib/common-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/common-utils";
-export const pkgVersion = "0.32.0";
+export const pkgVersion = "0.32.1";

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-example/search-menu": "^0.45.0",
     "@fluid-internal/client-api": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -36,7 +36,7 @@
     "@fluid-experimental/fluid-static": "^0.45.0",
     "@fluid-experimental/tinylicious-client": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/runtime-definitions": "^0.45.0",
     "react": "^16.10.2",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/agent-scheduler": "^0.45.0",
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/cell": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/merge-tree": "^0.45.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -37,7 +37,7 @@
     "@fluid-experimental/task-manager": "^0.45.0",
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime-definitions": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@fluid-example/flow-util-lib": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/data-object-base": "^0.45.0",
     "@fluidframework/map": "^0.45.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/property-proxy": "^0.45.0",
     "@fluid-experimental/schemas": "^0.45.0",
     "@fluidframework/aqueduct": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/property-proxy": "^0.45.0",
     "@fluid-experimental/schemas": "^0.45.0",
     "@fluidframework/aqueduct": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluid-experimental/property-changeset": "^0.45.0",
     "@fluid-experimental/property-properties": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/experimental/PropertyDDS/services/property-query/package.json
+++ b/experimental/PropertyDDS/services/property-query/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluid-experimental/property-dds": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/local-driver": "^0.45.0",
     "@fluidframework/mocha-test-setup": "^0.45.0",
     "@fluidframework/runtime-utils": "^0.45.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluid-experimental/ot": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/experimental/dds/tree-graphql/package.json
+++ b/experimental/dds/tree-graphql/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluid-experimental/tree": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@graphql-codegen/plugin-helpers": "^1.18.2",
     "@graphql-codegen/visitor-plugin-common": "^1.18.2",
     "graphql": "^15.4.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/protocol-base": "^0.1028.0-0",

--- a/experimental/framework/fluid-static/package.json
+++ b/experimental/framework/fluid-static/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime-definitions": "^0.45.0",

--- a/experimental/framework/tinylicious-client/package.json
+++ b/experimental/framework/tinylicious-client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluid-experimental/fluid-framework": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/driver-definitions": "^0.39.6",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -3602,9 +3602,9 @@
 			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.32.0-31336",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.0-31336.tgz",
-			"integrity": "sha512-Hk7jT/L8GeQkFTripkYPkRsNKVedJUIzZxq0ESkhlegKRcFzN8YeLzO62CnPl2I+7Yhc/+0SZBGehAo8wyg0nA==",
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.0.tgz",
+			"integrity": "sha512-2f+REsHPIL2LmE2ClPsE5caBIlp23qrMNyXe3zIb725e+IxRjazq19qB5fpgL5HiliHy0SKIzHTQC+ANuCIZkQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@types/events": "^3.0.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/driver-utils": "^0.45.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -53,7 +53,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/driver-utils": "^0.45.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/driver-utils": "^0.45.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/driver-utils": "^0.45.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/merge-tree": "^0.45.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/protocol-base": "^0.1028.0-0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/merge-tree": "^0.45.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.45.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",
     "@fluidframework/driver-utils": "^0.45.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime-definitions": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -33,7 +33,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/odsp-driver": "^0.45.0",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-base": "^0.45.0",
     "@fluidframework/driver-definitions": "^0.39.6",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-base": "^0.45.0",
     "@fluidframework/driver-definitions": "^0.39.6",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/driver-base": "^0.45.0",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@types/debug": "^4.1.5",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/map": "^0.45.0",
     "@fluidframework/merge-tree": "^0.45.0",
     "@fluidframework/runtime-definitions": "^0.45.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-runtime-definitions": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/runtime-definitions": "^0.45.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-utils": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/telemetry-utils": "^0.45.0"

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/gitresources": "^0.1028.0-0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",
     "@fluidframework/protocol-definitions": "^0.1024.0"

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.45.0",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/cell": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime-definitions": "^0.45.0",
     "@fluidframework/container-utils": "^0.45.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-utils": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/runtime-definitions": "^0.45.0"
   },
   "devDependencies": {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-runtime-definitions": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.45.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/base-host": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/cell": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluid-internal/replay-tool": "^0.45.0",
     "@fluidframework/cell": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/counter": "^0.45.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -50,7 +50,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/local-driver": "^0.45.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -104,7 +104,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "random-js": "^1.0.8"
   },
   "devDependencies": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -64,7 +64,7 @@
     "@fluid-experimental/task-manager": "^0.45.0",
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
     "@fluidframework/cell": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluid-internal/fluidapp-odsp-urlresolver": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/datastore": "^0.45.0",
     "@fluidframework/driver-definitions": "^0.39.6",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -30,7 +30,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-runtime": "^0.45.0",
     "@fluidframework/file-driver": "^0.45.0",
     "@fluidframework/merge-tree": "^0.45.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluidframework/cell": "^0.45.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/container-runtime": "^0.45.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.45.0",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.45.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/driver-utils": "^0.45.0",
     "@fluidframework/odsp-driver-definitions": "^0.45.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "debug": "^4.1.1",
     "events": "^3.1.0"
   },

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -56,7 +56,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/odsp-doclib-utils": "^0.45.0",
     "@fluidframework/protocol-base": "^0.1028.0-0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -430,16 +430,23 @@
 			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
 		},
 		"@fluidframework/common-utils": {
-			"version": "0.32.0-31185",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.0-31185.tgz",
-			"integrity": "sha512-8hq/bInV2RXyZWEgYTu+mRsnhtr7BQOvBOGljar4p8NqSfoUcECXrjrBC63deNG5Uk+Cdiku81T2mt9MvVlgRw==",
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.0.tgz",
+			"integrity": "sha512-2f+REsHPIL2LmE2ClPsE5caBIlp23qrMNyXe3zIb725e+IxRjazq19qB5fpgL5HiliHy0SKIzHTQC+ANuCIZkQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@types/events": "^3.0.0",
-				"base64-js": "^1.3.1",
+				"base64-js": "^1.5.1",
 				"events": "^3.1.0",
 				"lodash": "^4.17.21",
 				"sha.js": "^2.4.11"
+			},
+			"dependencies": {
+				"base64-js": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+					"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+				}
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/server-services-client": "^0.1028.0",
     "@fluidframework/server-services-core": "^0.1028.0",
     "async": "^3.2.0",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-base": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1028.0",
     "@fluidframework/server-memory-orderer": "^0.1028.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/protocol-base": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1028.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -54,7 +54,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "lodash": "^4.17.21"

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-kafka-orderer": "^0.1028.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -38,7 +38,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-kafka-orderer": "^0.1028.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -51,7 +51,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-base": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1028.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/server-services-core": "^0.1028.0",
     "@fluidframework/server-services-ordering-zookeeper": "^0.1028.0",
     "moniker": "^0.1.2",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-base": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -48,7 +48,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1028.0",
     "@fluidframework/server-services-core": "^0.1028.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -46,7 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0",
     "@fluidframework/protocol-base": "^0.1028.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -180,9 +180,9 @@
       "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/common-utils": {
-      "version": "0.32.0-31336",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.0-31336.tgz",
-      "integrity": "sha512-Hk7jT/L8GeQkFTripkYPkRsNKVedJUIzZxq0ESkhlegKRcFzN8YeLzO62CnPl2I+7Yhc/+0SZBGehAo8wyg0nA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.0.tgz",
+      "integrity": "sha512-2f+REsHPIL2LmE2ClPsE5caBIlp23qrMNyXe3zIb725e+IxRjazq19qB5fpgL5HiliHy0SKIzHTQC+ANuCIZkQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@types/events": "^3.0.0",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -28,7 +28,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluidframework/common-utils": "^0.32.0-0",
+    "@fluidframework/common-utils": "^0.32.0",
     "@fluidframework/gitresources": "^0.1028.0-0",
     "@fluidframework/protocol-base": "^0.1028.0-0",
     "@fluidframework/protocol-definitions": "^0.1024.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.23.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.0 (unchanged)
      @fluidframework/common-definitions:     0.21.0 (unchanged)
            @fluidframework/common-utils:     0.32.0 -> 0.32.1
    @fluidframework/container-definitions:     0.40.0 (unchanged)
         @fluidframework/core-interfaces:     0.40.0 (unchanged)
      @fluidframework/driver-definitions:     0.40.0 (unchanged)
    @fluidframework/protocol-definitions:   0.1025.0 (unchanged)
                                  Server:   0.1028.0 (unchanged)
                                  Client:     0.45.0 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for common-utils
            @fluidframework/common-utils -> ^0.32.0