### PR TITLE
Adjust noop frequency up from 250ms to 2s based on feedback from ODSP TAP 40 scalability run.

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -225,12 +225,13 @@ export async function waitContainerToCatchUp(container: Container) {
 //    aggressive noop sending from client side.
 // 5. Number of ops sent by all clients is proportional to number of "write" clients (every client sends noops),
 //    but number of sequenced noops is a function of time (one op per 2 seconds at most).
+//    We should consider impact to both outbound traffic (might be huge, depends on number of clients) and file size.
 // Please also see Issue #5629 for more discussions.
 //
 // With that, the current algorithm is as follows:
-// 1. Sent noop 250 ms of receiving an op if no ops were sent by this client within this timeframe.
-//    This will ensure that MSN moves forward with reasonable speed. If that results in too many noops, server timeout
-//    of 2000ms should be reconsidered to be increased.
+// 1. Sent noop 2000 ms of receiving an op if no ops were sent by this client within this timeframe.
+//    This will ensure that MSN moves forward with reasonable speed. If that results in too many sequenced noops,
+//    server timeout of 2000ms should be reconsidered to be increased.
 // 2. If there are more than 50 ops received without sending any ops, send noop to keep collab window small.
 //    Note that system ops (including noops themselves) are excluded, so it's 1 noop per 50 real ops.
 export class CollabWindowTracker {
@@ -240,7 +241,7 @@ export class CollabWindowTracker {
     constructor(
         private readonly submit: (type: MessageType, contents: any) => void,
         private readonly activeConnection: () => boolean,
-        NoopTimeFrequency: number = 250,
+        NoopTimeFrequency: number = 2000,
         private readonly NoopCountFrequency: number = 50,
     ) {
         this.timer = new Timer(NoopTimeFrequency, () => {


### PR DESCRIPTION

With current (prior to fix) numbers, we were spamming PUSH with too many ops, causing it not handling workload.
2s adjustment will have (using TAP 40 payload) 8x difference in outbound traffic, and should have zero impact on final file size (due to 5 ops / sec of real traffic that results in all noops not being sequenced).
That said, it will regress certain workloads (search quality, size of snapshots), so we will need to re-evaluate impact and next steps.

Long term, we should strongly consider "alternative solution" proposed in https://github.com/microsoft/FluidFramework/issues/5629, as well as make our system less susceptible to collab window size (i.e. how summaries are working for Sequence and how search works for Sequence).