### PR TITLE
Adding TLS support for rdkafka and other Kafka changes

### DIFF
--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -9,7 +9,10 @@ RUN apt-get update && apt-get install -y \
     make \
     git \
     curl \
-    g++
+    g++ \
+    openssl \
+    libssl-dev \
+    ca-certificates
 
 # Add Tini
 ENV TINI_VERSION v0.18.0

--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -4,27 +4,41 @@ services:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
+            - /usr/src/server/node_modules/node-rdkafka
+            - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     deli:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
+            - /usr/src/server/node_modules/node-rdkafka
+            - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     scriptorium:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
+            - /usr/src/server/node_modules/node-rdkafka
+            - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     copier:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
+            - /usr/src/server/node_modules/node-rdkafka
+            - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     scribe:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
+            - /usr/src/server/node_modules/node-rdkafka
+            - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     foreman:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
+            - /usr/src/server/node_modules/node-rdkafka
+            - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     riddler:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
+            - /usr/src/server/node_modules/node-rdkafka
+            - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -108,7 +108,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
         const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
         const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
         const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
-        const kafkaSslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
+        const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
 
         const producer = services.createProducer(
             kafkaLibrary,
@@ -119,7 +119,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
             kafkaProducerPollIntervalMs,
             kafkaNumberOfPartitions,
             kafkaReplicationFactor,
-            kafkaSslCACertLocation);
+            kafkaSslCACertFilePath);
 
         const redisConfig = config.get("redis");
         const webSocketLibrary = config.get("alfred:webSocketLib");

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -108,6 +108,8 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
         const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
         const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
         const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
+        const kafkaSslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
+
         const producer = services.createProducer(
             kafkaLibrary,
             kafkaEndpoint,
@@ -116,7 +118,8 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
             false,
             kafkaProducerPollIntervalMs,
             kafkaNumberOfPartitions,
-            kafkaReplicationFactor);
+            kafkaReplicationFactor,
+            kafkaSslCACertLocation);
 
         const redisConfig = config.get("redis");
         const webSocketLibrary = config.get("alfred:webSocketLib");

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -24,11 +24,15 @@
     },
     "kafka": {
         "lib": {
-            "name": "kafka-node",
+            "name": "rdkafka",
             "endpoint": "kafka:9092",
             "producerPollIntervalMs": 10,
             "numberOfPartitions": 8,
-            "replicationFactor": 1
+            "replicationFactor": 1,
+            "rdkafkaOptimizedRebalance": true,
+            "rdkafkaAutomaticConsume": true,
+            "rdkafkaConsumeTimeout": 5,
+            "rdkafkaMaxConsumerCommitRetries": 10
         }
     },
     "zookeeper": {

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -19,7 +19,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
     const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
-    const kafkaSslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
+    const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
 
     const kafkaForwardClientId = config.get("deli:kafkaClientId");
     const kafkaReverseClientId = config.get("alfred:kafkaClientId");
@@ -49,7 +49,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
-        kafkaSslCACertLocation);
+        kafkaSslCACertFilePath);
     const reverseProducer = services.createProducer(
         kafkaLibrary,
         kafkaEndpoint,
@@ -59,7 +59,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
-        kafkaSslCACertLocation);
+        kafkaSslCACertFilePath);
 
     const redisConfig = config.get("redis");
     const redisOptions: RedisOptions = {

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -19,6 +19,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
     const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
+    const kafkaSslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
 
     const kafkaForwardClientId = config.get("deli:kafkaClientId");
     const kafkaReverseClientId = config.get("alfred:kafkaClientId");
@@ -47,7 +48,8 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         true,
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
-        kafkaReplicationFactor);
+        kafkaReplicationFactor,
+        kafkaSslCACertLocation);
     const reverseProducer = services.createProducer(
         kafkaLibrary,
         kafkaEndpoint,
@@ -56,7 +58,8 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         false,
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
-        kafkaReplicationFactor);
+        kafkaReplicationFactor,
+        kafkaSslCACertLocation);
 
     const redisConfig = config.get("redis");
     const redisOptions: RedisOptions = {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -26,6 +26,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
     const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
+    const kafkaSslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
     const sendTopic = config.get("lambdas:deli:topic");
     const kafkaClientId = config.get("scribe:kafkaClientId");
     const mongoExpireAfterSeconds = config.get("mongo:expireAfterSeconds") as number;
@@ -76,7 +77,8 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         false,
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
-        kafkaReplicationFactor);
+        kafkaReplicationFactor,
+        kafkaSslCACertLocation);
 
     return new ScribeLambdaFactory(
         mongoManager,

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -26,7 +26,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");
     const kafkaNumberOfPartitions = config.get("kafka:lib:numberOfPartitions");
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
-    const kafkaSslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
+    const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
     const sendTopic = config.get("lambdas:deli:topic");
     const kafkaClientId = config.get("scribe:kafkaClientId");
     const mongoExpireAfterSeconds = config.get("mongo:expireAfterSeconds") as number;
@@ -78,7 +78,7 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         kafkaProducerPollIntervalMs,
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
-        kafkaSslCACertLocation);
+        kafkaSslCACertFilePath);
 
     return new ScribeLambdaFactory(
         mongoManager,

--- a/server/routerlicious/packages/services-ordering-rdkafka/README.md
+++ b/server/routerlicious/packages/services-ordering-rdkafka/README.md
@@ -3,3 +3,113 @@
 Fluid server services rdkafka orderer implementation for [Fluid reference service](../routerlicious).
 
 See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.
+
+## SSL Setup
+Fundamentally, to setup SSL/TLS for Kafka, both Kafka client and Kafka server changes are needed.
+
+This implementation using `node-rdkafka` provides built-in support for SSL/TLS. But, by default, SSL is disabled in this implementation since the setup in routerlicious' docker-compose.yml does not configure SSL for the Kafka service.
+
+If you wish to enable SSL for Kafka, please follow these instructions:
+
+1. Configure SSL in the Kafka service. General instructions on how to do that can be found in the [official Kafka documentation](http://kafka.apache.org/documentation.html#security_ssl). But since we are using [`node-rdkafka`](https://github.com/blizzard/node-rdkafka), which is based on [`librdkafka`](https://github.com/edenhill/librdkafka), you can use `librdkafka`'s [`gen-ssl-certs.sh`](https://github.com/edenhill/librdkafka/blob/master/tests/gen-ssl-certs.sh) script to help you with the process. Instructions are available [here](https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka). An example of putting the instructions in practice can be found below. Please note that for this example we will be using self-signed certificates, plus Docker Kafka's service name as `BROKER`, and also the default passwords and values in the `gen-ssl-certs.sh` script. Finally, the example below only configures encryption, and not Kafka client authentication.
+
+   1. Under `FluidFramework/server/routerlicious`, create a directory called `certs`. Open the directory.
+
+      ```bash
+      $ mkdir certs
+      $ cd certs
+      ```
+
+   2. Save a copy of [`gen-ssl-certs.sh`](https://github.com/edenhill/librdkafka/blob/master/tests/gen-ssl-certs.sh) in `certs`.
+
+   3. Run the following commands:
+
+      ```bash
+      $ ./gen-ssl-certs.sh ca ca-cert Kafka-Security-CA
+      $ BROKER=kafka
+      $ ./gen-ssl-certs.sh -k server ca-cert broker_${BROKER}_ ${BROKER}
+      ```
+
+   You should now have new files under `certs`, including a JKS Truststore, a JKS Keystore and the ca-cert file.
+
+2. Update `docker-compose.yml` under `FluidFramework/server/routerlicious` to use the following setup for Kafka:
+
+    ```yaml
+    kafka:
+        image: wurstmeister/kafka:2.11-1.1.1
+        ports:
+            - "9092:9092"
+        environment:
+            KAFKA_ADVERTISED_LISTENERS: "SSL://kafka:9092"
+            KAFKA_LISTENERS: "SSL://0.0.0.0:9092"
+            KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+            KAFKA_CREATE_TOPICS: "deltas:8:1,rawdeltas:8:1,testtopic:8:1,deltas2:8:1,rawdeltas2:8:1"
+            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_SSL_KEYSTORE_TYPE: "JKS"
+            KAFKA_SSL_KEYSTORE_LOCATION: "/certs/broker_kafka_server.keystore.jks"
+            KAFKA_SSL_KEYSTORE_PASSWORD: "abcdefgh"
+            KAFKA_SSL_KEY_PASSWORD: "abcdefgh"
+            KAFKA_SSL_TRUSTSTORE_TYPE: "JKS"
+            KAFKA_SSL_TRUSTSTORE_LOCATION: "/certs/broker_kafka_server.truststore.jks"
+            KAFKA_SSL_TRUSTSTORE_PASSWORD: "abcdefgh"
+            KAFKA_SSL_CLIENT_AUTH: "none"
+            KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "SSL"
+        volumes:
+            - ./certs:/certs
+    ```
+
+3. Update `docker-compose.dev.yml` under `FluidFramework/server/routerlicious` to use volume mapping and copy the `certs` folder to the different Docker services. Please note that `...` below means that the other volume mapping rules have been omitted.
+
+    ```yaml
+    version: '3.4'
+    services:
+        alfred:
+            volumes:
+                ...
+                - ./certs:/certs
+        deli:
+            volumes:
+                ...
+                - ./certs:/certs
+        scriptorium:
+            volumes:
+                ...
+                - ./certs:/certs
+        copier:
+            volumes:
+                ...
+                - ./certs:/certs
+        scribe:
+            volumes:
+                ...
+                - ./certs:/certs
+        foreman:
+            volumes:
+                ...
+                - ./certs:/certs
+        riddler:
+            volumes:
+                ...
+                - ./certs:/certs
+    ```
+
+4. Update `config.json` under `FluidFramework/server/routerlicious/packages/routerlicious/config` to include the `sslCACertFilePath` property in `kafka.lib`. Example:
+
+    ```json
+    "kafka": {
+            "lib": {
+                "name": "rdkafka",
+                "endpoint": "kafka:9092",
+                "producerPollIntervalMs": 10,
+                "numberOfPartitions": 8,
+                "replicationFactor": 1,
+                "rdkafkaOptimizedRebalance": true,
+                "rdkafkaAutomaticConsume": true,
+                "rdkafkaConsumeTimeout": 5,
+                "rdkafkaMaxConsumerCommitRetries": 10,
+                "sslCACertFilePath": "/certs/ca-cert"
+            }
+        },
+    ```
+
+5. Now, you can build and run routerlicious and it will use SSL/TLS for Kafka.

--- a/server/routerlicious/packages/services-ordering-rdkafka/README.md
+++ b/server/routerlicious/packages/services-ordering-rdkafka/README.md
@@ -60,6 +60,7 @@ If you wish to enable SSL for Kafka, please follow these instructions:
             KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "SSL"
         volumes:
             - ./certs:/certs
+        restart: always
     ```
 
 3. Update `docker-compose.dev.yml` under `FluidFramework/server/routerlicious` to use volume mapping and copy the `certs` folder to the different Docker services. Please note that `...` below means that the other volume mapping rules have been omitted.

--- a/server/routerlicious/packages/services-ordering-rdkafka/README.md
+++ b/server/routerlicious/packages/services-ordering-rdkafka/README.md
@@ -20,7 +20,11 @@ If you wish to enable SSL for Kafka, please follow these instructions:
       $ cd certs
       ```
 
-   2. Save a copy of [`gen-ssl-certs.sh`](https://github.com/edenhill/librdkafka/blob/master/tests/gen-ssl-certs.sh) in `certs`.
+   2. Save a copy of [`gen-ssl-certs.sh`](https://github.com/edenhill/librdkafka/blob/master/tests/gen-ssl-certs.sh) in `certs`. Make sure to make it executable.
+
+      ```bash
+      $ chmod +rx gen-ssl-certs.sh
+      ```
 
    3. Run the following commands:
 
@@ -112,4 +116,4 @@ If you wish to enable SSL for Kafka, please follow these instructions:
         },
     ```
 
-5. Now, you can build and run routerlicious and it will use SSL/TLS for Kafka.
+5. Now, you can build and run routerlicious as usual and it will use SSL/TLS for Kafka.

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -36,6 +36,7 @@ export abstract class RdkafkaBase extends EventEmitter {
         }
 
         this.kafka = kafka;
+        console.log(`[KAFKA FEATURES]: ${kafka.features}`);
         this.options = {
             ...options,
             numberOfPartitions: options?.numberOfPartitions ?? 32,

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -46,10 +46,21 @@ export abstract class RdkafkaBase extends EventEmitter {
 
         // In RdKafka, we can check what features are enabled using kafka.features. If "ssl" is listed,
         // it means RdKafka has been built with support for SSL.
+        // To build node-rdkafka with SSL support, make sure OpenSSL libraries are available in the
+        // environment node-rdkafka would be running. Once OpenSSL is available, building node-rdkafka
+        // as usual will automatically include SSL support.
         const rdKafkaHasSSLEnabled =
             kafka.features.filter((feature) => feature.toLowerCase().indexOf("ssl") >= 0).length > 0;
 
-        if (rdKafkaHasSSLEnabled && options?.sslCACertFilePath) {
+        if (options?.sslCACertFilePath) {
+            // If the use of SSL is desired, but rdkafka has not been built with SSL support,
+            // throw an error making that clear to the user.
+            if (!rdKafkaHasSSLEnabled) {
+                throw new Error(
+                    "Attempted to configure SSL, but rdkafka has not been built to support it. " +
+                    "Please make sure OpenSSL is available and build rdkafka again.");
+            }
+
             this.sslOptions = {
                 "security.protocol": "ssl",
                 "ssl.ca.location": options?.sslCACertFilePath,

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -11,7 +11,7 @@ import { tryImportNodeRdkafka } from "./tryImport";
 export interface IKafkaBaseOptions {
     numberOfPartitions: number;
     replicationFactor: number;
-    sslCACertLocation?: string;
+    sslCACertFilePath?: string;
 }
 
 export interface IKafkaEndpoints {
@@ -50,10 +50,10 @@ export abstract class RdkafkaBase extends EventEmitter {
         const rdKafkaHasSSLEnabled =
             kafka.features.filter((feature) => feature.toLowerCase().indexOf("ssl") >= 0).length > 0;
 
-        if (rdKafkaHasSSLEnabled && options?.sslCACertLocation) {
+        if (rdKafkaHasSSLEnabled && options?.sslCACertFilePath) {
             this.sslOptions = {
                 "security.protocol": "ssl",
-                "ssl.ca.location": options?.sslCACertLocation,
+                "ssl.ca.location": options?.sslCACertFilePath,
             };
         }
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -81,10 +81,15 @@ export abstract class RdkafkaBase extends EventEmitter {
     }
 
     protected async ensureTopics() {
-        const adminClient = this.kafka.AdminClient.create({
+        const options: kafkaTypes.GlobalConfig = {
             "client.id": `${this.clientId}-admin`,
             "metadata.broker.list": this.endpoints.kafka.join(","),
-        });
+            ...this.sslOptions,
+        };
+
+        console.log(`[RDKAFKA ADMIN CLIENT OPTIONS]: ${JSON.stringify(options)}`);
+
+        const adminClient = this.kafka.AdminClient.create(options);
 
         const newTopic: kafkaTypes.NewTopic = {
             topic: this.topic,

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -38,7 +38,6 @@ export abstract class RdkafkaBase extends EventEmitter {
         }
 
         this.kafka = kafka;
-        console.log(`[KAFKA FEATURES]: ${kafka.features}`);
         this.options = {
             ...options,
             numberOfPartitions: options?.numberOfPartitions ?? 32,
@@ -56,8 +55,6 @@ export abstract class RdkafkaBase extends EventEmitter {
                 "ssl.ca.location": options?.sslCACertFilePath,
             };
         }
-
-        console.log(`[RDKAFKA SSL OPTIONS]: ${JSON.stringify(this.sslOptions)}`);
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.initialize();
@@ -86,8 +83,6 @@ export abstract class RdkafkaBase extends EventEmitter {
             "metadata.broker.list": this.endpoints.kafka.join(","),
             ...this.sslOptions,
         };
-
-        console.log(`[RDKAFKA ADMIN CLIENT OPTIONS]: ${JSON.stringify(options)}`);
 
         const adminClient = this.kafka.AdminClient.create(options);
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -83,11 +83,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			"offset_commit_cb": true,
 			"rebalance_cb": this.consumerOptions.optimizedRebalance ? this.rebalance.bind(this) : true,
 			...this.consumerOptions.additionalOptions,
-            'security.protocol': 'ssl',
-            'ssl.key.location': '/path/to/ssl.key',
-            'ssl.certificate.location': '/path/to/ssl.cert',
-            'ssl.ca.location': '/path/to/ssl.ca'
+			...this.sslOptions,
 		};
+
+		console.log(`[RDKAFKA ALL CONSUMER OPTIONS]: ${JSON.stringify(options)}`);
 
 		const consumer: kafkaTypes.KafkaConsumer = this.consumer =
 			new this.kafka.KafkaConsumer(options, { "auto.offset.reset": "latest" });

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -86,8 +86,6 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			...this.sslOptions,
 		};
 
-		console.log(`[RDKAFKA ALL CONSUMER OPTIONS]: ${JSON.stringify(options)}`);
-
 		const consumer: kafkaTypes.KafkaConsumer = this.consumer =
 			new this.kafka.KafkaConsumer(options, { "auto.offset.reset": "latest" });
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -83,6 +83,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			"offset_commit_cb": true,
 			"rebalance_cb": this.consumerOptions.optimizedRebalance ? this.rebalance.bind(this) : true,
 			...this.consumerOptions.additionalOptions,
+            'security.protocol': 'ssl',
+            'ssl.key.location': '/path/to/ssl.key',
+            'ssl.certificate.location': '/path/to/ssl.cert',
+            'ssl.ca.location': '/path/to/ssl.ca'
 		};
 
 		const consumer: kafkaTypes.KafkaConsumer = this.consumer =

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -76,7 +76,10 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			"queue.buffering.max.ms": 0.5,
 			"batch.num.messages": 10000,
 			...this.producerOptions.additionalOptions,
+			...this.sslOptions,
 		};
+
+		console.log(`[RDKAFKA ALL PRODUCER OPTIONS]: ${JSON.stringify(options)}`);
 
 		const producer: kafkaTypes.Producer = this.producer =
 			new this.kafka.HighLevelProducer(options, this.producerOptions.topicConfig);

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -79,8 +79,6 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			...this.sslOptions,
 		};
 
-		console.log(`[RDKAFKA ALL PRODUCER OPTIONS]: ${JSON.stringify(options)}`);
-
 		const producer: kafkaTypes.Producer = this.producer =
 			new this.kafka.HighLevelProducer(options, this.producerOptions.topicConfig);
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -52,7 +52,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const automaticConsume = config.get("kafka:lib:rdkafkaAutomaticConsume");
         const consumeTimeout = config.get("kafka:lib:rdkafkaConsumeTimeout");
         const maxConsumerCommitRetries = config.get("kafka:lib:rdkafkaMaxConsumerCommitRetries");
-        const sslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
+        const sslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -79,7 +79,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
                 automaticConsume,
                 consumeTimeout,
                 maxConsumerCommitRetries,
-                sslCACertLocation,
+                sslCACertFilePath,
             },
         );
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -52,6 +52,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const automaticConsume = config.get("kafka:lib:rdkafkaAutomaticConsume");
         const consumeTimeout = config.get("kafka:lib:rdkafkaConsumeTimeout");
         const maxConsumerCommitRetries = config.get("kafka:lib:rdkafkaMaxConsumerCommitRetries");
+        const sslCACertLocation: string = config.get("kafka:lib:sslCACertLocation");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -78,6 +79,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
                 automaticConsume,
                 consumeTimeout,
                 maxConsumerCommitRetries,
+                sslCACertLocation,
             },
         );
 

--- a/server/routerlicious/packages/services/src/index.ts
+++ b/server/routerlicious/packages/services/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export * from "./kafkaFactory";
+export * from "./kafkaProducerFactory";
 export * from "./messageReceiver";
 export * from "./messageSender";
 export * from "./metricClient";

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -18,7 +18,7 @@ export function createProducer(
     pollIntervalMs?: number,
     numberOfPartitions?: number,
     replicationFactor?: number,
-    sslCACertLocation?: string): IProducer {
+    sslCACertFilePath?: string): IProducer {
     let producer: IProducer;
 
     if (type === "rdkafka") {
@@ -26,7 +26,7 @@ export function createProducer(
             { kafka: [kafkaEndPoint] },
             clientId,
             topic,
-            { enableIdempotence, pollIntervalMs, numberOfPartitions, replicationFactor, sslCACertLocation });
+            { enableIdempotence, pollIntervalMs, numberOfPartitions, replicationFactor, sslCACertFilePath });
 
         producer.on("error", (error, errorData: IContextErrorData) => {
             if (errorData?.restart) {

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -5,33 +5,9 @@
 
 import { inspect } from "util";
 import winston from "winston";
-import { IConsumer, IContextErrorData, IProducer } from "@fluidframework/server-services-core";
-import { KafkaNodeConsumer, KafkaNodeProducer } from "@fluidframework/server-services-ordering-kafkanode";
-import { RdkafkaConsumer, RdkafkaProducer } from "@fluidframework/server-services-ordering-rdkafka";
-
-export function createConsumer(
-    type: string,
-    kafkaEndPoint: string,
-    zookeeperEndPoint: string,
-    clientId: string,
-    groupId: string,
-    topic: string,
-    numberOfPartitions?: number,
-    replicationFactor?: number): IConsumer {
-    if (type === "rdkafka") {
-        const endpoints = { kafka: [kafkaEndPoint], zooKeeper: [zookeeperEndPoint] };
-        return new RdkafkaConsumer(endpoints, clientId, topic, groupId, { numberOfPartitions, replicationFactor });
-    }
-
-    return new KafkaNodeConsumer(
-        { kafkaHost: kafkaEndPoint },
-        clientId,
-        groupId,
-        topic,
-        zookeeperEndPoint,
-        numberOfPartitions,
-        replicationFactor);
-}
+import { IContextErrorData, IProducer } from "@fluidframework/server-services-core";
+import { KafkaNodeProducer } from "@fluidframework/server-services-ordering-kafkanode";
+import { RdkafkaProducer } from "@fluidframework/server-services-ordering-rdkafka";
 
 export function createProducer(
     type: string,
@@ -41,7 +17,8 @@ export function createProducer(
     enableIdempotence?: boolean,
     pollIntervalMs?: number,
     numberOfPartitions?: number,
-    replicationFactor?: number): IProducer {
+    replicationFactor?: number,
+    sslCACertLocation?: string): IProducer {
     let producer: IProducer;
 
     if (type === "rdkafka") {
@@ -49,7 +26,7 @@ export function createProducer(
             { kafka: [kafkaEndPoint] },
             clientId,
             topic,
-            { enableIdempotence, pollIntervalMs, numberOfPartitions, replicationFactor });
+            { enableIdempotence, pollIntervalMs, numberOfPartitions, replicationFactor, sslCACertLocation });
 
         producer.on("error", (error, errorData: IContextErrorData) => {
             if (errorData?.restart) {


### PR DESCRIPTION
One security requirement of production services is that communication over the network be made securely. Most of the times, that means employing TLS/SSL encryption. This PR introduces support for TLS/SSL in Kafka through `node-rdkafka`, which is what we use in customer-facing environments (that is done through the `services-ordering-rdkafka` package). Kafka TLS is not enabled by default, though, since setup is also required on the Kafka server side. Here is a detailed list of changes:
1. Include OpenSSL + other dependencies in Dockerfile. They are required to build `node-rdkafka` with SSL support
2. `rdkafka` configurations to support TLS/SSL encryption (client authentication would need further changes)
3. Updated `services-ordering-rdkafka` README.md to include specific instructions on how to make r11s run with Kafka TLS, including `docker-compose.yml` changes required for Kafka SSL support.
4. Switched default Kafka library in r11s Docker to `node-rdkafka` (we were using`kafka-node` in Docker, but we are using  `node-rdkafka` everywhere else. Next step would be to remove our `services-ordering-kafkanode` code since it is not in use anymore)
5. `docker-compose.dev.yml` changes required to run r11s with `rdkafka` on Docker on Mac - basically, we should not map the volumes because `rdkafka` uses `librdkafka` native code, which is different depending on the OS
6. Updating `KafkaFactory` to only create `KafkaProducer` instances, since we create all consumers through each specific `resourcesFactory.ts`
