### PR TITLE
r11s-driver: fix delta url typo

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -98,7 +98,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 `All endpoints urls must be provided. [deltaStorageUrl:${deltaStorageUrl}]`);
         }
         const parsedDeltaStorageUrl = new URL(deltaStorageUrl);
-        parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
+        parsedDeltaStorageUrl.pathname = replaceDocumentIdInPath(parsedDeltaStorageUrl.pathname, documentId);
 
         return this.createDocumentService(
             {


### PR DESCRIPTION
as they say, "move fast and break things". Didn't know it was a warning!