### PR TITLE
Remove name from ContainerSchema

### DIFF
--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -27,7 +27,6 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 export interface ContainerSchema {
     dynamicObjectTypes?: LoadableObjectClass<any>[];
     initialObjects: LoadableObjectClassRecord;
-    name: string;
 }
 
 // @public

--- a/examples/data-objects/focus-tracker/src/app.ts
+++ b/examples/data-objects/focus-tracker/src/app.ts
@@ -19,7 +19,6 @@ import { FocusTracker } from "./FocusTracker";
 // This includes the DataObjects we support and any initial DataObjects we want created
 // when the container is first created.
 const containerSchema: ContainerSchema = {
-    name: "focus-tracker-container",
     initialObjects: {
         /* [id]: DataObject */
         signalManager: SignalManager,

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -58,7 +58,6 @@ const connectionConfig: AzureConnectionConfig = useAzure ? {
 // This includes the DataObjects we support and any initial DataObjects we want created
 // when the container is first created.
 const containerSchema = {
-    name: "dice-roller-container",
     initialObjects: {
         /* [id]: DataObject */
         map1: SharedMap,

--- a/packages/framework/azure-client/README.md
+++ b/packages/framework/azure-client/README.md
@@ -73,7 +73,6 @@ See [`ContainerSchema`](./src/types.ts) in [`./src/types/ts`](./src/types.ts) fo
 
 ```typescript
 const schema = {
-    name: "my-container",
     initialObjects: {
         /* ... */
     },
@@ -110,7 +109,6 @@ The most common way to use Fluid is through initial collaborative objects that a
 // Define the keys and types of the initial list of collaborative objects.
 // Here, we are using a SharedMap DDS on key "map1" and a SharedString on key "text1".
 const schema = {
-    name: "my-container",
     initialObjects: {
         map1: SharedMap,
         text1: SharedString,
@@ -137,7 +135,6 @@ Dynamic objects are loaded on-demand to optimize for data virtualization. To get
 
 ```typescript
 const schema = {
-    name: "my-container",
     initialObjects: {
         map1: SharedMap,
     },

--- a/packages/framework/azure-client/src/test/AzureClient.spec.ts
+++ b/packages/framework/azure-client/src/test/AzureClient.spec.ts
@@ -10,7 +10,6 @@ import { createAzureClient } from "./AzureClientFactory";
 describe("AzureClient", () => {
     const client = createAzureClient();
     const schema: ContainerSchema = {
-        name: "azure-client-test",
         initialObjects: {
             map1: SharedMap,
         },

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -19,14 +19,14 @@ export type LoadableObjectClass<T extends IFluidLoadable> = DataObjectClass<T> |
 
 /**
  * A DataObjectClass is a class that has a factory that can create a DataObject and a
- * contructor that will return the type of the DataObject.
+ * constructor that will return the type of the DataObject.
  */
 export type DataObjectClass<T extends IFluidLoadable>
     = { readonly factory: IFluidDataStoreFactory }  & LoadableObjectCtor<T>;
 
 /**
  * A SharedObjectClass is a class that has a factory that can create a DDS (SharedObject) and a
- * contructor that will return the type of the DataObject.
+ * constructor that will return the type of the DataObject.
  */
 export type SharedObjectClass<T extends IFluidLoadable>
     = { readonly getFactory: () => IChannelFactory } & LoadableObjectCtor<T>;
@@ -37,14 +37,6 @@ export type SharedObjectClass<T extends IFluidLoadable>
 export type LoadableObjectCtor<T extends IFluidLoadable> = new(...args: any[]) => T;
 
 export interface ContainerSchema {
-    /**
-     * Name of the container being defined.
-     *
-     * This property is not currently used by Fluid but instead provides the developer a centralized
-     * location to name their container. It is useful in multi-container scenarios.
-     */
-    name: string;
-
     /**
      * initialObjects defines loadable objects that will be created when the Container
      * is first created. It uses the key as the id and the value as the loadable object to create.

--- a/packages/framework/tinylicious-client/README.md
+++ b/packages/framework/tinylicious-client/README.md
@@ -37,7 +37,6 @@ See [`ContainerSchema`](./src/types.ts) in [`./src/types/ts`](./src/types.ts) fo
 
 ```javascript
 const schema = {
-    name: "my-container",
     initialObjects: {
         /* ... */
     },
@@ -71,7 +70,6 @@ The most common way to use Fluid is through initial collaborative objects that a
 
 ```javascript
 const schema = {
-    name: "my-container",
     initialObjects: {
         map1: SharedMap,
         text1: SharedString,
@@ -95,7 +93,6 @@ Dynamic objects are loaded on-demand to optimize for data virtualization. To get
 
 ```javascript
 const schema = {
-    name: "my-container",
     initialObjects: {
         map1: SharedMap,
     },

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -15,7 +15,6 @@ import {
 describe("TinyliciousClient", () => {
     let tinyliciousClient: TinyliciousClient;
     const schema: ContainerSchema = {
-        name: "tinylicious-client-test",
         initialObjects: {
             map1: SharedMap,
         },
@@ -184,7 +183,6 @@ describe("TinyliciousClient", () => {
      */
     it("can create/add loadable objects (DDS) dynamically during runtime", async () => {
         const dynamicSchema: ContainerSchema = {
-            name: "dynamic-schema-test",
             initialObjects: {
                 map1: SharedMap,
             },
@@ -215,7 +213,6 @@ describe("TinyliciousClient", () => {
      */
     it("can create/add loadable objects (custom data object) dynamically during runtime", async () => {
         const dynamicSchema: ContainerSchema = {
-            name: "dynamic-schema-test",
             initialObjects: {
                 map1: SharedMap,
             },


### PR DESCRIPTION
`name` was originally added for multi-container scenarios but has not materialized to be a useful schema property. The feedback from the team and partners has been negative to neutral.

If we need explicit support for multi-container scenarios we should add it in the future.

This initial change removes name from the ContainerSchema and some of the core README. We will do a followup to remove it from the rest of the docs.