### PR TITLE
Nit: Add missing '.npmignore' and fix type in fluid-build warnings

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/.npmignore
+++ b/experimental/PropertyDDS/packages/property-changeset/.npmignore
@@ -1,0 +1,6 @@
+nyc
+*.log
+**/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-properties/.npmignore
+++ b/experimental/PropertyDDS/packages/property-properties/.npmignore
@@ -1,0 +1,6 @@
+nyc
+*.log
+**/*.tsbuildinfo
+src/test
+dist/test
+**/_api-extractor-temp/**

--- a/tools/build-tools/src/common/fluidRepo.ts
+++ b/tools/build-tools/src/common/fluidRepo.ts
@@ -70,7 +70,7 @@ export class FluidRepo {
         }
 
         if (!clientMonoRepo) {
-            throw new Error("client entry not exist in package.json")
+            throw new Error("client entry does not exist in package.json")
         }
         this.clientMonoRepo = clientMonoRepo;
         this.packages = new Packages(loadedPackages);

--- a/tools/build-tools/src/common/fluidUtils.ts
+++ b/tools/build-tools/src/common/fluidUtils.ts
@@ -84,7 +84,7 @@ export async function getResolvedFluidRoot() {
 
     const resolvedRoot = path.resolve(root);
     if (!existsSync(resolvedRoot)) {
-        console.error(`ERROR: Repo root '${resolvedRoot}' not exist.`);
+        console.error(`ERROR: Repo root '${resolvedRoot}' does not exist.`);
         process.exit(-102);
     }
 

--- a/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/tools/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -449,7 +449,7 @@ export class FluidPackageCheck {
                 "dist/test",
             ];
         if (!existsSync(filename)) {
-            this.logWarn(pkg, `.npmignore not exist`, fix);
+            this.logWarn(pkg, `.npmignore does not exist`, fix);
             if (fix) {
                 await writeFileAsync(filename, expected.join("\n"), "utf8");
             }


### PR DESCRIPTION
The warning emitted by 'Fluid-Build' regarding missing files had a small typo -- fixed.

(Also fixed the missing '.npmignore' files that caused the error message to be emitted.)