### PR TITLE
Add server-side doc id generation to Tinylicious

### DIFF
--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -1069,6 +1069,12 @@
         "@types/node": "*"
       }
     },
+    "@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
+      "dev": true
+    },
     "@types/ws": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -60,6 +60,7 @@
     "semver": "^6.3.0",
     "socket.io": "^2.4.1",
     "split": "^1.0.0",
+    "uuid": "^8.3.2",
     "winston": "^3.3.3"
   },
   "devDependencies": {
@@ -84,6 +85,7 @@
     "@types/semver": "^6.2.0",
     "@types/socket.io": "^2.1.4",
     "@types/split": "^0.3.28",
+    "@types/uuid": "^8.3.1",
     "@types/ws": "^6.0.4",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/eslint-plugin-tslint": "~2.16.0",

--- a/server/tinylicious/src/routes/ordering/documents.ts
+++ b/server/tinylicious/src/routes/ordering/documents.ts
@@ -5,6 +5,7 @@
 
 import { IDocumentStorage } from "@fluidframework/server-services-core";
 import { Router } from "express";
+import { v4 as uuid } from "uuid";
 import { getParam } from "../../utils";
 
 export function create(storage: IDocumentStorage): Router {
@@ -29,7 +30,7 @@ export function create(storage: IDocumentStorage): Router {
     router.post("/:tenantId", (request, response, next) => {
         // Tenant and document
         const tenantId = getParam(request.params, "tenantId");
-        const id = request.body.id;
+        const id = request.body.id || uuid();
 
         // Summary information
         const summary = request.body.summary;


### PR DESCRIPTION
As of #7038, R11s accepts a blank doc id for creating documents, in which case R11s will generate the doc id. Tinylicious should also have that functionality.