### PR TITLE
Fixing Whole Summary Upload to include sequence number and tree type

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -432,8 +432,8 @@ export class SummaryWriter implements ISummaryWriter {
                     summaryObject = {
                         type: SummaryType.Blob,
                         content: treeEntry.value.encoding === "base64" ?
-                                fromBase64ToUtf8(treeEntry.value.contents) :
-                                treeEntry.value.contents,
+                                 fromBase64ToUtf8(treeEntry.value.contents) :
+                                 treeEntry.value.contents,
                     };
                     break;
                 }

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { fromBase64ToUtf8 } from "@fluidframework/common-utils";
 import { ICreateCommitParams, ICreateTreeEntry } from "@fluidframework/gitresources";
 import {
     generateServiceProtocolEntries,
@@ -156,7 +157,8 @@ export class SummaryWriter implements ISummaryWriter {
                 content.handle,
                 protocolEntries,
                 logTailEntries,
-                serviceProtocolEntries);
+                serviceProtocolEntries,
+                checkpoint.protocolState.sequenceNumber);
         } else {
             const [logTailTree, protocolTree, serviceProtocolTree, appSummaryTree] = await Promise.all([
                 this.summaryStorage.createTree({ entries: logTailEntries }),
@@ -254,7 +256,11 @@ export class SummaryWriter implements ISummaryWriter {
             JSON.stringify(checkpoint));
 
         if (this.enableWholeSummaryUpload) {
-            await this.createWholeServiceSummary(existingRef.object.sha, logTailEntries, serviceProtocolEntries);
+            await this.createWholeServiceSummary(
+                existingRef.object.sha,
+                logTailEntries,
+                serviceProtocolEntries,
+                op.sequenceNumber);
         } else {
             // Fetch the last commit and summary tree. Create new trees with logTail and serviceProtocol.
             const lastCommit = await this.summaryStorage.getCommit(existingRef.object.sha);
@@ -361,7 +367,8 @@ export class SummaryWriter implements ISummaryWriter {
         appSummaryHandle: string,
         protocolEntries: ITreeEntry[],
         logTailEntries: ITreeEntry[],
-        serviceProtocolEntries: ITreeEntry[]): Promise<string> {
+        serviceProtocolEntries: ITreeEntry[],
+        sequenceNumber: number): Promise<string> {
         const fullTree: ISummaryTree =  {
             type: SummaryType.Tree,
             tree: {
@@ -377,14 +384,15 @@ export class SummaryWriter implements ISummaryWriter {
             },
         };
         const uploadManager = new WholeSummaryUploadManager(this.summaryStorage);
-        const uploadHandle = await uploadManager.writeSummaryTree(fullTree, parentHandle, "container");
+        const uploadHandle = await uploadManager.writeSummaryTree(fullTree, parentHandle, "container", sequenceNumber);
         return uploadHandle;
     }
 
     private async createWholeServiceSummary(
         parentHandle: string,
         logTailEntries: ITreeEntry[],
-        serviceProtocolEntries: ITreeEntry[]): Promise<string> {
+        serviceProtocolEntries: ITreeEntry[],
+        sequenceNumber: number): Promise<string> {
         const fullTree: ISummaryTree =  {
             type: SummaryType.Tree,
             tree: {
@@ -395,19 +403,56 @@ export class SummaryWriter implements ISummaryWriter {
             },
         };
         const uploadManager = new WholeSummaryUploadManager(this.summaryStorage);
-        const uploadHandle = await uploadManager.writeSummaryTree(fullTree, parentHandle, "container");
+        const uploadHandle = await uploadManager.writeSummaryTree(fullTree, parentHandle, "container", sequenceNumber);
         return uploadHandle;
     }
 
     // We should optimize our API so that we don't have to do this conversion.
     private createSummaryTreeFromEntry(treeEntries: ITreeEntry[]): ISummaryTree {
-        const tree: { [path: string]: SummaryObject } = {};
-        for (const entry of treeEntries) {
-            tree[entry.path] = entry.value as SummaryObject;
-        }
+        const tree = this.createSummaryTreeFromEntryCore(treeEntries);
         return {
             tree,
             type: SummaryType.Tree,
         };
+    }
+
+    private createSummaryTreeFromEntryCore(treeEntries: ITreeEntry[]): { [path: string]: SummaryObject } {
+        const tree: { [path: string]: SummaryObject } = {};
+        for (const treeEntry of treeEntries) {
+            let summaryObject: SummaryObject;
+            switch(treeEntry.type) {
+                case TreeEntry.Attachment: {
+                    summaryObject = {
+                        type: SummaryType.Attachment,
+                        id: treeEntry.value.id,
+                    };
+                    break;
+                }
+                case TreeEntry.Blob: {
+                    summaryObject = {
+                        type: SummaryType.Blob,
+                        content: treeEntry.value.encoding === "base64" ?
+                                fromBase64ToUtf8(treeEntry.value.contents) :
+                                treeEntry.value.contents,
+                    };
+                    break;
+                }
+                case TreeEntry.Tree: {
+                    summaryObject = {
+                        type: SummaryType.Tree,
+                        unreferenced: treeEntry.value.unreferenced,
+                        tree: this.createSummaryTreeFromEntryCore(treeEntry.value.entries),
+                    };
+                    break;
+                }
+                default: {
+                    throw new Error(`Unexpected TreeEntry type: ${treeEntry.type} when converting ITreeEntry.`);
+                }
+            }
+
+            tree[treeEntry.path] = summaryObject;
+        }
+
+        return tree;
     }
 }

--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -116,10 +116,12 @@ export interface ISummaryUploadManager {
      * @param summaryTree Summary tree to write to storage
      * @param parentHandle Parent summary acked handle (if available from summary ack)
      * @param summaryType type of summary being uploaded
+     * @param sequenceNumber reference sequence number of the summary
      * @returns Id of created tree as a string.
      */
     writeSummaryTree(
         summaryTree: api.ISummaryTree,
         parentHandle: string,
-        summaryType: storage.IWholeSummaryPayloadType): Promise<string>;
+        summaryType: IWholeSummaryPayloadType,
+        sequenceNumber: number): Promise<string>;
 }

--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -114,10 +114,12 @@ export interface ISummaryUploadManager {
      * @param summaryTree Summary tree to write to storage
      * @param parentHandle Parent summary acked handle (if available from summary ack)
      * @param summaryType type of summary being uploaded
+     * @param sequenceNumber reference sequence number of the summary
      * @returns Id of created tree as a string.
      */
     writeSummaryTree(
         summaryTree: api.ISummaryTree,
         parentHandle: string,
-        summaryType: IWholeSummaryPayloadType): Promise<string>;
+        summaryType: IWholeSummaryPayloadType,
+        sequenceNumber: number): Promise<string>;
 }

--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -122,6 +122,6 @@ export interface ISummaryUploadManager {
     writeSummaryTree(
         summaryTree: api.ISummaryTree,
         parentHandle: string,
-        summaryType: IWholeSummaryPayloadType,
+        summaryType: storage.IWholeSummaryPayloadType,
         sequenceNumber: number): Promise<string>;
 }

--- a/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
@@ -31,6 +31,7 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
         summaryTree: ISummaryTree,
         parentHandle: string,
         summaryType: IWholeSummaryPayloadType,
+        sequenceNumber: number,
     ): Promise<string> {
         const previousFullSnapshot = await this.getPreviousFullSnapshot(parentHandle);
         return this.writeSummaryTreeCore(summaryTree, previousFullSnapshot ?? undefined);

--- a/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
@@ -24,8 +24,9 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
         summaryTree: ISummaryTree,
         parentHandle: string | undefined,
         summaryType: IWholeSummaryPayloadType,
+        sequenceNumber: number,
     ): Promise<string> {
-        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType);
+        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType, sequenceNumber);
         if (!id) {
             throw new Error(`Failed to write summary tree`);
         }
@@ -36,6 +37,7 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
         parentHandle: string | undefined,
         tree: ISummaryTree,
         type: IWholeSummaryPayloadType,
+        sequenceNumber: number,
     ): Promise<string> {
         const snapshotTree = convertSummaryTreeToWholeSummaryTree(
             parentHandle,
@@ -45,7 +47,7 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
         const snapshotPayload: IWholeSummaryPayload = {
             entries: snapshotTree.entries,
             message: undefined,
-            sequenceNumber: undefined,
+            sequenceNumber,
             type,
         };
 

--- a/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
@@ -31,8 +31,9 @@ import { IGitManager, ISummaryUploadManager } from "./storage";
         summaryTree: ISummaryTree,
         parentHandle: string | undefined,
         summaryType: IWholeSummaryPayloadType,
+        sequenceNumber: number,
     ): Promise<string> {
-        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType);
+        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType, sequenceNumber);
         if (!id) {
             throw new Error(`Failed to write summary tree`);
         }
@@ -43,6 +44,7 @@ import { IGitManager, ISummaryUploadManager } from "./storage";
         parentHandle: string | undefined,
         tree: ISummaryTree,
         type: IWholeSummaryPayloadType,
+        sequenceNumber: number,
     ): Promise<string> {
         const snapshotTree = await this.convertSummaryToSnapshotTree(
             parentHandle,
@@ -52,7 +54,7 @@ import { IGitManager, ISummaryUploadManager } from "./storage";
         const snapshotPayload: IWholeSummaryPayload = {
             entries: snapshotTree.entries,
             message: undefined,
-            sequenceNumber: undefined,
+            sequenceNumber,
             type,
         };
 

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -128,7 +128,7 @@ export class DocumentStorage implements IDocumentStorage {
         const uploadManager = this.enableWholeSummaryUpload ?
             new WholeSummaryUploadManager(gitManager) :
             new SummaryTreeUploadManager(gitManager, blobsShaCache, () => undefined);
-        const handle = await uploadManager.writeSummaryTree(fullTree, "", "container");
+        const handle = await uploadManager.writeSummaryTree(fullTree, "", "container", 0);
 
         winston.info(`Tree reference: ${JSON.stringify(handle)}`, { messageMetaData });
 


### PR DESCRIPTION
Fixing 2 things:
- `IWholeSummaryPayload` needs to include an actual valid `sequenceNumber`, that either comes from Scribe (when handling client/service summary) or is 0 when Alfred creates the initial document
- Converting `ITreeEntry[]` to `ISummaryTree` in Scribe was only taking the `value`, but we needed to provide the `type` as well.