### PR TITLE
Remove fluid:telemetry:OdspDriver:GetDeltas_cancel

### DIFF
--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -61,7 +61,6 @@ export class ParallelRequests<T> {
     public cancel() {
         if (this.working) {
             this.workingState = "canceled";
-            this.logger.sendTelemetryEvent({ eventName: "GetDeltas_cancel" });
             this.endEvent.resolve();
         }
     }


### PR DESCRIPTION
Please see issue #7040 for more details - this event is duplicating another event that has exactly same name which makes data analyzes very confusing.
