### PR TITLE
Fix pipeline that doesn't have test

### DIFF
--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -62,3 +62,4 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/lib/container-definitions
     tagName: container-definitions
+    taskTest: false

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -62,3 +62,4 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/lib/core-interfaces
     tagName: core-interfaces
+    taskTest: false

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -62,3 +62,4 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/lib/driver-definitions
     tagName: driver-definitions
+    taskTest: false

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -62,3 +62,4 @@ extends:
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: common/lib/protocol-definitions
     tagName: protocol-definitions
+    taskTest: false


### PR DESCRIPTION
Don't run the test task if there aren't any test.
The patch code coverage result task expect the file to be there.