### PR TITLE
Policy Check: Reduce noise, and improve error handling

### DIFF
--- a/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -99,11 +99,16 @@ export const handlers: Handler[] = [
 
             const validationResults = PJV.validate(jsonStr, 'npm', { warnings: false, recommendations: false });
 
-            // special handling for the end-to-end tests package since it uses non-standard version values.
-            if (file.includes("end-to-end-tests") && !validationResults.valid) {
+            if (!validationResults.valid) {
                 validationResults.errors = validationResults.errors.filter(
                     (error: string) => {
-                        return !error.startsWith("Invalid version range for dependency");
+                        // special handling for packages that use non-standard version values.
+                        // e.g. "name": "npm:package@version"
+                        // 'Invalid version range for dependency @fluidframework/protocol-definitions-0.1024.0: npm:@fluidframework/protocol-definitions@0.1024.0'
+                        const shouldIgnore =
+                            error.startsWith("Invalid version range for dependency")
+                            && error.startsWith(": npm:", error.indexOf(":"))
+                        return !shouldIgnore;
                     }
                 );
 

--- a/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
+++ b/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
@@ -23,7 +23,7 @@ const exclusions: RegExp[] = require('../../data/exclusions.json').map((e: strin
  * argument parsing
  */
 program
-    .option('-q|--quiet', 'Quiet mode')
+    .option('-v|--verbose', 'Verbose mode')
     .option('-r|--resolve', 'Resolve errors if possible')
     .option('-h|--handler <regex>', 'Filter handler names by <regex>')
     .option('-p|--path <regex>', 'Filter file paths by <regex>')
@@ -34,7 +34,7 @@ const handlerRegex = (program.handler ? new RegExp(program.handler, 'i') : /.?/)
 const pathRegex = (program.path ? new RegExp(program.path, 'i') : /.?/);
 
 function writeOutLine(output: string) {
-    if (!program.quiet) {
+    if (program.verbose) {
         console.log(output);
     }
 }


### PR DESCRIPTION
- Switch from default not quiet to default not verbose. This will make errors much more discoverable in build, as without this they get hidden by un-related output from the tool
- As part of #7198 we will be using named sub packages, so make the error handling more resilient across packages