### PR TITLE
Enable multiuser account for stress test

### DIFF
--- a/packages/utils/tool-utils/src/fluidToolRC.ts
+++ b/packages/utils/tool-utils/src/fluidToolRC.ts
@@ -61,6 +61,7 @@ export async function lockRC() {
         retries: {
             forever: true,
         },
+        stale:60000,
         realpath: false,
     });
 }

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -40,7 +40,7 @@ stages:
           env:
             login__microsoft__clientId: $(login-microsoft-clientId)
             login__microsoft__secret: $(login-microsoft-secret)
-            login__odsp__test__accounts: $(automation-stress-login-odsp-test-accounts)
+            login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           inputs:
             command: 'custom'


### PR DESCRIPTION
Follow up to PR #7148, enable multiuser account to be used in stress tests.
- Increase the time to wait for the token cache file lock (as more account needs to be auth and cached.
- Switch the pipeline to use the tenant accounts format