### PR TITLE
[main > 0.46]: Handle ServiceReadOnly error in odsp driver

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -157,6 +157,8 @@ export enum OdspErrorType {
     fluidNotEnabled = "fluidNotEnabled",
     invalidFileNameError = "invalidFileNameError",
     outOfStorageError = "outOfStorageError",
+    // (undocumented)
+    serviceReadOnly = "serviceReadOnly",
     snapshotTooBig = "snapshotTooBig"
 }
 

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -42,6 +42,10 @@ export enum OdspErrorType {
     // This condition will result in any local changes being lost (i.e. only way to save state is by user
     // copying it over manually)
     cannotCatchUp = "cannotCatchUp",
+
+    // SPO can occasionally return 403 for r/w operations on document when there is a fail over to another data center.
+    // So to preserve integrity of the data, the data becomes readonly.
+    serviceReadOnly = "serviceReadOnly",
 }
 
 /**

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -37,6 +37,7 @@ import { fetchJoinSession } from "./vroom";
 import { isOdcOrigin } from "./odspUrlHelper";
 import { EpochTracker } from "./epochTracker";
 import { OpsCache } from "./opsCaching";
+import { RetryErrorsStorageAdapter } from "./retryErrorsStorageAdapter";
 
 // Gate that when set to "1", instructs to fetch the binary format snapshot from the spo.
 function gatesBinaryFormatSnapshot() {
@@ -185,7 +186,7 @@ export class OdspDocumentService implements IDocumentService {
             );
         }
 
-        return this.storageManager;
+        return new RetryErrorsStorageAdapter(this.storageManager, this.logger);
     }
 
     /**

--- a/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
+++ b/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { LoggingError } from "@fluidframework/telemetry-utils";
+import {
+    IDocumentStorageService,
+    IDocumentStorageServicePolicies,
+    ISummaryContext,
+} from "@fluidframework/driver-definitions";
+import {
+    ICreateBlobResponse,
+    ISnapshotTree,
+    ISummaryHandle,
+    ISummaryTree,
+    ITree,
+    IVersion,
+} from "@fluidframework/protocol-definitions";
+import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
+import { runWithRetry } from "./retryUtils";
+
+export class RetryErrorsStorageAdapter implements IDocumentStorageService, IDisposable {
+    private _disposed = false;
+    constructor(
+        private readonly internalStorageService: IDocumentStorageService,
+        private readonly logger: ITelemetryLogger,
+    ) {
+    }
+
+    public get policies(): IDocumentStorageServicePolicies | undefined {
+        return this.internalStorageService.policies;
+    }
+    public get disposed() {return this._disposed;}
+    public dispose() {
+        this._disposed = true;
+    }
+
+    public get repositoryUrl(): string {
+        return this.internalStorageService.repositoryUrl;
+    }
+
+    public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null> {
+        return this.runWithRetry(
+            async () => this.internalStorageService.getSnapshotTree(version),
+            "storage_getSnapshotTree",
+        );
+    }
+
+    public async readBlob(id: string): Promise<ArrayBufferLike> {
+        return this.runWithRetry(
+            async () => this.internalStorageService.readBlob(id),
+            "storage_readBlob",
+        );
+    }
+
+    public async getVersions(versionId: string, count: number): Promise<IVersion[]> {
+        return this.runWithRetry(
+            async () => this.internalStorageService.getVersions(versionId, count),
+            "storage_getVersions",
+        );
+    }
+
+    public async write(tree: ITree, parents: string[], message: string, ref: string): Promise<IVersion> {
+        return this.runWithRetry(
+            async () => this.internalStorageService.write(tree, parents, message, ref),
+            "storage_write",
+        );
+    }
+
+    public async uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string> {
+        // Creation flow with attachment blobs - need to do retries!
+        return this.runWithRetry(
+            async () => this.internalStorageService.uploadSummaryWithContext(summary, context),
+            "storage_uploadSummaryWithContext",
+        );
+    }
+
+    public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
+        return this.runWithRetry(
+            async () => this.internalStorageService.downloadSummary(handle),
+            "storage_downloadSummary",
+        );
+    }
+
+    public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+        return this.runWithRetry(
+            async () => this.internalStorageService.createBlob(file),
+            "storage_createBlob",
+        );
+    }
+
+    private checkStorageDisposed() {
+        if (this._disposed) {
+            throw new LoggingError("storageServiceDisposedCannotRetry", { canRetry: false });
+        }
+    }
+
+    private async runWithRetry<T>(api: () => Promise<T>, callName: string): Promise<T> {
+        return runWithRetry(
+            api,
+            callName,
+            this.logger,
+            () => this.checkStorageDisposed(),
+        );
+    }
+}

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -34,9 +34,7 @@ export async function runWithRetry<T>(
                 throw error;
             }
 
-            // SPO itself does number of retries internally before returning 409 to client.
-            // That multiplied to 5 suggests need to reconsider current design, as client spends
-            // too much time / bandwidth doing the same thing without any progress.
+            // Retry for max of 5 times.
             if (retry === 5) {
                 logger.sendErrorEvent({
                     eventName: "ServiceReadonlyErrorTooManyRetries",

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { assert, delay, performance } from "@fluidframework/common-utils";
+import { canRetryOnError } from "@fluidframework/driver-utils";
+import { OdspErrorType } from "@fluidframework/odsp-driver-definitions";
+import { Odsp409Error } from "./epochTracker";
+
+/**
+ * This method retries only for retriable coherency and service read only errors.
+ */
+export async function runWithRetry<T>(
+    api: () => Promise<T>,
+    callName: string,
+    logger: ITelemetryLogger,
+    checkDisposed?: () => void,
+): Promise<T> {
+    let retryAfter = 1000;
+    const start = performance.now();
+    for (let retry = 1; ; retry++) {
+        if (checkDisposed !== undefined) {
+            checkDisposed();
+        }
+        try {
+            return await api();
+        } catch (error) {
+            const canRetry = canRetryOnError(error);
+
+            const coherencyError = error?.[Odsp409Error] === true;
+            const serviceReadonlyError = error?.errorType === OdspErrorType.serviceReadOnly;
+            // Retry for 409 coherency errors or serviceReadOnly errors.
+            if (!(coherencyError || serviceReadonlyError)) {
+                throw error;
+            }
+
+            // SPO itself does number of retries internally before returning 409 to client.
+            // That multiplied to 5 suggests need to reconsider current design, as client spends
+            // too much time / bandwidth doing the same thing without any progress.
+            if (retry === 5) {
+                logger.sendErrorEvent({
+                    eventName: coherencyError ? "CoherencyErrorTooManyRetries" : "ServiceReadonlyErrorTooManyRetries",
+                    callName,
+                    retry,
+                    duration: performance.now() - start, // record total wait time.
+                });
+                // Fail hard.
+                error.canRetry = false;
+                throw error;
+            }
+
+            assert(canRetry, "can retry");
+            await delay(Math.floor(retryAfter));
+            retryAfter += retryAfter / 4  * (1 + Math.random());
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #7241
SPO can occasionally return 403 for r/w operations on document when there is a fail over to another data center.
The intention here is that data is read-only for a while, while fail over happens, to preserve integrity of the data.
So when this error occurs, handle it and retry and then throw ServiceReadOnly error if it keeps occuring.