### PR TITLE
Remove extraneous devDependency from frs-client

### DIFF
--- a/experimental/framework/frs-client/package.json
+++ b/experimental/framework/frs-client/package.json
@@ -50,7 +50,6 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluid-experimental/fluid-framework": "^0.45.0",
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",


### PR DESCRIPTION
A dependency is duplicated in devDependencies and isn't getting bumped by the bump tool