### PR TITLE
Use path-browserify instead of node path in server-services-telemetry

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -16300,6 +16300,11 @@
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
+		"path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.0-0",
+    "path-browserify": "^1.0.1",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import path from "path";
+import * as path from "path-browserify";
 import { LumberEventName } from "./lumberEventNames";
 import { Lumber } from "./lumber";
 import {


### PR DESCRIPTION
We should not be using node libraries in code that is not explicitly node-only.  Webpack no longer implicitly does a polyfill fallback, so our downstream consumers are stuck handling this when we do.  path-browserify is used elsewhere (dds/map) over node path, so use that there as well.