### PR TITLE
Fix ODSP end-to-end tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -19,7 +19,6 @@ import {
     IDocumentService,
     IDocumentServiceFactory,
     IDocumentStorageService,
-    LoaderCachingPolicy,
 } from "@fluidframework/driver-definitions";
 import { NonRetryableError, readAndParse } from "@fluidframework/driver-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -90,10 +89,6 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
                     mockDs.connectToStorage = async () => {
                         const realStorage = await realDs.connectToStorage();
                         const mockstorage = Object.create(realStorage) as IDocumentStorageService;
-                        (mockstorage as any).policies = {
-                            ...realStorage.policies,
-                            caching: LoaderCachingPolicy.NoCaching,
-                        };
                         mockstorage.readBlob = async (id) => {
                             const blob = await realStorage.readBlob(id);
                             const blobObj = await readAndParse<any>(realStorage, id);


### PR DESCRIPTION
ODSP end-to-end tests are failing (outer feedback loop) after my recent change that added storage adapter with readonly policies:

> Cannot set property policies of #<RetryCoherencyErrorsStorageAdapter> which has only a getter
TypeError: Cannot set property policies of #<RetryCoherencyErrorsStorageAdapter> which has only a getter
    at OdspDocumentService.mockDs.connectToStorage (dist/test/sharedStringLoading.spec.js:73:46)


This code (that attempts to overwrite policies) was introduced in https://github.com/microsoft/FluidFramework/commit/dfcb17d3682a0a1c9aede15556fa3194a664feee#diff-0b7201fe28f3de70438235ba6a45aeaea5b550520447cc9c4aa0c9492b06cff3 when initial tests were added.

But I do not see a reason for policy change, it seems to be not needed (UTs passing) and it helps with standing up ODSP test that fail due to this code - see https://dev.azure.com/fluidframework/internal/_build/results?buildId=34861&view=ms.vss-test-web.build-test-results-tab&runId=635106&resultId=103463&paneView=debug

So removing this code.