### PR TITLE
Summary improvements: proper handling of retryable errors

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -253,6 +253,8 @@ export interface IAckNackSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
+    readonly retryAfterSeconds?: number;
+    // (undocumented)
     readonly summaryAckNackOp: ISummaryAckMessage | ISummaryNackMessage;
 }
 
@@ -260,6 +262,8 @@ export interface IAckNackSummaryResult {
 export interface IBaseSummarizeResult {
     readonly error: any;
     readonly referenceSequenceNumber: number;
+    // (undocumented)
+    readonly retryAfterSeconds?: number;
     // (undocumented)
     readonly stage: "base";
 }

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -253,8 +253,6 @@ export interface IAckNackSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
-    readonly retryAfterSeconds?: number;
-    // (undocumented)
     readonly summaryAckNackOp: ISummaryAckMessage | ISummaryNackMessage;
 }
 
@@ -262,8 +260,6 @@ export interface IAckNackSummaryResult {
 export interface IBaseSummarizeResult {
     readonly error: any;
     readonly referenceSequenceNumber: number;
-    // (undocumented)
-    readonly retryAfterSeconds?: number;
     // (undocumented)
     readonly stage: "base";
 }
@@ -694,6 +690,7 @@ export type SummarizeResultPart<T> = {
     data: T | undefined;
     message: string;
     error: any;
+    retryAfterSeconds?: number;
 };
 
 // @public (undocumented)

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -313,10 +313,7 @@ export class RetryableError<T extends string> extends NetworkErrorBasic<T> {
 }
 
 // @public (undocumented)
-export function runWithRetry<T>(api: () => Promise<T>, fetchCallName: string, refreshDelayInfo: (id: string) => void, emitDelayInfo: (id: string, retryInMs: number, err: any) => void, logger: ITelemetryLogger, shouldRetry?: () => {
-    retry: boolean;
-    error: any | undefined;
-}): Promise<T>;
+export function runWithRetry<T>(api: () => Promise<T>, fetchCallName: string, refreshDelayInfo: (id: string) => void, emitDelayInfo: (id: string, retryInMs: number, err: any) => void, logger: ITelemetryLogger, checkRetry?: () => void): Promise<T>;
 
 // @public (undocumented)
 export abstract class SnapshotExtractor {

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -180,6 +180,9 @@ export function getQuorumValuesFromProtocolSummary(protocolSummary: ISummaryTree
 export const getRetryDelayFromError: (error: any) => number | undefined;
 
 // @public (undocumented)
+export const getRetryDelaySecondsFromError: (error: any) => number | undefined;
+
+// @public (undocumented)
 export const isFluidResolvedUrl: (resolved: IResolvedUrl | undefined) => resolved is IFluidResolvedUrl;
 
 // @public (undocumented)

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -30,6 +30,8 @@ export type FetchType = "blob" | "createBlob" | "createFile" | "joinSession" | "
 
 export type FetchTypeInternal = FetchType | "cache";
 
+export const Odsp409Error = "Odsp409Error";
+
 /**
  * This class is a wrapper around fetch calls. It adds epoch to the request made so that the
  * server can match it with its epoch value in order to match the version.
@@ -272,7 +274,7 @@ export class EpochTracker implements IPersistedFileCache {
             // then it was coherency 409, so rethrow it as throttling error so that it can retried. Default throttling
             // time is 1s.
             this.logger.sendErrorEvent({ eventName: "Coherency409" }, error);
-            throw new ThrottlingError(error.errorMessage ?? "Coherency409", 1);
+            throw new ThrottlingError(error.errorMessage ?? "Coherency409", 1, { [Odsp409Error]: true });
         }
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -37,6 +37,7 @@ import { fetchJoinSession } from "./vroom";
 import { isOdcOrigin } from "./odspUrlHelper";
 import { EpochTracker } from "./epochTracker";
 import { OpsCache } from "./opsCaching";
+import { RetryCoherencyErrorsStorageAdapter } from "./retryCoherencyErrorsStorageAdapter";
 
 // Gate that when set to "1", instructs to fetch the binary format snapshot from the spo.
 function gatesBinaryFormatSnapshot() {
@@ -185,7 +186,7 @@ export class OdspDocumentService implements IDocumentService {
             );
         }
 
-        return this.storageManager;
+        return new RetryCoherencyErrorsStorageAdapter(this.storageManager, this.logger);
     }
 
     /**
@@ -358,7 +359,7 @@ export class OdspDocumentService implements IDocumentService {
     public dispose(error?: any) {
         // Error might indicate mismatch between client & server knowlege about file
         // (DriverErrorType.fileOverwrittenInStorage).
-        // For exaple, file might have been overwritten in storage without generating new epoch
+        // For example, file might have been overwritten in storage without generating new epoch
         // In such case client cached info is stale and has to be removed.
         if (error !== undefined) {
             this.epochTracker.removeEntries().catch(() => {});

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -34,7 +34,7 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
     public get policies(): IDocumentStorageServicePolicies | undefined {
         return this.internalStorageService.policies;
     }
-    public get disposed() {return this._disposed;}
+    public get disposed() { return this._disposed; }
     public dispose() {
         this._disposed = true;
     }
@@ -80,7 +80,9 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
         // 2. Similar, if we get 429 with retryAfter = 10 minutes, it's likely not the right call to retry summary
         //    upload in 10 minutes - it's better to keep processing ops and retry later. Though caller needs to take
         //    retryAfter into account!
-        assert((context.referenceSequenceNumber === 0) === (context.ackHandle === undefined), "");
+        // But retry loop is required for creation flow (Container.attach)
+        assert((context.referenceSequenceNumber === 0) === (context.ackHandle === undefined),
+            "creation summary has to have seq=0 && handle === undefined");
         if (context.referenceSequenceNumber !== 0) {
             return this.internalStorageService.uploadSummaryWithContext(summary, context);
         }

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -145,5 +145,8 @@ export function createGenericNetworkError(
  */
 export const canRetryOnError = (error: any): boolean => error?.canRetry === true;
 
+export const getRetryDelaySecondsFromError = (error: any): number | undefined =>
+    error?.retryAfterSeconds as number | undefined;
+
 export const getRetryDelayFromError = (error: any): number | undefined => error?.retryAfterSeconds !== undefined ?
     error.retryAfterSeconds * 1000 : undefined;

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -14,7 +14,7 @@ export async function runWithRetry<T>(
     refreshDelayInfo: (id: string) => void,
     emitDelayInfo: (id: string, retryInMs: number, err: any) => void,
     logger: ITelemetryLogger,
-    shouldRetry?: () => { retry: boolean, error: any | undefined},
+    checkRetry?: () => void,
 ): Promise<T> {
     let result: T | undefined;
     let success = false;
@@ -31,14 +31,8 @@ export async function runWithRetry<T>(
             }
             success = true;
         } catch (err) {
-            if (shouldRetry !== undefined) {
-                const res = shouldRetry();
-                if (res.retry === false) {
-                    if (res.error !== undefined) {
-                        throw res.error;
-                    }
-                    throw err;
-                }
+            if (checkRetry !== undefined) {
+                checkRetry();
             }
             // If it is not retriable, then just throw the error.
             if (!canRetryOnError(err)) {

--- a/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
+++ b/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
@@ -181,7 +181,7 @@ describe("runWithRetry Tests", () => {
                 voidEmitDelayInfo,
                 logger,
                 () => {
-                    return { retry: false, error: "disposed"};
+                    throw new Error("disposed");
                 },
             ));
             assert.fail("Should not succeed");

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -4,12 +4,11 @@
  */
 
 import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
-import { Deferred, PromiseTimer } from "@fluidframework/common-utils";
+import { assert, Deferred, PromiseTimer } from "@fluidframework/common-utils";
 import {
     ISequencedDocumentMessage,
     ISequencedDocumentSystemMessage,
     ISummaryConfiguration,
-    ISummaryNack,
     MessageType,
 } from "@fluidframework/protocol-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
@@ -288,31 +287,35 @@ export class RunningSummarizer implements IDisposable {
                 const { delaySeconds: regularDelaySeconds = 0, ...options } = attempts[attemptPhase];
                 const delaySeconds = overrideDelaySeconds ?? regularDelaySeconds;
                 if (delaySeconds > 0) {
-                    this.logger.sendTelemetryEvent({
-                        eventName: "SummarizeAttemptDelay",
-                        retryAfterSeconds: overrideDelaySeconds, // delay from retryAfter summaryNack response
-                        regularDelaySeconds, // delay from regular attempt retry
-                    });
+                    if (overrideDelaySeconds !== undefined) {
+                        this.logger.sendErrorEvent({
+                            eventName: "SummarizeAttemptNackDelay",
+                            delay: overrideDelaySeconds,
+                        });
+                    } else {
+                        this.logger.sendPerformanceEvent({
+                            eventName: "SummarizeAttemptDelay",
+                            delay: regularDelaySeconds,
+                        });
+                    }
                     await new Promise((resolve) => setTimeout(resolve, delaySeconds * 1000));
                 }
                 const attemptReason = retryNumber > 0 ? `retry${retryNumber}` as const : reason;
                 const result = await this.generator.summarize(attemptReason, options).receivedSummaryAckOrNack;
                 await this.generator.waitSummarizing();
-                if (result.success && result.data.summaryAckNackOp.type === MessageType.SummaryAck) {
-                    // Note: checking for MessageType.SummaryAck is redundant since success is false for nack.
+
+                if (result.success) {
+                    assert(result.data.summaryAckNackOp.type === MessageType.SummaryAck, "not nack");
                     return;
                 }
-                // Check for retryDelay in summaryNack response.
-                // TODO: cast needed until dep on protocol-definitions version bump
-                const summaryNack = result.data?.summaryAckNackOp.type === MessageType.SummaryNack
-                    ? result.data.summaryAckNackOp.contents as ISummaryNack & { message?: string; retryAfter?: number; }
-                    : undefined;
-                if (summaryNack?.retryAfter !== undefined && summaryNack.retryAfter > 0) {
+                // Check for retryDelay that can come from summaryNack or upload summary flow.
+                const retryAfterSeconds = result.data?.retryAfterSeconds;
+                if (retryAfterSeconds !== undefined && retryAfterSeconds > 0) {
                     if (overrideDelaySeconds !== undefined) {
                         // Retry the same step only once per retryAfter response.
                         attemptPhase++;
                     }
-                    overrideDelaySeconds = summaryNack.retryAfter;
+                    overrideDelaySeconds = retryAfterSeconds;
                 } else {
                     attemptPhase++;
                     overrideDelaySeconds = undefined;

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -119,6 +119,7 @@ export interface IBaseSummarizeResult {
     readonly error: any;
     /** Reference sequence number as of the generate summary attempt. */
     readonly referenceSequenceNumber: number;
+    readonly retryAfterSeconds?: number;
 }
 
 /** Results of submitSummary after generating the summary tree. */
@@ -175,6 +176,7 @@ export interface IBroadcastSummaryResult {
 export interface IAckNackSummaryResult {
     readonly summaryAckNackOp: ISummaryAckMessage | ISummaryNackMessage;
     readonly ackNackDuration: number;
+    readonly retryAfterSeconds?: number;
 }
 
 export type SummarizeResultPart<T> = {

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -119,7 +119,6 @@ export interface IBaseSummarizeResult {
     readonly error: any;
     /** Reference sequence number as of the generate summary attempt. */
     readonly referenceSequenceNumber: number;
-    readonly retryAfterSeconds?: number;
 }
 
 /** Results of submitSummary after generating the summary tree. */
@@ -176,7 +175,6 @@ export interface IBroadcastSummaryResult {
 export interface IAckNackSummaryResult {
     readonly summaryAckNackOp: ISummaryAckMessage | ISummaryNackMessage;
     readonly ackNackDuration: number;
-    readonly retryAfterSeconds?: number;
 }
 
 export type SummarizeResultPart<T> = {
@@ -187,6 +185,7 @@ export type SummarizeResultPart<T> = {
     data: T | undefined;
     message: string;
     error: any;
+    retryAfterSeconds?: number;
 };
 
 export interface ISummarizeResults {

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -408,7 +408,7 @@ describe("Runtime", () => {
                         {
                             eventName: "Running:Summarize_cancel",
                             summaryGenTag: (runCount - 1),
-                            message: "summaryNack",
+                            reason: "summaryNack",
                         },
                         { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
                         { eventName: "Running:SummaryOp", summaryGenTag: runCount },
@@ -426,7 +426,7 @@ describe("Runtime", () => {
                         {
                             eventName: "Running:Summarize_cancel",
                             summaryGenTag: (runCount - 1),
-                            message: "summaryNack",
+                            reason: "summaryNack",
                         },
                         { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
                         { eventName: "Running:SummaryOp", summaryGenTag: runCount },
@@ -444,7 +444,7 @@ describe("Runtime", () => {
                         {
                             eventName: "Running:Summarize_cancel",
                             summaryGenTag: (runCount - 1),
-                            message: "summaryNack",
+                            reason: "summaryNack",
                         },
                         { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
                         { eventName: "Running:SummaryOp", summaryGenTag: runCount },
@@ -487,8 +487,9 @@ describe("Runtime", () => {
                         {
                             eventName: "Running:Summarize_cancel",
                             summaryGenTag: (runCount - 1),
-                            message: "summaryNack",
+                            reason: "summaryNack",
                         },
+                        { eventName: "Running:SummarizeAttemptDelay", summaryGenTag: runCount - 1 },
                         { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
                         { eventName: "Running:SummaryOp", summaryGenTag: runCount },
                     ]), "unexpected log sequence");
@@ -505,8 +506,9 @@ describe("Runtime", () => {
                         {
                             eventName: "Running:Summarize_cancel",
                             summaryGenTag: (runCount - 1),
-                            message: "summaryNack",
+                            reason: "summaryNack",
                         },
+                        { eventName: "Running:SummarizeAttemptDelay", summaryGenTag: runCount - 1 },
                         { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
                         { eventName: "Running:SummaryOp", summaryGenTag: runCount },
                     ]), "unexpected log sequence");

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -92,7 +92,7 @@ extends EventForwarder<IDocumentDeltaConnectionEvents> implements IDocumentDelta
         super(internal);
     }
 
-    public get disposed() {return this._disposed;}
+    public get disposed() { return this._disposed; }
 
     public get clientId() { return this.internal.clientId;}
 


### PR DESCRIPTION
**Addresses a number of problems**:
1. We do not want 429 errors to be retried by summarizer. If SPO tells us to come back in 10 minutes, it's much better for summarizer to keep processing ops all that time and retry with new state, vs. sit without movement and retry to resubmit old summary.
2. That said, this does not apply to a very first summary that creates a file (in case of Whiteboard like scenario - Container.attach() flow should not need to know about it.
3. 409 errors (coherency failures) are different. They are SPO specific and ideally should not be happening at all - we are likely to get better there with PUSH not flushing ops on client connection and client controlling ops flushing (image upload may still cause these failures). ODSP driver is in much better position to reason about these, and logic around retries. I've added some number of retries with random back-off (to increase chances that clients would not step on each other and make progress), but it fails with critical error. It involves # 1 above for summaries, but will result in container closure for other workflows. I want to monitor this and make determination on next steps. It's similar in nature with "Failed to retrieve ops from storage: too many retries" error that while resulted in critical errors, helped bring attention to a lot of problems on client & server that we were able to address.
4. Change logging in summarizeCore() to log most of the issues as errors, as opposed to general events. This help us bring more attention to summarization problems. Exception is made for "disconnect" error. This is temporary (there is no other good way to exclude disconnects at this layer), check improve in next iteration that will follow.

**Next is series**: Proper propagation of cancelation object across layers to have single source of truth that controls when and how summaries are cancelled.