### PR TITLE
Explicitly set perMessageDeflate flag

### DIFF
--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -123,7 +123,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
     blockSize: 64436,
     maxMessageSize: 16 * 1024,
     enableTraces: true,
-    enableLambdaMetrics: true,
+    enableLambdaMetrics: false,
     enableLumberMetrics: true,
     summary: {
         idleTime: 5000,

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -117,6 +117,7 @@ export function create(
     const io = new Server(server, {
         // enable compatibility with socket.io v2 clients
         allowEIO3: true,
+        perMessageDeflate: false,
         // ensure long polling is never used
         transports: [ "websocket" ],
         cors: {


### PR DESCRIPTION
The perMessageDeflate flag is known to cause memory issues: https://github.com/socketio/socket.io/issues/3477
Explicitly setting this flag to false.

The metrics in the critical path of the lambdas seem to add a noticeable increase in latency. Disabling it by default.