### PR TITLE
Strongly typed deli event emitter

### DIFF
--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -47,6 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
     "@fluidframework/protocol-base": "^0.1030.0",

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable no-null/no-null */
 
-import { EventEmitter } from "events";
 import { isServiceMessageType } from "@fluidframework/protocol-base";
 import {
     ISequencedDocumentAugmentedMessage,
@@ -55,6 +54,8 @@ import {
     SessionState,
 } from "@fluidframework/server-services-telemetry";
 import { DocumentContext } from "@fluidframework/server-lambdas-driver";
+import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { IEvent } from "@fluidframework/common-definitions";
 import { setQueuedMessageProperties, logCommonSessionEndMetrics, createSessionMetric } from "../utils";
 import { CheckpointContext } from "./checkpointContext";
 import { ClientSequenceNumberManager } from "./clientSeqManager";
@@ -100,7 +101,13 @@ export enum OpEventType {
     MaxTime,
 }
 
-export class DeliLambda extends EventEmitter implements IPartitionLambda {
+export interface IDeliLambdaEvents extends IEvent {
+    (event: "opEvent",
+        listener: (type: OpEventType, sequenceNumber: number, sequencedMessagesSinceLastOpEvent: number) => void);
+    (event: "updatedDurableSequenceNumber", listener: (durableSequenceNumber: number) => void);
+}
+
+export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements IPartitionLambda {
     private sequenceNumber: number;
     private durableSequenceNumber: number;
 
@@ -677,6 +684,8 @@ export class DeliLambda extends EventEmitter implements IPartitionLambda {
                                 this.nackMessages = undefined;
                             }
                         }
+
+                        this.emit("updatedDurableSequenceNumber", dsn);
 
                         if (this.serviceConfiguration.deli.opEvent.enable) {
                             // since the dsn updated, ops were reliably stored


### PR DESCRIPTION
- Use `TypedEventEmitter` to strongly type the events.
- Add an `updatedDurableSequenceNumber` event that is emitted when the dsn is updated.