### PR TITLE
remove value from DB close log

### DIFF
--- a/server/routerlicious/packages/services-core/src/mongo.ts
+++ b/server/routerlicious/packages/services-core/src/mongo.ts
@@ -62,7 +62,7 @@ export class MongoManager {
                 });
 
                 db.on("close", (value) => {
-                    debug("DB Close", value);
+                    debug("DB Close");
                     this.reconnect(this.reconnectDelayMs);
                 });
 


### PR DESCRIPTION
The "value" param in the debug log when DB Close event is triggered was printing out the CosmosDB connection string which is a security issue.