### PR TITLE
fix blob test failing on r11s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -228,7 +228,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
 
         await assert.rejects(
             container.attach(provider.driver.createCreateNewRequest(provider.documentId)),
-            /(0x206)|(0x202)/,
+            /(0x206)|(0x202)|(0x204)/,
         );
     });
 


### PR DESCRIPTION
This code was left out when replacing the error string with the shortcodes.

The behavior being tested is not fully implemented, and is only partially implemented on ODSP. The test checks that attach() throws an error when attachment blobs are present, or that an error is thrown by the r11s or local document service factory beforehand. The error message is the same in r11s and local, but was replaced by different shortcodes.