### PR TITLE
Add debug dependency in local-server as peer for axios

### DIFF
--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -60,6 +60,7 @@
     "@fluidframework/server-services-core": "^0.1029.0",
     "@fluidframework/server-services-telemetry": "^0.1029.0",
     "@fluidframework/server-test-utils": "^0.1029.0",
+    "debug": "^4.1.1",
     "jsrsasign": "^10.2.0",
     "uuid": "^8.3.1"
   },


### PR DESCRIPTION
This is as a convenience for our partners who are consuming local-server and using pnpm; it should have no effect for us.

`axios` has a dependency on `follow-redirects`, which has `debug` set as an optional peer dependency (yes it's a thing).  If there's a package using `axios` that provides the peer and one that doesn't, pnpm represents that in the lock file as two separate entries (one with the dependency and one without), and this gets reflected in packaging as well where the split entry is duplicated.

Because of this behavior, `server-lambdas` gets duplicated when there is a dependency on `local-server` and `server-lambdas`, as is the case in `local-server`.  This is because `server-lambdas` depends on `axios` but not `debug`, and `server-services` depend on both `server-lambdas` and `debug`.  `local-server` depends on `server-services` and `server-lambdas`, and pnpm interprets this as needing a version of `server-lambdas` both with and without `debug`.  For regular npm (unsure on other managers), it gets coalesced.

Adding the `debug` dependency at `local-server` fixes this case at the point it's created.