### PR TITLE
Added logging when data stores that are unreferenced for more than a specific time are used

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -296,6 +296,7 @@ export interface ISummarizerNodeConfig {
 // @public (undocumented)
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
     readonly gcDisabled?: boolean;
+    readonly maxUnreferencedTime?: number;
 }
 
 // @public

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -296,7 +296,7 @@ export interface ISummarizerNodeConfig {
 // @public (undocumented)
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
     readonly gcDisabled?: boolean;
-    readonly maxUnreferencedTime?: number;
+    readonly maxUnreferencedDurationMs?: number;
 }
 
 // @public

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -873,8 +873,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 throwOnFailure: true,
                 // If GC is disabled, let the summarizer node know so that it does not track GC state.
                 gcDisabled: !this.shouldRunGC,
-                // The max time for which objects can be unreferenced before they are eligible for deletion.
-                maxUnreferencedTime: this.runtimeOptions.gcOptions.maxUnreferencedTime,
+                // The max duration for which objects can be unreferenced before they are eligible for deletion.
+                maxUnreferencedDurationMs: this.runtimeOptions.gcOptions.maxUnreferencedDurationMs,
             },
         );
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -873,6 +873,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 throwOnFailure: true,
                 // If GC is disabled, let the summarizer node know so that it does not track GC state.
                 gcDisabled: !this.shouldRunGC,
+                // The max time for which objects can be unreferenced before they are eligible for deletion.
+                maxUnreferencedTime: this.runtimeOptions.gcOptions.maxUnreferencedTime,
             },
         );
 

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -62,6 +62,8 @@ export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
      * This is propagated to all child nodes.
      */
     readonly gcDisabled?: boolean;
+    /** The max time for which a node can be unreferenced before it is eligible for deletion. */
+    readonly maxUnreferencedTime?: number;
 }
 
 export enum CreateSummarizerNodeSource {

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -62,8 +62,8 @@ export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
      * This is propagated to all child nodes.
      */
     readonly gcDisabled?: boolean;
-    /** The max time for which a node can be unreferenced before it is eligible for deletion. */
-    readonly maxUnreferencedTime?: number;
+    /** The max duration for which a node can be unreferenced before it is eligible for deletion. */
+    readonly maxUnreferencedDurationMs?: number;
 }
 
 export enum CreateSummarizerNodeSource {

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -68,6 +68,7 @@
     "@fluidframework/runtime-definitions": "^0.48.0"
   },
   "devDependencies": {
+    "@fluid-internal/mock-logger": "^0.48.0",
     "@fluidframework/build-common": "^0.23.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.48.0",

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -437,6 +437,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     }
 
     public recordChange(op: ISequencedDocumentMessage): void {
+        // If the node is changed after it has expired, log an error as this may mean use-after-delete.
         this.logErrorIfExpired("expiredObjectChanged");
         super.recordChange(op);
     }

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -129,7 +129,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         });
     }
 
-    // Returns the GC details that my be added to this node's summary.
+    // Returns the GC details that may be added to this node's summary.
     public getGCSummaryDetails(): IGarbageCollectionSummaryDetails {
         return {
             gcData: this.gcData,

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -4,9 +4,9 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert, LazyPromise } from "@fluidframework/common-utils";
+import { assert, LazyPromise, Timer } from "@fluidframework/common-utils";
 import { cloneGCData } from "@fluidframework/garbage-collector";
-import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
     CreateChildSummarizerNodeParam,
     gcBlobKey,
@@ -26,6 +26,8 @@ import {
     ISummarizerNodeRootContract,
     SummaryNode,
 } from "./summarizerNodeUtils";
+
+const defaultmaxUnreferencedTime = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export interface IRootSummarizerNodeWithGC extends ISummarizerNodeWithGC, ISummarizerNodeRootContract {}
 
@@ -62,7 +64,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     private referenceUsedRoutes: string[] | undefined;
 
     // The GC details of this node in the initial summary.
-    private readonly gcDetailsInInitialSummaryP: LazyPromise<IGarbageCollectionSummaryDetails>;
+    private gcDetailsInInitialSummaryP: LazyPromise<IGarbageCollectionSummaryDetails> | undefined;
 
     private gcData: IGarbageCollectionData | undefined;
 
@@ -74,14 +76,14 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     // If this node is marked as unreferenced, the time when it marked as such.
     private unreferencedTimestamp: number | undefined;
 
-    // Returns the GC details that my be added to this node's summary.
-    public getGCSummaryDetails(): IGarbageCollectionSummaryDetails {
-        return {
-            gcData: this.gcData,
-            usedRoutes: this.usedRoutes,
-            unrefTimestamp: this.unreferencedTimestamp,
-        };
-    }
+    // The max amount of time this node can be unreferenced before it is eligible for deletion.
+    private readonly maxUnreferencedTime: number;
+
+    // The timer that runs when the node is marked unreferenced.
+    private readonly unreferencedTimer: Timer;
+
+    // Tracks whether this node has expired after being unreferenced for maxUnreferencedTime.
+    private expired: boolean = false;
 
     // True if GC is disabled for this node. If so, do not track GC specific state for a summary.
     private readonly gcDisabled: boolean;
@@ -113,6 +115,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         );
 
         this.gcDisabled = config.gcDisabled === true;
+        this.maxUnreferencedTime = config.maxUnreferencedTime ?? defaultmaxUnreferencedTime;
 
         this.gcDetailsInInitialSummaryP = new LazyPromise(async () => {
             // back-compat: 0.32. getInitialGCSummaryDetailsFn() returns undefined in 0.31. Remove undefined check
@@ -120,6 +123,19 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
             const gcSummaryDetails = await getInitialGCSummaryDetailsFn?.();
             return gcSummaryDetails ?? { usedRoutes: [] };
         });
+
+        this.unreferencedTimer = new Timer(this.maxUnreferencedTime, () => {
+            this.expired = true;
+        });
+    }
+
+    // Returns the GC details that my be added to this node's summary.
+    public getGCSummaryDetails(): IGarbageCollectionSummaryDetails {
+        return {
+            gcData: this.gcData,
+            usedRoutes: this.usedRoutes,
+            unrefTimestamp: this.unreferencedTimestamp,
+        };
     }
 
     /**
@@ -129,24 +145,19 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
      * - gcData: The garbage collection data of this node that is required for running GC.
      */
     private async loadInitialGCSummaryDetails() {
-        // If referenceUsedRoutes exists, don't do anything because we have already initialized.
-        if (this.referenceUsedRoutes !== undefined) {
+        if (this.gcDetailsInInitialSummaryP === undefined) {
             return;
         }
 
-        const gcDetailsInInitialSummary = await this.gcDetailsInInitialSummaryP;
+        const gcDetailsInInitialSummaryP = this.gcDetailsInInitialSummaryP;
+        this.gcDetailsInInitialSummaryP = undefined;
 
-        // Possible re-entrancy. It's possible that referenceUsedRoutes was set while we were waiting to get the
-        // initial GC details.
-        if (this.referenceUsedRoutes !== undefined) {
-            return;
-        }
-
-        this.referenceUsedRoutes = gcDetailsInInitialSummary.usedRoutes;
+        const gcDetailsInInitialSummary = await gcDetailsInInitialSummaryP;
         // If the GC details has GC data, initialize our GC data from it.
         if (gcDetailsInInitialSummary.gcData !== undefined) {
             this.gcData = cloneGCData(gcDetailsInInitialSummary.gcData);
         }
+        this.referenceUsedRoutes = gcDetailsInInitialSummary.usedRoutes;
         this.unreferencedTimestamp = gcDetailsInInitialSummary.unrefTimestamp;
     }
 
@@ -326,6 +337,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
                 ...config,
                 // Propagate our gcDisabled state to the child if its not explicity specified in child's config.
                 gcDisabled: config.gcDisabled ?? this.gcDisabled,
+                maxUnreferencedTime: config.maxUnreferencedTime ?? this.maxUnreferencedTime,
             },
             createDetails.changeSequenceNumber,
             createDetails.latestSummary,
@@ -369,19 +381,74 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         // are in the same order.
         this.usedRoutes = usedRoutes.sort();
 
-        // If this node is referenced, clear unreferencedTimestamp, if any.
-        // If this node is not referenced and unreferencedTimestamp is undefined, it just became unreferenced. Update
-        // unreferencedTimestamp to the gcTimestamp.
-        if (this.isReferenced()) {
-            this.unreferencedTimestamp = undefined;
-        } else if (this.unreferencedTimestamp === undefined) {
-            this.unreferencedTimestamp = gcTimestamp;
-        }
-
         // If GC is not disabled and we are tracking a summary, update the work-in-progress used routes so that it can
         // be tracked for this summary.
         if (!this.gcDisabled && this.isTrackingInProgress()) {
             this.wipSerializedUsedRoutes = JSON.stringify(this.usedRoutes);
+        }
+
+        if (this.isReferenced()) {
+            // If this node has been unreferenced for longer than maxUnreferencedTime and is being referenced,
+            // log an error as this may mean the maxUnreferencedTime is not long enough.
+            this.logErrorIfExpired("expiredObjectRevived", gcTimestamp);
+
+            // Clear unreferenced / expired state, if any.
+            this.expired = false;
+            this.unreferencedTimestamp = undefined;
+            this.unreferencedTimer.clear();
+            return;
+        }
+
+        // This node is unreferenced. We need to check if this node has expired or if we need to start the unreferenced
+        // timer which would mark the node as expired.
+
+        // If there is no timestamp when GC was run, we don't have enough information to determine whether this content
+        // should be expired.
+        if (gcTimestamp === undefined) {
+            return;
+        }
+
+        // If unreferencedTimestamp is not present, this node just became unreferenced. Update unreferencedTimestamp and
+        // start the unreferenced timer.
+        // Note that it's possible this node has been unreferenced before but the unreferencedTimestamp was not added.
+        // For example, older versions where this concept did not exist or if gcTimestamp wasn't available. In such
+        // cases, we track them as if the content just became unreferenced.
+        if (this.unreferencedTimestamp === undefined) {
+            this.unreferencedTimestamp = gcTimestamp;
+            this.unreferencedTimer.start();
+            return;
+        }
+
+        // If we are here, this node was unreferenced earlier.
+
+        // If it has already expired or has an unreferenced timer running, there is no more work to be done.
+        if (this.expired || this.unreferencedTimer.hasTimer) {
+            return;
+        }
+
+        // If it has been unreferenced longer than maxUnreferencedTime, mark it as expired. Otherwise, start the
+        // unreferenced timer for the duration left for it to reach maxUnreferencedTime.
+        const currentUnreferencedTime = gcTimestamp - this.unreferencedTimestamp;
+        if (currentUnreferencedTime >= this.maxUnreferencedTime) {
+            this.expired = true;
+        } else {
+            this.unreferencedTimer.start(this.maxUnreferencedTime - currentUnreferencedTime);
+        }
+    }
+
+    public recordChange(op: ISequencedDocumentMessage): void {
+        this.logErrorIfExpired("expiredObjectChanged");
+        super.recordChange(op);
+    }
+
+    private logErrorIfExpired(eventName: string, currentTimestamp?: number) {
+        if (this.expired) {
+            assert(this.unreferencedTimestamp !== undefined, "Node should not expire without unreferencedTimestamp");
+            this.defaultLogger.sendErrorEvent({
+                eventName,
+                unreferencedTime: currentTimestamp ?? Date.now() - this.unreferencedTimestamp,
+                maxUnreferencedTime: this.maxUnreferencedTime,
+            });
         }
     }
 

--- a/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
@@ -27,7 +27,7 @@ describe("SummarizerNodeWithGC Tests", () => {
     const subNode1Id = "/gcNode1/subNode";
     const subNode2Id = "/gcNode2/subNode";
 
-    const maxUnreferencedTime = 1000;
+    const maxUnreferencedDurationMs = 1000;
 
     let internalGCData: IGarbageCollectionData;
     let initialGCSummaryDetails: IGarbageCollectionSummaryDetails;
@@ -48,7 +48,7 @@ describe("SummarizerNodeWithGC Tests", () => {
             summarizeInternal,
             summarizerNodeId,
             { type: CreateSummarizerNodeSource.FromSummary },
-            { maxUnreferencedTime },
+            { maxUnreferencedDurationMs },
             getInternalGCData,
             getinitialGCSummaryDetails,
         );
@@ -234,7 +234,7 @@ describe("SummarizerNodeWithGC Tests", () => {
             const op: Partial<ISequencedDocumentMessage> = { sequenceNumber: 1 };
             summarizerNode.recordChange(op as ISequencedDocumentMessage);
             assert(
-                mockLogger.matchEvents([{ eventName: expiredObjectChangedEvent, maxUnreferencedTime }]),
+                mockLogger.matchEvents([{ eventName: expiredObjectChangedEvent, maxUnreferencedDurationMs }]),
                 "expiredObjectChanged event not generated as expected",
             );
 
@@ -242,7 +242,7 @@ describe("SummarizerNodeWithGC Tests", () => {
             // expiredObjectRevived event since the object expired.
             summarizerNode.updateUsedRoutes([""], Date.now());
             assert(
-                mockLogger.matchEvents([{ eventName: expiredObjectRevivedEvent, maxUnreferencedTime }]),
+                mockLogger.matchEvents([{ eventName: expiredObjectRevivedEvent, maxUnreferencedDurationMs }]),
                 "expiredObjectRevived event not generated as expected",
             );
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcExpiredDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcExpiredDataStore.spec.ts
@@ -33,10 +33,10 @@ describeNoCompat("GC unreferenced data store timeout expiry", (getTestObjectProv
         TestDataObject,
         [],
         []);
-    const maxUnreferencedTime = 2000;
+    const maxUnreferencedDurationMs = 2000;
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: { generateSummaries: false },
-        gcOptions: { gcAllowed: true, maxUnreferencedTime },
+        gcOptions: { gcAllowed: true, maxUnreferencedDurationMs },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
         dataObjectFactory,
@@ -117,7 +117,7 @@ describeNoCompat("GC unreferenced data store timeout expiry", (getTestObjectProv
         });
         validateNoExpiredEvents();
 
-        // Wait for 3000 ms which is > the configured maxUnreferencedTime (2000). This will ensure that the
+        // Wait for 3000 ms which is > the configured maxUnreferencedDurationMs (2000). This will ensure that the
         // unreferenced data store is expired.
         await waitForTimeout(3000);
 
@@ -125,7 +125,7 @@ describeNoCompat("GC unreferenced data store timeout expiry", (getTestObjectProv
         dataStore1._root.set("key", "value");
         await provider.ensureSynchronized();
         assert(
-            mockLogger.matchEvents([{ eventName: expiredObjectChangedEvent, maxUnreferencedTime }]),
+            mockLogger.matchEvents([{ eventName: expiredObjectChangedEvent, maxUnreferencedDurationMs }]),
             "expiredObjectChanged event not generated as expected",
         );
 
@@ -139,7 +139,7 @@ describeNoCompat("GC unreferenced data store timeout expiry", (getTestObjectProv
             summaryLogger,
         });
         assert(
-            mockLogger.matchEvents([{ eventName: expiredObjectRevivedEvent, maxUnreferencedTime }]),
+            mockLogger.matchEvents([{ eventName: expiredObjectRevivedEvent, maxUnreferencedDurationMs }]),
             "expiredObjectRevived event not generated as expected",
         );
     }).timeout(10000);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcExpiredDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcExpiredDataStore.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { MockLogger } from "@fluid-internal/mock-logger";
 import {
     ContainerRuntimeFactoryWithDefaultDataStore,
     DataObject,
@@ -13,7 +14,6 @@ import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { Container } from "@fluidframework/container-loader";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { MockLogger } from "@fluidframework/test-runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcExpiredDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcExpiredDataStore.spec.ts
@@ -1,0 +1,146 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    ContainerRuntimeFactoryWithDefaultDataStore,
+    DataObject,
+    DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { Container } from "@fluidframework/container-loader";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { MockLogger } from "@fluidframework/test-runtime-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
+
+class TestDataObject extends DataObject {
+    public get _root() {
+        return this.root;
+    }
+
+    public get _context() {
+        return this.context;
+    }
+}
+
+describeNoCompat("GC unreferenced data store timeout expiry", (getTestObjectProvider) => {
+    const dataObjectFactory = new DataObjectFactory(
+        "TestDataObject",
+        TestDataObject,
+        [],
+        []);
+    const maxUnreferencedTime = 2000;
+    const runtimeOptions: IContainerRuntimeOptions = {
+        summaryOptions: { generateSummaries: false },
+        gcOptions: { gcAllowed: true, maxUnreferencedTime },
+    };
+    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+        dataObjectFactory,
+        [
+            [dataObjectFactory.type, Promise.resolve(dataObjectFactory)],
+        ],
+        undefined,
+        undefined,
+        runtimeOptions,
+    );
+    const summaryLogger = new TelemetryNullLogger();
+    const expiredObjectRevivedEvent = "fluid:telemetry:expiredObjectRevived";
+    const expiredObjectChangedEvent = "fluid:telemetry:expiredObjectChanged";
+
+    let provider: ITestObjectProvider;
+    let containerRuntime: ContainerRuntime;
+    let defaultDataStore: TestDataObject;
+    let mockLogger: MockLogger;
+
+    const createContainer = async (logger: MockLogger) => provider.createContainer(runtimeFactory, { logger });
+
+    /** Waits for the given amount of time to be passed. */
+    async function waitForTimeout(timeout: number): Promise<void> {
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, timeout);
+        });
+    }
+
+    /** Validates that none of the expired events have been logged since the last run. */
+    function validateNoExpiredEvents() {
+        assert(
+            !mockLogger.matchAnyEvent([
+                { eventName: expiredObjectRevivedEvent },
+                { eventName: expiredObjectChangedEvent },
+            ]),
+            "expired object events should not have been logged",
+        );
+    }
+
+    before(function() {
+        provider = getTestObjectProvider();
+        // These tests validate the end-to-end behavior of GC features by generating ops and summaries. However, it does
+        // not post these summaries or download them. So, it doesn't need to run against real services.
+        if (provider.driver.type !== "local") {
+            this.skip();
+        }
+    });
+
+    beforeEach(async () => {
+        mockLogger = new MockLogger();
+        const container = await createContainer(mockLogger) as Container;
+        defaultDataStore = await requestFluidObject<TestDataObject>(container, "/");
+        containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
+    });
+
+    it("can generate events when unreferenced data store is accessed after timeout expires", async () => {
+        const dataStore1 = await dataObjectFactory.createInstance(containerRuntime);
+        defaultDataStore._root.set("dataStore1", dataStore1.handle);
+
+        // Summarize with dataStore1 as referenced and validate that no unreferneced errors were logged.
+        await provider.ensureSynchronized();
+        await containerRuntime.summarize({
+            runGC: true,
+            fullTree: true,
+            trackState: false,
+            summaryLogger,
+        });
+        validateNoExpiredEvents();
+
+        // Mark dataStore1 as unreferenced, summarize and validate that no unreferenced errors were logged.
+        defaultDataStore._root.delete("dataStore1");
+        await provider.ensureSynchronized();
+        await containerRuntime.summarize({
+            runGC: true,
+            fullTree: true,
+            trackState: false,
+            summaryLogger,
+        });
+        validateNoExpiredEvents();
+
+        // Wait for 3000 ms which is > the configured maxUnreferencedTime (2000). This will ensure that the
+        // unreferenced data store is expired.
+        await waitForTimeout(3000);
+
+        // Make changes to the expired data store and validate that we get the expiredObjectChanged event.
+        dataStore1._root.set("key", "value");
+        await provider.ensureSynchronized();
+        assert(
+            mockLogger.matchEvents([{ eventName: expiredObjectChangedEvent, maxUnreferencedTime }]),
+            "expiredObjectChanged event not generated as expected",
+        );
+
+        // Revive the expired data store and validate that we get the expiredObjectRevivedEvent event.
+        defaultDataStore._root.set("dataStore1", dataStore1.handle);
+        await provider.ensureSynchronized();
+        await containerRuntime.summarize({
+            runGC: true,
+            fullTree: true,
+            trackState: false,
+            summaryLogger,
+        });
+        assert(
+            mockLogger.matchEvents([{ eventName: expiredObjectRevivedEvent, maxUnreferencedTime }]),
+            "expiredObjectRevived event not generated as expected",
+        );
+    }).timeout(10000);
+});

--- a/packages/utils/mock-logger/src/mockLogger.ts
+++ b/packages/utils/mock-logger/src/mockLogger.ts
@@ -21,13 +21,34 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     }
 
     /**
-     * Search events logged since the last time matchEvents was called,
-     * looking for the given expected events in order.
+     * Search events logged since the last time matchEvents was called, looking for the given expected
+     * events in order.
      * @param expectedEvents - events in order that are expected to appear in the recorded log.
      * These event objects may be subsets of the logged events.
      * Note: category is ommitted from the type because it's usually uninteresting and tedious to type.
      */
     matchEvents(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): boolean {
+        const matchedExpectedEventCount = this.getMatchedEventsCount(expectedEvents);
+        // How many expected events were left over? Hopefully none.
+        const unmatchedExpectedEventCount = expectedEvents.length - matchedExpectedEventCount;
+        assert(unmatchedExpectedEventCount >= 0);
+        return unmatchedExpectedEventCount === 0;
+    }
+
+    /**
+     * Search events logged since the last time matchEvents was called, looking for any of the given
+     * expected events.
+     * @param expectedEvents - events that are expected to appear in the recorded log.
+     * These event objects may be subsets of the logged events.
+     * Note: category is ommitted from the type because it's usually uninteresting and tedious to type.
+     * @returns if any of the expected events is found.
+     */
+    matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): boolean {
+        const matchedExpectedEventCount = this.getMatchedEventsCount(expectedEvents);
+        return matchedExpectedEventCount > 0;
+    }
+
+    private getMatchedEventsCount(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): number {
         let iExpectedEvent = 0;
         this.events.forEach((event) => {
             if (iExpectedEvent < expectedEvents.length &&
@@ -41,10 +62,8 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
         // Remove the events so far; next call will just compare subsequent events from here
         this.events = [];
 
-        // How many expected events were left over? Hopefully none.
-        const unmatchedExpectedEventCount = expectedEvents.length - iExpectedEvent;
-        assert(unmatchedExpectedEventCount >= 0);
-        return unmatchedExpectedEventCount === 0;
+        // Return the count of matched events.
+        return iExpectedEvent;
     }
 
     /**


### PR DESCRIPTION
Fixes #7129.

If a data store has been unreferenced for more than 7 days, log an error log if:
1. It receives an op.
2. It is marked as referenced.