### PR TITLE
Fixing parameters when creating Routerlicious driver's DocumentStorageService

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -76,7 +76,8 @@ export class DocumentService implements api.IDocumentService {
             this.documentId,
             gitManager,
             this.logger,
-            documentStorageServicePolicies);
+            documentStorageServicePolicies,
+            this.driverPolicies);
         return this.documentStorageService;
     }
 


### PR DESCRIPTION
Follow up to #7020 - adding the IRouterliciousDriverPolicies object when we create the DocumentStorageService.