### PR TITLE
Send test start and end events for e2e realsvc test

### DIFF
--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -12,7 +12,8 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules) {
 
     const testDriver = process.env.fluid__test__driver ? process.env.fluid__test__driver : "local";
     const r11sEndpointName = process.env.fluid__test__r11sEndpointName;
-    const testVariant = (testDriver === "r11s" || testDriver === "routerlicious") && (r11sEndpointName !== "r11s")? `r11s-${r11sEndpointName}` : testDriver;
+    const testVariant = (testDriver === "r11s" || testDriver === "routerlicious")
+        && (r11sEndpointName !== undefined && r11sEndpointName !== "r11s") ? `r11s-${r11sEndpointName}` : testDriver;
     const moduleDir = `${packageDir}/node_modules`;
 
     const requiredModules = [

--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -56,8 +56,25 @@ export const mochaHooks = {
         const context = this as any as Context;
         currentTestName = context.currentTest?.fullTitle();
         currentTestLogger = undefined;
+
+        // send event on test start
+        originalLogger.send({
+            category: "generic",
+            eventName: "fluid:telemetry:Test_start",
+            testName: currentTestName,
+        });
     },
     afterEach() {
+        // send event on test end
+        const context = this as any as Context;
+        originalLogger.send({
+            category: "generic",
+            eventName: "fluid:telemetry:Test_end",
+            testName: currentTestName,
+            state: context.currentTest?.state,
+            duration: context.currentTest?.duration,
+        });
+
         console.log = log;
         console.error = error;
         console.warn = warn;


### PR DESCRIPTION
End events also include the `state` and `duration` of the test

Also fix the test title to not include "undefined" endpoint which defaults to the r11 endpoint