### PR TITLE
Take advantage of detached state for initializing model

### DIFF
--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -16,7 +16,7 @@ import {
 import { v4 as uuid } from "uuid";
 import { DiceRollerController } from "./controller";
 import { ConsoleLogger } from "./ConsoleLogger";
-import { renderAudience, renderDiceRoller } from "./view";
+import { makeAppView } from "./view";
 
 export interface ICustomUserDetails {
     gender: string;
@@ -65,6 +65,16 @@ const containerSchema = {
     },
 };
 
+async function initializeNewContainer(container: FluidContainer): Promise<void> {
+    // Initialize both of our SharedMaps for usage with a DiceRollerController
+    const sharedMap1 = container.initialObjects.map1 as SharedMap;
+    const sharedMap2 = container.initialObjects.map2 as SharedMap;
+    await Promise.all([
+        DiceRollerController.initializeModel(sharedMap1),
+        DiceRollerController.initializeModel(sharedMap2),
+    ]);
+}
+
 async function start(): Promise<void> {
     // Create a custom ITelemetryBaseLogger object to pass into the Tinylicious container
     // and hook to the Telemetry system
@@ -78,54 +88,36 @@ async function start(): Promise<void> {
     let id: string;
 
     // Get or create the document depending if we are running through the create new flow
-    const createNew = !location.hash;
+    const createNew = location.hash.length === 0;
     if (createNew) {
         // The client will create a new detached container using the schema
         // A detached container will enable the app to modify the container before attaching it to the client
         ({container, services} = await client.createContainer(containerSchema));
+        // Initialize our models so they are ready for use with our controllers
+        await initializeNewContainer(container);
 
-        // If the app is in a `createNew` state, and the container is detached, we attach the container
-        // so that all new ops are communicated to the client
+        // If the app is in a `createNew` state, and the container is detached, we attach the container.
+        // This uploads the container to the service and connects to the collaboration session.
         id = await container.attach();
         // The newly attached container is given a unique ID that can be used to access the container in another session
         location.hash = id;
     } else {
         id = location.hash.substring(1);
-        // Use the unique container ID to fetch the container created earlier
+        // Use the unique container ID to fetch the container created earlier.  It will already be connected to the
+        // collaboration session.
         ({container, services} = await client.getContainer(id, containerSchema));
     }
 
     document.title = id;
 
-    // We now get the first SharedMap from the container
+    // Here we are guaranteed that the maps have already been initialized for use with a DiceRollerController
     const sharedMap1 = container.initialObjects.map1 as SharedMap;
-
-    // Our controller manipulates the data object (model).
-    const diceRollerController = new DiceRollerController(sharedMap1);
-    await diceRollerController.initialize(createNew);
-
-    // We create a view which uses the controller.
-    const contentDiv = document.getElementById("content") as HTMLDivElement;
-    const div1 = document.createElement("div");
-    contentDiv.appendChild(div1);
-
-    // We now get the second SharedMap from the container
     const sharedMap2 = container.initialObjects.map2 as SharedMap;
-
-    // Our controller manipulates the data object (model).
+    const diceRollerController1 = new DiceRollerController(sharedMap1);
     const diceRollerController2 = new DiceRollerController(sharedMap2);
-    await diceRollerController2.initialize(createNew);
 
-    // We create a second view which uses the second controller.
-    const div2 = document.createElement("div");
-    contentDiv.appendChild(div2);
-
-    // Now that the container is attached, our app can render the views and listen for updates
-    renderDiceRoller(diceRollerController, div1);
-    renderDiceRoller(diceRollerController2, div2);
-
-    // Render the audience information for the members currently in the session
-    renderAudience(services.audience, contentDiv);
+    const contentDiv = document.getElementById("content") as HTMLDivElement;
+    contentDiv.append(makeAppView([diceRollerController1, diceRollerController2], services.audience));
 }
 
 start().catch(console.error);

--- a/examples/hosts/app-integration/external-controller/src/controller.ts
+++ b/examples/hosts/app-integration/external-controller/src/controller.ts
@@ -52,7 +52,7 @@ export class DiceRollerController extends EventEmitter implements IDiceRollerCon
         super();
         const value = this.props.get(diceValueKey);
         if (typeof value !== "number") {
-            throw new Error("Model is incorrect - did you call DiceRollerController.initialize() to set it up?");
+            throw new Error("Model is incorrect - did you call DiceRollerController.initializeModel() to set it up?");
         }
         this.props.on("valueChanged", (changed) => {
             if (changed.key === diceValueKey) {
@@ -65,7 +65,7 @@ export class DiceRollerController extends EventEmitter implements IDiceRollerCon
     public get value() {
         const value = this.props.get(diceValueKey);
         if (typeof value !== "number") {
-            throw new Error("Model is incorrect - did you call DiceRollerController.initialize() to set it up?");
+            throw new Error("Model is incorrect - did you call DiceRollerController.initializeModel() to set it up?");
         }
         return value;
     }

--- a/examples/hosts/app-integration/external-controller/src/view.ts
+++ b/examples/hosts/app-integration/external-controller/src/view.ts
@@ -7,15 +7,9 @@ import { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
 import { ICustomUserDetails } from "./app";
 import { IDiceRollerController } from "./controller";
 
-/**
- * Render an IDiceRollerController into a given div as a text character, with a button to roll it.
- * @param diceRoller - The dice roller to be rendered
- * @param div - The div to render into
- */
-export function renderDiceRoller(diceRoller: IDiceRollerController, div: HTMLDivElement) {
+function makeDiceRollerView(diceRoller: IDiceRollerController): HTMLDivElement {
     const wrapperDiv = document.createElement("div");
     wrapperDiv.style.textAlign = "center";
-    div.appendChild(wrapperDiv);
 
     const diceCharDiv = document.createElement("div");
     diceCharDiv.style.fontSize = "200px";
@@ -38,18 +32,19 @@ export function renderDiceRoller(diceRoller: IDiceRollerController, div: HTMLDiv
 
     // Use the diceRolled event to trigger the rerender whenever the value changes.
     diceRoller.on("diceRolled", updateDiceChar);
+    return wrapperDiv;
 }
 
-/**
- * Render the user names of the members currently active in the session into the provided div
- * @param audience - Object that provides the list of current members and listeners for when the list changes
- * @param div - The div to render into
- */
-export function renderAudience(audience: IAzureAudience, div: HTMLDivElement) {
+function makeAudienceView(audience?: IAzureAudience): HTMLDivElement {
+    // Accommodating the test which doesn't provide an audience
+    if (audience === undefined) {
+        const noAudienceDiv = document.createElement("div");
+        noAudienceDiv.textContent = "No audience provided";
+        return noAudienceDiv;
+    }
     const wrapperDiv = document.createElement("div");
     wrapperDiv.style.textAlign = "center";
     wrapperDiv.style.margin = "70px";
-    div.appendChild(wrapperDiv);
 
     const audienceDiv = document.createElement("div");
     audienceDiv.style.fontSize = "20px";
@@ -81,4 +76,17 @@ export function renderAudience(audience: IAzureAudience, div: HTMLDivElement) {
     audience.on("membersChanged", onAudienceChanged);
 
     wrapperDiv.appendChild(audienceDiv);
+    return wrapperDiv;
+}
+
+export function makeAppView(
+    diceRollerControllers: IDiceRollerController[],
+    audience?: IAzureAudience,
+): HTMLDivElement {
+    const diceRollerViews = diceRollerControllers.map(makeDiceRollerView);
+    const audienceView = makeAudienceView(audience);
+
+    const wrapperDiv = document.createElement("div");
+    wrapperDiv.append(...diceRollerViews, audienceView);
+    return wrapperDiv;
 }


### PR DESCRIPTION
Since FluidContainer supports detached state now, we can initialize the data prior to attaching and drop the initialize call which waits on the key to be ready.  This is recommendable and less error-prone (it's easy to forget that the second client might arrive before a post-attach value is set).  Here I do this via a static method on the controller.

This change also evicts some view logic from the app and restructures the view a bit -- probably this should just be converted to React at this point but I stop short of that here.