### PR TITLE
Correct encoding of the keys in tinylicious.

### DIFF
--- a/server/tinylicious/src/services/levelDbCollection.ts
+++ b/server/tinylicious/src/services/levelDbCollection.ts
@@ -157,8 +157,9 @@ export class Collection<T> implements ICollection<T> {
         const indexLen = isRange ? indexes.length - 1 : indexes.length;
         const queryValues = [];
         for (let i = 0; i < indexLen; ++i) {
-            if (query[indexes[i]] !== undefined) {
-                queryValues.push(query[indexes[i]]);
+            const queryValue = query[indexes[i]];
+            if (queryValue !== undefined) {
+                queryValues.push(isNaN(queryValue) ? queryValue : charwise.encode(Number(queryValue)));
             }
         }
         const key = queryValues.join("!");


### PR DESCRIPTION
This fixes a bug in the leveldb storage driver for tinylicious. In the primary keys numbers are escaped when written to the database, but not when read back. This causes the problem that documents with numeric documentids are not found in the database.

With this patch, we now use the same encoding logic, when fetching records that is also used in the function getKey, which is called when storing the record.