### PR TITLE
Fix contents of blobs when binary contents are specified for r11s driver

### DIFF
--- a/packages/drivers/routerlicious-driver/src/createNewUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/createNewUtils.ts
@@ -6,6 +6,11 @@
 import { Uint8ArrayToString } from "@fluidframework/common-utils";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 
+/**
+ * Utility api to convert ISummaryTree to a summary tree where blob contents are only utf8 strings.
+ * @param summary - Summary supplied by the runtime to upload.
+ * @returns - Modified summary tree where the blob contents could be utf8 string only.
+ */
 export function convertSummaryToCreateNewSummary(summary: ISummaryTree): ISummaryTree {
     const keys = Object.keys(summary.tree);
     for (const key of keys) {

--- a/packages/drivers/routerlicious-driver/src/createNewUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/createNewUtils.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Uint8ArrayToString } from "@fluidframework/common-utils";
+import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+
+export function convertSummaryToCreateNewSummary(summary: ISummaryTree): ISummaryTree {
+    const keys = Object.keys(summary.tree);
+    for (const key of keys) {
+        const summaryObject = summary.tree[key];
+
+        switch (summaryObject.type) {
+            case SummaryType.Tree: {
+                summary.tree[key] = convertSummaryToCreateNewSummary(summaryObject);
+                break;
+            }
+            case SummaryType.Blob: {
+                summaryObject.content = typeof summaryObject.content === "string" ?
+                    summaryObject.content : Uint8ArrayToString(summaryObject.content, "utf8");
+                break;
+            }
+            case SummaryType.Handle: {
+                throw new Error("No handle should be present for first summary!!");
+            }
+            default: {
+                throw new Error(`Unknown tree type ${summaryObject.type}`);
+            }
+        }
+    }
+
+    return summary;
+}

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -23,6 +23,7 @@ import { DocumentService } from "./documentService";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
+import { convertSummaryToCreateNewSummary } from "./createNewUtils";
 
 const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
@@ -85,7 +86,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             `/documents/${tenantId}`,
             {
                 id,
-                summary: appSummary,
+                summary: convertSummaryToCreateNewSummary(appSummary),
                 sequenceNumber: documentAttributes.sequenceNumber,
                 values: quorumValues,
             },


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/7089
Blob contents needs to be converted to string when Unint8Array is supplied to create new summary.