### PR TITLE
r11s: Explicitly allow blank document ids on create doc only

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -52,7 +52,7 @@ export function create(
      */
     router.post(
         "/:tenantId",
-        verifyStorageToken(tenantManager, config),
+        verifyStorageToken(tenantManager, config, true),
         throttle(throttler, winston, commonThrottleOptions),
         (request, response, next) => {
             // Tenant and document

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -52,7 +52,7 @@ export function create(
      */
     router.post(
         "/:tenantId",
-        verifyStorageToken(tenantManager, config, true),
+        verifyStorageToken(tenantManager, config, false),
         throttle(throttler, winston, commonThrottleOptions),
         (request, response, next) => {
             // Tenant and document


### PR DESCRIPTION
We want to allow blank doc ids to be passed to Alfred, which will then generate the id. #7020 added the generation functionality, but neglected the necessary token validation logic.