### PR TITLE
Anonymous types for azure and tinylicious clients

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -28,8 +28,14 @@ export class AzureAudience extends ServiceAudience<AzureMember> implements IAzur
 // @public
 export class AzureClient {
     constructor(connectionConfig: AzureConnectionConfig, logger?: ITelemetryBaseLogger | undefined);
-    createContainer(containerSchema: ContainerSchema): Promise<AzureResources>;
-    getContainer(id: string, containerSchema: ContainerSchema): Promise<AzureResources>;
+    createContainer(containerSchema: ContainerSchema): Promise<{
+        container: FluidContainer;
+        services: AzureContainerServices;
+    }>;
+    getContainer(id: string, containerSchema: ContainerSchema): Promise<{
+        container: FluidContainer;
+        services: AzureContainerServices;
+    }>;
     }
 
 // @public (undocumented)
@@ -64,14 +70,6 @@ export interface AzureMember<T = any> extends IMember {
     additionalDetails?: T;
     // (undocumented)
     userName: string;
-}
-
-// @public (undocumented)
-export interface AzureResources {
-    // (undocumented)
-    containerServices: AzureContainerServices;
-    // (undocumented)
-    fluidContainer: FluidContainer;
 }
 
 // @public (undocumented)

--- a/api-report/tinylicious-client.api.md
+++ b/api-report/tinylicious-client.api.md
@@ -57,14 +57,6 @@ export interface TinyliciousMember extends IMember {
     userName: string;
 }
 
-// @public (undocumented)
-export interface TinyliciousResources {
-    // (undocumented)
-    containerServices: TinyliciousContainerServices;
-    // (undocumented)
-    fluidContainer: FluidContainer;
-}
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-report/tinylicious-client.api.md
+++ b/api-report/tinylicious-client.api.md
@@ -24,8 +24,14 @@ export class TinyliciousAudience extends ServiceAudience<TinyliciousMember> impl
 // @public
 class TinyliciousClient {
     constructor(serviceConnectionConfig?: TinyliciousConnectionConfig, logger?: ITelemetryBaseLogger | undefined);
-    createContainer(containerSchema: ContainerSchema): Promise<TinyliciousResources>;
-    getContainer(id: string, containerSchema: ContainerSchema): Promise<TinyliciousResources>;
+    createContainer(containerSchema: ContainerSchema): Promise<{
+        container: FluidContainer;
+        services: TinyliciousContainerServices;
+    }>;
+    getContainer(id: string, containerSchema: ContainerSchema): Promise<{
+        container: FluidContainer;
+        services: TinyliciousContainerServices;
+    }>;
     }
 
 export { TinyliciousClient }

--- a/examples/data-objects/focus-tracker/src/app.ts
+++ b/examples/data-objects/focus-tracker/src/app.ts
@@ -3,11 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerSchema, SignalManager } from "@fluidframework/fluid-static";
+import {
+    FluidContainer,
+    ContainerSchema,
+    SignalManager,
+} from "fluid-framework";
 import {
     TinyliciousClient,
     TinyliciousMember,
-    TinyliciousResources,
+    TinyliciousContainerServices,
 } from "@fluidframework/tinylicious-client";
 import { FocusTracker } from "./FocusTracker";
 
@@ -47,32 +51,32 @@ function renderFocusPresence(focusTracker: FocusTracker, div: HTMLDivElement) {
 async function start(): Promise<void> {
     // Get or create the document depending if we are running through the create new flow
     const client = new TinyliciousClient();
-    let resources: TinyliciousResources;
+    let container: FluidContainer;
+    let services: TinyliciousContainerServices;
     let containerId: string;
 
     // Get or create the document depending if we are running through the create new flow
     const createNew = !location.hash;
     if (createNew) {
         // The client will create a new container using the schema
-        resources = await client.createContainer(containerSchema);
-        containerId = await resources.fluidContainer.attach();
+        ({container, services} = await client.createContainer(containerSchema));
+        containerId = await container.attach();
         // The new container has its own unique ID that can be used to access it in another session
         location.hash = containerId;
     } else {
         containerId = location.hash.substring(1);
         // Use the unique container ID to fetch the container created earlier
-        resources = await client.getContainer(containerId, containerSchema);
+        ({container, services} = await client.getContainer(containerId, containerSchema));
     }
     // create/get container API returns a combination of the container and associated container services
-    const { fluidContainer, containerServices } = resources;
     document.title = containerId;
 
     // Render page focus information for audience members
     const contentDiv = document.getElementById("content") as HTMLDivElement;
     const focusTracker = new FocusTracker(
-        fluidContainer,
-        containerServices.audience,
-        fluidContainer.initialObjects.signalManager as SignalManager,
+        container,
+        services.audience,
+        container.initialObjects.signalManager as SignalManager,
     );
     renderFocusPresence(focusTracker, contentDiv);
 }

--- a/packages/framework/azure-client/README.md
+++ b/packages/framework/azure-client/README.md
@@ -16,14 +16,14 @@ Fluid requires a backing service to enable collaborative communication. The `Azu
 
 NOTE: You can use one instance of the `AzureClient` to create/fetch multiple containers from the same FRS service instance.
 
-In the example below we will walk through both connecting to a a live FRS service instance by providing the tenant ID and key that is uniquely generated for us when onboarding to the service, as well as using a tenant ID of "local" for development purposes to run our application against Tinylicious. We make use of `AzureFunctionTokenProvider` for token generation while running against a live FRS instance and `InsecureTokenProvider` to authenticate a given user for access to the service locally. The `AzureFunctionTokenProvider` is an implemention that fulfills the `ITokenProvider` interface without exposing the tenant key secret in client-side code.
+In the example below we will walk through both connecting to a a live FRS service instance by providing the tenant ID and key that is uniquely generated for us when onboarding to the service, as well as using a tenant ID of "local" for development purposes to run our application against Tinylicious. We make use of `AzureFunctionTokenProvider` for token generation while running against a live FRS instance and `InsecureTokenProvider` to authenticate a given user for access to the service locally. The `AzureFunctionTokenProvider` is an implementation that fulfills the `ITokenProvider` interface without exposing the tenant key secret in client-side code.
 
 ### Backed Locally
 
 To run Tinylicious on the default values of `localhost:7070`, please enter the following into a terminal window:
 
 ```sh
-npx tinylicous
+npx tinylicious
 ```
 
 Now, with our local service running in the background, we need to connect the application to it. For this, we first need to create our `ITokenProvider` instance to authenticate the current user to the service. For this, we can use the `InsecureTokenProvider` where we can pass anything into the key (since we are running locally) and an object identifying the current user. Both our orderer and storage URLs will point to the domain and port that our Tinylicous instance is running at.
@@ -80,11 +80,11 @@ const schema = {
     dynamicObjectTypes: [ /*...*/ ],
 }
 const azureClient = new AzureClient(config);
-const { fluidContainer, containerServices } = await azureClient.createContainer(schema);
+const { container, services } = await azureClient.createContainer(schema);
 
 // Set any default data on the container's `initialObjects` before attaching
 // Returned ID can be used to fetch the container via `getContainer` below
-const id = await fluidContainer.attach();
+const id = await container.attach();
 ```
 
 ## Using Fluid Containers
@@ -95,7 +95,7 @@ Using the `AzureClient` object the developer can create and get Fluid containers
 import { AzureClient } from "@fluidframework/azure-client";
 
 const azureClient = new AzureClient(config);
-const { fluidContainer, containerServices } = await azureClient.getContainer("_unique-id_", schema);
+const { container, services } = await azureClient.getContainer("_unique-id_", schema);
 ```
 
 NOTE: When using the `AzureClient` with tenant ID as "local", all containers that have been created will be deleted when the instance of the Tinylicious service (not client) that was run from the terminal window is closed. However, any containers created when running against the FRS service itself will be persisted. Container IDs can NOT be reused between Tinylicious and FRS to fetch back the same container.
@@ -108,23 +108,23 @@ The most common way to use Fluid is through initial collaborative objects that a
 
 ```typescript
 // Define the keys and types of the initial list of collaborative objects.
-// Here, we are using a SharedMap DDS on key "map1" and a KeyValueDataObject on key "pair1".
+// Here, we are using a SharedMap DDS on key "map1" and a SharedString on key "text1".
 const schema = {
     name: "my-container",
     initialObjects: {
         map1: SharedMap,
-        pair1: KeyValueDataObject,
+        text1: SharedString,
     }
 }
 
 // Fetch back the container that had been created earlier with the same ID and schema
-const { fluidContainer, containerServices } = await azureClient.getContainer("_unique-id_", schema);
+const { container, services } = await azureClient.getContainer("_unique-id_", schema);
 
 // Get our list of initial objects that we had defined in the schema. initialObjects here will have the same signature
-const initialObjects = fluidContainer.initialObjects;
-// Use the keys that we had set in the schema to load the individiual objects
+const initialObjects = container.initialObjects;
+// Use the keys that we had set in the schema to load the individual objects
 const map1 = initialObjects.map1;
-const pair1 = initialObjects["pair1"];
+const text1 = initialObjects["text1"];
 ```
 
 ## Using dynamic objects
@@ -141,23 +141,23 @@ const schema = {
     initialObjects: {
         map1: SharedMap,
     },
-    dynamicObjectTypes: [ KeyValueDataObject ],
+    dynamicObjectTypes: [ SharedString ],
 }
 
-const { fluidContainer, containerServices } = await azureClient.getContainer("_unique-id_", schema);
+const { container, services } = await azureClient.getContainer("_unique-id_", schema);
 const map1 = container.initialObjects.map1;
 
-const newPair = await container.create(KeyValueDataObject);
-map1.set("pair-unique-id", newPair.handle);
+const text1 = await container.create(SharedString);
+map1.set("text1-unique-id", text1.handle);
 
 // ...
 
-const pairHandle = map1.get("pair-unique-id"); // Get the handle
-const pair = await map1.get(); // Resolve the handle to get the object
+const text1Handle = map1.get("text1-unique-id"); // Get the handle
+const text1 = await map1.get(); // Resolve the handle to get the object
 
 // or
 
-const pair = await map1.get("pair-unique-id").get();
+const text1 = await map1.get("text1-unique-id").get();
 ```
 
 See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.

--- a/packages/framework/azure-client/src/AzureClient.ts
+++ b/packages/framework/azure-client/src/AzureClient.ts
@@ -20,7 +20,6 @@ import {
 import {
     AzureConnectionConfig,
     AzureContainerServices,
-    AzureResources,
 } from "./interfaces";
 import { AzureAudience } from "./AzureAudience";
 import { AzureUrlResolver } from "./AzureUrlResolver";
@@ -53,7 +52,7 @@ export class AzureClient {
      */
     public async createContainer(
         containerSchema: ContainerSchema,
-    ): Promise<AzureResources> {
+    ): Promise<{ container: FluidContainer; services: AzureContainerServices }> {
         const loader = this.createLoader(containerSchema);
         const container = await loader.createDetachedContainer({
             package: "no-dynamic-package",
@@ -74,7 +73,7 @@ export class AzureClient {
     public async getContainer(
         id: string,
         containerSchema: ContainerSchema,
-    ): Promise<AzureResources> {
+    ): Promise<{ container: FluidContainer; services: AzureContainerServices }> {
         const loader = this.createLoader(containerSchema);
         const container = await loader.resolve({ url: id });
         return this.getFluidContainerAndServices(id, container);
@@ -84,15 +83,15 @@ export class AzureClient {
     private async getFluidContainerAndServices(
         id: string,
         container: Container,
-    ): Promise<AzureResources> {
+    ): Promise<{ container: FluidContainer; services: AzureContainerServices }> {
         const attach = async () => {
             await container.attach({ url: id });
             return id;
         };
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
         const fluidContainer: FluidContainer = new FluidContainer(container, rootDataObject, attach);
-        const containerServices: AzureContainerServices = this.getContainerServices(container);
-        return { fluidContainer, containerServices };
+        const services: AzureContainerServices = this.getContainerServices(container);
+        return { container: fluidContainer, services };
     }
 
     private getContainerServices(

--- a/packages/framework/azure-client/src/interfaces.ts
+++ b/packages/framework/azure-client/src/interfaces.ts
@@ -5,7 +5,6 @@
 
 import { ITokenProvider } from "@fluidframework/routerlicious-driver";
 import {
-    FluidContainer,
     IMember,
     IServiceAudience,
 } from "fluid-framework";
@@ -39,11 +38,6 @@ export interface AzureContainerServices {
 export interface AzureMember<T = any> extends IMember {
     userName: string;
     additionalDetails?: T;
-}
-
-export interface AzureResources {
-    fluidContainer: FluidContainer;
-    containerServices: AzureContainerServices;
 }
 
 export type IAzureAudience = IServiceAudience<AzureMember>;

--- a/packages/framework/azure-client/src/test/AzureClient.spec.ts
+++ b/packages/framework/azure-client/src/test/AzureClient.spec.ts
@@ -25,36 +25,36 @@ describe("AzureClient", () => {
             "container cannot be created in FRS",
         );
 
-        const { fluidContainer } = await resources;
-        assert.equal(Object.keys(fluidContainer.initialObjects), Object.keys(schema.initialObjects));
+        const { container } = await resources;
+        assert.equal(Object.keys(container.initialObjects), Object.keys(schema.initialObjects));
     });
 
     it("Created container is detached", async () => {
-        const { fluidContainer } = await client.createContainer(schema);
-        assert.strictEqual(fluidContainer.attachState, AttachState.Detached, "Container should be detached");
+        const { container } = await client.createContainer(schema);
+        assert.strictEqual(container.attachState, AttachState.Detached, "Container should be detached");
     });
 
     it("Can attach container", async () => {
-        const {fluidContainer} = await client.createContainer(schema);
-        const containerId = await fluidContainer.attach();
+        const {container} = await client.createContainer(schema);
+        const containerId = await container.attach();
 
         assert.strictEqual(
             typeof(containerId) === "string",
             "Attach did not return a string ID",
         );
         assert.strictEqual(
-            fluidContainer.attachState, AttachState.Attached,
+            container.attachState, AttachState.Attached,
             "Container is not attached after attach is called",
         );
         await assert.rejects(
-            fluidContainer.attach(),
+            container.attach(),
             ()=> true,
             "Container should not attached twice",
         );
     });
 
     it("can retrieve existing FRS container successfully", async () => {
-        const { fluidContainer: newContainer } = await client.createContainer(schema);
+        const { container: newContainer } = await client.createContainer(schema);
         const containerId = await newContainer.attach();
 
         const resources = client.getContainer(containerId, schema);
@@ -64,7 +64,7 @@ describe("AzureClient", () => {
             "container cannot be retrieved from FRS",
         );
 
-        const { fluidContainer } = await resources;
-        assert.equal(Object.keys(fluidContainer.initialObjects), Object.keys(schema.initialObjects));
+        const { container } = await resources;
+        assert.equal(Object.keys(container.initialObjects), Object.keys(schema.initialObjects));
     });
 });

--- a/packages/framework/azure-client/src/test/AzureClient.spec.ts
+++ b/packages/framework/azure-client/src/test/AzureClient.spec.ts
@@ -35,7 +35,7 @@ describe("AzureClient", () => {
     });
 
     it("Can attach container", async () => {
-        const {container} = await client.createContainer(schema);
+        const { container } = await client.createContainer(schema);
         const containerId = await container.attach();
 
         assert.strictEqual(

--- a/packages/framework/tinylicious-client/README.md
+++ b/packages/framework/tinylicious-client/README.md
@@ -44,11 +44,11 @@ const schema = {
     dynamicObjectTypes: [ /*...*/ ],
 }
 const tinyliciousClient = new TinyliciousClient();
-const { fluidContainer, containerServices } = await tinyliciousClient.createContainer(schema);
+const { container, services } = await tinyliciousClient.createContainer(schema);
 
 // Set any default data on the container's `initialObjects` before attaching
 // Returned ID can be used to fetch the container via `getContainer` below
-const id = await fluidContainer.attach();
+const id = await container.attach();
 ```
 ## Using Fluid Containers
 
@@ -58,7 +58,7 @@ Using the default `TinyliciousClient` object the developer can create and get Fl
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 
 const tinyliciousClient = new TinyliciousClient(config);
-const { fluidContainer, containerServices } = await tinyliciousClient.getContainer("_unique-id_", schema);
+const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema);
 ```
 
 ## Using initial objects
@@ -74,15 +74,15 @@ const schema = {
     name: "my-container",
     initialObjects: {
         map1: SharedMap,
-        pair1: KeyValueDataObject,
+        text1: SharedString,
     }
 }
 const tinyliciousClient = new TinyliciousClient();
-const { fluidContainer, containerServices } = await tinyliciousClient.getContainer("_unique-id_", schema);
+const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema);
 
 const initialObjects = container.initialObjects;
 const map1 = initialObjects.map1;
-const pair1 = initialObjects["pair1"];
+const text1 = initialObjects["text1"];
 ```
 
 ## Using dynamic objects
@@ -99,23 +99,23 @@ const schema = {
     initialObjects: {
         map1: SharedMap,
     },
-    dynamicObjectTypes: [ KeyValueDataObject ],
+    dynamicObjectTypes: [ SharedString ],
 }
 const tinyliciousClient = new TinyliciousClient();
-const { fluidContainer, containerServices } = await tinyliciousClient.getContainer("_unique-id_", schema);
+const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema);
 const map1 = container.initialObjects.map1;
 
-const newPair = await container.create(KeyValueDataObject);
-map1.set("pair-unique-id", newPair.handle);
+const newText = await container.create(SharedString);
+map1.set("text-unique-id", newText.handle);
 
 // ...
 
-const pairHandle = map1.get("pair-unique-id"); // Get the handle
-const pair = await map1.get(); // Resolve the handle to get the object
+const textHandle = map1.get("text-unique-id"); // Get the handle
+const text = await map1.get(); // Resolve the handle to get the object
 
 // or
 
-const pair = await map1.get("pair-unique-id").get();
+const text = await map1.get("text-unique-id").get();
 ```
 
 See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -24,7 +24,6 @@ import {
 import {
     TinyliciousConnectionConfig,
     TinyliciousContainerServices,
-    TinyliciousResources,
 } from "./interfaces";
 import { TinyliciousAudience } from "./TinyliciousAudience";
 
@@ -61,7 +60,7 @@ export class TinyliciousClient {
      */
     public async createContainer(
         containerSchema: ContainerSchema,
-    ): Promise<TinyliciousResources> {
+    ): Promise<{container: FluidContainer; services: TinyliciousContainerServices}> {
         // temporarily we'll generate the new container ID here
         // until container ID changes are settled in lower layers.
         const id = uuid();
@@ -78,7 +77,7 @@ export class TinyliciousClient {
     public async getContainer(
         id: string,
         containerSchema: ContainerSchema,
-    ): Promise<TinyliciousResources> {
+    ): Promise<{container: FluidContainer; services: TinyliciousContainerServices}> {
         const container = await this.getContainerCore(id, containerSchema, false);
         return this.getFluidContainerAndServices(id, container);
     }
@@ -87,16 +86,15 @@ export class TinyliciousClient {
     private async getFluidContainerAndServices(
         id: string,
         container: Container,
-    ): Promise<TinyliciousResources> {
+    ): Promise<{container: FluidContainer; services: TinyliciousContainerServices}> {
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
         const attach = async () => {
             await container.attach({ url: id });
             return id;
         };
         const fluidContainer: FluidContainer = new FluidContainer(container, rootDataObject, attach);
-        const containerServices: TinyliciousContainerServices = this.getContainerServices(container);
-        const tinyliciousResources: TinyliciousResources = { fluidContainer, containerServices };
-        return tinyliciousResources;
+        const services: TinyliciousContainerServices = this.getContainerServices(container);
+        return { container: fluidContainer, services };
     }
 
     private getContainerServices(

--- a/packages/framework/tinylicious-client/src/interfaces.ts
+++ b/packages/framework/tinylicious-client/src/interfaces.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { FluidContainer, IMember, IServiceAudience } from "fluid-framework";
+import { IMember, IServiceAudience } from "fluid-framework";
 
 export interface TinyliciousConnectionConfig {
     port?: number;
@@ -22,11 +22,6 @@ export interface TinyliciousContainerServices {
      * listeners for when the roster has any changes from users joining/leaving the session
      */
     audience: ITinyliciousAudience;
-}
-
-export interface TinyliciousResources {
-    fluidContainer: FluidContainer;
-    containerServices: TinyliciousContainerServices;
 }
 
 /**

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -98,28 +98,28 @@ describe("TinyliciousClient", () => {
     });
 
     it("creates a container with detached state", async () => {
-        const {fluidContainer} = await tinyliciousClient.createContainer(schema);
+        const {container} = await tinyliciousClient.createContainer(schema);
         assert.strictEqual(
-            fluidContainer.attachState, AttachState.Detached,
+            container.attachState, AttachState.Detached,
             "Container should be detached after creation",
         );
     });
 
     it("creates a container that can only be attached once", async () => {
-        const {fluidContainer} = await tinyliciousClient.createContainer(schema);
-        const containerId = await fluidContainer.attach();
+        const {container} = await tinyliciousClient.createContainer(schema);
+        const containerId = await container.attach();
 
         assert.strictEqual(
             typeof(containerId) === "string",
             "Attach did not return a string ID",
         );
         assert.strictEqual(
-            fluidContainer.attachState, AttachState.Attached,
+            container.attachState, AttachState.Attached,
             "Container is not attached after attach is called",
         );
 
         await assert.rejects(
-            fluidContainer.attach(),
+            container.attach(),
             ()=> true,
             "Container should not attached twice",
         );
@@ -132,7 +132,7 @@ describe("TinyliciousClient", () => {
      * Expected behavior: containerCreate should have the identical SharedMap ID as containerGet.
      */
     it("can get a container successfully", async () => {
-        const containerCreate = (await tinyliciousClient.createContainer(schema)).fluidContainer;
+        const containerCreate = (await tinyliciousClient.createContainer(schema)).container;
         await new Promise<void>((resolve, reject) => {
             containerCreate.on("connected", () => {
                 resolve();
@@ -141,7 +141,7 @@ describe("TinyliciousClient", () => {
 
         const containerId = await containerCreate.attach();
 
-        const containerGet = (await tinyliciousClient.getContainer(containerId, schema)).fluidContainer;
+        const containerGet = (await tinyliciousClient.getContainer(containerId, schema)).container;
         const map1Create = containerCreate.initialObjects.map1 as SharedMap;
         const map1Get = containerGet.initialObjects.map1 as SharedMap;
         assert.strictEqual(map1Get.id, map1Create.id, "Error getting a container");
@@ -154,7 +154,7 @@ describe("TinyliciousClient", () => {
      * each other after value is changed.
      */
     it("can change initialObjects value", async () => {
-        const containerCreate = (await tinyliciousClient.createContainer(schema)).fluidContainer;
+        const containerCreate = (await tinyliciousClient.createContainer(schema)).container;
         await new Promise<void>((resolve, reject) => {
             containerCreate.on("connected", () => {
                 resolve();
@@ -168,7 +168,7 @@ describe("TinyliciousClient", () => {
         map1Create.set("new-key", "new-value");
         const valueCreate = await map1Create.get("new-key");
 
-        const containerGet = (await tinyliciousClient.getContainer(containerId, schema)).fluidContainer;
+        const containerGet = (await tinyliciousClient.getContainer(containerId, schema)).container;
         const map1Get = containerGet.initialObjects.map1 as SharedMap;
         const valueGet = await map1Get.get("new-key");
         assert.strictEqual(valueGet, valueCreate, "container can't connect with initial objects");
@@ -191,7 +191,7 @@ describe("TinyliciousClient", () => {
             dynamicObjectTypes: [SharedDirectory],
         };
 
-        const container = (await tinyliciousClient.createContainer(dynamicSchema)).fluidContainer;
+        const container = (await tinyliciousClient.createContainer(dynamicSchema)).container;
 
         await new Promise<void>((resolve, reject) => {
             container.on("connected", () => {
@@ -222,7 +222,7 @@ describe("TinyliciousClient", () => {
             dynamicObjectTypes: [DiceRoller],
         };
 
-        const createFluidContainer = (await tinyliciousClient.createContainer(dynamicSchema)).fluidContainer;
+        const createFluidContainer = (await tinyliciousClient.createContainer(dynamicSchema)).container;
         await new Promise<void>((resolve, reject) => {
             createFluidContainer.on("connected", () => {
                 resolve();

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -98,7 +98,7 @@ describe("TinyliciousClient", () => {
     });
 
     it("creates a container with detached state", async () => {
-        const {container} = await tinyliciousClient.createContainer(schema);
+        const { container } = await tinyliciousClient.createContainer(schema);
         assert.strictEqual(
             container.attachState, AttachState.Detached,
             "Container should be detached after creation",


### PR DESCRIPTION
Change the return type of `createContainer` and `getContainer` from specifically defined types to anonymous types. Also rename the object types to be more generic `fluildContainer -> container` `containerServices -> services`

