### PR TITLE
Fix published path for server docker builds, optional NOTICE, and test docker image tag

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -197,6 +197,7 @@ stages:
       - template: include-generate-notice-steps.yml
         parameters:
           buildDirectory: ${{ parameters.buildDirectory }}
+          requireNotice: ${{ eq(variables.releaseImage, true) }}
 
     # Set version
     - ${{ if eq(parameters.setVersion, true) }}:

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -78,7 +78,6 @@ variables:
 - ${{ if eq(variables.testBuild, false) }}:
   - name: buildContainerName
     value: build/${{ parameters.containerName }}
-
 - name: baseContainerTag
   value: base:$(containerTagSuffix)
 - ${{ if eq(variables.pushImage, false) }}:
@@ -240,7 +239,7 @@ stages:
           displayName: Pack
           inputs:
             action: 'Run a Docker command'
-            customCommand: 'run -v $(System.DefaultWorkingDirectory)/pack:/usr/src/pack -t $(baseContainerTag) npx lerna exec --no-private -- mv `npm pack` /usr/src/pack/scoped'
+            customCommand: 'run -v $(System.DefaultWorkingDirectory)/pack/scoped:/usr/src/pack -t $(baseContainerTag) npx lerna exec --no-private -- mv `npm pack` /usr/src/pack'
 
         - task: PublishBuildArtifacts@1
           displayName: Publish Artifact - pack

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -235,7 +235,7 @@ stages:
           displayName: Pack
           inputs:
             action: 'Run a Docker command'
-            customCommand: 'run -v $(System.DefaultWorkingDirectory)/pack:/usr/src/pack -t $(baseContainerTag) npx lerna exec --no-private -- mv `npm pack` /usr/src/pack'
+            customCommand: 'run -v $(System.DefaultWorkingDirectory)/pack:/usr/src/pack -t $(baseContainerTag) npx lerna exec --no-private -- mv `npm pack` /usr/src/pack/scoped'
 
         - task: PublishBuildArtifacts@1
           displayName: Publish Artifact - pack

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -72,8 +72,13 @@ variables:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
 - group: container-registry-info
-- name: buildContainerName
-  value: build/${{ parameters.containerName }}
+- ${{ if eq(variables.testBuild, true) }}:
+  - name: buildContainerName
+    value: test/${{ parameters.containerName }}
+- ${{ if eq(variables.testBuild, false) }}:
+  - name: buildContainerName
+    value: build/${{ parameters.containerName }}
+
 - name: baseContainerTag
   value: base:$(containerTagSuffix)
 - ${{ if eq(variables.pushImage, false) }}:

--- a/tools/pipelines/templates/include-generate-notice-steps.yml
+++ b/tools/pipelines/templates/include-generate-notice-steps.yml
@@ -4,6 +4,8 @@
 parameters:
 - name: buildDirectory
   type: string
+- name: requireNotice
+  type: boolean
 
 steps:
 # special case server/routerlicious
@@ -28,10 +30,14 @@ steps:
     verbosity: Verbose
     scanType: Register
     alertWarningLevel: High
+
 - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
   displayName: 'NOTICE File Generator'
+  continueOnError: ${{ parameters.requireNotice }}
+
 - task: DownloadPipelineArtifact@2
   displayName: 'Download NOTICE'
+  condition: succeeded()
   inputs:
     artifact: NOTICE.txt
     path: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-generate-notice-steps.yml
+++ b/tools/pipelines/templates/include-generate-notice-steps.yml
@@ -37,7 +37,7 @@ steps:
 
 - task: DownloadPipelineArtifact@2
   displayName: 'Download NOTICE'
-  condition: succeeded()
+  continueOnError: ${{ parameters.requireNotice }}
   inputs:
     artifact: NOTICE.txt
     path: ${{ parameters.buildDirectory }}


### PR DESCRIPTION
- PR #7159 subdivided the publish packages into scoped and non-scoped to be published in separate steps.  The server packages are all scoped and need to put into the right path for publishing
- NOTICE generation fail randomly, make it not required if we don't publish the docker image
- If we are doing manual test build, don't push it to the same container repository as the main official CI build (use `test/` instead of `build/`.