### PR TITLE
Make r11s driver to keep port alive in e2e test for compat driver as well

### DIFF
--- a/api-report/test-drivers.api.md
+++ b/api-report/test-drivers.api.md
@@ -140,6 +140,7 @@ export class OdspTestDriver implements ITestDriver {
 // @public (undocumented)
 export const RouterliciousDriverApi: {
     version: string;
+    modulePath: string;
     RouterliciousDocumentServiceFactory: typeof RouterliciousDocumentServiceFactory;
 };
 

--- a/packages/test/test-drivers/src/factory.ts
+++ b/packages/test/test-drivers/src/factory.ts
@@ -4,6 +4,7 @@
  */
 
 import http from "http";
+import * as path from "path";
 import Axios from "axios";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { unreachableCase } from "@fluidframework/common-utils";
@@ -27,18 +28,25 @@ export const DriverApi: DriverApiType = {
     RouterliciousDriverApi,
 };
 
-let hasSetKeepAlive = false;
-function setKeepAlive() {
-    // Make sure we only do it once so that createFluidTestDriver can be called multiple times.
-    if (!hasSetKeepAlive) {
-        // Each TCP connect has a delay to allow it to be reuse after close, and unit test make a lot of connection,
-        // which might cause port exhaustion.
+let httpAgent: http.Agent | undefined;
+function setKeepAlive(api: RouterliciousDriverApiType) {
+    // Each TCP connect has a delay to disallow it to be reused after close, and unit test make a lot of connection,
+    // which might cause port exhaustion.
 
-        // For drivers that use Axios (t9s and r11s), keep the TCP connection open so that they can be reused
-        // TODO: no solution for node-fetch used by ODSP driver.
-        // TODO: currently the driver use a global setting.  Might want to make this encapsulated.
-        Axios.defaults.httpAgent = new http.Agent({ keepAlive: true });
-        hasSetKeepAlive = true;
+    // For drivers that use Axios (t9s and r11s), keep the TCP connection open so that they can be reused
+    // TODO: no solution for node-fetch used by ODSP driver.
+    // TODO: currently the driver use a global setting.  Might want to make this encapsulated.
+
+    // create the keepAlive httpAgent only once
+    if (httpAgent === undefined) {
+        httpAgent = new http.Agent({ keepAlive: true });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const axios = api.modulePath === "" ? Axios : require(path.join(api.modulePath, "node_modules", "axios"));
+    // Don't override it if there is already one
+    if (axios.defaults.httpAgent === undefined) {
+        axios.defaults.httpAgent = httpAgent;
     }
 }
 
@@ -59,11 +67,11 @@ export async function createFluidTestDriver(
             return new LocalServerTestDriver(api.LocalDriverApi);
 
         case "tinylicious":
-            setKeepAlive();
+            setKeepAlive(api.RouterliciousDriverApi);
             return new TinyliciousTestDriver(api.RouterliciousDriverApi);
 
         case "routerlicious":
-            setKeepAlive();
+            setKeepAlive(api.RouterliciousDriverApi);
             return RouterliciousTestDriver.createFromEnv(api.RouterliciousDriverApi);
 
         case "odsp":

--- a/packages/test/test-drivers/src/routerliciousDriverApi.ts
+++ b/packages/test/test-drivers/src/routerliciousDriverApi.ts
@@ -8,6 +8,7 @@ import { pkgVersion } from "./packageVersion";
 
 export const RouterliciousDriverApi = {
     version: pkgVersion,
+    modulePath: "",
     RouterliciousDocumentServiceFactory,
 };
 

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -169,6 +169,7 @@ export function getDriverApi(requested?: number | string): typeof DriverApi {
 
     const routerliciousDriverApi: typeof DriverApi.RouterliciousDriverApi = {
         version,
+        modulePath,
         RouterliciousDocumentServiceFactory:
             loadPackage(modulePath, "@fluidframework/routerlicious-driver").RouterliciousDocumentServiceFactory,
     };


### PR DESCRIPTION
We need to load the `Axios` version that is used by the back compat version of the r11s driver to set the http agent with `keepAlive` flag on.