### PR TITLE
Disbale rehydrate test as older driver version is not compatible

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -98,9 +98,9 @@
     "@fluidframework/test-utils": "^0.46.0",
     "@fluidframework/test-version-utils": "^0.46.0",
     "@fluidframework/undo-redo": "^0.46.0",
-    "compare-versions": "^3.6.0",
     "cross-env": "^7.0.2",
     "mocha": "^8.4.0",
+    "semver": "^7.3.4",
     "start-server-and-test": "^1.11.7",
     "tinylicious": "^0.4.21640",
     "uuid": "^8.3.1"

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -98,6 +98,7 @@
     "@fluidframework/test-utils": "^0.46.0",
     "@fluidframework/test-version-utils": "^0.46.0",
     "@fluidframework/undo-redo": "^0.46.0",
+    "compare-versions": "^3.6.0",
     "cross-env": "^7.0.2",
     "mocha": "^8.4.0",
     "start-server-and-test": "^1.11.7",

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import compareVersions from "compare-versions";
+import { compare } from "semver";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { Container, Loader } from "@fluidframework/container-loader";
 import {
@@ -148,7 +148,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
 
     beforeEach(async function() {
         provider = getTestObjectProvider();
-        if (compareVersions(provider.driver.version, "0.46.0") === -1) {
+        if (compare(provider.driver.version, "0.46.0") === -1) {
             this.skip();
         }
         const documentId = createDocumentId();

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -148,7 +148,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
 
     beforeEach(async function() {
         provider = getTestObjectProvider();
-        if (compare(provider.driver.version, "0.46.0") === -1) {
+        if (compare(provider.driver.version, "0.46.0") === -1 && provider.driver.type !== "odsp") {
             this.skip();
         }
         const documentId = createDocumentId();

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -148,7 +148,8 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
 
     beforeEach(async function() {
         provider = getTestObjectProvider();
-        if (compare(provider.driver.version, "0.46.0") === -1 && provider.driver.type !== "odsp") {
+        if (compare(provider.driver.version, "0.46.0") === -1
+            && (provider.driver.type === "routerlicious" || provider.driver.type === "tinylicious")) {
             this.skip();
         }
         const documentId = createDocumentId();

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import compareVersions from "compare-versions";
 import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { Container, Loader } from "@fluidframework/container-loader";
 import {
@@ -145,8 +146,11 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
         return getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
     };
 
-    beforeEach(async () => {
+    beforeEach(async function() {
         provider = getTestObjectProvider();
+        if (compareVersions(provider.driver.version, "0.46.0") === -1) {
+            this.skip();
+        }
         const documentId = createDocumentId();
         request = provider.driver.createCreateNewRequest(documentId);
         loader = createTestLoader();


### PR DESCRIPTION
Disbale rehydrate test as older driver version is not compatible due to lack of ability of r11s driver to convert arraybuffer content to string before submitting create new summary in rehydrate case.