### PR TITLE
Add timestamp to IConnected and IClient

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -76,6 +76,7 @@ export interface IClient {
     permission: string[];
     // (undocumented)
     scopes: string[];
+    timestamp?: number;
     // (undocumented)
     user: IUser;
 }
@@ -144,6 +145,7 @@ export interface IConnected {
     serviceConfiguration: IClientConfiguration;
     supportedFeatures?: Record<string, any>;
     supportedVersions: string[];
+    timestamp?: number;
     version: string;
 }
 

--- a/common/lib/protocol-definitions/src/clients.ts
+++ b/common/lib/protocol-definitions/src/clients.ts
@@ -23,6 +23,11 @@ export interface IClient {
     permission: string[];
     user: IUser;
     scopes: string[];
+
+    /**
+     * The time the client connected
+     */
+    timestamp?: number;
 }
 
 export interface ISequencedClient {

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -58,7 +58,7 @@ export interface IConnect {
      * Features supported might be service specific.
      * If we have standardized features across all services, they need to be exposed in more structured way.
      */
-     supportedFeatures?: Record<string, any>;
+    supportedFeatures?: Record<string, any>;
 }
 
 /**
@@ -144,5 +144,10 @@ export interface IConnected {
      * Features supported might be service specific.
      * If we have standardized features across all services, they need to be exposed in more structured way.
      */
-     supportedFeatures?: Record<string, any>;
+    supportedFeatures?: Record<string, any>;
+
+    /**
+     * The time the client connected
+     */
+    timestamp?: number;
 }

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -236,11 +236,16 @@ export function configureWebSocketServices(
                 return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);
             }
 
+            const connectedTimestamp = Date.now();
+
             // Todo: should all the client details come from the claims???
             // we are still trusting the users permissions and type here.
             const messageClient: Partial<IClient> = message.client ? message.client : {};
             messageClient.user = claims.user;
             messageClient.scopes = claims.scopes;
+
+            // back-compat: remove cast to any once new definition of IClient comes through.
+            (messageClient as any).timestamp = connectedTimestamp;
 
             // Cache the scopes.
             scopeMap.set(clientId, messageClient.scopes);
@@ -255,8 +260,8 @@ export function configureWebSocketServices(
                 return Promise.reject({
                     code: 400,
                     message: `Unsupported client protocol. ` +
-                    `Server: ${protocolVersions}. ` +
-                    `Client: ${JSON.stringify(connectVersions)}`,
+                        `Server: ${protocolVersions}. ` +
+                        `Client: ${JSON.stringify(connectVersions)}`,
                 });
             }
 
@@ -368,6 +373,9 @@ export function configureWebSocketServices(
                     version,
                 };
             }
+
+            // back-compat: remove cast to any once new definition of IConnected comes through.
+            (connectedMessage as any).timestamp = connectedTimestamp;
 
             return {
                 connection: connectedMessage,


### PR DESCRIPTION
Add `timestamp` property to `IConnected` and `IClient` objects. The timestamp is the time the client connected.

Fixes #7152