### PR TITLE
Update CI pipeline to support non-scoped packages

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -22,6 +22,11 @@ parameters:
     - default
     - skip
     - force
+- name: nonScopedPackages
+  displayName: Non-scoped packages to publish
+  type: object
+  default: 
+  - fluid-framework
 
 trigger:
   branches:
@@ -71,6 +76,7 @@ extends:
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    nonScopedPackages: ${{ parameters.nonScopedPackages }}
     buildDirectory: .
     tagName: client
     poolBuild: Main

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -68,14 +68,15 @@ parameters:
   type: string
   default:
 
+- name: nonScopedPackages
+  type: object
+  default: []
+
 - name: publishOverride
   type: string
 
 - name: releaseBuildOverride
   type: string
-
-- name: nonScopedPackages
-  type: object
 
 - name: tagName
   type: string

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -94,6 +94,7 @@ variables:
       publishOverride: ${{ parameters.publishOverride }}
       releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
       buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+      nonScopedPackages: ${{ parameters.nonScopedPackages }}
 
 stages:
   # Install / Build / Test Stage
@@ -146,6 +147,7 @@ stages:
                 componentDetection=${{ variables.componentDetection }}
                 publish=${{ variables.publish }}
                 canRelease=${{ variables.canRelease }}
+                publishNonScopedPackages=${{ variables.publishNonScopedPackages }}
 
                 release=$(release)"
 
@@ -269,7 +271,9 @@ stages:
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
                 mkdir $(Build.ArtifactStagingDirectory)/pack-scoped/
-                mkdir $(Build.ArtifactStagingDirectory)/pack-non-scoped/
+                if [[ "${{ variables.publishNonScopedPackages }}" == "True" ]]; then
+                  mkdir $(Build.ArtifactStagingDirectory)/pack-non-scoped/
+                fi
                 if [ -f "lerna.json" ]; then
                   npx lerna exec --no-private --no-sort -- npm pack --unsafe-perm
                   npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack-scoped/ ./*.tgz
@@ -277,15 +281,16 @@ stages:
                   npm pack --unsafe-perm
                   mv -t $(Build.ArtifactStagingDirectory)/pack-scoped/ ./*.tgz
                 fi
-              
-          - ${{ each parameter in parameters.nonScopedPackages }}:
-            - task: Bash@3
-              displayName: Move Non-Scoped Package ${{parameter}}
-              inputs:
-                targetType: 'inline'
-                workingDirectory: ${{ parameters.buildDirectory }}
-                script: |
-                  mv -t $(Build.ArtifactStagingDirectory)/pack-non-scoped/ $(Build.ArtifactStagingDirectory)/pack-scoped/${{parameter}}*.tgz
+
+          - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+            - ${{ each parameter in parameters.nonScopedPackages }}:
+              - task: Bash@3
+                displayName: Move Non-Scoped Package ${{parameter}}
+                inputs:
+                  targetType: 'inline'
+                  workingDirectory: ${{ parameters.buildDirectory }}
+                  script: |
+                    mv -t $(Build.ArtifactStagingDirectory)/pack-non-scoped/ $(Build.ArtifactStagingDirectory)/pack-scoped/${{parameter}}*.tgz
 
           - task: PublishBuildArtifacts@1
             displayName: Publish Artifact for Scoped Packages - pack-scoped
@@ -294,12 +299,13 @@ stages:
               ArtifactName: 'pack-scoped'
               publishLocation: 'Container'
 
-          - task: PublishBuildArtifacts@1
-            displayName: Publish Artifact for Non-Scoped Packages - pack-non-scoped
-            inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack-non-scoped'
-              ArtifactName: 'pack-non-scoped'
-              publishLocation: 'Container'
+          - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+            - task: PublishBuildArtifacts@1
+              displayName: Publish Artifact for Non-Scoped Packages - pack-non-scoped
+              inputs:
+                PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack-non-scoped'
+                ArtifactName: 'pack-non-scoped'
+                publishLocation: 'Container'
 
         # Collect/publish/run bundle analysis
         - ${{ if eq(parameters.taskBundleAnalysis, true) }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -270,16 +270,17 @@ stages:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                mkdir $(Build.ArtifactStagingDirectory)/pack-scoped/
+                mkdir $(Build.ArtifactStagingDirectory)/pack/
+                mkdir $(Build.ArtifactStagingDirectory)/pack/scoped/
                 if [[ "${{ variables.publishNonScopedPackages }}" == "True" ]]; then
-                  mkdir $(Build.ArtifactStagingDirectory)/pack-non-scoped/
+                  mkdir $(Build.ArtifactStagingDirectory)/pack/non-scoped/
                 fi
                 if [ -f "lerna.json" ]; then
                   npx lerna exec --no-private --no-sort -- npm pack --unsafe-perm
-                  npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack-scoped/ ./*.tgz
+                  npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack/scoped/ ./*.tgz
                 else
                   npm pack --unsafe-perm
-                  mv -t $(Build.ArtifactStagingDirectory)/pack-scoped/ ./*.tgz
+                  mv -t $(Build.ArtifactStagingDirectory)/pack/scoped/ ./*.tgz
                 fi
 
           - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
@@ -290,22 +291,14 @@ stages:
                   targetType: 'inline'
                   workingDirectory: ${{ parameters.buildDirectory }}
                   script: |
-                    mv -t $(Build.ArtifactStagingDirectory)/pack-non-scoped/ $(Build.ArtifactStagingDirectory)/pack-scoped/${{parameter}}*.tgz
+                    mv -t $(Build.ArtifactStagingDirectory)/pack/non-scoped/ $(Build.ArtifactStagingDirectory)/pack/scoped/${{parameter}}*.tgz
 
           - task: PublishBuildArtifacts@1
-            displayName: Publish Artifact for Scoped Packages - pack-scoped
+            displayName: Publish Artifact - pack
             inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack-scoped'
-              ArtifactName: 'pack-scoped'
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack'
+              ArtifactName: 'pack'
               publishLocation: 'Container'
-
-          - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
-            - task: PublishBuildArtifacts@1
-              displayName: Publish Artifact for Non-Scoped Packages - pack-non-scoped
-              inputs:
-                PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack-non-scoped'
-                ArtifactName: 'pack-non-scoped'
-                publishLocation: 'Container'
 
         # Collect/publish/run bundle analysis
         - ${{ if eq(parameters.taskBundleAnalysis, true) }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -139,7 +139,7 @@ stages:
                 TestCoverage=$(testCoverage)
               
               Publish Parameters:
-                nonScopedPackages=${{join(', ',parameters.nonScopedPackages)}}
+                nonScopedPackages=${{ join(', ', parameters.nonScopedPackages) }}
 
               Computed variables:
                 shouldPublish=${{ variables.shouldPublish }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -395,3 +395,4 @@ stages:
       parameters:
         namespace: ${{ parameters.namespace }}
         tagName: ${{ parameters.tagName }}
+        publishNonScopedPackages: ${{ variables.publishNonScopedPackages }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -74,6 +74,9 @@ parameters:
 - name: releaseBuildOverride
   type: string
 
+- name: nonScopedPackages
+  type: object
+
 - name: tagName
   type: string
 
@@ -133,6 +136,9 @@ stages:
                 Test=${{ parameters.taskTest }}
                 BuildDoc=${{ parameters.taskBuildDocs }}
                 TestCoverage=$(testCoverage)
+              
+              Publish Parameters:
+                nonScopedPackages=${{join(', ',parameters.nonScopedPackages)}}
 
               Computed variables:
                 shouldPublish=${{ variables.shouldPublish }}
@@ -261,20 +267,37 @@ stages:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                mkdir $(Build.ArtifactStagingDirectory)/pack/
+                mkdir $(Build.ArtifactStagingDirectory)/pack-scoped/
+                mkdir $(Build.ArtifactStagingDirectory)/pack-non-scoped/
                 if [ -f "lerna.json" ]; then
                   npx lerna exec --no-private --no-sort -- npm pack --unsafe-perm
-                  npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack/ ./*.tgz
+                  npx lerna exec --no-private --no-sort --parallel -- mv -t $(Build.ArtifactStagingDirectory)/pack-scoped/ ./*.tgz
                 else
                   npm pack --unsafe-perm
-                  mv -t $(Build.ArtifactStagingDirectory)/pack/ ./*.tgz
+                  mv -t $(Build.ArtifactStagingDirectory)/pack-scoped/ ./*.tgz
                 fi
+              
+          - ${{ each parameter in parameters.nonScopedPackages }}:
+            - task: Bash@3
+              displayName: Move Non-Scoped Package ${{parameter}}
+              inputs:
+                targetType: 'inline'
+                workingDirectory: ${{ parameters.buildDirectory }}
+                script: |
+                  mv -t $(Build.ArtifactStagingDirectory)/pack-non-scoped/ $(Build.ArtifactStagingDirectory)/pack-scoped/${{parameter}}*.tgz
 
           - task: PublishBuildArtifacts@1
-            displayName: Publish Artifact - pack
+            displayName: Publish Artifact for Scoped Packages - pack-scoped
             inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack'
-              ArtifactName: 'pack'
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack-scoped'
+              ArtifactName: 'pack-scoped'
+              publishLocation: 'Container'
+
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Artifact for Non-Scoped Packages - pack-non-scoped
+            inputs:
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)/pack-non-scoped'
+              ArtifactName: 'pack-non-scoped'
               publishLocation: 'Container'
 
         # Collect/publish/run bundle analysis

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -20,7 +20,7 @@ parameters:
 - name: official
   type: string
 
-- name: artifact
+- name: artifactPath
   type: string
 
 - name: publishFlags
@@ -36,8 +36,8 @@ parameters:
   default:
 
 jobs:
-- deployment: publish_${{ replace(parameters.environment, '-', '_') }}_${{ replace(parameters.artifact, '-', '_') }}
-  displayName: Publish ${{ parameters.environment }} for ${{ parameters.artifact }}
+- deployment: publish_${{ replace(parameters.environment, '-', '_') }}_${{ replace(parameters.artifactPath, '-', '_') }}
+  displayName: Publish ${{ parameters.environment }} for ${{ parameters.artifactPath }}
   pool: ${{ parameters.pool }}
   environment: ${{ parameters.environment }}
   workspace:
@@ -50,7 +50,7 @@ jobs:
         deploy:
             steps:
             - download: current
-              artifact: ${{ parameters.artifact }}
+              artifact: pack
             - task: UseNode@1
               displayName: Use Node 12.x
               inputs:
@@ -59,7 +59,7 @@ jobs:
               displayName: Generate .npmrc
               inputs:
                 targetType: 'inline'
-                workingDirectory: $(Pipeline.Workspace)/${{ parameters.artifact }}
+                workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
                 ${{ if eq(parameters.namespace, true) }}:
                   ${{ if eq(parameters.official, false) }}:
                     script: |
@@ -93,13 +93,13 @@ jobs:
             - task: npmAuthenticate@0
               displayName: npm Authenticate
               inputs:
-                workingFile: $(Pipeline.Workspace)/${{ parameters.artifact }}/.npmrc
+                workingFile: $(Pipeline.Workspace)/pack//${{ parameters.artifactPath }}/.npmrc
                 customEndPoint: ${{ parameters.customEndPoint }}
             - task: Bash@3
               displayName: Publish Packages
               inputs:
                 targetType: 'inline'
-                workingDirectory: $(Pipeline.Workspace)/${{ parameters.artifact }}
+                workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
                 script: |
                   tag="--tag canary"
                   if [[ "$(release)" == "release" ]]; then

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -37,7 +37,7 @@ parameters:
 
 jobs:
 - deployment: publish_${{ replace(parameters.environment, '-', '_') }}_${{ replace(parameters.artifact, '-', '_') }}
-  displayName: Publish ${{ parameters.environment }} for ${{parameters.artifact}}
+  displayName: Publish ${{ parameters.environment }} for ${{ parameters.artifact }}
   pool: ${{ parameters.pool }}
   environment: ${{ parameters.environment }}
   workspace:

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -20,6 +20,9 @@ parameters:
 - name: official
   type: string
 
+- name: artifact
+  type: string
+
 - name: publishFlags
   type: string
   default:
@@ -33,8 +36,8 @@ parameters:
   default:
 
 jobs:
-- deployment: publish_${{ replace(parameters.environment, '-', '_') }}
-  displayName: Publish ${{ parameters.environment }}
+- deployment: publish_${{ replace(parameters.environment, '-', '_') }}_${{ replace(parameters.artifact, '-', '_') }}
+  displayName: Publish ${{ parameters.environment }} for ${{parameters.artifact}}
   pool: ${{ parameters.pool }}
   environment: ${{ parameters.environment }}
   workspace:
@@ -47,7 +50,7 @@ jobs:
         deploy:
             steps:
             - download: current
-              artifact: pack
+              artifact: ${{ parameters.artifact }}
             - task: UseNode@1
               displayName: Use Node 12.x
               inputs:
@@ -56,7 +59,7 @@ jobs:
               displayName: Generate .npmrc
               inputs:
                 targetType: 'inline'
-                workingDirectory: $(Pipeline.Workspace)/pack
+                workingDirectory: $(Pipeline.Workspace)/${{ parameters.artifact }}
                 ${{ if eq(parameters.namespace, true) }}:
                   ${{ if eq(parameters.official, false) }}:
                     script: |
@@ -77,9 +80,9 @@ jobs:
                       echo "always-auth=true" >> ./.npmrc
                       cat .npmrc
 
-                      echo Deleteing @fluid-internal packages
+                      echo Deleting @fluid-internal packages
                       rm -f fluid-internal-*
-                      echo Deleteing @fluid-example packages
+                      echo Deleting @fluid-example packages
                       rm -f fluid-example-*
                 ${{ if eq(parameters.namespace, false) }}:
                   script: |
@@ -90,13 +93,13 @@ jobs:
             - task: npmAuthenticate@0
               displayName: npm Authenticate
               inputs:
-                workingFile: $(Pipeline.Workspace)/pack/.npmrc
+                workingFile: $(Pipeline.Workspace)/${{ parameters.artifact }}/.npmrc
                 customEndPoint: ${{ parameters.customEndPoint }}
             - task: Bash@3
               displayName: Publish Packages
               inputs:
                 targetType: 'inline'
-                workingDirectory: $(Pipeline.Workspace)/pack
+                workingDirectory: $(Pipeline.Workspace)/${{ parameters.artifact }}
                 script: |
                   tag="--tag canary"
                   if [[ "$(release)" == "release" ]]; then

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -23,7 +23,6 @@ stages:
       environment: test-package-build-feed
       official: false
       artifact: pack-scoped
-
   - template: include-publish-npm-package-steps.yml
     parameters:
       namespace: false

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -22,6 +22,15 @@ stages:
       feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
       environment: test-package-build-feed
       official: false
+      artifact: pack-scoped
+
+  - template: include-publish-npm-package-steps.yml
+    parameters:
+      namespace: false
+      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
+      environment: test-package-build-feed
+      official: false
+      artifact: pack-non-scoped
 
 - stage: publish_npm_internal
   dependsOn: build
@@ -34,6 +43,14 @@ stages:
       feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
       environment: package-build-feed
       official: false
+      artifact: pack-scoped
+  - template: include-publish-npm-package-steps.yml
+    parameters:
+      namespace: false
+      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+      environment: package-build-feed
+      official: false
+      artifact: pack-non-scoped
 
 - stage: publish_npm_official
   dependsOn: build
@@ -49,3 +66,14 @@ stages:
       official: true
       publishFlags: --access public
       tagName: ${{ parameters.tagName }}
+      artifact: pack-scoped
+  - template: include-publish-npm-package-steps.yml
+    parameters:
+      namespace: false
+      feedName: https://registry.npmjs.org
+      environment: package-npmjs-feed
+      customEndPoint: npmjs
+      official: true
+      publishFlags: --access public
+      tagName: ${{ parameters.tagName }}
+      artifact: pack-non-scoped

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -23,13 +23,14 @@ stages:
       environment: test-package-build-feed
       official: false
       artifact: pack-scoped
-  - template: include-publish-npm-package-steps.yml
-    parameters:
-      namespace: false
-      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
-      environment: test-package-build-feed
-      official: false
-      artifact: pack-non-scoped
+  - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+    - template: include-publish-npm-package-steps.yml
+      parameters:
+        namespace: false
+        feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
+        environment: test-package-build-feed
+        official: false
+        artifact: pack-non-scoped
 
 - stage: publish_npm_internal
   dependsOn: build
@@ -43,13 +44,14 @@ stages:
       environment: package-build-feed
       official: false
       artifact: pack-scoped
-  - template: include-publish-npm-package-steps.yml
-    parameters:
-      namespace: false
-      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
-      environment: package-build-feed
-      official: false
-      artifact: pack-non-scoped
+  - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+    - template: include-publish-npm-package-steps.yml
+      parameters:
+        namespace: false
+        feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+        environment: package-build-feed
+        official: false
+        artifact: pack-non-scoped
 
 - stage: publish_npm_official
   dependsOn: build
@@ -66,13 +68,14 @@ stages:
       publishFlags: --access public
       tagName: ${{ parameters.tagName }}
       artifact: pack-scoped
-  - template: include-publish-npm-package-steps.yml
-    parameters:
-      namespace: false
-      feedName: https://registry.npmjs.org
-      environment: package-npmjs-feed
-      customEndPoint: npmjs
-      official: true
-      publishFlags: --access public
-      tagName: ${{ parameters.tagName }}
-      artifact: pack-non-scoped
+  - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+    - template: include-publish-npm-package-steps.yml
+      parameters:
+        namespace: false
+        feedName: https://registry.npmjs.org
+        environment: package-npmjs-feed
+        customEndPoint: npmjs
+        official: true
+        publishFlags: --access public
+        tagName: ${{ parameters.tagName }}
+        artifact: pack-non-scoped

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -26,7 +26,7 @@ stages:
       feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
       environment: test-package-build-feed
       official: false
-      artifact: pack-scoped
+      artifactPath: scoped
   - ${{ if eq(parameters.publishNonScopedPackages, true) }}:  
     - template: include-publish-npm-package-steps.yml
       parameters:
@@ -34,7 +34,7 @@ stages:
         feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
         environment: test-package-build-feed
         official: false
-        artifact: pack-non-scoped
+        artifactPath: non-scoped
 
 - stage: publish_npm_internal
   dependsOn: build
@@ -47,7 +47,7 @@ stages:
       feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
       environment: package-build-feed
       official: false
-      artifact: pack-scoped
+      artifactPath: scoped
   - ${{ if eq(parameters.publishNonScopedPackages, true) }}:  
     - template: include-publish-npm-package-steps.yml
       parameters:
@@ -55,7 +55,7 @@ stages:
         feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
         environment: package-build-feed
         official: false
-        artifact: pack-non-scoped
+        artifactPath: non-scoped
 
 - stage: publish_npm_official
   dependsOn: build
@@ -71,7 +71,7 @@ stages:
       official: true
       publishFlags: --access public
       tagName: ${{ parameters.tagName }}
-      artifact: pack-scoped
+      artifactPath: scoped
   - ${{ if eq(parameters.publishNonScopedPackages, true) }}:  
     - template: include-publish-npm-package-steps.yml
       parameters:
@@ -82,4 +82,4 @@ stages:
         official: true
         publishFlags: --access public
         tagName: ${{ parameters.tagName }}
-        artifact: pack-non-scoped
+        artifactPath: non-scoped

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -10,6 +10,10 @@ parameters:
 - name: tagName
   type: string
 
+- name: publishNonScopedPackages
+  type: boolean
+  default: false
+
 stages:
 - stage: publish_npm_internal_test
   dependsOn: build
@@ -23,7 +27,7 @@ stages:
       environment: test-package-build-feed
       official: false
       artifact: pack-scoped
-  - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+  - ${{ if eq(parameters.publishNonScopedPackages, true) }}:  
     - template: include-publish-npm-package-steps.yml
       parameters:
         namespace: false
@@ -44,7 +48,7 @@ stages:
       environment: package-build-feed
       official: false
       artifact: pack-scoped
-  - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+  - ${{ if eq(parameters.publishNonScopedPackages, true) }}:  
     - template: include-publish-npm-package-steps.yml
       parameters:
         namespace: false
@@ -68,7 +72,7 @@ stages:
       publishFlags: --access public
       tagName: ${{ parameters.tagName }}
       artifact: pack-scoped
-  - ${{ if eq(variables.publishNonScopedPackages, true) }}:  
+  - ${{ if eq(parameters.publishNonScopedPackages, true) }}:  
     - template: include-publish-npm-package-steps.yml
       parameters:
         namespace: false

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -38,7 +38,7 @@ jobs:
     - name: testPackageFilePattern
       value: ${{ replace(replace(parameters.testPackage, '@', '' ), '/', '-') }}-*.tgz
     - name: testPackagePathPattern
-      value: $(Pipeline.Workspace)/client/pack-scoped/${{ variables.testPackageFilePattern }}
+      value: $(Pipeline.Workspace)/client/pack/scoped/${{ variables.testPackageFilePattern }}
 
     steps:
     # Setup
@@ -72,7 +72,7 @@ jobs:
     # Download artifact
     - download: client
       displayName: Download test package
-      artifact: pack-scoped
+      artifact: pack
       patterns: "**/${{ variables.testPackageFilePattern }}"
 
     - task: Bash@3

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -38,7 +38,7 @@ jobs:
     - name: testPackageFilePattern
       value: ${{ replace(replace(parameters.testPackage, '@', '' ), '/', '-') }}-*.tgz
     - name: testPackagePathPattern
-      value: $(Pipeline.Workspace)/client/pack/${{ variables.testPackageFilePattern }}
+      value: $(Pipeline.Workspace)/client/pack-scoped/${{ variables.testPackageFilePattern }}
 
     steps:
     # Setup
@@ -72,7 +72,7 @@ jobs:
     # Download artifact
     - download: client
       displayName: Download test package
-      artifact: pack
+      artifact: pack-scoped
       patterns: "**/${{ variables.testPackageFilePattern }}"
 
     - task: Bash@3

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -16,6 +16,10 @@ parameters:
   type: boolean
   default: false
 
+- name: nonScopedPackages
+  type: object
+  default: []
+
 - name: buildNumberInPatch
   type: string
 
@@ -74,6 +78,12 @@ variables:
     and(
       eq(variables.pushImage, true),
       eq(parameters.releaseImage, true)
+    )}}
+- name: publishNonScopedPackages
+  value: ${{
+    ne(
+      length(parameters.nonScopedPackages),
+      0
     )}}
 
 # compute the release variable


### PR DESCRIPTION
This PR aims to add support for non-scoped packages (such as the fluid-framework uber package) to our build and release process.
Changes made:
- Add a new `nonScopedPackages` parameter to our client build pipeline that takes in a list of package names that we'd like to publish that don't have any scope attached to them. By default, it is just the fluid-framework package atm
- Updates the build to generate two separate artifacts for scoped (`pack-scoped`) and non-scoped (`pack-non-scoped`) packages respectively
- Adds an additional `artifact` parameter to `include-publish-npm-package-steps.yml` template so that we can reuse this for both types of packages
- Each release now has an additional task to publish the non-scoped packages where `namespace` is passed as false so that the `.npmrc` file that is generated sets the non-scoped registry to be the assigned feed
- Sets a `publishNonScopedPackages` variable that will check to see if any non-scoped package parameters have been provided and only then run the above additional steps for packing , artifact upload, and package publishing

Example of build and release with non-scoped packages on test feed: https://dev.azure.com/fluidframework/internal/_build/results?buildId=34247&view=results
Example of build and release pipeline with no non-scoped packages: https://dev.azure.com/fluidframework/internal/_build/results?buildId=34256&view=results