### PR TITLE
Enable full compat for GC end-to-end tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
@@ -15,7 +15,7 @@ import { IRequest } from "@fluidframework/core-interfaces";
 import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { IAckedSummary, IContainerRuntimeOptions, SummaryCollection } from "@fluidframework/container-runtime";
 import { flattenRuntimeOptions } from "../flattenRuntimeOptions";
 
@@ -33,8 +33,7 @@ class TestDataObject extends DataObject {
     }
 }
 
-// REVIEW: enable compat testing?
-describeNoCompat("GC Data Store Requests", (getTestObjectProvider) => {
+describeFullCompat("GC Data Store Requests", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const dataObjectFactory = new DataObjectFactory(
         "TestDataObject",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
@@ -19,7 +19,7 @@ import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { UndoRedoStackManager } from "@fluidframework/undo-redo";
 import { flattenRuntimeOptions } from "../flattenRuntimeOptions";
 
@@ -63,8 +63,7 @@ class TestDataObject extends DataObject {
     }
 }
 
-// REVIEW: enable compat testing?
-describeNoCompat("GC reference updates in local summary", (getTestObjectProvider) => {
+describeFullCompat("GC reference updates in local summary", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const factory = new DataObjectFactory(
         "TestDataObject",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
@@ -19,7 +19,7 @@ import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { SharedString } from "@fluidframework/sequence";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { UndoRedoStackManager } from "@fluidframework/undo-redo";
 import { flattenRuntimeOptions } from "../flattenRuntimeOptions";
 
@@ -63,8 +63,7 @@ class TestDataObject extends DataObject {
     }
 }
 
-// REVIEW: enable compat testing?
-describeNoCompat("GC reference updates in summarizer", (getTestObjectProvider) => {
+describeFullCompat("GC reference updates in summarizer", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const factory = new DataObjectFactory(
         "TestDataObject",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -16,7 +16,7 @@ import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions"
 import { ISummaryStats } from "@fluidframework/runtime-definitions";
 import { calculateStats, mergeStats, requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { flattenRuntimeOptions } from "../flattenRuntimeOptions";
 
 /**
@@ -33,8 +33,7 @@ class TestDataObject extends DataObject {
     }
 }
 
-// REVIEW: enable compat testing?
-describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
+describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
     const dataObjectFactory = new DataObjectFactory(
         "TestDataObject",
         TestDataObject,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSummaryTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSummaryTests.spec.ts
@@ -14,7 +14,7 @@ import { Container } from "@fluidframework/container-loader";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { flattenRuntimeOptions } from "../flattenRuntimeOptions";
 
 class TestDataObject extends DataObject {
@@ -27,8 +27,7 @@ class TestDataObject extends DataObject {
     }
 }
 
-// REVIEW: enable compat testing?
-describeNoCompat("Garbage Collection", (getTestObjectProvider) => {
+describeFullCompat("Garbage Collection", (getTestObjectProvider) => {
     // If deleteUnreferencedContent is true, GC is run in test mode where content that is not referenced is
     // deleted after each GC run.
     const tests = (deleteUnreferencedContent: boolean = false) => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagValidation.spec.ts
@@ -17,7 +17,7 @@ import {
 import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { flattenRuntimeOptions } from "../flattenRuntimeOptions";
 import { wrapDocumentServiceFactory } from "./gcDriverWrappers";
 
@@ -31,8 +31,7 @@ class TestDataObject extends DataObject {
     }
 }
 
-// REVIEW: enable compat testing?
-describeNoCompat("GC unreferenced flag validation in snapshot", (getTestObjectProvider) => {
+describeFullCompat("GC unreferenced flag validation in snapshot", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const factory = new DataObjectFactory(
         "TestDataObject",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
@@ -27,7 +27,7 @@ import {
 import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { flattenRuntimeOptions } from "../flattenRuntimeOptions";
 import { wrapDocumentServiceFactory } from "./gcDriverWrappers";
 
@@ -55,8 +55,7 @@ class ContainerRuntimeFactoryWithGC extends ContainerRuntimeFactoryWithDefaultDa
     }
 }
 
-// REVIEW: enable compat testing?
-describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
+describeFullCompat("GC version upgrade", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     const factory = new DataObjectFactory(
         "TestDataObject",
@@ -107,7 +106,7 @@ describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
         const requestHeader = {
             [LoaderHeader.cache]: false,
             [LoaderHeader.clientDetails]: {
-                capabilities: { interactive: false },
+                capabilities: { interactive: true },
                 type: "summarizer",
             },
             [DriverHeader.summarizingClient]: true,


### PR DESCRIPTION
The features tested by these tests have been there for >2 versions so full backwards compat  can be enabled.