### PR TITLE
Adjust latency telemetry based on recent regression in scalability runs experience

### DIFF
--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -97,7 +97,7 @@ class OpPerfTelemetry {
         this.socketLatency += latency;
         const aggregateCount = 100;
         if (this.pongCount === aggregateCount) {
-            this.logger.sendTelemetryEvent({
+            this.logger.sendPerformanceEvent({
                 eventName: "DeltaLatency",
                 duration: this.socketLatency / aggregateCount,
             });
@@ -138,10 +138,23 @@ class OpPerfTelemetry {
             this.clientSequenceNumberForLatencyStatistics === message.clientSequenceNumber) {
             assert(this.opSendTimeForLatencyStatistics !== undefined,
                 0x120 /* "Undefined latency statistics (op send time)" */);
+
+            const duration = Date.now() - this.opSendTimeForLatencyStatistics;
+
+            // One of the core expectations for Fluid service is to be fast.
+            // When it's not the case, we want to learn about it and be able to investigate, so
+            // raise awareness.
+            // This also helps identify cases where it's due to client behavior (sending too many ops)
+            // that results in overwhelming ordering service and thus starting to see long latencies.
+            // The threshold could be adjusted, but ideally it stays  workload-agnostic, as service
+            // performance impacts all workloads relying on service.
+            const category = duration > 5000 ? "error" : "performance";
+
             this.logger.sendPerformanceEvent({
                 eventName: "OpRoundtripTime",
                 sequenceNumber,
-                duration: Date.now() - this.opSendTimeForLatencyStatistics,
+                duration,
+                category,
             });
             this.clientSequenceNumberForLatencyStatistics = undefined;
         }


### PR DESCRIPTION
Client change overwhelmed PUSH but it was not very obvious from client logs.
Make sure such issues are more visible through usage of error events.

Also correctly format duration for another event by using performance event API (it converts floats to ints, making it easier to consume in telemetry and reducing size a bit).