### PR TITLE
add runWithRetry method in services-util

### DIFF
--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,6 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1029.0",
     "@fluidframework/server-services-core": "^0.1029.0",

--- a/server/routerlicious/packages/services-utils/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-utils/src/runWithRetry.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { delay } from "@fluidframework/common-utils";
+import * as winston from "winston";
+
+export async function runWithRetry<T>(
+    api: () => Promise<T>,
+    callName: string,
+    shouldRetry?: (error) => boolean,
+): Promise<T | undefined> {
+    let result: T | undefined;
+    let retryCount = 0;
+    const retryAfterMs = 1000;
+    let success = false;
+    do  {
+        try {
+            result = await api();
+            success = true;
+        } catch (error) {
+            winston.info(`Error running ${callName}: ${error}`);
+            if (shouldRetry !== undefined && shouldRetry(error) === false) {
+                break;
+            } else {
+                if (retryCount > 3) {
+                    // Needs to be a full rejection here
+                    return Promise.reject(error);
+                }
+                await delay(retryAfterMs * 2 ** retryCount);
+                retryCount++;
+            }
+        }
+    } while (!success);
+
+    return result;
+}


### PR DESCRIPTION
To be able to reuse retry logic (similar to what is done in driver-utils) on the server side. E.g. in this PR: https://github.com/microsoft/FluidFramework/pull/7134