### PR TITLE
Use a single user only on older odsp driver

### DIFF
--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -67,6 +67,7 @@
     "@fluidframework/tinylicious-driver": "^0.47.0",
     "@fluidframework/tool-utils": "^0.47.0",
     "axios": "^0.21.1",
+    "semver": "^7.3.4",
     "uuid": "^8.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Older odsp driver doesn't support the `isolateSocketCache` flag, so just pick one and stick to it thru out the process.