### PR TITLE
Drivers: Using retryAfterSeconds in more places in drivers vs. retryAfterMs

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,7 +113,7 @@ export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolS
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
 
 // @public (undocumented)
-export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterMs?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
+export function createGenericNetworkError(errorMessage: string, canRetry: boolean, retryAfterSeconds?: number, props?: ITelemetryProperties): ThrottlingError | GenericNetworkError;
 
 // @public (undocumented)
 export const createWriteError: (errorMessage: string) => NonRetryableError<DriverErrorType.writeError>;

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -49,7 +49,7 @@ export type R11sError = DriverError | IR11sError;
 export function createR11sNetworkError(
     errorMessage: string,
     statusCode?: number,
-    retryAfterMs?: number,
+    retryAfterSeconds?: number,
 ): R11sError {
     switch (statusCode) {
         case undefined:
@@ -65,24 +65,24 @@ export function createR11sNetworkError(
                 errorMessage, R11sErrorType.fileNotFoundOrAccessDeniedError, { statusCode });
         case 429:
             return createGenericNetworkError(
-                errorMessage, true, retryAfterMs, { statusCode });
+                errorMessage, true, retryAfterSeconds, { statusCode });
         case 500:
             return new GenericNetworkError(errorMessage, true, { statusCode });
         default:
             return createGenericNetworkError(
-                errorMessage, retryAfterMs !== undefined, retryAfterMs, { statusCode });
+                errorMessage, retryAfterSeconds !== undefined, retryAfterSeconds, { statusCode });
     }
 }
 
 export function throwR11sNetworkError(
     errorMessage: string,
     statusCode?: number,
-    retryAfterMs?: number,
+    retryAfterSeconds?: number,
 ): never {
     const networkError = createR11sNetworkError(
         errorMessage,
         statusCode,
-        retryAfterMs);
+        retryAfterSeconds);
 
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw networkError;

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -96,6 +96,6 @@ export function errorObjectFromSocketError(socketError: IR11sSocketError, handle
     return createR11sNetworkError(
         message,
         socketError.code,
-        socketError.retryAfterMs,
+        socketError.retryAfterMs === undefined ? undefined : socketError.retryAfterMs * 1000,
     );
 }

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -34,7 +34,7 @@ describe("ErrorUtils", () => {
         });
         it("creates retriable error on 429 with retry-after", () => {
             const message = "test error";
-            const error = createR11sNetworkError(message, 429, 5000);
+            const error = createR11sNetworkError(message, 429, 5);
             assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
             assert.strictEqual(error.canRetry, true);
             assert.strictEqual((error as IThrottlingWarning).retryAfterSeconds, 5);
@@ -59,7 +59,7 @@ describe("ErrorUtils", () => {
         });
         it("creates retriable error on anything else with retryAfter", () => {
             const message = "test error";
-            const error = createR11sNetworkError(message, 400, 100000);
+            const error = createR11sNetworkError(message, 400, 100);
             assert.strictEqual(error.errorType, DriverErrorType.throttlingError);
             assert.strictEqual(error.canRetry, true);
             assert.strictEqual((error as any).retryAfterSeconds, 100);
@@ -105,7 +105,7 @@ describe("ErrorUtils", () => {
         it("throws retriable error on 429 with retry-after", () => {
             const message = "test error";
             assert.throws(() => {
-                throwR11sNetworkError(message, 429, 5000);
+                throwR11sNetworkError(message, 429, 5);
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,
@@ -142,7 +142,7 @@ describe("ErrorUtils", () => {
         it("throws retriable error on anything else with retryAfter", () => {
             const message = "test error";
             assert.throws(() => {
-                throwR11sNetworkError(message, 400, 200000);
+                throwR11sNetworkError(message, 400, 200);
             }, {
                 errorType: DriverErrorType.throttlingError,
                 canRetry: true,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -75,8 +75,7 @@ const DefaultChunkSize = 16 * 1024;
 function getNackReconnectInfo(nackContent: INackContent) {
     const reason = `Nack: ${nackContent.message}`;
     const canRetry = nackContent.code !== 403;
-    const retryAfterMs = nackContent.retryAfter !== undefined ? nackContent.retryAfter * 1000 : undefined;
-    return createGenericNetworkError(reason, canRetry, retryAfterMs, { statusCode: nackContent.code });
+    return createGenericNetworkError(reason, canRetry, nackContent.retryAfter, { statusCode: nackContent.code });
 }
 
 const createReconnectError = (prefix: string, err: any) =>

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -129,11 +129,11 @@ export const createWriteError = (errorMessage: string) =>
 export function createGenericNetworkError(
     errorMessage: string,
     canRetry: boolean,
-    retryAfterMs?: number,
+    retryAfterSeconds?: number,
     props?: ITelemetryProperties,
 ): ThrottlingError | GenericNetworkError {
-    if (retryAfterMs !== undefined && canRetry) {
-        return new ThrottlingError(errorMessage, retryAfterMs / 1000, props);
+    if (retryAfterSeconds !== undefined && canRetry) {
+        return new ThrottlingError(errorMessage, retryAfterSeconds, props);
     }
     return new GenericNetworkError(errorMessage, canRetry, props);
 }

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -186,8 +186,7 @@ export function createOdspNetworkError(
             error = new NonRetryableError(errorMessage, OdspErrorType.fetchTokenError, { statusCode });
             break;
         default:
-            const retryAfterMs = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : undefined;
-            error = createGenericNetworkError(errorMessage, true, retryAfterMs, { statusCode });
+            error = createGenericNetworkError(errorMessage, true, retryAfterSeconds, { statusCode });
             break;
     }
     enrichOdspError(error, response, responseText, props);


### PR DESCRIPTION
It seems like we are converging on using seconds across various driver layers, not ms.
But there are couple places where we convert back and forth.
Trying to fix it by using seconds in more workflows.

Please let me know if it feels better or worse :)