### PR TITLE
Update docId in deltaStorageUrl when retrieved from service

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -131,7 +131,6 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         resolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService> {
-        console.debug(resolvedUrl);
         ensureFluidResolvedUrl(resolvedUrl);
 
         const fluidResolvedUrl = resolvedUrl;

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -91,13 +91,32 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 values: quorumValues,
             },
         );
-        parsedUrl.pathname = parsedUrl.pathname.split("/").slice(0, -1).concat([documentId]).join("/");
+        /**
+         * Assume documentId is at end of url path.
+         * This is true for Routerlicious' and Tinylicious' documentUrl and deltaStorageUrl.
+         * Routerlicious and Tinylicious do not use documentId in storageUrl nor ordererUrl.
+         * TODO: Ideally we would be able to regenerate the resolvedUrl, rather than patching the current one.
+         */
+        const replaceDocumentIdInPath = (urlPath: string): string =>
+            urlPath.split("/").slice(0, -1).concat([documentId]).join("/");
+        parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname);
+        const deltaStorageUrl = resolvedUrl.endpoints.deltaStorageUrl;
+        if (!deltaStorageUrl) {
+            throw new Error(
+                `All endpoints urls must be provided. [deltaStorageUrl:${deltaStorageUrl}]`);
+        }
+        const parsedDeltaStorageUrl = parse(deltaStorageUrl);
+        parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname);
 
         return this.createDocumentService(
             {
                 ...resolvedUrl,
                 url: parsedUrl.href,
                 id: documentId,
+                endpoints: {
+                    ...resolvedUrl.endpoints,
+                    deltaStorageUrl: parsedDeltaStorageUrl.href,
+                },
             },
             logger);
     }
@@ -112,6 +131,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         resolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
     ): Promise<IDocumentService> {
+        console.debug(resolvedUrl);
         ensureFluidResolvedUrl(resolvedUrl);
 
         const fluidResolvedUrl = resolvedUrl;


### PR DESCRIPTION
#7037 started using documentId from the server as source of truth when creating a container from r11s-driver. However, I failed to realize that deltaStorageUrl also contains documentId when patching the resolvedUrl to continue from createContainer.