### PR TITLE
Backwards compatibility for startsession metric

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -180,8 +180,8 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
         this.lastSentMSN = lastCheckpoint.lastSentMSN ?? 0;
         this.logOffset = lastCheckpoint.logOffset;
         this.nackMessages = lastCheckpoint.nackMessages;
-        this.successfullyStartedLambdas = lastCheckpoint.successfullyStartedLambdas ?
-            lastCheckpoint.successfullyStartedLambdas : [];
+        // Null coalescing for backward compatibility
+        this.successfullyStartedLambdas = lastCheckpoint.successfullyStartedLambdas ?? [];
 
         const msn = this.clientSeqManager.getMinimumSequenceNumber();
         this.noActiveClients = msn === -1;

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -180,7 +180,8 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
         this.lastSentMSN = lastCheckpoint.lastSentMSN ?? 0;
         this.logOffset = lastCheckpoint.logOffset;
         this.nackMessages = lastCheckpoint.nackMessages;
-        this.successfullyStartedLambdas = lastCheckpoint.successfullyStartedLambdas;
+        this.successfullyStartedLambdas = lastCheckpoint.successfullyStartedLambdas ?
+            lastCheckpoint.successfullyStartedLambdas : [];
 
         const msn = this.clientSeqManager.getMinimumSequenceNumber();
         this.noActiveClients = msn === -1;


### PR DESCRIPTION
Possible N/N-1 issue. lastCheckpoint.successfullyStartedLambdas was recently added to IDeliState. While the server moves from the build without successfullyStartedLambdas to a build with it, checkpoint.successfullyStartedLambdas will be undefined. This should replace it with the default empty array.