### PR TITLE
Elected summarizer client occasionally does not start summarizer.

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -30,7 +30,6 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
-import { IFluidRunnable } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/core-interfaces';
 import { IFluidTokenProvider } from '@fluidframework/container-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
@@ -462,10 +461,10 @@ export interface ISummarizeOptions {
 export const ISummarizer: keyof IProvideSummarizer;
 
 // @public (undocumented)
-export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidRunnable, IFluidLoadable {
+export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable {
     enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult;
     // (undocumented)
-    run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<void>;
+    run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;
     // (undocumented)
     stop(reason: SummarizerStopReason): void;
     summarizeOnDemand(options: IOnDemandSummarizeOptions): OnDemandSummarizeResult;
@@ -652,7 +651,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
-    run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<void>;
+    run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;
     stop(reason: SummarizerStopReason): void;
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -306,7 +306,7 @@ export interface IConnectableRuntime {
     // (undocumented)
     readonly disposed: boolean;
     // (undocumented)
-    once(event: "connected" | "disconnected", listener: () => void): this;
+    once(event: "connected" | "disconnected" | "dispose", listener: () => void): this;
 }
 
 // @public

--- a/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
+++ b/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
@@ -88,6 +88,7 @@ export class RunWhileConnectedCoordinator implements ICancellableSummarizerContr
             }
             this.stop("summarizerClientDisconnected");
         });
+        this.runtime.once("dispose", () => this.stop("summarizerClientDisconnected"));
     }
 
     /**

--- a/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
+++ b/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
@@ -26,7 +26,6 @@ export const neverCancelledSummaryToken: ISummaryCancellationToken = {
  * when disconnected or if stop() is called.
  */
 export class RunWhileConnectedCoordinator implements ICancellableSummarizerController {
-    private everConnected = false;
     private _cancelled = false;
     private readonly stopDeferred = new Deferred<SummarizerStopReason>();
 
@@ -64,44 +63,35 @@ export class RunWhileConnectedCoordinator implements ICancellableSummarizerContr
     }
 
     protected constructor(private readonly runtime: IConnectableRuntime) {
-        // Try to determine if the runtime has ever been connected
-        if (this.runtime.connected) {
-            this.everConnected = true;
-        } else if (this.runtime.disposed) {
-            this.everConnected = true;
-            this.stop("summarizerClientDisconnected");
-        } else {
-            this.runtime.once("connected", () => this.everConnected = true);
-        }
-        // We only listen on disconnected event for clientType === "summarizer" container!
-        // And only do it here - no other place should check it! That way we have only one place
-        // that controls policy and it's easy to change policy in the future if we want to!
-        // We do not listen for "main" (aka interactive) container disconnect here, as it's
-        // responsibility of SummaryManager to decide if that's material or not. There are cases
-        // like "lastSummary", or main client experiencing nacks / disconnects due to hitting limit
-        // of non-summarized ops, where can make determination to continue with summary even if main
-        // client is disconnected.
-        this.runtime.once("disconnected", () => {
-            // Sometimes the initial connection state is raised as disconnected
-            if (!this.everConnected) {
-                return;
-            }
-            this.stop("summarizerClientDisconnected");
-        });
-        this.runtime.once("dispose", () => this.stop("summarizerClientDisconnected"));
     }
 
     /**
      * Starts and waits for a promise which resolves when connected.
      * The promise will also resolve if stopped either externally or by disconnect.
+     *
+     * We only listen on disconnected event for clientType === "summarizer" container!
+     * And only do it here - no other place should check it! That way we have only one place
+     * that controls policy and it's easy to change policy in the future if we want to!
+     * We do not listen for "main" (aka interactive) container disconnect here, as it's
+     * responsibility of SummaryManager to decide if that's material or not. There are cases
+     * like "lastSummary", or main client experiencing nacks / disconnects due to hitting limit
+     * of non-summarized ops, where can make determination to continue with summary even if main
+     * client is disconnected.
      */
     protected async waitStart() {
-        if (!this.runtime.connected && !this.everConnected) {
-            assert(!this._cancelled, "not cancelled");
+        if (this.runtime.disposed) {
+            this.stop("summarizerClientDisconnected");
+            return;
+        }
+
+        this.runtime.once("dispose", () => this.stop("summarizerClientDisconnected"));
+
+        if (!this.runtime.connected) {
             const waitConnected = new Promise<void>((resolve) =>
                 this.runtime.once("connected", resolve));
-            return Promise.race([waitConnected, this.waitCancelled]);
+            await Promise.race([waitConnected, this.waitCancelled]);
         }
+        this.runtime.once("disconnected", () => this.stop("summarizerClientDisconnected"));
     }
 
     /**

--- a/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
+++ b/packages/runtime/container-runtime/src/runWhileConnectedCoordinator.ts
@@ -68,9 +68,9 @@ export class RunWhileConnectedCoordinator implements ICancellableSummarizerContr
         if (this.runtime.connected) {
             this.everConnected = true;
         } else if (this.runtime.disposed) {
+            this.everConnected = true;
             this.stop("summarizerClientDisconnected");
-        }
-        else {
+        } else {
             this.runtime.once("connected", () => this.everConnected = true);
         }
         // We only listen on disconnected event for clientType === "summarizer" container!
@@ -94,8 +94,9 @@ export class RunWhileConnectedCoordinator implements ICancellableSummarizerContr
      * Starts and waits for a promise which resolves when connected.
      * The promise will also resolve if stopped either externally or by disconnect.
      */
-    public async waitStart() {
+    protected async waitStart() {
         if (!this.runtime.connected && !this.everConnected) {
+            assert(!this._cancelled, "not cancelled");
             const waitConnected = new Promise<void>((resolve) =>
                 this.runtime.once("connected", resolve));
             return Promise.race([waitConnected, this.waitCancelled]);

--- a/packages/runtime/container-runtime/src/summarizerClientElection.ts
+++ b/packages/runtime/container-runtime/src/summarizerClientElection.ts
@@ -119,7 +119,6 @@ export class SummarizerClientElection
                 // If there are no eligible clients, just wait until a client joins
                 // and will be auto-elected.
                 this.clientElection.resetElectedClient(sequenceNumber);
-                return;
             }
             // Election can trigger a change in SummaryManager state.
             this.emit("electedSummarizerChanged");

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -10,7 +10,6 @@ import {
 } from "@fluidframework/common-definitions";
 import {
     IFluidRouter,
-    IFluidRunnable,
     IFluidLoadable,
 } from "@fluidframework/core-interfaces";
 import { ContainerWarning, IDeltaManager } from "@fluidframework/container-definitions";
@@ -278,9 +277,9 @@ export interface ISummarizerEvents extends IEvent {
     (event: "summarizingError", listener: (error: ISummarizingWarning) => void);
 }
 
-export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidRunnable, IFluidLoadable {
+export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable {
     stop(reason: SummarizerStopReason): void;
-    run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<void>;
+    run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;
 
     /**
      * Attempts to generate a summary on demand. If already running, takes no action.

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -82,7 +82,7 @@ export interface IConnectableRuntime {
     readonly connected: boolean;
     readonly clientId: string | undefined;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    once(event: "connected" | "disconnected", listener: () => void): this;
+    once(event: "connected" | "disconnected" | "dispose", listener: () => void): this;
 }
 
 export interface ISummarizerRuntime extends IConnectableRuntime {

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -17,7 +17,9 @@ import {
 } from "../summaryManager";
 import { Summarizer } from "../summarizer";
 import {
-    ISummarizer, ISummarizerEvents,
+    ISummarizer,
+    ISummarizerEvents,
+    SummarizerStopReason,
 } from "../summarizerTypes";
 import { ISummarizerClientElection, ISummarizerClientElectionEvents } from "../summarizerClientElection";
 
@@ -77,7 +79,7 @@ describe("Summary Manager", () => {
         public stop(reason?: string): void {
             this.stopDeferred.resolve(reason);
         }
-        public async run(onBehalfOf: string): Promise<void> {
+        public async run(onBehalfOf: string): Promise<SummarizerStopReason> {
             this.onBehalfOf = onBehalfOf;
             this.state = "running";
             await Promise.all([
@@ -85,6 +87,7 @@ describe("Summary Manager", () => {
                 this.runDeferred.promise,
             ]);
             this.state = "stopped";
+            return "summarizerClientDisconnected";
         }
 
         public readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"] = () => this.notImplemented();


### PR DESCRIPTION
Issue #7311: Summarizer election may result in summarizer not being started 
Much more details are in https://onedrive.visualstudio.com/SPIN/_queries/edit/1186576/?triage=true

The core of the problem that client who is assigned to be a summarizer never creates summarizing client.
So I've been doing a bunch of code reviewing to figure out all possible reasons for why it may happen.
But looking back at history for this container, it actually was elected summarizer before, and summarizer started, but never finished and there were no events regarding the end. So that pointed to it never finishing booting in the first place.
So from code, it looks like a condition that was never handled correctly - container being disposed before summarizer even had a chance to start. So addressing this.

Also while reviewing all the ways how we propagate events RE leader election, we might run into state where events and state is not synchronized due to an early return statement in summarizerClientElection.ts. Fixing that too.