### PR TITLE
Disable TLS 1.0 and 1.1 in Nginx Ingress Controller for security reasons

### DIFF
--- a/server/routerlicious/kubernetes/nginx/README.md
+++ b/server/routerlicious/kubernetes/nginx/README.md
@@ -38,6 +38,7 @@ $ kubectl create configmap nginx-template --from-file=nginx.tmpl=./nginx.tmpl
 If your kube cluster uses rbac, deploy the roles and bindings from the rbac folder. 
 
 Deploy the controller now. This assumes a rbac enabled cluster, so remove <em>serviceAccountName: nginx-serviceaccount</em> line from the deployment files if your cluster is not rbac enabled.
+For security reasons, TLS 1.0 and 1.1 are disabled. Only TLS 1.2 is supported.
 
 ```bash
 $ kubectl create -f ./nginx-ingress-controller.yml

--- a/server/routerlicious/kubernetes/nginx/config/nginx.tmpl
+++ b/server/routerlicious/kubernetes/nginx/config/nginx.tmpl
@@ -198,6 +198,7 @@ http {
     server_name_in_redirect off;
     port_in_redirect        off;
 
+    # For security reasons, disable TLS 1.0 and 1.1; Only TLS 1.2 is supported
     ssl_protocols TLSv1.2;
 
     # turn on session caching to drastically improve performance

--- a/server/routerlicious/kubernetes/nginx/config/nginx.tmpl
+++ b/server/routerlicious/kubernetes/nginx/config/nginx.tmpl
@@ -198,7 +198,7 @@ http {
     server_name_in_redirect off;
     port_in_redirect        off;
 
-    ssl_protocols {{ $cfg.SSLProtocols }};
+    ssl_protocols TLSv1.2;
 
     # turn on session caching to drastically improve performance
     {{ if $cfg.SSLSessionCache }}


### PR DESCRIPTION
Change tmpl file to disable TLS 1.0 and 1.1 in Nginx Ingress Controller. By default, it supports TLS 1.0, 1.1 and 1.2