### PR TITLE
Remove unused dependencies from Focus tracker example

### DIFF
--- a/examples/data-objects/focus-tracker/README.md
+++ b/examples/data-objects/focus-tracker/README.md
@@ -2,7 +2,7 @@
 
 **_This demo is a work-in-progress_**
 
-**Focus Tracker** is an example that demonstrates how transient state of audience members can be tracked among other audience members using signals.  It does so using fluid-static's `FluidContainer`, `ServiceAudience`, and `ISignaler`.
+**Focus Tracker** is an example that demonstrates how transient state of audience members can be tracked among other audience members using signals.  It does so using fluid-framework's `FluidContainer`, `IServiceAudience`, and `SignalManager`.
 
 This implementation visualizes the Container in a standalone application, rather than using the webpack-fluid-loader environment that most of our examples use.  This implementation relies on [Tinylicious](/server/tinylicious), so there are a few extra steps to get started.  We bring our own view that we will bind to the data in the container.
 

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -34,13 +34,8 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.39.8",
-    "@fluidframework/fluid-static": "^0.47.0",
-    "@fluidframework/runtime-definitions": "^0.47.0",
     "@fluidframework/tinylicious-client": "^0.47.0",
-    "fluid-framework": "^0.47.0",
-    "react": "^16.10.2",
-    "react-dom": "^16.10.2"
+    "fluid-framework": "^0.47.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.22.0",

--- a/examples/data-objects/focus-tracker/tsconfig.json
+++ b/examples/data-objects/focus-tracker/tsconfig.json
@@ -8,7 +8,7 @@
         "rootDir": "./src",
         "outDir": "dist",
         "jsx": "react",
-        "types": ["react", "react-dom", "jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"]
+        "types": ["jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"]
     },
     "include": [
         "src/**/*",


### PR DESCRIPTION
Small change similar to #7266 to drop unused dependencies.