### PR TITLE
Drop merge-tree from fluid-framework package

### DIFF
--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -8,7 +8,6 @@
 export * from "@fluidframework/aqueduct";
 export * from "@fluidframework/fluid-static";
 export * from "@fluidframework/map";
-export * from "@fluidframework/merge-tree";
 export * from "@fluidframework/sequence";
 
 // (No @packageDocumentation comment for this package)

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -30,7 +30,6 @@
     "@fluidframework/aqueduct": "^0.47.0",
     "@fluidframework/fluid-static": "^0.47.0",
     "@fluidframework/map": "^0.47.0",
-    "@fluidframework/merge-tree": "^0.47.0",
     "@fluidframework/sequence": "^0.47.0"
   },
   "devDependencies": {

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -8,5 +8,4 @@
 export * from  "./aqueduct";
 export * from  "./fluidStatic";
 export * from  "./map";
-export * from  "./mergeTree";
 export * from  "./sequence";

--- a/packages/framework/fluid-framework/src/mergeTree.ts
+++ b/packages/framework/fluid-framework/src/mergeTree.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export * from  "@fluidframework/merge-tree";


### PR DESCRIPTION
For the target audience of the `fluid-framework` package, I'd expect we'll recommend they use members of the `sequence` package rather than `merge-tree` directly (e.g. scenarios along the lines of the `react-inputs` example package).