### PR TITLE
[0.45] get_ops flow is broken due to raising events on wrong object

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -377,7 +377,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                         duration: performance.now() - data.start,
                         length: messages.length,
                     });
-                    this.socket.emit("op", this.documentId, messages);
+                    this.emit("op", this.documentId, messages);
                 }
             }
         });


### PR DESCRIPTION
The bug became obvious due to latest PUSH rollout to SPDF that removes initial Ops on connection, making this part of code critical in loading flow.
Unfortunately we did not see this issue despite a bunch of testing, and it was missed on PUSH rollout as PUSH is using 0.44.x bits in its CI loop.
Bug shows up only if client uses IConnect.supportedFeatures.api_get_ops = true as that changes behavior of PUSH.
While 0.45 itself should not have a regression as client does not provide IConnect.supportedFeatures.api_get_ops, it's safe to fix it and we know (from telemetry) that we run into "too many retries" issues in general (much less frequently than with this regression, but we still run into these issues with some frequency).

I'm in the process of validating all these claims