### PR TITLE
[main -> 0.45] Bump socket.io-client dep from 2.1.1 to 2.4.0 to resolve security iss…

### DIFF
--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -70,7 +70,7 @@
     "abort-controller": "^3.0.0",
     "debug": "^4.1.1",
     "node-fetch": "^2.6.1",
-    "socket.io-client": "^2.1.1",
+    "socket.io-client": "^2.4.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -68,7 +68,7 @@
     "axios": "^0.21.1",
     "debug": "^4.1.1",
     "json-stringify-safe": "5.0.1",
-    "socket.io-client": "^2.1.1",
+    "socket.io-client": "^2.4.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
…ue in xmlhttprequest-ssl (#7099)

There is a security issue in xmlhttprequest-ssl 1.5.5, which we are getting from our socket.io-client version. It is resolved in 1.6.1, which we can get by bumping our dep for socket.io-client to 2.4.0. We already resolve socket.io-client to 2.4.0, so this should functionally be a no-op for us.