### PR TITLE
[main -> 0.45] Port change to use common-utils hash in odsp-driver

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -8,6 +8,7 @@
 - [webpack-fluid-loader package name changed](#webpack-fluid-loader-package-name-changed)
 - [Loggers without tag support now deprecated in ContainerContext](#loggers-without-tag-support-now-deprecated-in-containercontext)
 - [Creating new containers with Container.load is no longer supported](#Creating-new-containers-with-Containerload-is-no-longer-supported)
+- [getHashedDocumentId is now async](#gethasheddocumentid-is-now-async)
 
 ### Changes to local testing in insecure environments and associated bundle size increase
 Previously the `@fluidframework/common-utils` package exposed a `setInsecureContextHashFn` function so users could set an override when testing locally in insecure environments because the `crypto.subtle` library is not available.  This is now done automatically as a fallback and the function is removed.  The fallback exists as a dynamic import of our equivalent Node platform implementation, and will show as a chunk named "FluidFramework-HashFallback" and be up to ~25KB parsed in size.  It will not be served when running normally in a modern browser.
@@ -37,6 +38,9 @@ The `logger` property of `ContainerContext` has been marked deprecated. Loggers 
 - See [Creating new containers with Container.load has been deprecated](#Creating-new-containers-with-Containerload-has-been-deprecated)
 - The `createOnLoad` flag to inside `IContainerLoadOptions` has been removed.
 - `LegacyCreateOnLoadEnvironmentKey` from `@fluidframework/container-loader` has been removed.
+
+### getHashedDocumentId is now async
+`@fluidframework/odsp-driver`'s `getHashedDocumentId` function is now async to take advantage of shared hashing functionality.  It drops its dependency on the `sha.js` package as a result, which contributed ~37KB to the parsed size of the `odsp-driver` bundle.
 
 ## 0.44 Breaking changes
 - [Property removed from ContainerRuntime class](#Property-removed-from-the-ContainerRuntime-class)

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -38,7 +38,7 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
 export function getApiRoot(origin: string): string;
 
 // @public (undocumented)
-export function getHashedDocumentId(driveId: string, itemId: string): string;
+export function getHashedDocumentId(driveId: string, itemId: string): Promise<string>;
 
 // @public
 export function getLocatorFromOdspUrl(url: URL): OdspFluidDataStoreLocator | undefined;

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -70,7 +70,6 @@
     "abort-controller": "^3.0.0",
     "debug": "^4.1.1",
     "node-fetch": "^2.6.1",
-    "sha.js": "^2.4.11",
     "socket.io-client": "^2.1.1",
     "uuid": "^8.3.1"
   },

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -95,7 +95,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
             };
         }
         const { siteUrl, driveId, itemId, path, containerPackageName, fileVersion } = decodeOdspUrl(request.url);
-        const hashedDocumentId = getHashedDocumentId(driveId, itemId);
+        const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
         assert(!hashedDocumentId.includes("/"), 0x0a8 /* "Docid should not contain slashes!!" */);
 
         let documentUrl = `fluid-odsp://placeholder/placeholder/${hashedDocumentId}/${removeBeginningSlash(path)}`;

--- a/packages/drivers/odsp-driver/src/odspPublicUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspPublicUtils.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import sha from "sha.js";
+import { hashFile, IsoBuffer } from "@fluidframework/common-utils";
 
-export function getHashedDocumentId(driveId: string, itemId: string): string {
-    return encodeURIComponent(new sha.sha256().update(`${driveId}_${itemId}`).digest("base64"));
+export async function getHashedDocumentId(driveId: string, itemId: string): Promise<string> {
+    const buffer = IsoBuffer.from(`${driveId}_${itemId}`);
+    return encodeURIComponent(await hashFile(buffer, "SHA-256", "base64"));
 }

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -87,7 +87,7 @@ describe("Create New Utils Tests", () => {
         const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
         const driveId = "driveId";
         const itemId = "itemId";
-        const hashedDocumentId = getHashedDocumentId(driveId, itemId);
+        const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
         const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
         const localCache = createUtLocalCache();
         // use null logger here as we expect errors

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -25,8 +25,13 @@ describe("Tests for Epoch Tracker", () => {
     const itemId = "itemId";
     let epochTracker: EpochTracker;
     let localCache: LocalPersistentCache;
-    const hashedDocumentId = getHashedDocumentId(driveId, itemId);
+    let hashedDocumentId: string;
     const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
+
+    before(async () => {
+        hashedDocumentId = await getHashedDocumentId(driveId, itemId);
+    });
+
     beforeEach(() => {
         localCache = createUtLocalCache();
         // use null logger here as we expect errors

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -39,8 +39,12 @@ describe("Tests for Epoch Tracker With Redemption", () => {
     const driveId = "driveId";
     const itemId = "itemId";
     let epochTracker: EpochTrackerWithRedemption;
-    const hashedDocumentId = getHashedDocumentId(driveId, itemId);
+    let hashedDocumentId: string;
     let epochCallback: DeferralWithCallback;
+
+    before(async () => {
+        hashedDocumentId = await getHashedDocumentId(driveId, itemId);
+    });
 
     beforeEach(() => {
         const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -80,7 +80,7 @@ describe("Odsp Create Container Test", () => {
 
     it("Check Document Service Successfully", async () => {
         const resolved = await resolver.resolve(request);
-        const docID = getHashedDocumentId(driveId, itemId);
+        const docID = await getHashedDocumentId(driveId, itemId);
         const summary = createSummary(true, true);
         const docService = await mockFetchOk(
             async () => odspDocumentServiceFactory.createContainer(summary, resolved, new TelemetryUTLogger()),

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -205,7 +205,7 @@ describe("Odsp Driver Resolver", () => {
         assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
         assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
         assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be equal");
-        assert.strictEqual(resolvedUrl.hashedDocumentId, getHashedDocumentId(driveId, itemId),
+        assert.strictEqual(resolvedUrl.hashedDocumentId, await getHashedDocumentId(driveId, itemId),
             "Doc id should be present");
         assert.notStrictEqual(resolvedUrl.endpoints.snapshotStorageUrl, "", "Snapshot url should be present");
 
@@ -231,7 +231,7 @@ describe("Odsp Driver Resolver", () => {
         assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
         assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
         assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be equal");
-        assert.strictEqual(resolvedUrl.hashedDocumentId, getHashedDocumentId(driveId, itemId),
+        assert.strictEqual(resolvedUrl.hashedDocumentId, await getHashedDocumentId(driveId, itemId),
             "Doc id should be present");
         assert.notStrictEqual(resolvedUrl.endpoints.snapshotStorageUrl, "", "Snapshot url should be present");
 
@@ -257,7 +257,7 @@ describe("Odsp Driver Resolver", () => {
         assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
         assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
         assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be equal");
-        assert.strictEqual(resolvedUrl.hashedDocumentId, getHashedDocumentId(driveId, itemId),
+        assert.strictEqual(resolvedUrl.hashedDocumentId, await getHashedDocumentId(driveId, itemId),
             "Doc id should be present");
         assert.notStrictEqual(resolvedUrl.endpoints.snapshotStorageUrl, "", "Snapshot url should be present");
 
@@ -295,7 +295,7 @@ describe("Odsp Driver Resolver", () => {
         assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
         assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
         assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be equal");
-        assert.strictEqual(resolvedUrl.hashedDocumentId, getHashedDocumentId(driveId, itemId),
+        assert.strictEqual(resolvedUrl.hashedDocumentId, await getHashedDocumentId(driveId, itemId),
             "Doc id should be present");
         assert.notStrictEqual(resolvedUrl.endpoints.snapshotStorageUrl, "", "Snapshot url should be present");
         assert.strictEqual(resolvedUrl.fileVersion, fileVersion, "FileVersion should be equal");

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -59,7 +59,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
                 assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
                 assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be equal");
                 assert.strictEqual(resolvedUrl.fileVersion, urlWithNav.hasVersion ? fileVersion : undefined);
-                assert.strictEqual(resolvedUrl.hashedDocumentId, getHashedDocumentId(driveId, itemId), "Doc id should be equal");
+                assert.strictEqual(resolvedUrl.hashedDocumentId, await getHashedDocumentId(driveId, itemId), "Doc id should be equal");
                 assert(resolvedUrl.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
             };
             await runTest(urlResolverWithShareLinkFetcher);
@@ -75,7 +75,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
                 assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");
                 assert.strictEqual(resolvedUrl2.itemId, itemId, "Item id should be equal");
                 assert.strictEqual(resolvedUrl2.fileVersion, urlWithNav.hasVersion  ? fileVersion : undefined);
-                assert.strictEqual(resolvedUrl2.hashedDocumentId, getHashedDocumentId(driveId, itemId), "Doc id should be equal");
+                assert.strictEqual(resolvedUrl2.hashedDocumentId, await getHashedDocumentId(driveId, itemId), "Doc id should be equal");
                 assert(resolvedUrl2.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
             };
             await runTest(urlResolverWithShareLinkFetcher);

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -47,7 +47,7 @@ async function initializeODSPCore(
         return;
     }
 
-    const docId = odsp.getHashedDocumentId(driveId, itemId);
+    const docId = await odsp.getHashedDocumentId(driveId, itemId);
 
     console.log(`Connecting to ODSP:
   server: ${server}


### PR DESCRIPTION
Port of #7010

Use the updated hash functions from common-utils (with new SHA256/base64 support) instead of sha.js, which removes the sha.js and downstream dependencies and cuts ~37KB from the odsp-driver package. Requires making getHashedDocumentId async, which is only used by bohemia for anonymization in telemetry.