### PR TITLE
r11s-driver: fix url parsing and patching

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { parse } from "url";
 import { assert } from "@fluidframework/common-utils";
 import {
     IDocumentService,
@@ -24,6 +23,7 @@ import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
+import { parseFluidUrl, replaceDocumentIdInPath } from "./urlUtils";
 
 const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
@@ -59,7 +59,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         ensureFluidResolvedUrl(resolvedUrl);
         assert(!!createNewSummary, 0x204 /* "create empty file not supported" */);
         assert(!!resolvedUrl.endpoints.ordererUrl, 0x0b2 /* "Missing orderer URL!" */);
-        const parsedUrl = parse(resolvedUrl.url);
+        const parsedUrl = parseFluidUrl(resolvedUrl.url);
         if (!parsedUrl.pathname) {
             throw new Error("Parsed url should contain tenant and doc Id!!");
         }
@@ -91,31 +91,23 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 values: quorumValues,
             },
         );
-        /**
-         * Assume documentId is at end of url path.
-         * This is true for Routerlicious' and Tinylicious' documentUrl and deltaStorageUrl.
-         * Routerlicious and Tinylicious do not use documentId in storageUrl nor ordererUrl.
-         * TODO: Ideally we would be able to regenerate the resolvedUrl, rather than patching the current one.
-         */
-        const replaceDocumentIdInPath = (urlPath: string): string =>
-            urlPath.split("/").slice(0, -1).concat([documentId]).join("/");
-        parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname);
+        parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
         const deltaStorageUrl = resolvedUrl.endpoints.deltaStorageUrl;
         if (!deltaStorageUrl) {
             throw new Error(
                 `All endpoints urls must be provided. [deltaStorageUrl:${deltaStorageUrl}]`);
         }
-        const parsedDeltaStorageUrl = parse(deltaStorageUrl);
-        parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname);
+        const parsedDeltaStorageUrl = parseFluidUrl(deltaStorageUrl);
+        parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
 
         return this.createDocumentService(
             {
                 ...resolvedUrl,
-                url: parsedUrl.href,
+                url: parsedUrl.toString(),
                 id: documentId,
                 endpoints: {
                     ...resolvedUrl.endpoints,
-                    deltaStorageUrl: parsedDeltaStorageUrl.href,
+                    deltaStorageUrl: parsedDeltaStorageUrl.toString(),
                 },
             },
             logger);
@@ -142,7 +134,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 `All endpoints urls must be provided. [ordererUrl:${ordererUrl}][deltaStorageUrl:${deltaStorageUrl}]`);
         }
 
-        const parsedUrl = parse(fluidResolvedUrl.url);
+        const parsedUrl = parseFluidUrl(fluidResolvedUrl.url);
         const [, tenantId, documentId] = parsedUrl.pathname.split("/");
         if (!documentId || !tenantId) {
             throw new Error(

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { parseFluidUrl, replaceDocumentIdInPath } from "../urlUtils";
+
+describe("UrlUtils", () => {
+    const exampleFluidUrl1 = "fluid://orderer.examplehost.com/example-tenant/some-document?param1=value1";
+    const exampleFluidUrl2 = "fluid://examplehost.com/other-tenant/";
+    describe("parseFluidUrl()", () => {
+        it("parses fluid url", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl1);
+            assert.strictEqual(parsedUrl.protocol, "fluid:");
+            assert.strictEqual(parsedUrl.host, "orderer.examplehost.com");
+            assert.strictEqual(parsedUrl.hostname, "orderer.examplehost.com");
+            assert.strictEqual(parsedUrl.pathname, "/example-tenant/some-document");
+            assert.strictEqual(parsedUrl.searchParams.get("param1"), "value1");
+            assert.strictEqual(parsedUrl.href, exampleFluidUrl1);
+            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl1);
+        });
+
+        it("parses fluid url with blank document id", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl2);
+            assert.strictEqual(parsedUrl.protocol, "fluid:");
+            assert.strictEqual(parsedUrl.host, "examplehost.com");
+            assert.strictEqual(parsedUrl.hostname, "examplehost.com");
+            assert.strictEqual(parsedUrl.pathname, "/other-tenant/");
+            assert.strictEqual(parsedUrl.href, exampleFluidUrl2);
+            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl2);
+        });
+
+        it("updating pathname alters toString of parsedUrl", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl2);
+            parsedUrl.pathname = "/not-same";
+            assert.strictEqual(parsedUrl.href, "fluid://examplehost.com/not-same");
+            assert.strictEqual(parsedUrl.toString(), "fluid://examplehost.com/not-same");
+        });
+    });
+
+    describe("replaceDocumentIdInPath()", () => {
+        it("replaces documentId", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl1);
+            assert.strictEqual(replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc"), "/example-tenant/otherdoc");
+        });
+        it("replaces blank documentId", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl2);
+            assert.strictEqual(replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc"), "/other-tenant/otherdoc");
+        });
+    });
+});

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -10,7 +10,7 @@ describe("UrlUtils", () => {
     const exampleFluidUrl1 = "fluid://orderer.examplehost.com/example-tenant/some-document?param1=value1";
     const exampleFluidUrl2 = "fluid://examplehost.com/other-tenant/";
     describe("parseFluidUrl()", () => {
-        it("parses fluid url", () => {
+        it("parses Fluid url", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl1);
             assert.strictEqual(parsedUrl.protocol, "fluid:");
             assert.strictEqual(parsedUrl.host, "orderer.examplehost.com");
@@ -21,7 +21,7 @@ describe("UrlUtils", () => {
             assert.strictEqual(parsedUrl.toString(), exampleFluidUrl1);
         });
 
-        it("parses fluid url with blank document id", () => {
+        it("parses Fluid url with blank document id", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl2);
             assert.strictEqual(parsedUrl.protocol, "fluid:");
             assert.strictEqual(parsedUrl.host, "examplehost.com");

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const parseFluidUrl = (fluidUrl: string): URL => {
+    return new URL(fluidUrl);
+};
+
+/**
+ * Assume documentId is at end of url path.
+ * This is true for Routerlicious' and Tinylicious' documentUrl and deltaStorageUrl.
+ * Routerlicious and Tinylicious do not use documentId in storageUrl nor ordererUrl.
+ * TODO: Ideally we would be able to regenerate the resolvedUrl, rather than patching the current one.
+ */
+export const replaceDocumentIdInPath = (urlPath: string, documentId: string): string =>
+    urlPath.split("/").slice(0, -1).concat([documentId]).join("/");


### PR DESCRIPTION
Turns out that `url.parse` behaves differently than the `new URL` API, so href from does not get updated when the pathname changes. `url.parse` is deprecated anyways.

This fixes parsing and patching for server-side doc ids. Nothing is broken for doc ids generated by the client.