### PR TITLE
Disable tests for fetching the binary snapshot format in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -457,8 +457,8 @@ export async function downloadSnapshot(
     epochTracker?: EpochTracker,
 ): Promise<ISnapshotRequestAndResponseOptions> {
     if (fetchBinarySnapshotFormat) {
-        // Logging an error event here as it is not supposed to be used in production yet and only in experimental mode.
-        logger.sendErrorEvent({ eventName: "BinarySnapshotFetched" });
+        // Logging an event here as it is not supposed to be used in production yet and only in experimental mode.
+        logger.sendTelemetryEvent({ eventName: "BinarySnapshotFetched" });
         return fetchSnapshotContentsCoreV2(odspResolvedUrl, storageToken, snapshotOptions, controller, epochTracker);
     } else {
         return fetchSnapshotContentsCoreV1(odspResolvedUrl, storageToken, snapshotOptions, controller, epochTracker);

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -61,7 +61,7 @@ export const generateOdspHostStoragePolicy = (seed: number)=> {
         sessionOptions: [undefined, ...generatePairwiseOptions(odspSessionOptions, seed)],
         enableRedeemFallback: booleanCases,
         cacheCreateNewSummary: booleanCases,
-        fetchBinarySnapshotFormat: booleanCases,
+        fetchBinarySnapshotFormat: [false],
     };
     return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };


### PR DESCRIPTION
Disable tests for fetching the binary snapshot format in odsp driver for now as there is some problem in the snapshot returned by the spo in prod. So disabling it.