### PR TITLE
Remove fluid-framework dependencies from client packages

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -4,20 +4,20 @@
 
 ```ts
 
-import { ContainerSchema } from 'fluid-framework';
-import { FluidContainer } from 'fluid-framework';
+import { ContainerSchema } from '@fluidframework/fluid-static';
+import { FluidContainer } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IFluidResolvedUrl } from '@fluidframework/driver-definitions';
-import { IMember } from 'fluid-framework';
+import { IMember } from '@fluidframework/fluid-static';
 import { InsecureTokenProvider } from '@fluidframework/test-runtime-utils';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
-import { IServiceAudience } from 'fluid-framework';
+import { IServiceAudience } from '@fluidframework/fluid-static';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { ITokenResponse } from '@fluidframework/routerlicious-driver';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
-import { ServiceAudience } from 'fluid-framework';
+import { ServiceAudience } from '@fluidframework/fluid-static';
 
 // @public (undocumented)
 export class AzureAudience extends ServiceAudience<AzureMember> implements IAzureAudience {

--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -9,7 +9,6 @@ import { FluidContainer } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IFluidResolvedUrl } from '@fluidframework/driver-definitions';
 import { IMember } from '@fluidframework/fluid-static';
-import { InsecureTokenProvider } from '@fluidframework/test-runtime-utils';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IServiceAudience } from '@fluidframework/fluid-static';
@@ -83,10 +82,6 @@ export class AzureUrlResolver implements IUrlResolver {
 
 // @public (undocumented)
 export type IAzureAudience = IServiceAudience<AzureMember>;
-
-export { InsecureTokenProvider }
-
-export { ITokenProvider }
 
 
 // (No @packageDocumentation comment for this package)

--- a/api-report/tinylicious-client.api.md
+++ b/api-report/tinylicious-client.api.md
@@ -4,13 +4,13 @@
 
 ```ts
 
-import { ContainerSchema } from 'fluid-framework';
-import { FluidContainer } from 'fluid-framework';
+import { ContainerSchema } from '@fluidframework/fluid-static';
+import { FluidContainer } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
-import { IMember } from 'fluid-framework';
-import { IServiceAudience } from 'fluid-framework';
+import { IMember } from '@fluidframework/fluid-static';
+import { IServiceAudience } from '@fluidframework/fluid-static';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
-import { ServiceAudience } from 'fluid-framework';
+import { ServiceAudience } from '@fluidframework/fluid-static';
 
 // @public (undocumented)
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@fluidframework/azure-client": "^0.47.0",
     "@fluidframework/common-definitions": "^0.20.1",
+    "@fluidframework/test-runtime-utils": "^0.47.0",
     "fluid-framework": "^0.47.0",
     "uuid": "^8.3.1"
   },

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -6,9 +6,9 @@ import {
     AzureFunctionTokenProvider,
     AzureClient,
     AzureConnectionConfig,
-    InsecureTokenProvider,
     AzureContainerServices,
 } from "@fluidframework/azure-client";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 import {
     FluidContainer,
     SharedMap,

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -46,7 +46,6 @@
     "@fluidframework/routerlicious-driver": "^0.47.0",
     "@fluidframework/runtime-utils": "^0.47.0",
     "@fluidframework/server-services-client": "^0.1030.0-0",
-    "@fluidframework/test-runtime-utils": "^0.47.0",
     "axios": "^0.21.1",
     "uuid": "^8.3.1"
   },
@@ -54,6 +53,7 @@
     "@fluidframework/build-common": "^0.22.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@fluidframework/test-runtime-utils": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",
     "concurrently": "^5.2.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -40,13 +40,14 @@
     "@fluidframework/container-loader": "^0.47.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.39.6",
+    "@fluidframework/fluid-static": "^0.47.0",
+    "@fluidframework/map": "^0.47.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/routerlicious-driver": "^0.47.0",
     "@fluidframework/runtime-utils": "^0.47.0",
     "@fluidframework/server-services-client": "^0.1030.0-0",
     "@fluidframework/test-runtime-utils": "^0.47.0",
     "axios": "^0.21.1",
-    "fluid-framework": "^0.47.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/framework/azure-client/src/AzureAudience.ts
+++ b/packages/framework/azure-client/src/AzureAudience.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { ServiceAudience } from "@fluidframework/fluid-static";
 import { IClient } from "@fluidframework/protocol-definitions";
-import { ServiceAudience } from "fluid-framework";
 import { IAzureAudience, AzureMember } from "./interfaces";
 
 export class AzureAudience extends ServiceAudience<AzureMember> implements IAzureAudience {

--- a/packages/framework/azure-client/src/AzureClient.ts
+++ b/packages/framework/azure-client/src/AzureClient.ts
@@ -8,14 +8,14 @@ import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import {
     IDocumentServiceFactory,
 } from "@fluidframework/driver-definitions";
-import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ContainerSchema,
     DOProviderContainerRuntimeFactory,
     FluidContainer,
     RootDataObject,
-} from "fluid-framework";
+} from "@fluidframework/fluid-static";
+import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 
 import {
     AzureConnectionConfig,

--- a/packages/framework/azure-client/src/index.ts
+++ b/packages/framework/azure-client/src/index.ts
@@ -3,9 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
-export { ITokenProvider } from "@fluidframework/routerlicious-driver";
-
 export * from "./AzureAudience";
 export * from "./AzureClient";
 export * from "./AzureFunctionTokenProvider";

--- a/packages/framework/azure-client/src/interfaces.ts
+++ b/packages/framework/azure-client/src/interfaces.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { ITokenProvider } from "@fluidframework/routerlicious-driver";
 import {
     IMember,
     IServiceAudience,
-} from "fluid-framework";
+} from "@fluidframework/fluid-static";
+import { ITokenProvider } from "@fluidframework/routerlicious-driver";
 
 export interface AzureConnectionConfig {
     tenantId: "local" | string;

--- a/packages/framework/azure-client/src/test/AzureClient.spec.ts
+++ b/packages/framework/azure-client/src/test/AzureClient.spec.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { SharedMap, ContainerSchema } from "fluid-framework";
 import { AttachState } from "@fluidframework/container-definitions";
+import { ContainerSchema } from "@fluidframework/fluid-static";
+import { SharedMap } from "@fluidframework/map";
 import { createAzureClient } from "./AzureClientFactory";
 
 describe("AzureClient", () => {

--- a/packages/framework/azure-client/src/test/AzureClientFactory.ts
+++ b/packages/framework/azure-client/src/test/AzureClientFactory.ts
@@ -4,9 +4,9 @@
  */
 
 import { generateUser } from "@fluidframework/server-services-client";
+import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 import {
     AzureClient,
-    InsecureTokenProvider,
 } from "..";
 
 // This function will detemine if local or remote mode is required (based on FLUID_CLIENT),

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -39,11 +39,12 @@
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/container-loader": "^0.47.0",
     "@fluidframework/driver-definitions": "^0.39.6",
+    "@fluidframework/fluid-static": "^0.47.0",
+    "@fluidframework/map": "^0.47.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/routerlicious-driver": "^0.47.0",
     "@fluidframework/runtime-utils": "^0.47.0",
     "@fluidframework/tinylicious-driver": "^0.47.0",
-    "fluid-framework": "^0.47.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/framework/tinylicious-client/src/TinyliciousAudience.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousAudience.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { ServiceAudience } from "@fluidframework/fluid-static";
 import { IClient } from "@fluidframework/protocol-definitions";
-import { ServiceAudience } from "fluid-framework";
 import { ITinyliciousAudience, TinyliciousMember } from "./interfaces";
 
 export class TinyliciousAudience extends ServiceAudience<TinyliciousMember> implements ITinyliciousAudience {

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -20,7 +20,7 @@ import {
     DOProviderContainerRuntimeFactory,
     FluidContainer,
     RootDataObject,
-} from "fluid-framework";
+} from "@fluidframework/fluid-static";
 import {
     TinyliciousConnectionConfig,
     TinyliciousContainerServices,

--- a/packages/framework/tinylicious-client/src/interfaces.ts
+++ b/packages/framework/tinylicious-client/src/interfaces.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IMember, IServiceAudience } from "fluid-framework";
+import { IMember, IServiceAudience } from "@fluidframework/fluid-static";
 
 export interface TinyliciousConnectionConfig {
     port?: number;

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -4,9 +4,10 @@
  */
 
 import { strict as assert } from "assert";
-import { SharedMap, SharedDirectory, ContainerSchema } from "fluid-framework";
 import { DiceRoller } from "@fluid-example/diceroller";
 import { AttachState } from "@fluidframework/container-definitions";
+import { ContainerSchema } from "@fluidframework/fluid-static";
+import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import {
     TinyliciousClient,
     TinyliciousConnectionConfig,

--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -152,9 +152,7 @@
             "HostUtils": {
                 "dev": true,
                 "packages": [
-                    "@fluidframework/azure-client",
-                    "@fluid-experimental/get-container",
-                    "@fluidframework/tinylicious-client"
+                    "@fluid-experimental/get-container"
                 ],
                 "deps": [
                     "Framework",
@@ -184,7 +182,6 @@
                 "packages": [
                     "@fluid-internal/client-api",
                     "@fluid-experimental/data-objects",
-                    "fluid-framework",
                     "@fluidframework/fluid-static"
                 ],
                 "dirs": [
@@ -193,6 +190,30 @@
                     "packages/framework/"
                 ],
                 "deps": [
+                    "Hosts",
+                    "Runtime"
+                ]
+            },
+            "ServiceClients": {
+                "packages": [
+                    "@fluidframework/azure-client",
+                    "@fluidframework/tinylicious-client"
+                ],
+                "deps": [
+                    "Framework",
+                    "Loader",
+                    "Routerlicious-Driver",
+                    "Server-Libs",
+                    "Server-Shared-Utils",
+                    "Test"
+                ]
+            },
+            "UberPackage": {
+                "packages": [
+                    "fluid-framework"
+                ],
+                "deps": [
+                    "Framework",
                     "Hosts",
                     "Runtime"
                 ]


### PR DESCRIPTION
The `fluid-framework` package is intended for consumption by 3rd party app developers.  Although it conveniently has some contents that the client packages need, it's not the package's intent.  Removing the dependency removes the temptation to add packages to `fluid-framework` to support client authors (who have pretty divergent requirements from a 3rd party app developer).