### PR TITLE
Loosen generic constraints for event implementations

### DIFF
--- a/common/lib/common-utils/src/eventForwarder.ts
+++ b/common/lib/common-utils/src/eventForwarder.ts
@@ -12,7 +12,7 @@ import { TypedEventEmitter } from "./typedEventEmitter";
  * This can be useful when all arbitrary listeners need to be removed,
  * but the primary source needs to stay intact.
  */
-export class EventForwarder<TEvent extends IEvent = IEvent>
+export class EventForwarder<TEvent = IEvent>
     extends TypedEventEmitter<TEvent> implements IDisposable {
     protected static isEmitterEvent(event: string): boolean {
         return event === EventForwarder.newListenerEvent || event === EventForwarder.removeListenerEvent;
@@ -24,9 +24,10 @@ export class EventForwarder<TEvent extends IEvent = IEvent>
     public get disposed() { return this.isDisposed; }
     private isDisposed: boolean = false;
 
-    private readonly forwardingEvents = new Map<string, Map<EventEmitter | IEventProvider<TEvent>, () => void>>();
+    private readonly forwardingEvents =
+        new Map<string, Map<EventEmitter | IEventProvider<TEvent & IEvent>, () => void>>();
 
-    constructor(source?: EventEmitter | IEventProvider<TEvent>) {
+    constructor(source?: EventEmitter | IEventProvider<TEvent & IEvent>) {
         super();
         if (source !== undefined) {
             // NewListener event is raised whenever someone starts listening to this events, so
@@ -54,7 +55,7 @@ export class EventForwarder<TEvent extends IEvent = IEvent>
         this.forwardingEvents.clear();
     }
 
-    protected forwardEvent(source: EventEmitter | IEventProvider<TEvent>, ...events: string[]): void {
+    protected forwardEvent(source: EventEmitter | IEventProvider<TEvent & IEvent>, ...events: string[]): void {
         for (const event of events) {
             if (source !== undefined && event !== undefined && !EventForwarder.isEmitterEvent(event)) {
                 let sources = this.forwardingEvents.get(event);
@@ -71,7 +72,7 @@ export class EventForwarder<TEvent extends IEvent = IEvent>
         }
     }
 
-    protected unforwardEvent(source: EventEmitter | IEventProvider<TEvent>, ...events: string[]): void {
+    protected unforwardEvent(source: EventEmitter | IEventProvider<TEvent & IEvent>, ...events: string[]): void {
         for (const event of events) {
             if (event !== undefined && !EventForwarder.isEmitterEvent(event)) {
                 const sources = this.forwardingEvents.get(event);

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -10,7 +10,7 @@ import { IEvent, TransformedEvent, IEventTransformer, IEventProvider } from "@fl
 // this allow us to correctly handle either type
 export type EventEmitterEventType = EventEmitter extends { on(event: infer E, listener: any) } ? E : never;
 
-export type TypedEventTransform<TThis, TEvent extends IEvent> =
+export type TypedEventTransform<TThis, TEvent> =
     // Event emitter supports some special events for the emitter itself to use
     // this exposes those events for the TypedEventEmitter.
     // Since we know what the shape of these events are, we can describe them directly via a TransformedEvent
@@ -18,14 +18,14 @@ export type TypedEventTransform<TThis, TEvent extends IEvent> =
     // eslint-disable-next-line max-len
     TransformedEvent<TThis, "newListener" | "removeListener", Parameters<(event: string, listener: (...args: any[]) => void) => void>> &
     // Expose all the events provides by TEvent
-    IEventTransformer<TThis, TEvent> &
+    IEventTransformer<TThis, TEvent & IEvent> &
     // Add the default overload so this is covertable to EventEmitter regardless of environment
     TransformedEvent<TThis, EventEmitterEventType, any[]>;
 
 /**
  * Event Emitter helper class the supports emitting typed events
  */
-export class TypedEventEmitter<TEvent extends IEvent> extends EventEmitter implements IEventProvider<TEvent> {
+export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventProvider<TEvent & IEvent> {
     constructor() {
         super();
         this.addListener = super.addListener.bind(this) as TypedEventTransform<this, TEvent>;


### PR DESCRIPTION
The existing constraints  create a tight coupling between common-def and common-utils. By loosening the constraints I reduce this coupling. This will enable removing the common-def dependency in protocol-definitions which greatly simplifies our hierarchy of definition dependencies

#6540 