### PR TITLE
Strip .app in buildHeirarchy from protocol-base

### DIFF
--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -54,7 +54,7 @@ export class BlobTreeEntry {
 }
 
 // @public
-export function buildHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>): ISnapshotTreeEx;
+export function buildHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
 
 // @public
 export class CommitTreeEntry {


### PR DESCRIPTION
Optionally strip .app path prefix in buildHeirarchy from protocol-base to support summaries with .app nodes in container trees