### PR TITLE
Azure pipelines

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -22,7 +22,7 @@ variables:
 - name: testWorkspace
   value: $(Pipeline.Workspace)/test
 
-stages
+stages:
   # end-to-end tests local server
   - stage:
     displayName: e2e - local server

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -26,6 +26,7 @@ stages:
   # end-to-end tests local server
   - stage:
     displayName: e2e - local server
+    dependsOn: []
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
@@ -45,6 +46,7 @@ stages:
   # end-to-end tests routerlicious
   - stage:
     displayName: e2e - routerlicious
+    dependsOn: []
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:


### PR DESCRIPTION
## Chage about configuration version is not supported.

```javascript
- name: testWorkspace
  value: $(Pipeline.Workspace)/test

stages
stages:
  # end-to-end tests local server
  - stage:
    displayName: e2e - local server
    dependsOn: []
    jobs:
    - template: templates/include-test-real-service.yml
      parameters:
@@ -45,7 +46,7 @@ stages
  # end-to-end tests routerlicious
  - stage:
    displayName: e2e - routerlicious
    dependsOn: []
    jobs:
    - template: templates/include-test-real-service.yml
      parameters:
```