### PR TITLE
Initializing Lumberjack for microservices and other changes

### DIFF
--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -50,7 +50,6 @@
     "@fluidframework/server-services-client": "^0.1030.0",
     "@fluidframework/server-services-core": "^0.1030.0",
     "@fluidframework/server-services-shared": "^0.1030.0",
-    "@fluidframework/server-services-telemetry": "^0.1030.0",
     "@fluidframework/server-services-utils": "^0.1030.0",
     "commander": "^2.17.1",
     "express": "^4.16.3",

--- a/server/routerlicious/packages/routerlicious/src/kafka-service/command.ts
+++ b/server/routerlicious/packages/routerlicious/src/kafka-service/command.ts
@@ -5,12 +5,11 @@
 
 import { IKafkaResources, KafkaRunnerFactory } from "@fluidframework/server-lambdas-driver";
 import * as core from "@fluidframework/server-services-core";
-import { configureLogging, WinstonLumberjackEngine } from "@fluidframework/server-services-utils";
+import { configureLogging } from "@fluidframework/server-services-utils";
 import commander from "commander";
 import nconf from "nconf";
 import * as winston from "winston";
 import { runService } from "@fluidframework/server-services-shared";
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
 export function execute(
     factoryFn: (name: string, lambda: string) => core.IResourcesFactory<IKafkaResources>,
@@ -24,8 +23,6 @@ export function execute(
         .arguments("<name> <lambda>")
         .action((name: string, lambda: string) => {
             configureLogging(configOrPath);
-            const lumberjackEngine = new WinstonLumberjackEngine();
-            Lumberjack.setup([lumberjackEngine]);
             action = true;
 
             runService(

--- a/server/routerlicious/packages/services-telemetry/README.md
+++ b/server/routerlicious/packages/services-telemetry/README.md
@@ -3,3 +3,60 @@
 Fluid server package containing telemetry utilities used across Fluid service code.
 
 See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.
+
+## Overview
+The `services-telemetry` package is built around 3 main components:
+
+1. A `Lumberjack` class: the main telemetry manager. `Lumberjack` is the telemetry interface to be used when instrumenting the code. It is a singleton responsible for managing a list of “engines” that implement the app-specific telemetry logic. It can be used to initialize a metric/data instance (which we call `Lumber`). It also supports the logging functionality.
+2. An `ILumberjackEngine` interface: defining the requirements for an implementation of the engines employed by `Lumberjack`.
+3. `Lumber`: the self-contained class representing a metric or event. `Lumber` should be created through `Lumberjack`, which will provide `Lumber` with the list of `LumberjackEngines` that define how to handle the data. After being created, `Lumber` can be used to add properties to a property bag and can be finally completed either as a successful or failed operation, while keeping track of duration of the event.
+
+The idea behind `Lumberjack` is convenience, available through a globally accessible telemetry tool. It is customizable through the app-specific `ILumberjackEngine` implementations and is capable of handling 2 types of telemetry data. Metrics represent events or operations that can usually be associated with a result of success or failure, that can be measured in terms of duration and that can generally be used in the context of service monitoring/alerting. Logs, on the other hand, should be used in situations where there is no event being evaluated; in other words, where there is not an associated concept of success or failure, duration, etc.
+
+At the start of each Node.js process, `Lumberjack` should be initialized so that it can be used in singleton style throughout the code. However, it is also possible to create individual instances of `Lumberjack` at any time. `Lumberjack` must be initialized with a mandatory `ILumberjackEngine[]` parameter (it uses each `ILumberjackEngine` in the list to emit the telemetry data according to the `ILumberjackEngine` logic). `Lumberjack` can also take an optional `ILumberjackSchemaValidator`, which defines the requirements for mandatory parameters and values associated with each `Lumber` instance.
+
+## How to use
+In these examples, we will be using [`WinstonLumberjackEngine`](https://github.com/microsoft/FluidFramework/blob/da99118135fc383fd69a401a48d6b99caaa18378/server/routerlicious/packages/services-utils/src/winstonLumberjackEngine.ts#L11) as our `ILumberjackEngine` sample implementation.
+
+### Initializing Lumberjack
+```typescript
+// Singleton style, at the start of each process
+const lumberjackEngine = new WinstonLumberjackEngine();
+Lumberjack.setup([lumberjackEngine]);
+
+// Instance style
+const lumberjackEngine = new WinstonLumberjackEngine();
+const customInstance = Lumberjack.createInstance([lumberjackEngine]);
+```
+
+In [FluidFramework Server code](https://github.com/microsoft/FluidFramework/tree/main/server), `Lumberjack` initialization is taken care of automatically thanks to [`configureLogging()`](https://github.com/microsoft/FluidFramework/blob/da99118135fc383fd69a401a48d6b99caaa18378/server/routerlicious/packages/services-utils/src/logger.ts#L24) in the `server-services-utils` package.
+
+### Metrics
+Metrics are associated with types of events, and each event type should have a unique name. The list of Events is kept in the [`LumberEventName` enum](https://github.com/microsoft/FluidFramework/blob/main/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts). `Lumberjack` also supports simple `string` event names. Example:
+```typescript
+const lumberJackMetric = Lumberjack.newLumberMetric(LumberEventName.DeliHandler);
+
+lumberJackMetric.setProperties({
+    [BaseTelemetryProperties.tenantId]: this.tenantId,
+    [BaseTelemetryProperties.documentId]: this.documentId,
+});
+
+try {
+    ... // Event being tracked
+    lumberJackMetric.success("Success message!");
+}
+catch (error) {
+    lumberJackMetric.error("Error message :(", error);
+}
+```
+
+### Logs
+`Lumberjack` provides a static method for logging. Example:
+```typescript
+const props = {
+    property1: "prop1",
+    property2: "prop2",
+};
+
+Lumberjack.log("Sample message", LogLevel.Info, properties);
+```

--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -65,7 +65,7 @@ export class Lumber<T extends string = LumberEventName> {
         public readonly eventName: T,
         public readonly type: LumberType,
         private readonly _engineList: ILumberjackEngine[],
-        private readonly _schemaValidator?: ILumberjackSchemaValidator,
+        private readonly _schemaValidators?: ILumberjackSchemaValidator[],
         properties?: Map<string, any> | Record<string, any>) {
             if (properties) {
                 this.setProperties(properties);
@@ -124,14 +124,16 @@ export class Lumber<T extends string = LumberEventName> {
             return;
         }
 
-        if (this._schemaValidator) {
-            const validation = this._schemaValidator.validate(this.properties);
-            if (!validation.validationPassed) {
-                handleError(
-                    LumberEventName.LumberjackSchemaValidationFailure,
-                    `Schema validation failed for properties: ${validation.validationFailedForProperties.toString()}.\
-                    [eventName: ${this.eventName}][id: ${this.id}]`,
-                    this._engineList);
+        if (this._schemaValidators) {
+            for (const schemaValidator of this._schemaValidators) {
+                const validation = schemaValidator.validate(this.properties);
+                if (!validation.validationPassed) {
+                    handleError(
+                        LumberEventName.LumberjackSchemaValidationFailure,
+                        `Schema validation failed for props: ${validation.validationFailedForProperties.toString()}.\
+                        [eventName: ${this.eventName}][id: ${this.id}]`,
+                        this._engineList);
+                }
             }
         }
 

--- a/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
@@ -131,6 +131,11 @@ export class Lumberjack {
         const defaultStackTracePreparer = Error.prepareStackTrace;
         try {
             Error.prepareStackTrace = (_, structuredStackTrace) => {
+                // Since we have a static log() and an instance log(), we should discard the first entry
+                // in the call stack in case the static log() called the singleton's instance log()
+                if (structuredStackTrace[0].getFileName() === __filename) {
+                    structuredStackTrace.shift();
+                }
                 const caller = structuredStackTrace[0];
                 const fileName = caller.getFileName() ?? "FilenameNotAvailable";
                 const functionName = caller.getFunctionName() ?? caller.getMethodName() ?? "FunctionNameNotAvailable";

--- a/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
@@ -174,11 +174,12 @@ describe("Lumber", () => {
     it("Makes sure we can complete Lumber if schema validation succeeds.", () => {
         const successMessage = "SuccessMessage";
         const engine = new TestEngine1();
+        const schemaValidator = new TestSchemaValidator(true);
         const lumber = new Lumber(
             LumberEventName.UnitTestEvent,
             LumberType.Metric,
             [engine],
-            new TestSchemaValidator(true)); // Setting this as true to force validation to succeed
+            [schemaValidator]); // Setting this as true to force validation to succeed
 
         assert.strictEqual(lumber.successful, undefined);
 
@@ -193,11 +194,12 @@ describe("Lumber", () => {
     it("Makes sure we cannot complete Lumber if schema validation fails.", () => {
         const successMessage = "SuccessMessage";
         const engine = new TestEngine1();
+        const schemaValidator = new TestSchemaValidator(false);
         const lumber = new Lumber(
             LumberEventName.UnitTestEvent,
             LumberType.Metric,
             [engine],
-            new TestSchemaValidator(false)); // Setting this as false to force validation to fail
+            [schemaValidator]); // Setting this as false to force validation to fail
 
         assert.strictEqual(lumber.successful, undefined);
 

--- a/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
@@ -24,7 +24,7 @@ describe("Lumberjack", () => {
 
     it("Sets up a custom Lumberjack instance and creates a Lumber metric.", () => {
         const engine = new TestEngine1();
-        const customInstance = TestLumberjack.create([engine]);
+        const customInstance = TestLumberjack.createInstance([engine]);
         try {
             customInstance.newLumberMetric(LumberEventName.UnitTestEvent);
         } catch (err) {
@@ -37,7 +37,7 @@ describe("Lumberjack", () => {
         const engine2 = new TestEngine2();
         TestLumberjack.setup([engine1]);
         try {
-            TestLumberjack.create([engine2]);
+            TestLumberjack.createInstance([engine2]);
         } catch (err) {
             assert.fail("Creating a custom Lumberjack instance should not have failed since global and custom instances should be independent.");
         }

--- a/server/routerlicious/packages/services-utils/src/logger.ts
+++ b/server/routerlicious/packages/services-utils/src/logger.ts
@@ -8,6 +8,8 @@ import * as winston from "winston";
 import nconf from "nconf";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import Transport = require("winston-transport");
+import { ILumberjackEngine, ILumberjackSchemaValidator, Lumberjack } from "@fluidframework/server-services-telemetry";
+import { WinstonLumberjackEngine } from "./winstonLumberjackEngine";
 
 export interface IWinstonConfig {
     colorize: boolean;
@@ -66,4 +68,17 @@ export function configureLogging(configOrPath: nconf.Provider | string) {
         const name = this.namespace;
         args[0] = `${name} ${args[0]}`;
     };
+
+    const genevaConfig = config.get("lumberjack");
+    const engineList =
+        genevaConfig && genevaConfig.engineList ?
+        genevaConfig.engineList as ILumberjackEngine[] :
+        [new WinstonLumberjackEngine()];
+
+    const schemaValidatorList =
+        genevaConfig && genevaConfig.schemaValidator ?
+        genevaConfig.schemaValidator as ILumberjackSchemaValidator[] :
+        undefined;
+
+    Lumberjack.setup(engineList, schemaValidatorList);
 }


### PR DESCRIPTION
1. Initializing `Lumberjack` so it can be used throughout different microservices such as Alfred, Riddler and kafka-services (Deli, Scribe, Scriptorium, etc). That happens in `logger.ts`'s `configureLogging`, which is called at the entry point of each of those microservices.
2. Adding README documentation for `Lumberjack`.
3. Renaming `Lumberjack`'s `create()` to `createInstance()` so it is clear that the method applies to when the user wants to create a separate instance of `Lumberjack`. For the usual, singleton scenario, `setup()` should be used.
4. Making `Lumberjack` accept a list of `ILumberjackSchemaValidator` instead of only one.
5. Fixing `Lumberjack`'s `getLogCallerInfo()` to take into account the fact that `Lumberjack`'s static `log()` could be calling the singleton's instance `log()`. When that happens, it means we need to trim the stack trace one more time after (the first time is when we tell `Error.captureStackTrace()` to give us the frames after `this.log`.