### PR TITLE
Fixing breaking change in ISummaryUploadManager

### DIFF
--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -116,12 +116,12 @@ export interface ISummaryUploadManager {
      * @param summaryTree Summary tree to write to storage
      * @param parentHandle Parent summary acked handle (if available from summary ack)
      * @param summaryType type of summary being uploaded
-     * @param sequenceNumber reference sequence number of the summary
+     * @param sequenceNumber optional reference sequence number of the summary
      * @returns Id of created tree as a string.
      */
     writeSummaryTree(
         summaryTree: api.ISummaryTree,
         parentHandle: string,
         summaryType: storage.IWholeSummaryPayloadType,
-        sequenceNumber: number): Promise<string>;
+        sequenceNumber?: number): Promise<string>;
 }

--- a/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
@@ -31,7 +31,7 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
         summaryTree: ISummaryTree,
         parentHandle: string,
         summaryType: IWholeSummaryPayloadType,
-        sequenceNumber: number,
+        sequenceNumber?: number,
     ): Promise<string> {
         const previousFullSnapshot = await this.getPreviousFullSnapshot(parentHandle);
         return this.writeSummaryTreeCore(summaryTree, previousFullSnapshot ?? undefined);

--- a/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
@@ -24,9 +24,9 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
         summaryTree: ISummaryTree,
         parentHandle: string | undefined,
         summaryType: IWholeSummaryPayloadType,
-        sequenceNumber: number,
+        sequenceNumber?: number,
     ): Promise<string> {
-        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType, sequenceNumber);
+        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType, sequenceNumber ?? 0);
         if (!id) {
             throw new Error(`Failed to write summary tree`);
         }


### PR DESCRIPTION
#7282 introduced a breaking change by adding a new required argument for `writeSummaryTree()` in `ISummaryUploadManager `. This PR fixes the breaking change by making that argument optional.