### PR TITLE
Adding config in Historian to control GitCache

### DIFF
--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -41,5 +41,8 @@ data:
             "maxRequestBurst": {{ .Values.historian.throttling.maxRequestBurst }},
             "minCooldownIntervalInMs": {{ .Values.historian.throttling.minCooldownIntervalInMs }},
             "minThrottleIntervalInMs": {{ .Values.historian.throttling.minThrottleIntervalInMs }}
+        },
+        "restGitService": {
+            "disableGitCache": {{ .Values.historian.restGitService.disableGitCache }},
         }
     }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -25,6 +25,8 @@ historian:
     maxRequestBurst: 1000000
     minCooldownIntervalInMs: 1000000
     minThrottleIntervalInMs: 1000000
+  restGitService:
+    disableGitCache: false
 
 gitrest:
   name: gitrest

--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -29,8 +29,8 @@ const stream = split().on("data", (message) => {
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
+    cache?: ICache,
     asyncLocalStorage?: AsyncLocalStorage<string>) {
     // Express app configuration
     const app: express.Express = express();
@@ -63,7 +63,7 @@ export function create(
     app.use(cors());
     app.use(bindCorrelationId(asyncLocalStorage));
 
-    const apiRoutes = routes.create(config, tenantService, cache, throttler, asyncLocalStorage);
+    const apiRoutes = routes.create(config, tenantService, throttler, cache, asyncLocalStorage);
     app.use(apiRoutes.git.blobs);
     app.use(apiRoutes.git.refs);
     app.use(apiRoutes.git.tags);

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -14,11 +14,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -30,7 +31,13 @@ export function create(
         tenantId: string,
         authorization: string,
         body: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.createBlob(body);
     }
 
@@ -39,7 +46,13 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<git.IBlob> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getBlob(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -16,10 +16,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,13 +30,7 @@ export function create(
         tenantId: string,
         authorization: string,
         body: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createBlob(body);
     }
 
@@ -46,13 +39,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<git.IBlob> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getBlob(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/git/commits.ts
@@ -16,10 +16,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,13 +30,7 @@ export function create(
         tenantId: string,
         authorization: string,
         params: ICreateCommitParams): Promise<ICommit> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createCommit(params);
     }
 
@@ -46,13 +39,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<ICommit> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getCommit(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/git/commits.ts
@@ -14,11 +14,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -30,7 +31,13 @@ export function create(
         tenantId: string,
         authorization: string,
         params: ICreateCommitParams): Promise<ICommit> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.createCommit(params);
     }
 
@@ -39,7 +46,13 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<ICommit> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getCommit(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -17,10 +17,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -29,24 +28,12 @@ export function create(
     };
 
     async function getRefs(tenantId: string, authorization: string): Promise<git.IRef[]> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getRefs();
     }
 
     async function getRef(tenantId: string, authorization: string, ref: string): Promise<git.IRef> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getRef(ref);
     }
 
@@ -54,13 +41,7 @@ export function create(
         tenantId: string,
         authorization: string,
         params: ICreateRefParamsExternal): Promise<git.IRef> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createRef(params);
     }
 
@@ -69,13 +50,7 @@ export function create(
         authorization: string,
         ref: string,
         params: IPatchRefParamsExternal): Promise<git.IRef> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.updateRef(ref, params);
     }
 
@@ -83,13 +58,7 @@ export function create(
         tenantId: string,
         authorization: string,
         ref: string): Promise<void> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.deleteRef(ref);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -15,11 +15,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -28,12 +29,24 @@ export function create(
     };
 
     async function getRefs(tenantId: string, authorization: string): Promise<git.IRef[]> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getRefs();
     }
 
     async function getRef(tenantId: string, authorization: string, ref: string): Promise<git.IRef> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getRef(ref);
     }
 
@@ -41,7 +54,13 @@ export function create(
         tenantId: string,
         authorization: string,
         params: ICreateRefParamsExternal): Promise<git.IRef> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.createRef(params);
     }
 
@@ -50,7 +69,13 @@ export function create(
         authorization: string,
         ref: string,
         params: IPatchRefParamsExternal): Promise<git.IRef> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.updateRef(ref, params);
     }
 
@@ -58,7 +83,13 @@ export function create(
         tenantId: string,
         authorization: string,
         ref: string): Promise<void> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.deleteRef(ref);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/tags.ts
+++ b/server/historian/packages/historian-base/src/routes/git/tags.ts
@@ -14,11 +14,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -30,12 +31,24 @@ export function create(
         tenantId: string,
         authorization: string,
         params: git.ICreateTagParams): Promise<git.ITag> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.createTag(params);
     }
 
     async function getTag(tenantId: string, authorization: string, tag: string): Promise<git.ITag> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getTag(tag);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/tags.ts
+++ b/server/historian/packages/historian-base/src/routes/git/tags.ts
@@ -16,10 +16,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,24 +30,12 @@ export function create(
         tenantId: string,
         authorization: string,
         params: git.ICreateTagParams): Promise<git.ITag> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createTag(params);
     }
 
     async function getTag(tenantId: string, authorization: string, tag: string): Promise<git.ITag> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getTag(tag);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/trees.ts
+++ b/server/historian/packages/historian-base/src/routes/git/trees.ts
@@ -14,11 +14,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -30,7 +31,13 @@ export function create(
         tenantId: string,
         authorization: string,
         params: git.ICreateTreeParams): Promise<git.ITree> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.createTree(params);
     }
 
@@ -40,7 +47,13 @@ export function create(
         sha: string,
         recursive: boolean,
         useCache: boolean): Promise<git.ITree> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getTree(sha, recursive, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/git/trees.ts
+++ b/server/historian/packages/historian-base/src/routes/git/trees.ts
@@ -16,10 +16,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,13 +30,7 @@ export function create(
         tenantId: string,
         authorization: string,
         params: git.ICreateTreeParams): Promise<git.ITree> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createTree(params);
     }
 
@@ -47,13 +40,7 @@ export function create(
         sha: string,
         recursive: boolean,
         useCache: boolean): Promise<git.ITree> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getTree(sha, recursive, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/index.ts
+++ b/server/historian/packages/historian-base/src/routes/index.ts
@@ -38,24 +38,25 @@ export interface IRoutes {
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
     asyncLocalStorage?: AsyncLocalStorage<string>): IRoutes {
+    const cacheEnabled = config.get("restGitService:cacheEnabled") as boolean | undefined;
     return {
         git: {
-            blobs: blobs.create(store, tenantService, cache, throttler, asyncLocalStorage),
-            commits: commits.create(store, tenantService, cache, throttler, asyncLocalStorage),
-            refs: refs.create(store, tenantService, cache, throttler, asyncLocalStorage),
-            tags: tags.create(store, tenantService, cache, throttler, asyncLocalStorage),
-            trees: trees.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            blobs: blobs.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            commits: commits.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            refs: refs.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            tags: tags.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            trees: trees.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
         },
         repository: {
-            commits: repositoryCommits.create(store, tenantService, cache, throttler, asyncLocalStorage),
-            contents: contents.create(store, tenantService, cache, throttler, asyncLocalStorage),
-            headers: headers.create(store, tenantService, cache, throttler, asyncLocalStorage),
+            commits: repositoryCommits.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            contents: contents.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            headers: headers.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
         },
-        summaries: summaries.create(store, tenantService, cache, throttler, asyncLocalStorage),
+        summaries: summaries.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
     };
 }

--- a/server/historian/packages/historian-base/src/routes/index.ts
+++ b/server/historian/packages/historian-base/src/routes/index.ts
@@ -40,23 +40,22 @@ export interface IRoutes {
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
+    cache?: ICache,
     asyncLocalStorage?: AsyncLocalStorage<string>): IRoutes {
-    const cacheEnabled = config.get("restGitService:cacheEnabled") as boolean | undefined;
     return {
         git: {
-            blobs: blobs.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
-            commits: commits.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
-            refs: refs.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
-            tags: tags.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
-            trees: trees.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            blobs: blobs.create(config, tenantService, throttler, cache, asyncLocalStorage),
+            commits: commits.create(config, tenantService, throttler, cache, asyncLocalStorage),
+            refs: refs.create(config, tenantService, throttler, cache, asyncLocalStorage),
+            tags: tags.create(config, tenantService, throttler, cache, asyncLocalStorage),
+            trees: trees.create(config, tenantService, throttler, cache, asyncLocalStorage),
         },
         repository: {
-            commits: repositoryCommits.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
-            contents: contents.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
-            headers: headers.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+            commits: repositoryCommits.create(config, tenantService, throttler, cache, asyncLocalStorage),
+            contents: contents.create(config, tenantService, throttler, cache, asyncLocalStorage),
+            headers: headers.create(config, tenantService, throttler, cache, asyncLocalStorage),
         },
-        summaries: summaries.create(config, tenantService, cache, throttler, asyncLocalStorage, cacheEnabled),
+        summaries: summaries.create(config, tenantService, throttler, cache, asyncLocalStorage),
     };
 }

--- a/server/historian/packages/historian-base/src/routes/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/commits.ts
@@ -16,10 +16,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -32,13 +31,7 @@ export function create(
         authorization: string,
         sha: string,
         count: number): Promise<git.ICommitDetails[]> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getCommits(sha, count);
     }
 

--- a/server/historian/packages/historian-base/src/routes/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/commits.ts
@@ -14,11 +14,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,7 +32,13 @@ export function create(
         authorization: string,
         sha: string,
         count: number): Promise<git.ICommitDetails[]> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getCommits(sha, count);
     }
 

--- a/server/historian/packages/historian-base/src/routes/repository/contents.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/contents.ts
@@ -15,10 +15,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,13 +30,7 @@ export function create(
         authorization: string,
         path: string,
         ref: string): Promise<any> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getContent(path, ref);
     }
 

--- a/server/historian/packages/historian-base/src/routes/repository/contents.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/contents.ts
@@ -13,11 +13,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -30,7 +31,13 @@ export function create(
         authorization: string,
         path: string,
         ref: string): Promise<any> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getContent(path, ref);
     }
 

--- a/server/historian/packages/historian-base/src/routes/repository/headers.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/headers.ts
@@ -14,11 +14,12 @@ import { ICache, ITenantService } from "../../services";
 import * as utils from "../utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,7 +32,13 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<IHeader> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getHeader(sha, useCache);
     }
 
@@ -40,7 +47,13 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<any> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getFullTree(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/repository/headers.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/headers.ts
@@ -16,10 +16,9 @@ import * as utils from "../utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -32,13 +31,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<IHeader> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getHeader(sha, useCache);
     }
 
@@ -47,13 +40,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<any> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getFullTree(sha, useCache);
     }
 

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -14,11 +14,12 @@ import { ICache, ITenantService } from "../services";
 import * as utils from "./utils";
 
 export function create(
-    store: nconf.Provider,
+    config: nconf.Provider,
     tenantService: ITenantService,
     cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
+    asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -31,7 +32,13 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<IWholeFlatSummary> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.getSummary(sha, useCache);
     }
 
@@ -39,7 +46,13 @@ export function create(
         tenantId: string,
         authorization: string,
         params: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
-        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        const service = await utils.createGitService(
+            tenantId,
+            authorization,
+            tenantService,
+            cache,
+            asyncLocalStorage,
+            cacheEnabled);
         return service.createSummary(params);
     }
 

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -16,10 +16,9 @@ import * as utils from "./utils";
 export function create(
     config: nconf.Provider,
     tenantService: ITenantService,
-    cache: ICache,
     throttler: IThrottler,
-    asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true): Router {
+    cache?: ICache,
+    asyncLocalStorage?: AsyncLocalStorage<string>): Router {
     const router: Router = Router();
 
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
@@ -32,13 +31,7 @@ export function create(
         authorization: string,
         sha: string,
         useCache: boolean): Promise<IWholeFlatSummary> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.getSummary(sha, useCache);
     }
 
@@ -46,13 +39,7 @@ export function create(
         tenantId: string,
         authorization: string,
         params: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
-        const service = await utils.createGitService(
-            tenantId,
-            authorization,
-            tenantService,
-            cache,
-            asyncLocalStorage,
-            cacheEnabled);
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
         return service.createSummary(params);
     }
 

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -39,9 +39,8 @@ export async function createGitService(
     tenantId: string,
     authorization: string,
     tenantService: ITenantService,
-    cache: ICache,
+    cache?: ICache,
     asyncLocalStorage?: AsyncLocalStorage<string>,
-    cacheEnabled: boolean = true,
 ): Promise<RestGitService> {
     let token: string;
     if (authorization) {
@@ -67,12 +66,12 @@ export async function createGitService(
     const decoded = jwt.decode(token) as ITokenClaims;
      const service = new RestGitService(
          details.storage,
-         cache,
+
          writeToExternalStorage,
          tenantId,
          decoded.documentId,
-         asyncLocalStorage,
-         cacheEnabled);
+         cache,
+         asyncLocalStorage);
 
     return service;
 }

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -66,7 +66,6 @@ export async function createGitService(
     const decoded = jwt.decode(token) as ITokenClaims;
      const service = new RestGitService(
          details.storage,
-
          writeToExternalStorage,
          tenantId,
          decoded.documentId,

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -24,6 +24,8 @@ export function handleResponse<T>(
         (result) => {
             if (cache) {
                 response.setHeader("Cache-Control", "public, max-age=31536000");
+            } else {
+                response.setHeader("Cache-Control", "no-store, max-age=0");
             }
 
             response.status(status).json(result);
@@ -39,6 +41,7 @@ export async function createGitService(
     tenantService: ITenantService,
     cache: ICache,
     asyncLocalStorage?: AsyncLocalStorage<string>,
+    cacheEnabled: boolean = true,
 ): Promise<RestGitService> {
     let token: string;
     if (authorization) {
@@ -68,7 +71,8 @@ export async function createGitService(
          writeToExternalStorage,
          tenantId,
          decoded.documentId,
-         asyncLocalStorage);
+         asyncLocalStorage,
+         cacheEnabled);
 
     return service;
 }

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -20,8 +20,8 @@ export class HistorianRunner implements IRunner {
         private readonly config: Provider,
         private readonly port: string | number,
         private readonly riddler: ITenantService,
-        private readonly cache: ICache,
         private readonly throttler: IThrottler,
+        private readonly cache?: ICache,
         private readonly asyncLocalStorage?: AsyncLocalStorage<string>) {
     }
 
@@ -29,7 +29,7 @@ export class HistorianRunner implements IRunner {
     public start(): Promise<void> {
         this.runningDeferred = new Deferred<void>();
         // Create the historian app
-        const historian = app.create(this.config, this.riddler, this.cache, this.throttler, this.asyncLocalStorage);
+        const historian = app.create(this.config, this.riddler, this.throttler, this.cache, this.asyncLocalStorage);
         historian.set("port", this.port);
 
         this.server = this.serverFactory.create(historian);

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -19,8 +19,8 @@ export class HistorianResources implements core.IResources {
         public readonly config: Provider,
         public readonly port: string | number,
         public readonly riddler: historianServices.ITenantService,
-        public readonly cache: historianServices.RedisCache,
         public readonly throttler: core.IThrottler,
+        public readonly cache?: historianServices.RedisCache,
         public readonly asyncLocalStorage?: AsyncLocalStorage<string>) {
         this.webServerFactory = new services.BasicWebServerFactory();
     }
@@ -49,7 +49,8 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
         };
 
         const redisClient = new Redis(redisOptions);
-        const gitCache = new historianServices.RedisCache(redisClient, redisParams);
+        const disableGitCache = config.get("restGitService:disableGitCache") as boolean | undefined;
+        const gitCache = disableGitCache ?  undefined : new historianServices.RedisCache(redisClient, redisParams);
         const tenantCache = new historianServices.RedisTenantCache(redisClient, redisParams);
         // Create services
         const riddlerEndpoint = config.get("riddler");
@@ -84,7 +85,7 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 
         const port = normalizePort(process.env.PORT || "3000");
 
-        return new HistorianResources(config, port, riddler, gitCache, throttler, asyncLocalStorage);
+        return new HistorianResources(config, port, riddler, throttler, gitCache, asyncLocalStorage);
     }
 }
 
@@ -95,8 +96,8 @@ export class HistorianRunnerFactory implements core.IRunnerFactory<HistorianReso
             resources.config,
             resources.port,
             resources.riddler,
-            resources.cache,
             resources.throttler,
+            resources.cache,
             resources.asyncLocalStorage);
     }
 }

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -54,7 +54,8 @@ export class RestGitService {
         private readonly writeToExternalStorage: boolean,
         private readonly tenantId: string,
         private readonly documentId: string,
-        private readonly asyncLocalStorage?: AsyncLocalStorage<string>) {
+        private readonly asyncLocalStorage?: AsyncLocalStorage<string>,
+        private readonly cacheEnabled: boolean = true) {
         const defaultHeaders: OutgoingHttpHeaders = {
             "User-Agent": userAgent,
             "Storage-Routing-Id": this.getStorageRoutingHeaderValue(),
@@ -363,7 +364,7 @@ export class RestGitService {
     }
 
     private async resolve<T>(key: string, fetch: () => Promise<T>, useCache: boolean): Promise<T> {
-        if (useCache) {
+        if (this.cacheEnabled && useCache) {
             // Attempt to grab the value from the cache. Log any errors but don't fail the request
             const cachedValue: T | undefined = await this.cache.get<T>(key).catch((error) => {
                 winston.error(`Error fetching ${key} from cache`, error);

--- a/server/historian/packages/historian-base/src/test/routes.spec.ts
+++ b/server/historian/packages/historian-base/src/test/routes.spec.ts
@@ -73,8 +73,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -145,8 +145,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -227,8 +227,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -298,8 +298,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -343,8 +343,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -382,8 +382,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -422,8 +422,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -486,8 +486,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -556,8 +556,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -636,8 +636,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -705,8 +705,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -748,8 +748,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -785,8 +785,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);
@@ -823,8 +823,8 @@ describe("routes", () => {
                 app = historianApp.create(
                     defaultProvider,
                     defaultTenantService,
-                    defaultCache,
                     throttler,
+                    defaultCache,
                     asyncLocalStorage,
                 );
                 superTest = request(app);

--- a/server/historian/packages/historian/config.json
+++ b/server/historian/packages/historian/config.json
@@ -27,6 +27,6 @@
         "minThrottleIntervalInMs": 1000000
     },
     "restGitService": {
-        "cacheEnabled": true
+        "disableGitCache": false
     }
 }

--- a/server/historian/packages/historian/config.json
+++ b/server/historian/packages/historian/config.json
@@ -25,5 +25,8 @@
         "maxRequestBurst": 1000000,
         "minCooldownIntervalInMs": 1000000,
         "minThrottleIntervalInMs": 1000000
+    },
+    "restGitService": {
+        "cacheEnabled": true
     }
 }


### PR DESCRIPTION
1. Adding a new config `restGitService:disableGitCache` that will prevent the Redis cache to be used for caching Git/storage data when set to `true`(default value is `false`)
2. Adding associated Kubernetes/Helm chart updates to include the new config in Historian's configmap
3. As pointed out by @znewton, "the browser will still cache the resource if disableCache=true. In Historian, we remove the Cache-Control header from the response when [`disableCache=true`](https://github.com/microsoft/FluidFramework/blob/32a5edea0bc6b2a396cb2642c0198faa5bab6e3f/server/routerlicious/packages/services/src/tenant.ts#L84), however, browser default behavior is to cache when no cache-control header is present. [The more correct way to do it in Historian would be to set `Cache-Control=no-store`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_caching). Doing that as well