### PR TITLE
Move summary nack messages logic to deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -413,7 +413,14 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
             this.sessionMetric?.error("No service summary before lambda close");
         } else if (closeType === LambdaCloseType.ActivityTimeout) {
             this.sessionMetric?.setProperties({ [CommonProperties.sessionState]: SessionState.end });
-            this.sessionMetric?.success("Session terminated due to inactivity");
+
+            if (this.nackMessages?.identifier === NackMessagesType.SummaryMaxOps) {
+                this.sessionMetric?.error(
+                    "Session terminated due to inactivity while exceeding max ops since last summary");
+            } else {
+                this.sessionMetric?.success("Session terminated due to inactivity");
+            }
+
         } else {
             this.sessionMetric?.error("Unknown session end state");
         }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -17,6 +17,7 @@ import {
     ITrace,
     MessageType,
     NackErrorType,
+    ScopeType,
 } from "@fluidframework/protocol-definitions";
 import { canSummarize } from "@fluidframework/server-services-client";
 import {
@@ -34,6 +35,7 @@ import {
     ISequencedOperationMessage,
     IServiceConfiguration,
     ITicketedMessage,
+    NackMessagesType,
     NackOperationType,
     RawOperationType,
     SequencedOperationType,
@@ -263,6 +265,21 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
                     this.setNoopConsolidationTimer();
                     continue;
                 }
+
+                // Check if Deli is over the max ops since last summary nack limit
+                if (this.serviceConfiguration.deli.summaryNackMessages.enable && !this.nackMessages) {
+                    const opsSinceLastSummary = this.sequenceNumber - this.durableSequenceNumber;
+                    if (opsSinceLastSummary > this.serviceConfiguration.deli.summaryNackMessages.maxOps) {
+                        // this op brings us over the limit
+                        // start nacking non-system ops and ops that are submitted by non-summarizers
+                        this.nackMessages = {
+                            identifier: NackMessagesType.SummaryMaxOps,
+                            content: this.serviceConfiguration.deli.summaryNackMessages.nackContent,
+                            allowSystemMessages: true,
+                            allowedScopes: [ScopeType.SummaryWrite],
+                        };
+                    }
+                }
             }
 
             // Update the msn last sent.
@@ -320,7 +337,7 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
                 this.sequencedMessagesSinceLastOpEvent += sequencedMessageCount;
 
                 if (this.sequencedMessagesSinceLastOpEvent > maxOps) {
-                    lumberJackMetric?.setProperties({[CommonProperties.maxOpsSinceLastSummary]: true});
+                    lumberJackMetric?.setProperties({ [CommonProperties.maxOpsSinceLastSummary]: true });
                     this.emitOpEvent(OpEventType.MaxOps);
                 }
             }
@@ -352,16 +369,17 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
         }
 
         if (failMetric) {
-            this.sessionStartMetric?.setProperties({ [CommonProperties.sessionState]:
-                SessionState.LambdaStartFailed });
+            this.sessionStartMetric?.setProperties({
+                [CommonProperties.sessionState]: SessionState.LambdaStartFailed,
+            });
             this.sessionStartMetric?.error("Lambda start failed");
             return;
         }
 
         if (this.verifyRequiredLambdaStarted()) {
             if (this.isNewDocument) {
-                    this.sessionStartMetric?.setProperties({ [CommonProperties.sessionState]: SessionState.started });
-                    this.sessionStartMetric?.success("Session started successfully");
+                this.sessionStartMetric?.setProperties({ [CommonProperties.sessionState]: SessionState.started });
+                this.sessionStartMetric?.success("Session started successfully");
             } else {
                 this.sessionStartMetric?.setProperties({ [CommonProperties.sessionState]: SessionState.resumed });
                 this.sessionStartMetric?.success("Session resumed successfully");
@@ -646,6 +664,19 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
                         }
 
                         this.durableSequenceNumber = dsn;
+
+                        // note: "!this.nackMessages.identifier" is for backwards compat
+                        if (this.serviceConfiguration.deli.summaryNackMessages.enable && this.nackMessages &&
+                            (!this.nackMessages.identifier ||
+                                this.nackMessages.identifier === NackMessagesType.SummaryMaxOps)) {
+                            // Deli is nacking messages due to summary max ops
+                            // Check if this new dsn gets it out of that state
+                            const opsSinceLastSummary = this.sequenceNumber - this.durableSequenceNumber;
+                            if (opsSinceLastSummary <= this.serviceConfiguration.deli.summaryNackMessages.maxOps) {
+                                // stop nacking future messages
+                                this.nackMessages = undefined;
+                            }
+                        }
 
                         if (this.serviceConfiguration.deli.opEvent.enable) {
                             // since the dsn updated, ops were reliably stored

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -420,7 +420,6 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
             } else {
                 this.sessionMetric?.success("Session terminated due to inactivity");
             }
-
         } else {
             this.sessionMetric?.error("Unknown session end state");
         }

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -24,6 +24,9 @@ export interface IDeliServerConfiguration {
 
     // Consider service summary status for successful session close
     checkServiceSummaryStatus: boolean;
+
+    // Controls if ops should be nacked if a summary hasn't been made for a while
+    summaryNackMessages: IDeliSummaryNackMessagesServerConfiguration;
 }
 
 export interface IDeliOpEventServerConfiguration {
@@ -53,12 +56,9 @@ export interface IScribeServerConfiguration {
 
     // Enables writing a summary nack when an exception occurs during summary creation
     ignoreStorageException: boolean;
-
-    // Controls if ops should be nacked if a summarizer hasn't been made for a while
-    nackMessages: IScribeNackMessagesServerConfiguration;
 }
 
-export interface IScribeNackMessagesServerConfiguration {
+export interface IDeliSummaryNackMessagesServerConfiguration {
     // Enables nacking non-system & non-summarizer client message if
     // the op count since the last summary exceeds this limit
     enable: boolean;
@@ -143,13 +143,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
             maxTime: 5 * 60 * 1000,
             maxOps: 1500,
         },
-    },
-    scribe: {
-        generateServiceSummary: true,
-        enablePendingCheckpointMessages: true,
-        clearCacheAfterServiceSummary: false,
-        ignoreStorageException: false,
-        nackMessages: {
+        summaryNackMessages: {
             enable: false,
             maxOps: 5000,
             nackContent: {
@@ -159,6 +153,12 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
                 message: "Submit a summary before inserting additional operations",
             },
         },
+    },
+    scribe: {
+        generateServiceSummary: true,
+        enablePendingCheckpointMessages: true,
+        clearCacheAfterServiceSummary: false,
+        ignoreStorageException: false,
     },
     moira: {
         enable: false,

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -166,7 +166,20 @@ export interface IUpdateDSNControlMessageContents {
     clearCache: boolean;
 }
 
+/**
+ * Nack messages types
+ */
+export enum NackMessagesType {
+    // Used when ops should be nacked because a summary hasn't been made for a while
+    SummaryMaxOps = "summaryMaxOps",
+}
+
 export interface INackMessagesControlMessageContents {
+    /**
+     * Identifier for the type/reason for this nack messages
+     */
+    identifier: NackMessagesType | undefined;
+
     /**
      * The INackContent to send when nacking the message
      */


### PR DESCRIPTION
This change moves all the summary nack messages logic into deli. This makes the nack messages flow easier to follow and it should prevent any further issues with the system because deli will be in charge of both nacking messages & controlling the signal/logic itself.

Related ICM: https://portal.microsofticm.com/imp/v3/incidents/details/256835627/home
There is some bug in the existing logic that is causing deli to nack messages even though a summary has been created within the last 10k ops. I have not been able to determine the cause of the issue. However I have verified that deli knows the durableSequenceNumber moved forward so moving this logic to deli would solve/prevent that issue.
Note: We were already going to move this logic to deli - doing it now works out well.