### PR TITLE
r11s-driver: Use containerID from server as source of truth

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -81,7 +81,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             rateLimiter,
             resolvedUrl.endpoints.ordererUrl,
         );
-        await ordererRestWrapper.post(
+        const containerId = await ordererRestWrapper.post<string>(
             `/documents/${tenantId}`,
             {
                 id,
@@ -90,8 +90,15 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 values: quorumValues,
             },
         );
+        parsedUrl.pathname = parsedUrl.pathname.split("/").slice(0, -1).concat([containerId]).join("/");
 
-        return this.createDocumentService(resolvedUrl, logger);
+        return this.createDocumentService(
+            {
+                ...resolvedUrl,
+                url: parsedUrl.href,
+                id: containerId,
+            },
+            logger);
     }
 
     /**
@@ -116,7 +123,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         }
 
         const parsedUrl = parse(fluidResolvedUrl.url);
-        const [, tenantId, documentId] = parsedUrl.pathname!.split("/");
+        const [, tenantId, documentId] = parsedUrl.pathname.split("/");
         if (!documentId || !tenantId) {
             throw new Error(
                 `Couldn't parse documentId and/or tenantId. [documentId:${documentId}][tenantId:${tenantId}]`);

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -81,7 +81,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             rateLimiter,
             resolvedUrl.endpoints.ordererUrl,
         );
-        const containerId = await ordererRestWrapper.post<string>(
+        const documentId = await ordererRestWrapper.post<string>(
             `/documents/${tenantId}`,
             {
                 id,
@@ -90,13 +90,13 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 values: quorumValues,
             },
         );
-        parsedUrl.pathname = parsedUrl.pathname.split("/").slice(0, -1).concat([containerId]).join("/");
+        parsedUrl.pathname = parsedUrl.pathname.split("/").slice(0, -1).concat([documentId]).join("/");
 
         return this.createDocumentService(
             {
                 ...resolvedUrl,
                 url: parsedUrl.href,
-                id: containerId,
+                id: documentId,
             },
             logger);
     }


### PR DESCRIPTION
Alfred returns the id of the created and stored document. We should use that in r11s-driver as a step toward having Alfred always generate the id.