### PR TITLE
r11s-driver: fix fluid url patching

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -11271,6 +11271,11 @@
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
 			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
 		},
+		"@types/url-parse": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.4.tgz",
+			"integrity": "sha512-KtQLad12+4T/NfSxpoDhmr22+fig3T7/08QCgmutYA6QSznSRmEtuL95GrhVV40/0otTEdFc+etRcCTqhh1q5Q=="
+		},
 		"@types/uuid": {
 			"version": "8.3.1",
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -68,6 +68,7 @@
     "axios": "^0.21.1",
     "json-stringify-safe": "5.0.1",
     "socket.io-client": "^2.4.0",
+    "url-parse": "^1.5.3",
     "uuid": "^8.3.1"
   },
   "devDependencies": {
@@ -78,6 +79,7 @@
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",
     "@types/socket.io-client": "^1.4.32",
+    "@types/url-parse": "^1.4.4",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -23,7 +23,7 @@ import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
-import { parseFluidUrl, replaceDocumentIdInPath, stringifyAsFluidUrl } from "./urlUtils";
+import { parseFluidUrl, replaceDocumentIdInPath } from "./urlUtils";
 
 const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
@@ -91,7 +91,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 values: quorumValues,
             },
         );
-        parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
+        parsedUrl.set("pathname", replaceDocumentIdInPath(parsedUrl.pathname, documentId));
         const deltaStorageUrl = resolvedUrl.endpoints.deltaStorageUrl;
         if (!deltaStorageUrl) {
             throw new Error(
@@ -103,7 +103,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         return this.createDocumentService(
             {
                 ...resolvedUrl,
-                url: stringifyAsFluidUrl(parsedUrl),
+                url: parsedUrl.toString(),
                 id: documentId,
                 endpoints: {
                     ...resolvedUrl.endpoints,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { parse } from "url";
 import { assert } from "@fluidframework/common-utils";
 import {
     IDocumentService,
@@ -24,6 +23,7 @@ import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
+import { parseFluidUrl, replaceDocumentIdInPath } from "./urlUtils";
 
 const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
@@ -59,7 +59,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         ensureFluidResolvedUrl(resolvedUrl);
         assert(!!createNewSummary, 0x204 /* "create empty file not supported" */);
         assert(!!resolvedUrl.endpoints.ordererUrl, 0x0b2 /* "Missing orderer URL!" */);
-        const parsedUrl = parse(resolvedUrl.url);
+        const parsedUrl = parseFluidUrl(resolvedUrl.url);
         if (!parsedUrl.pathname) {
             throw new Error("Parsed url should contain tenant and doc Id!!");
         }
@@ -91,31 +91,23 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 values: quorumValues,
             },
         );
-        /**
-         * Assume documentId is at end of url path.
-         * This is true for Routerlicious' and Tinylicious' documentUrl and deltaStorageUrl.
-         * Routerlicious and Tinylicious do not use documentId in storageUrl nor ordererUrl.
-         * TODO: Ideally we would be able to regenerate the resolvedUrl, rather than patching the current one.
-         */
-        const replaceDocumentIdInPath = (urlPath: string): string =>
-            urlPath.split("/").slice(0, -1).concat([documentId]).join("/");
-        parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname);
+        parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
         const deltaStorageUrl = resolvedUrl.endpoints.deltaStorageUrl;
         if (!deltaStorageUrl) {
             throw new Error(
                 `All endpoints urls must be provided. [deltaStorageUrl:${deltaStorageUrl}]`);
         }
-        const parsedDeltaStorageUrl = parse(deltaStorageUrl);
-        parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname);
+        const parsedDeltaStorageUrl = parseFluidUrl(deltaStorageUrl);
+        parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
 
         return this.createDocumentService(
             {
                 ...resolvedUrl,
-                url: parsedUrl.href,
+                url: parsedUrl.toString(),
                 id: documentId,
                 endpoints: {
                     ...resolvedUrl.endpoints,
-                    deltaStorageUrl: parsedDeltaStorageUrl.href,
+                    deltaStorageUrl: parsedDeltaStorageUrl.toString(),
                 },
             },
             logger);
@@ -142,7 +134,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 `All endpoints urls must be provided. [ordererUrl:${ordererUrl}][deltaStorageUrl:${deltaStorageUrl}]`);
         }
 
-        const parsedUrl = parse(fluidResolvedUrl.url);
+        const parsedUrl = parseFluidUrl(fluidResolvedUrl.url);
         const [, tenantId, documentId] = parsedUrl.pathname.split("/");
         if (!documentId || !tenantId) {
             throw new Error(

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -23,7 +23,7 @@ import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
-import { parseFluidUrl, replaceDocumentIdInPath } from "./urlUtils";
+import { parseFluidUrl, replaceDocumentIdInPath, stringifyAsFluidUrl } from "./urlUtils";
 
 const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
@@ -97,13 +97,13 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             throw new Error(
                 `All endpoints urls must be provided. [deltaStorageUrl:${deltaStorageUrl}]`);
         }
-        const parsedDeltaStorageUrl = parseFluidUrl(deltaStorageUrl);
+        const parsedDeltaStorageUrl = new URL(deltaStorageUrl);
         parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
 
         return this.createDocumentService(
             {
                 ...resolvedUrl,
-                url: parsedUrl.toString(),
+                url: stringifyAsFluidUrl(parsedUrl),
                 id: documentId,
                 endpoints: {
                     ...resolvedUrl.endpoints,

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { parseFluidUrl, replaceDocumentIdInPath, stringifyAsFluidUrl } from "../urlUtils";
+import { parseFluidUrl, replaceDocumentIdInPath } from "../urlUtils";
 
 describe("UrlUtils", () => {
     const exampleFluidUrl1 = "fluid://orderer.examplehost.com/example-tenant/some-document?param1=value1";
@@ -15,8 +15,8 @@ describe("UrlUtils", () => {
             assert.strictEqual(parsedUrl.host, "orderer.examplehost.com");
             assert.strictEqual(parsedUrl.hostname, "orderer.examplehost.com");
             assert.strictEqual(parsedUrl.pathname, "/example-tenant/some-document");
-            assert.strictEqual(parsedUrl.searchParams.get("param1"), "value1");
-            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), exampleFluidUrl1);
+            assert.strictEqual(parsedUrl.query.param1, "value1");
+            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl1);
         });
 
         it("parses Fluid url with blank document id", () => {
@@ -24,13 +24,13 @@ describe("UrlUtils", () => {
             assert.strictEqual(parsedUrl.host, "examplehost.com");
             assert.strictEqual(parsedUrl.hostname, "examplehost.com");
             assert.strictEqual(parsedUrl.pathname, "/other-tenant/");
-            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), exampleFluidUrl2);
+            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl2);
         });
 
         it("updating pathname alters toString of parsedUrl", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl2);
-            parsedUrl.pathname = "/not-same";
-            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), "fluid://examplehost.com/not-same");
+            parsedUrl.set("pathname", "/not-same");
+            assert.strictEqual(parsedUrl.toString(), "fluid://examplehost.com/not-same");
         });
     });
 
@@ -45,8 +45,8 @@ describe("UrlUtils", () => {
         });
         it("replaced pathname is altered in full URL", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl1);
-            parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc");
-            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), exampleFluidUrl1.replace("some-document", "otherdoc"));
+            parsedUrl.set("pathname", replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc"));
+            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl1.replace("some-document", "otherdoc"));
         });
     });
 });

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import { parseFluidUrl, replaceDocumentIdInPath } from "../urlUtils";
+
+describe("UrlUtils", () => {
+    const exampleFluidUrl1 = "fluid://orderer.examplehost.com/example-tenant/some-document?param1=value1";
+    const exampleFluidUrl2 = "fluid://examplehost.com/other-tenant/";
+    describe("parseFluidUrl()", () => {
+        it("parses fluid url", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl1);
+            assert.strictEqual(parsedUrl.protocol, "fluid:");
+            assert.strictEqual(parsedUrl.host, "orderer.examplehost.com");
+            assert.strictEqual(parsedUrl.hostname, "orderer.examplehost.com");
+            assert.strictEqual(parsedUrl.pathname, "/example-tenant/some-document");
+            assert.strictEqual(parsedUrl.searchParams.get("param1"), "value1");
+            assert.strictEqual(parsedUrl.href, exampleFluidUrl1);
+            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl1);
+        });
+
+        it("parses fluid url with blank document id", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl2);
+            assert.strictEqual(parsedUrl.protocol, "fluid:");
+            assert.strictEqual(parsedUrl.host, "examplehost.com");
+            assert.strictEqual(parsedUrl.hostname, "examplehost.com");
+            assert.strictEqual(parsedUrl.pathname, "/other-tenant/");
+            assert.strictEqual(parsedUrl.href, exampleFluidUrl2);
+            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl2);
+        });
+
+        it("updating pathname alters toString of parsedUrl", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl2);
+            parsedUrl.pathname = "/not-same";
+            assert.strictEqual(parsedUrl.href, "fluid://examplehost.com/not-same");
+            assert.strictEqual(parsedUrl.toString(), "fluid://examplehost.com/not-same");
+        });
+    });
+
+    describe("replaceDocumentIdInPath()", () => {
+        it("replaces documentId", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl1);
+            assert.strictEqual(replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc"), "/example-tenant/otherdoc");
+        });
+        it("replaces blank documentId", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl2);
+            assert.strictEqual(replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc"), "/other-tenant/otherdoc");
+        });
+    });
+});

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import { parseFluidUrl, replaceDocumentIdInPath } from "../urlUtils";
+import { parseFluidUrl, replaceDocumentIdInPath, stringifyAsFluidUrl } from "../urlUtils";
 
 describe("UrlUtils", () => {
     const exampleFluidUrl1 = "fluid://orderer.examplehost.com/example-tenant/some-document?param1=value1";
@@ -12,41 +12,41 @@ describe("UrlUtils", () => {
     describe("parseFluidUrl()", () => {
         it("parses Fluid url", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl1);
-            assert.strictEqual(parsedUrl.protocol, "fluid:");
             assert.strictEqual(parsedUrl.host, "orderer.examplehost.com");
             assert.strictEqual(parsedUrl.hostname, "orderer.examplehost.com");
             assert.strictEqual(parsedUrl.pathname, "/example-tenant/some-document");
             assert.strictEqual(parsedUrl.searchParams.get("param1"), "value1");
-            assert.strictEqual(parsedUrl.href, exampleFluidUrl1);
-            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl1);
+            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), exampleFluidUrl1);
         });
 
         it("parses Fluid url with blank document id", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl2);
-            assert.strictEqual(parsedUrl.protocol, "fluid:");
             assert.strictEqual(parsedUrl.host, "examplehost.com");
             assert.strictEqual(parsedUrl.hostname, "examplehost.com");
             assert.strictEqual(parsedUrl.pathname, "/other-tenant/");
-            assert.strictEqual(parsedUrl.href, exampleFluidUrl2);
-            assert.strictEqual(parsedUrl.toString(), exampleFluidUrl2);
+            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), exampleFluidUrl2);
         });
 
         it("updating pathname alters toString of parsedUrl", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl2);
             parsedUrl.pathname = "/not-same";
-            assert.strictEqual(parsedUrl.href, "fluid://examplehost.com/not-same");
-            assert.strictEqual(parsedUrl.toString(), "fluid://examplehost.com/not-same");
+            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), "fluid://examplehost.com/not-same");
         });
     });
 
     describe("replaceDocumentIdInPath()", () => {
-        it("replaces documentId", () => {
+        it("returns pathname with replacement", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl1);
             assert.strictEqual(replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc"), "/example-tenant/otherdoc");
         });
-        it("replaces blank documentId", () => {
+        it("returns pathname with replacement of blank documentId", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl2);
             assert.strictEqual(replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc"), "/other-tenant/otherdoc");
+        });
+        it("replaced pathname is altered in full URL", () => {
+            const parsedUrl = parseFluidUrl(exampleFluidUrl1);
+            parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, "otherdoc");
+            assert.strictEqual(stringifyAsFluidUrl(parsedUrl), exampleFluidUrl1.replace("some-document", "otherdoc"));
         });
     });
 });

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -10,7 +10,7 @@ describe("UrlUtils", () => {
     const exampleFluidUrl1 = "fluid://orderer.examplehost.com/example-tenant/some-document?param1=value1";
     const exampleFluidUrl2 = "fluid://examplehost.com/other-tenant/";
     describe("parseFluidUrl()", () => {
-        it("parses fluid url", () => {
+        it("parses Fluid url", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl1);
             assert.strictEqual(parsedUrl.protocol, "fluid:");
             assert.strictEqual(parsedUrl.host, "orderer.examplehost.com");
@@ -21,7 +21,7 @@ describe("UrlUtils", () => {
             assert.strictEqual(parsedUrl.toString(), exampleFluidUrl1);
         });
 
-        it("parses fluid url with blank document id", () => {
+        it("parses Fluid url with blank document id", () => {
             const parsedUrl = parseFluidUrl(exampleFluidUrl2);
             assert.strictEqual(parsedUrl.protocol, "fluid:");
             assert.strictEqual(parsedUrl.host, "examplehost.com");

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const parseFluidUrl = (fluidUrl: string): URL => {
+    return new URL(fluidUrl);
+};
+
+/**
+ * Assume documentId is at end of url path.
+ * This is true for Routerlicious' and Tinylicious' documentUrl and deltaStorageUrl.
+ * Routerlicious and Tinylicious do not use documentId in storageUrl nor ordererUrl.
+ * TODO: Ideally we would be able to regenerate the resolvedUrl, rather than patching the current one.
+ */
+export const replaceDocumentIdInPath = (urlPath: string, documentId: string): string =>
+    urlPath.split("/").slice(0, -1).concat([documentId]).join("/");

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -3,21 +3,11 @@
  * Licensed under the MIT License.
  */
 
-/**
- * Converts a Fluid URL string (e.g. `fluid://host.com/tenant/document`) into a URL object.
- * The browser API for URL does not treat `fluid:` as a valid protocol, so we replace it with http here.
- * IMPORTANT: When converting back to a full URL string, use `stringifyAsFluidUrl` from this package.
- */
-export const parseFluidUrl = (fluidUrl: string): URL => {
-    return new URL(fluidUrl.replace(/^fluid:/, "https:"));
-};
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import URLParse = require("url-parse");
 
-/**
- * Converts a URL object to a Fluid URL string by replacing `http:` or `https:` protocol with `fluid:`.
- * The browser API for URL does not treat `fluid:` as a valid protocol, so we replace it after stringifying the URL.
- */
-export const stringifyAsFluidUrl = (url: URL): string => {
-    return url.toString().replace(/^https?:/, "fluid:");
+export const parseFluidUrl = (fluidUrl: string): URLParse => {
+    return new URLParse(fluidUrl);
 };
 
 /**

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import URLParse = require("url-parse");
+import URLParse from "url-parse";
 
 export const parseFluidUrl = (fluidUrl: string): URLParse => {
     return new URLParse(fluidUrl);

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -6,7 +6,7 @@
 import URLParse from "url-parse";
 
 export const parseFluidUrl = (fluidUrl: string): URLParse => {
-    return new URLParse(fluidUrl);
+    return new URLParse(fluidUrl, true);
 };
 
 /**

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -3,8 +3,21 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Converts a Fluid URL string (e.g. `fluid://host.com/tenant/document`) into a URL object.
+ * The browser API for URL does not treat `fluid:` as a valid protocol, so we replace it with http here.
+ * IMPORTANT: When converting back to a full URL string, use `stringifyAsFluidUrl` from this package.
+ */
 export const parseFluidUrl = (fluidUrl: string): URL => {
-    return new URL(fluidUrl);
+    return new URL(fluidUrl.replace(/^fluid:/, "https:"));
+};
+
+/**
+ * Converts a URL object to a Fluid URL string by replacing `http:` or `https:` protocol with `fluid:`.
+ * The browser API for URL does not treat `fluid:` as a valid protocol, so we replace it after stringifying the URL.
+ */
+export const stringifyAsFluidUrl = (url: URL): string => {
+    return url.toString().replace(/^https?:/, "fluid:");
 };
 
 /**


### PR DESCRIPTION
Redo of #7301 (reverted by #7304)

#7301 didn't work because the browser's WhatWG URL API does not treat `fluid:` protocol as the same scheme as `http:`, unlike the Node.js WhatWG URL API. To resolve this, I added the url-parse library, which will ensure consistency across browser and Node.js.