### PR TITLE
Put client fetch correlation id when fetching ops

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -23,6 +23,11 @@ import { getWithRetryForTokenRefresh } from "./odspUtils";
  * Provides access to the underlying delta storage on the server for sharepoint driver.
  */
 export class OdspDeltaStorageService {
+    // This set is used to record the id for the request. The id is formed using the from/to of the ops fetch request.
+    // We don't want to put SPResponse guid in all ops fetch requests as it overrides the SPRequestGuid on server and
+    // then the server cannot determine the farm/time on which the request is executed. So for now we only want to
+    // use SpResponseGuid for requests that we think are retried requests. So if a request is made for same ops range
+    // then we put the SPResponseGuid in the fetch request.
     private readonly deltaRequestIdSet = new Set();
     constructor(
         private readonly deltaFeedUrl: string,

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -54,7 +54,7 @@ export class OdspDeltaStorageService {
             let postBody = `--${formBoundary}\r\n`;
             postBody += `Authorization: Bearer ${storageToken}\r\n`;
             postBody += `X-HTTP-Method-Override: GET\r\n`;
-            if (SPResponseGuid) {
+            if (SPResponseGuid !== undefined) {
                 postBody += `SPResponseGuid: ${SPResponseGuid}\r\n`;
             }
 

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -42,9 +42,11 @@ export class OdspDeltaStorageService {
             const storageToken = await this.getStorageToken(options, "DeltaStorage");
 
             const formBoundary = uuid();
+            const SPResponseGuid = uuid();
             let postBody = `--${formBoundary}\r\n`;
             postBody += `Authorization: Bearer ${storageToken}\r\n`;
             postBody += `X-HTTP-Method-Override: GET\r\n`;
+            postBody += `SPResponseGuid: ${SPResponseGuid}\r\n`;
 
             postBody += `_post: 1\r\n`;
             postBody += `\r\n--${formBoundary}--`;
@@ -83,6 +85,7 @@ export class OdspDeltaStorageService {
                 headers: Object.keys(headers).length !== 0 ? true : undefined,
                 length: messages.length,
                 duration: response.duration, // this duration for single attempt!
+                SPResponseGuid,
                 ...response.commonSpoHeaders,
                 attempts: options.refresh ? 2 : 1,
                 from,


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/7000
Put client fetch correlation id when fetching ops. This makes sure that the server uses the same guid as spRequestGuid at server to track this request and client can so the same at its end in case something goes wrong with the request.
Note: This should be done for debugging purposes only as the server loses some capability if it does not generate its own guid like tracking at which farm/time the request got executed.