### PR TITLE
More reliable last Summary flow

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -192,6 +192,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }): Promise<ISummaryTreeWithStats>;
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
+    // (undocumented)
     get summarizerClientId(): string | undefined;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -192,7 +192,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }): Promise<ISummaryTreeWithStats>;
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
-    // (undocumented)
     get summarizerClientId(): string | undefined;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
@@ -458,7 +457,7 @@ export interface ISummarizeHeuristicData {
 export interface ISummarizeHeuristicRunner {
     dispose(): void;
     run(): void;
-    runOnClose(): boolean;
+    shouldRunLastSummary(): boolean;
 }
 
 // @public
@@ -632,7 +631,7 @@ export class PendingStateManager implements IDisposable {
 // @public
 export class RunWhileConnectedCoordinator {
     constructor(runtime: IConnectableRuntime);
-    stop(): void;
+    stop(reason?: SummarizerStopReason): void;
     waitStart(): Promise<IStartedResult | INotStartedResult>;
     waitStopped(): Promise<void>;
 }
@@ -671,7 +670,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
     run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<void>;
-    stop(reason?: SummarizerStopReason): void;
+    stop(reason: SummarizerStopReason): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
@@ -697,14 +696,6 @@ export type SummarizeResultPart<T> = {
 export type SummarizerStopReason =
 /** Summarizer client failed to summarize in all 3 consecutive attempts. */
 "failToSummarize"
-/**
- * Summarizer client detected that its parent is no longer elected the summarizer.
- * Normally, the parent client would realize it is disconnected first and call stop
- * giving a "parentNotConnected" stop reason. If the summarizer client attempts to
- * generate a summary and realizes at that moment that the parent is not elected,
- * only then will it stop itself with this message.
- */
- | "parentNoLongerSummarizer"
 /** Parent client reported that it is no longer connected. */
  | "parentNotConnected"
 /**
@@ -714,8 +705,8 @@ export type SummarizerStopReason =
  * tries to stop its spawned summarizer client.
  */
  | "parentShouldNotSummarize"
-/** Parent client reported that it is disposed. */
- | "disposed";
+/** summarizer client disconnected */
+ | "summarizeClientDisconnected" | "summarizerException";
 
 // @public (undocumented)
 export class SummarizingWarning extends LoggingError implements ISummarizingWarning {

--- a/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
+++ b/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
@@ -4,6 +4,7 @@
  */
 
 import { Deferred } from "@fluidframework/common-utils";
+import { SummarizerStopReason } from "./summarizerTypes";
 
 /**
  * Start result indicating that the start was successful.
@@ -89,7 +90,7 @@ export class RunWhileConnectedCoordinator {
     /**
      * Stops running.
      */
-    public stop(): void {
+    public stop(reason?: SummarizerStopReason): void {
         this.stopDeferred.resolve();
     }
 }

--- a/packages/runtime/container-runtime/src/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summarizerHeuristics.ts
@@ -81,13 +81,9 @@ export class SummarizeHeuristicRunner implements ISummarizeHeuristicRunner {
         }
     }
 
-    public runOnClose(): boolean {
+    public shouldRunLastSummary(): boolean {
         const opsSinceLastAck = this.opsSinceLastAck;
-        if (opsSinceLastAck > this.minOpsForAttemptOnClose) {
-            this.trySummarize("lastSummary");
-            return true;
-        }
-        return false;
+        return (opsSinceLastAck > this.minOpsForAttemptOnClose);
     }
 
     public dispose() {

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -232,14 +232,6 @@ export type EnqueueSummarizeResult = (ISummarizeResults & {
 export type SummarizerStopReason =
     /** Summarizer client failed to summarize in all 3 consecutive attempts. */
     | "failToSummarize"
-    /**
-     * Summarizer client detected that its parent is no longer elected the summarizer.
-     * Normally, the parent client would realize it is disconnected first and call stop
-     * giving a "parentNotConnected" stop reason. If the summarizer client attempts to
-     * generate a summary and realizes at that moment that the parent is not elected,
-     * only then will it stop itself with this message.
-     */
-    | "parentNoLongerSummarizer"
     /** Parent client reported that it is no longer connected. */
     | "parentNotConnected"
     /**
@@ -249,8 +241,10 @@ export type SummarizerStopReason =
      * tries to stop its spawned summarizer client.
      */
     | "parentShouldNotSummarize"
-    /** Parent client reported that it is disposed. */
-    | "disposed";
+    /** summarizer client disconnected */
+    | "summarizeClientDisconnected"
+    /* running summarizer threw an exception */
+    | "summarizerException";
 
 export interface ISummarizerEvents extends IEvent {
     /**
@@ -337,7 +331,7 @@ export interface ISummarizeHeuristicRunner {
     run(): void;
 
     /** Runs a different heuristic to check if it should summarize before closing */
-    runOnClose(): boolean;
+    shouldRunLastSummary(): boolean;
 
     /** Disposes of resources */
     dispose(): void;

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -4,7 +4,7 @@
  */
 
 import { IDisposable, IEvent, IEventProvider, ITelemetryLogger } from "@fluidframework/common-definitions";
-import { Deferred, delay, TypedEventEmitter } from "@fluidframework/common-utils";
+import { delay, TypedEventEmitter, assert } from "@fluidframework/common-utils";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { IFluidRouter, IRequest } from "@fluidframework/core-interfaces";
 import { IDeltaManager, LoaderHeader } from "@fluidframework/container-definitions";
@@ -16,7 +16,7 @@ import { IThrottler } from "./throttler";
 import { ISummarizer, ISummarizerOptions, ISummarizingWarning, SummarizerStopReason } from "./summarizerTypes";
 import { SummaryCollection } from "./summaryCollection";
 
-const defaultInitialDelayMs = 5000;
+const defaultInitialDelayMs = 10000;
 const defaultOpsToBypassInitialDelay = 4000;
 
 export enum SummaryManagerState {
@@ -29,7 +29,7 @@ export enum SummaryManagerState {
 // Please note that all reasons in this list are not errors,
 // and thus they are not raised today to parent container as error.
 // If this needs to be changed in future, we should re-evaluate what and how we raise to summarizer
-type StopReason = Extract<SummarizerStopReason, "parentNotConnected" | "parentShouldNotSummarize" | "disposed">;
+type StopReason = Extract<SummarizerStopReason, "parentNotConnected" | "parentShouldNotSummarize">;
 type ShouldSummarizeState =
     | { shouldSummarize: true; }
     | { shouldSummarize: false; stopReason: StopReason; };
@@ -67,10 +67,15 @@ export interface ISummaryManagerConfig {
     opsToBypassInitialDelay: number;
 }
 
+/**
+ * SummaryManager is created by parent container (i.e. interactive container with clientType !== "summarizer") only.
+ * It observes changes in calculated summarizer and reacts to changes by either creating summarizer client or
+ * stopping existing summarizer client.
+ */
 export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> implements IDisposable {
     private readonly logger: ITelemetryLogger;
-    private readonly initialDelay = new Deferred<void>();
     private readonly opsToBypassInitialDelay: number;
+    private readonly initialDelayMs: number;
     private latestClientId: string | undefined;
     private state = SummaryManagerState.Off;
     private runningSummarizer?: ISummarizer;
@@ -87,6 +92,8 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
         private readonly connectedState: IConnectedState,
         private readonly summaryCollection: Pick<SummaryCollection, "opsSinceLastAck">,
         parentLogger: ITelemetryLogger,
+        /** Creates summarizer by asking interactive container to spawn summarizing container and
+         * get back its Summarizer instance. */
         private readonly requestSummarizerFn: () => Promise<ISummarizer>,
         private readonly startThrottler: IThrottler,
         {
@@ -107,11 +114,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
         this.latestClientId = this.connectedState.clientId;
 
         this.opsToBypassInitialDelay = opsToBypassInitialDelay;
-        if (opsToBypassInitialDelay > 0 && initialDelayMs > 0) {
-            delay(initialDelayMs).finally(() => this.initialDelay.resolve());
-        } else {
-            this.initialDelay.resolve();
-        }
+        this.initialDelayMs = initialDelayMs;
     }
 
     /**
@@ -125,7 +128,9 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
 
     private readonly handleConnected = (clientId: string) => {
         this.latestClientId = clientId;
-        this.runningSummarizer?.updateOnBehalfOf(clientId);
+        // If we have a summarizer, it should have been either cancelled on disconnected by now.
+        // But because of lastSummary process, it can still hang around, so there is not much we can
+        // check or assert.
         this.refreshSummarizer();
     };
 
@@ -139,7 +144,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
         } else if (this.connectedState.clientId !== this.clientElection.electedClientId) {
             return { shouldSummarize: false, stopReason: "parentShouldNotSummarize" };
         } else if (this.disposed) {
-            return { shouldSummarize: false, stopReason: "disposed" };
+            assert(false, "Disposed should mean disconnected!");
         } else {
             return { shouldSummarize: true };
         }
@@ -152,13 +157,11 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
         switch (this.state) {
             case SummaryManagerState.Off: {
                 if (shouldSummarizeState.shouldSummarize) {
-                    this.checkBypassInitialDelay();
                     this.startSummarization();
                 }
                 return;
             }
             case SummaryManagerState.Starting: {
-                this.checkBypassInitialDelay();
                 // Cannot take any action until summarizer is created
                 // state transition will occur after creation
                 return;
@@ -181,66 +184,67 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
     };
 
     private startSummarization() {
+        assert(this.state === SummaryManagerState.Off, "expected: off");
         this.state = SummaryManagerState.Starting;
 
-        // throttle creation of new summarizer containers to prevent spamming the server with websocket connections
-        const delayMs = this.startThrottler.getDelay();
-        if (delayMs > 0 && delayMs >= this.startThrottler.maxDelayMs) {
-            // we can't create a summarizer for some reason; raise error on container
-            this.emit(
-                "summarizerWarning",
-                createSummarizingWarning("SummaryManager: CreateSummarizer Max Throttle Delay", false),
-            );
-        }
+        assert(this.runningSummarizer === undefined, "Old summarizer is still working!");
 
-        this.createSummarizer(delayMs).then((summarizer) => {
+        this.delayBeforeCreatingSummarizer().then(async () => {
+            // Re-validate that it need to be running. Due to asynchrony, it may be not the case anymore
+            if (this.getShouldSummarizeState().shouldSummarize === false) {
+                return;
+            }
+
+            const summarizer = await this.requestSummarizerFn();
+
+            // Re-validate that it need to be running. Due to asynchrony, it may be not the case anymore
+            const shouldSummarizeState = this.getShouldSummarizeState();
+            if (shouldSummarizeState.shouldSummarize === false) {
+                summarizer.stop(shouldSummarizeState.stopReason);
+                return;
+            }
+
+            assert(this.state === SummaryManagerState.Starting, "Expected: starting");
+            this.state = SummaryManagerState.Running;
+
             summarizer.on("summarizingError",
                 (warning: ISummarizingWarning) => this.emit("summarizerWarning", warning));
-            this.runSummarizer(summarizer);
-        }, (error) => {
-            this.logger.sendErrorEvent({
-                eventName: "CreateSummarizerError",
-                attempt: this.startThrottler.numAttempts,
-            }, error);
-            this.tryRestart();
-        });
-    }
+            this.runningSummarizer = summarizer;
 
-    private runSummarizer(summarizer: ISummarizer) {
-        this.state = SummaryManagerState.Running;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const clientId = this.latestClientId!;
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const clientId = this.latestClientId!;
-        this.runningSummarizer = summarizer;
+            await PerformanceEvent.timedExecAsync(
+                this.logger,
+                { eventName: "RunningSummarizer", attempt: this.startThrottler.numAttempts },
+                async () => summarizer.run(clientId, this.summarizerOptions),
+            );
+            // assert(summarizer.cancelled, "should be cancelled by now");
+        }).catch((error) => {
+            this.logger.sendErrorEvent({ eventName: "SummarizerException" }, error);
+            this.emit("summarizerWarning", error);
 
-        PerformanceEvent.timedExecAsync(
-            this.logger,
-            { eventName: "RunningSummarizer", attempt: this.startThrottler.numAttempts },
-            async () => summarizer.run(clientId, this.summarizerOptions),
-        ).finally(() => {
-            this.runningSummarizer = undefined;
-            this.tryRestart();
-        });
-
-        const shouldSummarizeState = this.getShouldSummarizeState();
-        if (shouldSummarizeState.shouldSummarize === false) {
-            this.stop(shouldSummarizeState.stopReason);
-        }
-    }
-
-    private tryRestart(): void {
-        const shouldSummarizeState = this.getShouldSummarizeState();
-        if (shouldSummarizeState.shouldSummarize) {
-            this.startSummarization();
-        } else {
+            // Note that summarizer may keep going (like doing last summary).
+            // Ideally we await stopping process, but this code path is due to a bug
+            // that needs to be fixed either way.
+            this.stop("summarizerException");
+        }).finally(() => {
+            assert(this.state !== SummaryManagerState.Off, "Expected: Not Off");
             this.state = SummaryManagerState.Off;
-        }
+
+            this.runningSummarizer = undefined;
+
+            if (this.getShouldSummarizeState().shouldSummarize) {
+                this.startSummarization();
+            }
+        });
     }
 
     private stop(reason: SummarizerStopReason) {
+        assert(this.state === SummaryManagerState.Running, "Expected: Running");
         this.state = SummaryManagerState.Stopping;
 
-        if (this.runningSummarizer) {
+        if (this.runningSummarizer !== undefined) {
             // Stopping the running summarizer client should trigger a change
             // in states when the running summarizer closes
             this.runningSummarizer.stop(reason);
@@ -251,30 +255,41 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
         }
     }
 
-    private checkBypassInitialDelay() {
-        if (!this.initialDelay.isCompleted && this.summaryCollection.opsSinceLastAck >= this.opsToBypassInitialDelay) {
-            this.initialDelay.resolve();
+    private async delayBeforeCreatingSummarizer() {
+        // throttle creation of new summarizer containers to prevent spamming the server with websocket connections
+        let delayMs = this.startThrottler.getDelay();
+        if (delayMs > 0 && delayMs >= this.startThrottler.maxDelayMs) {
+            // we can't create a summarizer for some reason; raise error on container
+            this.emit(
+                "summarizerWarning",
+                createSummarizingWarning("SummaryManager: CreateSummarizer Max Throttle Delay", false),
+            );
         }
-    }
 
-    private async createSummarizer(delayMs: number): Promise<ISummarizer> {
         // We have been elected the summarizer. Some day we may be able to summarize with a live document but for
         // now we play it safe and launch a second copy.
         this.logger.sendTelemetryEvent({
             eventName: "CreatingSummarizer",
-            delayMs,
+            throttlerDelay: delayMs,
+            initialDelay: this.initialDelayMs,
             opsSinceLastAck: this.summaryCollection.opsSinceLastAck,
+            opsToBypassInitialDelay: this.opsToBypassInitialDelay,
         });
 
-        const shouldDelay = delayMs > 0;
-        if (shouldDelay || !this.initialDelay.isCompleted) {
-            await Promise.all([
-                this.initialDelay.promise,
-                shouldDelay ? delay(delayMs) : Promise.resolve(),
-            ]);
+        // This delay helps ensure that last summarizer that might be left from previous client
+        // has enough time to complete its summary and thus new summarizer not conflict with previous one.
+        // A better design would be for summarizer election logic to always select current summarizer as
+        // summarizing client (i.e. clientType === "summarizer" can be elected) to ensure that nobody else can
+        // summarizer while it finishes its work and moves to exit.
+        // It also helps with pure boot scenario (single client) to offset expensive work a bit out from
+        // critical boot sequence.
+        if (this.summaryCollection.opsSinceLastAck < this.opsToBypassInitialDelay) {
+            delayMs = Math.max(delayMs, this.initialDelayMs);
         }
 
-        return this.requestSummarizerFn();
+        if (delayMs > 0) {
+            await delay(delayMs);
+        }
     }
 
     public readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"] = (...args) => {

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -223,6 +223,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
                 { eventName: "RunningSummarizer", attempt: this.startThrottler.numAttempts },
                 async () => summarizer.run(clientId, this.summarizerOptions),
             );
+            // Follow-up: requires PR #7230 completion to enable this assert:
             // assert(summarizer.cancelled, "should be cancelled by now");
         }).catch((error) => {
             this.logger.sendErrorEvent({ eventName: "SummarizerException" }, error);

--- a/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerHeuristics.spec.ts
@@ -157,9 +157,7 @@ describe("Runtime", () => {
                 initialize({ refSequenceNumber: lastSummary, minOpsForAttemptOnClose });
 
                 data.lastOpSequenceNumber = lastSummary + minOpsForAttemptOnClose + 1;
-                assert(runner.runOnClose() === true, "should run on close");
-                assertAttemptCount(1, "should run");
-                assert(getLastAttempt() === "lastSummary");
+                assert(runner.shouldRunLastSummary() === true, "should run on close");
             });
 
             it("Should not summarize on close if insufficient outstanding ops", () => {
@@ -168,8 +166,7 @@ describe("Runtime", () => {
                 initialize({ refSequenceNumber: lastSummary, minOpsForAttemptOnClose });
 
                 data.lastOpSequenceNumber = lastSummary + minOpsForAttemptOnClose;
-                assert(runner.runOnClose() === false, "should not run on close");
-                assertAttemptCount(0, "should not run");
+                assert(runner.shouldRunLastSummary() === false, "should not run on close");
             });
 
             it("Should not run idle timer after dispose", () => {

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -196,7 +196,7 @@ describe("Summary Manager", () => {
     });
 
     it("Should become summarizer if elected, then connected; stop summarizer after unelected", async () => {
-        createSummaryManager({ opsToBypassInitialDelay: 0 });
+        createSummaryManager({ opsToBypassInitialDelay: 0, initialDelayMs: 0 });
         assertState(SummaryManagerState.Off, "should start off");
         clientElection.electClient(thisClientId);
         await flushPromises();
@@ -278,7 +278,15 @@ describe("Summary Manager", () => {
             assertState(SummaryManagerState.Running, "summarizer should be running");
         });
 
-        it("Should bypass initial delay if enough ops pass later", async () => {
+        // This test attempts to validate a case where summarizer client does not wait
+        // initial delay if there are enough unsummarized ops.
+        // The way it was implemented (and tested here) is that it only worked if given
+        // client was selected to be a summarizer in the past, then got disconnected and later
+        // again was elected a summarizer and at that moment we had enough ops to cut short wait.
+        // If we want to cut short such wait, we should do it properly by listening for incoming ops
+        // and cut wait short based on op count when an a single op triggers overflow, i.e.
+        // make it work in main scenario, not a some corner case that does not matter.
+        it.skip("Should bypass initial delay if enough ops pass later", async () => {
             summaryCollection.opsSinceLastAck = 500; // 500 < 1000, so do not bypass yet
             createSummaryManager({
                 initialDelayMs: 2000,

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -286,6 +286,7 @@ describe("Summary Manager", () => {
         // If we want to cut short such wait, we should do it properly by listening for incoming ops
         // and cut wait short based on op count when an a single op triggers overflow, i.e.
         // make it work in main scenario, not a some corner case that does not matter.
+        // Issue #7273 tracks making appropriate product and test change and re-enable the test.
         it.skip("Should bypass initial delay if enough ops pass later", async () => {
             summaryCollection.opsSinceLastAck = 500; // 500 < 1000, so do not bypass yet
             createSummaryManager({


### PR DESCRIPTION
Rework logic around managing 

The primary motivation for this change is to ensure that last summary always starts and has a chance to run in cases where document has too many ops (i.e. 10K limit in ODSP). Together with PR #7230 they sort of try to pull in different directions - PR #7230 ensures that summarization process cancels as quickly as possible when summarizer client loses connection, while this PR ensures that when main client decides it needs to move to exit, it gives a chance to summarizer client (if it is still connected) to run through full summary. It also ensures that new summarizer (interactive) client has a delay before it starts summarizer instance, thus reducing chances of collisions with another (running last summary) summarizer. Together, they substantially reduce number of cases where we see summary nacks due to overlapping summarizers. It does not eliminate it completely, because RunningSummarizer.trySummarize does 3 attempts to summarize, and it needs to try only once for lastSummary (this is subject for another change).

Most of the changes are reworking logic in SummaryManager as I found it hard to follow when logic is split between multiple functions when they call each other in various ways. Now main flow is one function - SummaryManager.startSummarization(), which I find much easier to follow. Plus I've added a bunch of asserts to ensure that state transition are easier to follow (and we catch any issues).

One core change here is that there was a delay before staring a summarizer client, but it only applied to when container was booting (i.e. if summarizer client was created at that moment). There was no delay when given client (that was already running for a while) was assigned summarization role - it would start summarizer right away, increasing substantially odds of stepping on previous summarizer client that is doing last summary.

I believe there were some other smaller issues, like not re-checking if given client is still elected summarizer after various async processes, leading to more chances that we have two summarizers running in parallel.

Long term, we should move away from delays as a way to solve these problems and look into ability for current summarizing (non-interactive) client to be elected as summarizer, such that last summary that keeps running for 10 mins never has to compete with other clients (but that's subject for another design / PR).

There are certain small bits & pieces that are spill over from https://github.com/microsoft/FluidFramework/pull/7230 (i.e. they resolve to nothing after that PR), like stop() reason in couple places. These PRs can go in any order, but it's better for this go last to create cleaner diff.

**Next in series**:
1. Implement only one attempt for last Summary instead of current 3
2. Add summary attempt field to all summarizer events (currently it's missing pretty much everywhere).