### PR TITLE
Type Validation: Specify Breaking Changes in Package.json

### DIFF
--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -54,5 +54,19 @@
     "typescript": "~4.1.3",
     "typescript-formatter": "7.1.0"
   },
-  "typeValidationVersion": "0.1025.0"
+  "typeValidation": {
+    "version": "0.1025.0",
+    "broken": {
+      "ICreateBlobResponse":{"backCompat": false},
+      "IQuorumEvents":{"backCompat": false},
+      "ISummaryAttachment": {"forwardCompat": false, "backCompat": false},
+      "ISummaryBlob": {"forwardCompat": false, "backCompat": false},
+      "ISummaryHandle": {"forwardCompat": false, "backCompat": false},
+      "ISummaryTree": {"forwardCompat": false, "backCompat": false},
+      "SummaryObject": {"forwardCompat": false, "backCompat": false},
+      "SummaryTree": {"forwardCompat": false, "backCompat": false},
+      "SummaryType": {"forwardCompat": false, "backCompat": false},
+      "SummaryTypeNoHandle": {"forwardCompat": false, "backCompat": false}
+    }
+  }
 }

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -57,16 +57,44 @@
   "typeValidation": {
     "version": "0.1025.0",
     "broken": {
-      "ICreateBlobResponse":{"backCompat": false},
-      "IQuorumEvents":{"backCompat": false},
-      "ISummaryAttachment": {"forwardCompat": false, "backCompat": false},
-      "ISummaryBlob": {"forwardCompat": false, "backCompat": false},
-      "ISummaryHandle": {"forwardCompat": false, "backCompat": false},
-      "ISummaryTree": {"forwardCompat": false, "backCompat": false},
-      "SummaryObject": {"forwardCompat": false, "backCompat": false},
-      "SummaryTree": {"forwardCompat": false, "backCompat": false},
-      "SummaryType": {"forwardCompat": false, "backCompat": false},
-      "SummaryTypeNoHandle": {"forwardCompat": false, "backCompat": false}
+      "ICreateBlobResponse": {
+        "backCompat": false
+      },
+      "IQuorum": {
+        "forwardCompat": false
+      },
+      "ISummaryAttachment": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "ISummaryBlob": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "ISummaryHandle": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "ISummaryTree": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "SummaryObject": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "SummaryTree": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "SummaryType": {
+        "forwardCompat": false,
+        "backCompat": false
+      },
+      "SummaryTypeNoHandle": {
+        "forwardCompat": false,
+        "backCompat": false
+      }
     }
   }
 }

--- a/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
@@ -6,828 +6,828 @@
 import * as old from "@fluidframework/protocol-definitions-0.1024.0";
 import * as current from "../index";
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ConnectionMode": {"forwardCompat": false}
-declare function set_current_ConnectionMode(set: current.ConnectionMode);
 declare function get_old_ConnectionMode(): old.ConnectionMode;
-set_current_ConnectionMode(get_old_ConnectionMode());
+declare function use_current_ConnectionMode(use: current.ConnectionMode);
+use_current_ConnectionMode(get_old_ConnectionMode());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ConnectionMode": {"backCompat": false}
-declare function set_old_ConnectionMode(set: old.ConnectionMode);
 declare function get_current_ConnectionMode(): current.ConnectionMode;
-set_old_ConnectionMode(get_current_ConnectionMode());
+declare function use_old_ConnectionMode(use: old.ConnectionMode);
+use_old_ConnectionMode(get_current_ConnectionMode());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "FileMode": {"forwardCompat": false}
-declare function set_current_FileMode(set: current.FileMode);
 declare function get_old_FileMode(): old.FileMode;
-set_current_FileMode(get_old_FileMode());
+declare function use_current_FileMode(use: current.FileMode);
+use_current_FileMode(get_old_FileMode());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "FileMode": {"backCompat": false}
-declare function set_old_FileMode(set: old.FileMode);
 declare function get_current_FileMode(): current.FileMode;
-set_old_FileMode(get_current_FileMode());
+declare function use_old_FileMode(use: old.FileMode);
+use_old_FileMode(get_current_FileMode());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IActorClient": {"forwardCompat": false}
-declare function set_current_IActorClient(set: current.IActorClient);
 declare function get_old_IActorClient(): old.IActorClient;
-set_current_IActorClient(get_old_IActorClient());
+declare function use_current_IActorClient(use: current.IActorClient);
+use_current_IActorClient(get_old_IActorClient());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IActorClient": {"backCompat": false}
-declare function set_old_IActorClient(set: old.IActorClient);
 declare function get_current_IActorClient(): current.IActorClient;
-set_old_IActorClient(get_current_IActorClient());
+declare function use_old_IActorClient(use: old.IActorClient);
+use_old_IActorClient(get_current_IActorClient());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IApprovedProposal": {"forwardCompat": false}
-declare function set_current_IApprovedProposal(set: current.IApprovedProposal);
 declare function get_old_IApprovedProposal(): old.IApprovedProposal;
-set_current_IApprovedProposal(get_old_IApprovedProposal());
+declare function use_current_IApprovedProposal(use: current.IApprovedProposal);
+use_current_IApprovedProposal(get_old_IApprovedProposal());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IApprovedProposal": {"backCompat": false}
-declare function set_old_IApprovedProposal(set: old.IApprovedProposal);
 declare function get_current_IApprovedProposal(): current.IApprovedProposal;
-set_old_IApprovedProposal(get_current_IApprovedProposal());
+declare function use_old_IApprovedProposal(use: old.IApprovedProposal);
+use_old_IApprovedProposal(get_current_IApprovedProposal());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IAttachment": {"forwardCompat": false}
-declare function set_current_IAttachment(set: current.IAttachment);
 declare function get_old_IAttachment(): old.IAttachment;
-set_current_IAttachment(get_old_IAttachment());
+declare function use_current_IAttachment(use: current.IAttachment);
+use_current_IAttachment(get_old_IAttachment());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IAttachment": {"backCompat": false}
-declare function set_old_IAttachment(set: old.IAttachment);
 declare function get_current_IAttachment(): current.IAttachment;
-set_old_IAttachment(get_current_IAttachment());
+declare function use_old_IAttachment(use: old.IAttachment);
+use_old_IAttachment(get_current_IAttachment());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IBlob": {"forwardCompat": false}
-declare function set_current_IBlob(set: current.IBlob);
 declare function get_old_IBlob(): old.IBlob;
-set_current_IBlob(get_old_IBlob());
+declare function use_current_IBlob(use: current.IBlob);
+use_current_IBlob(get_old_IBlob());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IBlob": {"backCompat": false}
-declare function set_old_IBlob(set: old.IBlob);
 declare function get_current_IBlob(): current.IBlob;
-set_old_IBlob(get_current_IBlob());
+declare function use_old_IBlob(use: old.IBlob);
+use_old_IBlob(get_current_IBlob());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IBranchOrigin": {"forwardCompat": false}
-declare function set_current_IBranchOrigin(set: current.IBranchOrigin);
 declare function get_old_IBranchOrigin(): old.IBranchOrigin;
-set_current_IBranchOrigin(get_old_IBranchOrigin());
+declare function use_current_IBranchOrigin(use: current.IBranchOrigin);
+use_current_IBranchOrigin(get_old_IBranchOrigin());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IBranchOrigin": {"backCompat": false}
-declare function set_old_IBranchOrigin(set: old.IBranchOrigin);
 declare function get_current_IBranchOrigin(): current.IBranchOrigin;
-set_old_IBranchOrigin(get_current_IBranchOrigin());
+declare function use_old_IBranchOrigin(use: old.IBranchOrigin);
+use_old_IBranchOrigin(get_current_IBranchOrigin());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ICapabilities": {"forwardCompat": false}
-declare function set_current_ICapabilities(set: current.ICapabilities);
 declare function get_old_ICapabilities(): old.ICapabilities;
-set_current_ICapabilities(get_old_ICapabilities());
+declare function use_current_ICapabilities(use: current.ICapabilities);
+use_current_ICapabilities(get_old_ICapabilities());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ICapabilities": {"backCompat": false}
-declare function set_old_ICapabilities(set: old.ICapabilities);
 declare function get_current_ICapabilities(): current.ICapabilities;
-set_old_ICapabilities(get_current_ICapabilities());
+declare function use_old_ICapabilities(use: old.ICapabilities);
+use_old_ICapabilities(get_current_ICapabilities());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IClient": {"forwardCompat": false}
-declare function set_current_IClient(set: current.IClient);
 declare function get_old_IClient(): old.IClient;
-set_current_IClient(get_old_IClient());
+declare function use_current_IClient(use: current.IClient);
+use_current_IClient(get_old_IClient());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IClient": {"backCompat": false}
-declare function set_old_IClient(set: old.IClient);
 declare function get_current_IClient(): current.IClient;
-set_old_IClient(get_current_IClient());
+declare function use_old_IClient(use: old.IClient);
+use_old_IClient(get_current_IClient());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IClientConfiguration": {"forwardCompat": false}
-declare function set_current_IClientConfiguration(set: current.IClientConfiguration);
 declare function get_old_IClientConfiguration(): old.IClientConfiguration;
-set_current_IClientConfiguration(get_old_IClientConfiguration());
+declare function use_current_IClientConfiguration(use: current.IClientConfiguration);
+use_current_IClientConfiguration(get_old_IClientConfiguration());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IClientConfiguration": {"backCompat": false}
-declare function set_old_IClientConfiguration(set: old.IClientConfiguration);
 declare function get_current_IClientConfiguration(): current.IClientConfiguration;
-set_old_IClientConfiguration(get_current_IClientConfiguration());
+declare function use_old_IClientConfiguration(use: old.IClientConfiguration);
+use_old_IClientConfiguration(get_current_IClientConfiguration());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IClientDetails": {"forwardCompat": false}
-declare function set_current_IClientDetails(set: current.IClientDetails);
 declare function get_old_IClientDetails(): old.IClientDetails;
-set_current_IClientDetails(get_old_IClientDetails());
+declare function use_current_IClientDetails(use: current.IClientDetails);
+use_current_IClientDetails(get_old_IClientDetails());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IClientDetails": {"backCompat": false}
-declare function set_old_IClientDetails(set: old.IClientDetails);
 declare function get_current_IClientDetails(): current.IClientDetails;
-set_old_IClientDetails(get_current_IClientDetails());
+declare function use_old_IClientDetails(use: old.IClientDetails);
+use_old_IClientDetails(get_current_IClientDetails());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IClientJoin": {"forwardCompat": false}
-declare function set_current_IClientJoin(set: current.IClientJoin);
 declare function get_old_IClientJoin(): old.IClientJoin;
-set_current_IClientJoin(get_old_IClientJoin());
+declare function use_current_IClientJoin(use: current.IClientJoin);
+use_current_IClientJoin(get_old_IClientJoin());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IClientJoin": {"backCompat": false}
-declare function set_old_IClientJoin(set: old.IClientJoin);
 declare function get_current_IClientJoin(): current.IClientJoin;
-set_old_IClientJoin(get_current_IClientJoin());
+declare function use_old_IClientJoin(use: old.IClientJoin);
+use_old_IClientJoin(get_current_IClientJoin());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ICommittedProposal": {"forwardCompat": false}
-declare function set_current_ICommittedProposal(set: current.ICommittedProposal);
 declare function get_old_ICommittedProposal(): old.ICommittedProposal;
-set_current_ICommittedProposal(get_old_ICommittedProposal());
+declare function use_current_ICommittedProposal(use: current.ICommittedProposal);
+use_current_ICommittedProposal(get_old_ICommittedProposal());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ICommittedProposal": {"backCompat": false}
-declare function set_old_ICommittedProposal(set: old.ICommittedProposal);
 declare function get_current_ICommittedProposal(): current.ICommittedProposal;
-set_old_ICommittedProposal(get_current_ICommittedProposal());
+declare function use_old_ICommittedProposal(use: old.ICommittedProposal);
+use_old_ICommittedProposal(get_current_ICommittedProposal());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IConnect": {"forwardCompat": false}
-declare function set_current_IConnect(set: current.IConnect);
 declare function get_old_IConnect(): old.IConnect;
-set_current_IConnect(get_old_IConnect());
+declare function use_current_IConnect(use: current.IConnect);
+use_current_IConnect(get_old_IConnect());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IConnect": {"backCompat": false}
-declare function set_old_IConnect(set: old.IConnect);
 declare function get_current_IConnect(): current.IConnect;
-set_old_IConnect(get_current_IConnect());
+declare function use_old_IConnect(use: old.IConnect);
+use_old_IConnect(get_current_IConnect());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IConnected": {"forwardCompat": false}
-declare function set_current_IConnected(set: current.IConnected);
 declare function get_old_IConnected(): old.IConnected;
-set_current_IConnected(get_old_IConnected());
+declare function use_current_IConnected(use: current.IConnected);
+use_current_IConnected(get_old_IConnected());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IConnected": {"backCompat": false}
-declare function set_old_IConnected(set: old.IConnected);
 declare function get_current_IConnected(): current.IConnected;
-set_old_IConnected(get_current_IConnected());
+declare function use_old_IConnected(use: old.IConnected);
+use_old_IConnected(get_current_IConnected());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ICreateBlobResponse": {"forwardCompat": false}
-declare function set_current_ICreateBlobResponse(set: current.ICreateBlobResponse);
 declare function get_old_ICreateBlobResponse(): old.ICreateBlobResponse;
-set_current_ICreateBlobResponse(get_old_ICreateBlobResponse());
+declare function use_current_ICreateBlobResponse(use: current.ICreateBlobResponse);
+use_current_ICreateBlobResponse(get_old_ICreateBlobResponse());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IDocumentAttributes": {"forwardCompat": false}
-declare function set_current_IDocumentAttributes(set: current.IDocumentAttributes);
 declare function get_old_IDocumentAttributes(): old.IDocumentAttributes;
-set_current_IDocumentAttributes(get_old_IDocumentAttributes());
+declare function use_current_IDocumentAttributes(use: current.IDocumentAttributes);
+use_current_IDocumentAttributes(get_old_IDocumentAttributes());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IDocumentAttributes": {"backCompat": false}
-declare function set_old_IDocumentAttributes(set: old.IDocumentAttributes);
 declare function get_current_IDocumentAttributes(): current.IDocumentAttributes;
-set_old_IDocumentAttributes(get_current_IDocumentAttributes());
+declare function use_old_IDocumentAttributes(use: old.IDocumentAttributes);
+use_old_IDocumentAttributes(get_current_IDocumentAttributes());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IDocumentMessage": {"forwardCompat": false}
-declare function set_current_IDocumentMessage(set: current.IDocumentMessage);
 declare function get_old_IDocumentMessage(): old.IDocumentMessage;
-set_current_IDocumentMessage(get_old_IDocumentMessage());
+declare function use_current_IDocumentMessage(use: current.IDocumentMessage);
+use_current_IDocumentMessage(get_old_IDocumentMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IDocumentMessage": {"backCompat": false}
-declare function set_old_IDocumentMessage(set: old.IDocumentMessage);
 declare function get_current_IDocumentMessage(): current.IDocumentMessage;
-set_old_IDocumentMessage(get_current_IDocumentMessage());
+declare function use_old_IDocumentMessage(use: old.IDocumentMessage);
+use_old_IDocumentMessage(get_current_IDocumentMessage());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IDocumentSystemMessage": {"forwardCompat": false}
-declare function set_current_IDocumentSystemMessage(set: current.IDocumentSystemMessage);
 declare function get_old_IDocumentSystemMessage(): old.IDocumentSystemMessage;
-set_current_IDocumentSystemMessage(get_old_IDocumentSystemMessage());
+declare function use_current_IDocumentSystemMessage(use: current.IDocumentSystemMessage);
+use_current_IDocumentSystemMessage(get_old_IDocumentSystemMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IDocumentSystemMessage": {"backCompat": false}
-declare function set_old_IDocumentSystemMessage(set: old.IDocumentSystemMessage);
 declare function get_current_IDocumentSystemMessage(): current.IDocumentSystemMessage;
-set_old_IDocumentSystemMessage(get_current_IDocumentSystemMessage());
+declare function use_old_IDocumentSystemMessage(use: old.IDocumentSystemMessage);
+use_old_IDocumentSystemMessage(get_current_IDocumentSystemMessage());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IHelpMessage": {"forwardCompat": false}
-declare function set_current_IHelpMessage(set: current.IHelpMessage);
 declare function get_old_IHelpMessage(): old.IHelpMessage;
-set_current_IHelpMessage(get_old_IHelpMessage());
+declare function use_current_IHelpMessage(use: current.IHelpMessage);
+use_current_IHelpMessage(get_old_IHelpMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IHelpMessage": {"backCompat": false}
-declare function set_old_IHelpMessage(set: old.IHelpMessage);
 declare function get_current_IHelpMessage(): current.IHelpMessage;
-set_old_IHelpMessage(get_current_IHelpMessage());
+declare function use_old_IHelpMessage(use: old.IHelpMessage);
+use_old_IHelpMessage(get_current_IHelpMessage());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "INack": {"forwardCompat": false}
-declare function set_current_INack(set: current.INack);
 declare function get_old_INack(): old.INack;
-set_current_INack(get_old_INack());
+declare function use_current_INack(use: current.INack);
+use_current_INack(get_old_INack());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "INack": {"backCompat": false}
-declare function set_old_INack(set: old.INack);
 declare function get_current_INack(): current.INack;
-set_old_INack(get_current_INack());
+declare function use_old_INack(use: old.INack);
+use_old_INack(get_current_INack());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "INackContent": {"forwardCompat": false}
-declare function set_current_INackContent(set: current.INackContent);
 declare function get_old_INackContent(): old.INackContent;
-set_current_INackContent(get_old_INackContent());
+declare function use_current_INackContent(use: current.INackContent);
+use_current_INackContent(get_old_INackContent());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "INackContent": {"backCompat": false}
-declare function set_old_INackContent(set: old.INackContent);
 declare function get_current_INackContent(): current.INackContent;
-set_old_INackContent(get_current_INackContent());
+declare function use_old_INackContent(use: old.INackContent);
+use_old_INackContent(get_current_INackContent());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IPendingProposal": {"forwardCompat": false}
-declare function set_current_IPendingProposal(set: current.IPendingProposal);
 declare function get_old_IPendingProposal(): old.IPendingProposal;
-set_current_IPendingProposal(get_old_IPendingProposal());
+declare function use_current_IPendingProposal(use: current.IPendingProposal);
+use_current_IPendingProposal(get_old_IPendingProposal());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IPendingProposal": {"backCompat": false}
-declare function set_old_IPendingProposal(set: old.IPendingProposal);
 declare function get_current_IPendingProposal(): current.IPendingProposal;
-set_old_IPendingProposal(get_current_IPendingProposal());
+declare function use_old_IPendingProposal(use: old.IPendingProposal);
+use_old_IPendingProposal(get_current_IPendingProposal());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IProcessMessageResult": {"forwardCompat": false}
-declare function set_current_IProcessMessageResult(set: current.IProcessMessageResult);
 declare function get_old_IProcessMessageResult(): old.IProcessMessageResult;
-set_current_IProcessMessageResult(get_old_IProcessMessageResult());
+declare function use_current_IProcessMessageResult(use: current.IProcessMessageResult);
+use_current_IProcessMessageResult(get_old_IProcessMessageResult());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IProcessMessageResult": {"backCompat": false}
-declare function set_old_IProcessMessageResult(set: old.IProcessMessageResult);
 declare function get_current_IProcessMessageResult(): current.IProcessMessageResult;
-set_old_IProcessMessageResult(get_current_IProcessMessageResult());
+declare function use_old_IProcessMessageResult(use: old.IProcessMessageResult);
+use_old_IProcessMessageResult(get_current_IProcessMessageResult());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IProposal": {"forwardCompat": false}
-declare function set_current_IProposal(set: current.IProposal);
 declare function get_old_IProposal(): old.IProposal;
-set_current_IProposal(get_old_IProposal());
+declare function use_current_IProposal(use: current.IProposal);
+use_current_IProposal(get_old_IProposal());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IProposal": {"backCompat": false}
-declare function set_old_IProposal(set: old.IProposal);
 declare function get_current_IProposal(): current.IProposal;
-set_old_IProposal(get_current_IProposal());
+declare function use_old_IProposal(use: old.IProposal);
+use_old_IProposal(get_current_IProposal());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IProtocolState": {"forwardCompat": false}
-declare function set_current_IProtocolState(set: current.IProtocolState);
 declare function get_old_IProtocolState(): old.IProtocolState;
-set_current_IProtocolState(get_old_IProtocolState());
+declare function use_current_IProtocolState(use: current.IProtocolState);
+use_current_IProtocolState(get_old_IProtocolState());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IProtocolState": {"backCompat": false}
-declare function set_old_IProtocolState(set: old.IProtocolState);
 declare function get_current_IProtocolState(): current.IProtocolState;
-set_old_IProtocolState(get_current_IProtocolState());
+declare function use_old_IProtocolState(use: old.IProtocolState);
+use_old_IProtocolState(get_current_IProtocolState());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IQueueMessage": {"forwardCompat": false}
-declare function set_current_IQueueMessage(set: current.IQueueMessage);
 declare function get_old_IQueueMessage(): old.IQueueMessage;
-set_current_IQueueMessage(get_old_IQueueMessage());
+declare function use_current_IQueueMessage(use: current.IQueueMessage);
+use_current_IQueueMessage(get_old_IQueueMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IQueueMessage": {"backCompat": false}
-declare function set_old_IQueueMessage(set: old.IQueueMessage);
 declare function get_current_IQueueMessage(): current.IQueueMessage;
-set_old_IQueueMessage(get_current_IQueueMessage());
+declare function use_old_IQueueMessage(use: old.IQueueMessage);
+use_old_IQueueMessage(get_current_IQueueMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IQuorum": {"backCompat": false}
-declare function set_old_IQuorum(set: old.IQuorum);
 declare function get_current_IQuorum(): current.IQuorum;
-set_old_IQuorum(get_current_IQuorum());
+declare function use_old_IQuorum(use: old.IQuorum);
+use_old_IQuorum(get_current_IQuorum());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IQuorumEvents": {"forwardCompat": false}
-declare function set_current_IQuorumEvents(set: current.IQuorumEvents);
 declare function get_old_IQuorumEvents(): old.IQuorumEvents;
-set_current_IQuorumEvents(get_old_IQuorumEvents());
+declare function use_current_IQuorumEvents(use: current.IQuorumEvents);
+use_current_IQuorumEvents(get_old_IQuorumEvents());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IQuorumEvents": {"backCompat": false}
-declare function set_old_IQuorumEvents(set: old.IQuorumEvents);
 declare function get_current_IQuorumEvents(): current.IQuorumEvents;
-set_old_IQuorumEvents(get_current_IQuorumEvents());
+declare function use_old_IQuorumEvents(use: old.IQuorumEvents);
+use_old_IQuorumEvents(get_current_IQuorumEvents());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISequencedClient": {"forwardCompat": false}
-declare function set_current_ISequencedClient(set: current.ISequencedClient);
 declare function get_old_ISequencedClient(): old.ISequencedClient;
-set_current_ISequencedClient(get_old_ISequencedClient());
+declare function use_current_ISequencedClient(use: current.ISequencedClient);
+use_current_ISequencedClient(get_old_ISequencedClient());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISequencedClient": {"backCompat": false}
-declare function set_old_ISequencedClient(set: old.ISequencedClient);
 declare function get_current_ISequencedClient(): current.ISequencedClient;
-set_old_ISequencedClient(get_current_ISequencedClient());
+declare function use_old_ISequencedClient(use: old.ISequencedClient);
+use_old_ISequencedClient(get_current_ISequencedClient());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISequencedDocumentAugmentedMessage": {"forwardCompat": false}
-declare function set_current_ISequencedDocumentAugmentedMessage(set: current.ISequencedDocumentAugmentedMessage);
 declare function get_old_ISequencedDocumentAugmentedMessage(): old.ISequencedDocumentAugmentedMessage;
-set_current_ISequencedDocumentAugmentedMessage(get_old_ISequencedDocumentAugmentedMessage());
+declare function use_current_ISequencedDocumentAugmentedMessage(use: current.ISequencedDocumentAugmentedMessage);
+use_current_ISequencedDocumentAugmentedMessage(get_old_ISequencedDocumentAugmentedMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISequencedDocumentAugmentedMessage": {"backCompat": false}
-declare function set_old_ISequencedDocumentAugmentedMessage(set: old.ISequencedDocumentAugmentedMessage);
 declare function get_current_ISequencedDocumentAugmentedMessage(): current.ISequencedDocumentAugmentedMessage;
-set_old_ISequencedDocumentAugmentedMessage(get_current_ISequencedDocumentAugmentedMessage());
+declare function use_old_ISequencedDocumentAugmentedMessage(use: old.ISequencedDocumentAugmentedMessage);
+use_old_ISequencedDocumentAugmentedMessage(get_current_ISequencedDocumentAugmentedMessage());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISequencedDocumentMessage": {"forwardCompat": false}
-declare function set_current_ISequencedDocumentMessage(set: current.ISequencedDocumentMessage);
 declare function get_old_ISequencedDocumentMessage(): old.ISequencedDocumentMessage;
-set_current_ISequencedDocumentMessage(get_old_ISequencedDocumentMessage());
+declare function use_current_ISequencedDocumentMessage(use: current.ISequencedDocumentMessage);
+use_current_ISequencedDocumentMessage(get_old_ISequencedDocumentMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISequencedDocumentMessage": {"backCompat": false}
-declare function set_old_ISequencedDocumentMessage(set: old.ISequencedDocumentMessage);
 declare function get_current_ISequencedDocumentMessage(): current.ISequencedDocumentMessage;
-set_old_ISequencedDocumentMessage(get_current_ISequencedDocumentMessage());
+declare function use_old_ISequencedDocumentMessage(use: old.ISequencedDocumentMessage);
+use_old_ISequencedDocumentMessage(get_current_ISequencedDocumentMessage());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISequencedDocumentSystemMessage": {"forwardCompat": false}
-declare function set_current_ISequencedDocumentSystemMessage(set: current.ISequencedDocumentSystemMessage);
 declare function get_old_ISequencedDocumentSystemMessage(): old.ISequencedDocumentSystemMessage;
-set_current_ISequencedDocumentSystemMessage(get_old_ISequencedDocumentSystemMessage());
+declare function use_current_ISequencedDocumentSystemMessage(use: current.ISequencedDocumentSystemMessage);
+use_current_ISequencedDocumentSystemMessage(get_old_ISequencedDocumentSystemMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISequencedDocumentSystemMessage": {"backCompat": false}
-declare function set_old_ISequencedDocumentSystemMessage(set: old.ISequencedDocumentSystemMessage);
 declare function get_current_ISequencedDocumentSystemMessage(): current.ISequencedDocumentSystemMessage;
-set_old_ISequencedDocumentSystemMessage(get_current_ISequencedDocumentSystemMessage());
+declare function use_old_ISequencedDocumentSystemMessage(use: old.ISequencedDocumentSystemMessage);
+use_old_ISequencedDocumentSystemMessage(get_current_ISequencedDocumentSystemMessage());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISequencedProposal": {"forwardCompat": false}
-declare function set_current_ISequencedProposal(set: current.ISequencedProposal);
 declare function get_old_ISequencedProposal(): old.ISequencedProposal;
-set_current_ISequencedProposal(get_old_ISequencedProposal());
+declare function use_current_ISequencedProposal(use: current.ISequencedProposal);
+use_current_ISequencedProposal(get_old_ISequencedProposal());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISequencedProposal": {"backCompat": false}
-declare function set_old_ISequencedProposal(set: old.ISequencedProposal);
 declare function get_current_ISequencedProposal(): current.ISequencedProposal;
-set_old_ISequencedProposal(get_current_ISequencedProposal());
+declare function use_old_ISequencedProposal(use: old.ISequencedProposal);
+use_old_ISequencedProposal(get_current_ISequencedProposal());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IServerError": {"forwardCompat": false}
-declare function set_current_IServerError(set: current.IServerError);
 declare function get_old_IServerError(): old.IServerError;
-set_current_IServerError(get_old_IServerError());
+declare function use_current_IServerError(use: current.IServerError);
+use_current_IServerError(get_old_IServerError());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IServerError": {"backCompat": false}
-declare function set_old_IServerError(set: old.IServerError);
 declare function get_current_IServerError(): current.IServerError;
-set_old_IServerError(get_current_IServerError());
+declare function use_old_IServerError(use: old.IServerError);
+use_old_IServerError(get_current_IServerError());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISignalClient": {"forwardCompat": false}
-declare function set_current_ISignalClient(set: current.ISignalClient);
 declare function get_old_ISignalClient(): old.ISignalClient;
-set_current_ISignalClient(get_old_ISignalClient());
+declare function use_current_ISignalClient(use: current.ISignalClient);
+use_current_ISignalClient(get_old_ISignalClient());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISignalClient": {"backCompat": false}
-declare function set_old_ISignalClient(set: old.ISignalClient);
 declare function get_current_ISignalClient(): current.ISignalClient;
-set_old_ISignalClient(get_current_ISignalClient());
+declare function use_old_ISignalClient(use: old.ISignalClient);
+use_old_ISignalClient(get_current_ISignalClient());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISignalMessage": {"forwardCompat": false}
-declare function set_current_ISignalMessage(set: current.ISignalMessage);
 declare function get_old_ISignalMessage(): old.ISignalMessage;
-set_current_ISignalMessage(get_old_ISignalMessage());
+declare function use_current_ISignalMessage(use: current.ISignalMessage);
+use_current_ISignalMessage(get_old_ISignalMessage());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISignalMessage": {"backCompat": false}
-declare function set_old_ISignalMessage(set: old.ISignalMessage);
 declare function get_current_ISignalMessage(): current.ISignalMessage;
-set_old_ISignalMessage(get_current_ISignalMessage());
+declare function use_old_ISignalMessage(use: old.ISignalMessage);
+use_old_ISignalMessage(get_current_ISignalMessage());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISnapshotTree": {"forwardCompat": false}
-declare function set_current_ISnapshotTree(set: current.ISnapshotTree);
 declare function get_old_ISnapshotTree(): old.ISnapshotTree;
-set_current_ISnapshotTree(get_old_ISnapshotTree());
+declare function use_current_ISnapshotTree(use: current.ISnapshotTree);
+use_current_ISnapshotTree(get_old_ISnapshotTree());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISnapshotTree": {"backCompat": false}
-declare function set_old_ISnapshotTree(set: old.ISnapshotTree);
 declare function get_current_ISnapshotTree(): current.ISnapshotTree;
-set_old_ISnapshotTree(get_current_ISnapshotTree());
+declare function use_old_ISnapshotTree(use: old.ISnapshotTree);
+use_old_ISnapshotTree(get_current_ISnapshotTree());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISnapshotTreeEx": {"forwardCompat": false}
-declare function set_current_ISnapshotTreeEx(set: current.ISnapshotTreeEx);
 declare function get_old_ISnapshotTreeEx(): old.ISnapshotTreeEx;
-set_current_ISnapshotTreeEx(get_old_ISnapshotTreeEx());
+declare function use_current_ISnapshotTreeEx(use: current.ISnapshotTreeEx);
+use_current_ISnapshotTreeEx(get_old_ISnapshotTreeEx());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISnapshotTreeEx": {"backCompat": false}
-declare function set_old_ISnapshotTreeEx(set: old.ISnapshotTreeEx);
 declare function get_current_ISnapshotTreeEx(): current.ISnapshotTreeEx;
-set_old_ISnapshotTreeEx(get_current_ISnapshotTreeEx());
+declare function use_old_ISnapshotTreeEx(use: old.ISnapshotTreeEx);
+use_old_ISnapshotTreeEx(get_current_ISnapshotTreeEx());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryAck": {"forwardCompat": false}
-declare function set_current_ISummaryAck(set: current.ISummaryAck);
 declare function get_old_ISummaryAck(): old.ISummaryAck;
-set_current_ISummaryAck(get_old_ISummaryAck());
+declare function use_current_ISummaryAck(use: current.ISummaryAck);
+use_current_ISummaryAck(get_old_ISummaryAck());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryAck": {"backCompat": false}
-declare function set_old_ISummaryAck(set: old.ISummaryAck);
 declare function get_current_ISummaryAck(): current.ISummaryAck;
-set_old_ISummaryAck(get_current_ISummaryAck());
+declare function use_old_ISummaryAck(use: old.ISummaryAck);
+use_old_ISummaryAck(get_current_ISummaryAck());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryAuthor": {"forwardCompat": false}
-declare function set_current_ISummaryAuthor(set: current.ISummaryAuthor);
 declare function get_old_ISummaryAuthor(): old.ISummaryAuthor;
-set_current_ISummaryAuthor(get_old_ISummaryAuthor());
+declare function use_current_ISummaryAuthor(use: current.ISummaryAuthor);
+use_current_ISummaryAuthor(get_old_ISummaryAuthor());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryAuthor": {"backCompat": false}
-declare function set_old_ISummaryAuthor(set: old.ISummaryAuthor);
 declare function get_current_ISummaryAuthor(): current.ISummaryAuthor;
-set_old_ISummaryAuthor(get_current_ISummaryAuthor());
+declare function use_old_ISummaryAuthor(use: old.ISummaryAuthor);
+use_old_ISummaryAuthor(get_current_ISummaryAuthor());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryCommitter": {"forwardCompat": false}
-declare function set_current_ISummaryCommitter(set: current.ISummaryCommitter);
 declare function get_old_ISummaryCommitter(): old.ISummaryCommitter;
-set_current_ISummaryCommitter(get_old_ISummaryCommitter());
+declare function use_current_ISummaryCommitter(use: current.ISummaryCommitter);
+use_current_ISummaryCommitter(get_old_ISummaryCommitter());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryCommitter": {"backCompat": false}
-declare function set_old_ISummaryCommitter(set: old.ISummaryCommitter);
 declare function get_current_ISummaryCommitter(): current.ISummaryCommitter;
-set_old_ISummaryCommitter(get_current_ISummaryCommitter());
+declare function use_old_ISummaryCommitter(use: old.ISummaryCommitter);
+use_old_ISummaryCommitter(get_current_ISummaryCommitter());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryConfiguration": {"forwardCompat": false}
-declare function set_current_ISummaryConfiguration(set: current.ISummaryConfiguration);
 declare function get_old_ISummaryConfiguration(): old.ISummaryConfiguration;
-set_current_ISummaryConfiguration(get_old_ISummaryConfiguration());
+declare function use_current_ISummaryConfiguration(use: current.ISummaryConfiguration);
+use_current_ISummaryConfiguration(get_old_ISummaryConfiguration());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryConfiguration": {"backCompat": false}
-declare function set_old_ISummaryConfiguration(set: old.ISummaryConfiguration);
 declare function get_current_ISummaryConfiguration(): current.ISummaryConfiguration;
-set_old_ISummaryConfiguration(get_current_ISummaryConfiguration());
+declare function use_old_ISummaryConfiguration(use: old.ISummaryConfiguration);
+use_old_ISummaryConfiguration(get_current_ISummaryConfiguration());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryContent": {"forwardCompat": false}
-declare function set_current_ISummaryContent(set: current.ISummaryContent);
 declare function get_old_ISummaryContent(): old.ISummaryContent;
-set_current_ISummaryContent(get_old_ISummaryContent());
+declare function use_current_ISummaryContent(use: current.ISummaryContent);
+use_current_ISummaryContent(get_old_ISummaryContent());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryContent": {"backCompat": false}
-declare function set_old_ISummaryContent(set: old.ISummaryContent);
 declare function get_current_ISummaryContent(): current.ISummaryContent;
-set_old_ISummaryContent(get_current_ISummaryContent());
+declare function use_old_ISummaryContent(use: old.ISummaryContent);
+use_old_ISummaryContent(get_current_ISummaryContent());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryNack": {"forwardCompat": false}
-declare function set_current_ISummaryNack(set: current.ISummaryNack);
 declare function get_old_ISummaryNack(): old.ISummaryNack;
-set_current_ISummaryNack(get_old_ISummaryNack());
+declare function use_current_ISummaryNack(use: current.ISummaryNack);
+use_current_ISummaryNack(get_old_ISummaryNack());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryNack": {"backCompat": false}
-declare function set_old_ISummaryNack(set: old.ISummaryNack);
 declare function get_current_ISummaryNack(): current.ISummaryNack;
-set_old_ISummaryNack(get_current_ISummaryNack());
+declare function use_old_ISummaryNack(use: old.ISummaryNack);
+use_old_ISummaryNack(get_current_ISummaryNack());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryProposal": {"forwardCompat": false}
-declare function set_current_ISummaryProposal(set: current.ISummaryProposal);
 declare function get_old_ISummaryProposal(): old.ISummaryProposal;
-set_current_ISummaryProposal(get_old_ISummaryProposal());
+declare function use_current_ISummaryProposal(use: current.ISummaryProposal);
+use_current_ISummaryProposal(get_old_ISummaryProposal());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryProposal": {"backCompat": false}
-declare function set_old_ISummaryProposal(set: old.ISummaryProposal);
 declare function get_current_ISummaryProposal(): current.ISummaryProposal;
-set_old_ISummaryProposal(get_current_ISummaryProposal());
+declare function use_old_ISummaryProposal(use: old.ISummaryProposal);
+use_old_ISummaryProposal(get_current_ISummaryProposal());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ISummaryTokenClaims": {"forwardCompat": false}
-declare function set_current_ISummaryTokenClaims(set: current.ISummaryTokenClaims);
 declare function get_old_ISummaryTokenClaims(): old.ISummaryTokenClaims;
-set_current_ISummaryTokenClaims(get_old_ISummaryTokenClaims());
+declare function use_current_ISummaryTokenClaims(use: current.ISummaryTokenClaims);
+use_current_ISummaryTokenClaims(get_old_ISummaryTokenClaims());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ISummaryTokenClaims": {"backCompat": false}
-declare function set_old_ISummaryTokenClaims(set: old.ISummaryTokenClaims);
 declare function get_current_ISummaryTokenClaims(): current.ISummaryTokenClaims;
-set_old_ISummaryTokenClaims(get_current_ISummaryTokenClaims());
+declare function use_old_ISummaryTokenClaims(use: old.ISummaryTokenClaims);
+use_old_ISummaryTokenClaims(get_current_ISummaryTokenClaims());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ITokenClaims": {"forwardCompat": false}
-declare function set_current_ITokenClaims(set: current.ITokenClaims);
 declare function get_old_ITokenClaims(): old.ITokenClaims;
-set_current_ITokenClaims(get_old_ITokenClaims());
+declare function use_current_ITokenClaims(use: current.ITokenClaims);
+use_current_ITokenClaims(get_old_ITokenClaims());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ITokenClaims": {"backCompat": false}
-declare function set_old_ITokenClaims(set: old.ITokenClaims);
 declare function get_current_ITokenClaims(): current.ITokenClaims;
-set_old_ITokenClaims(get_current_ITokenClaims());
+declare function use_old_ITokenClaims(use: old.ITokenClaims);
+use_old_ITokenClaims(get_current_ITokenClaims());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ITokenProvider": {"forwardCompat": false}
-declare function set_current_ITokenProvider(set: current.ITokenProvider);
 declare function get_old_ITokenProvider(): old.ITokenProvider;
-set_current_ITokenProvider(get_old_ITokenProvider());
+declare function use_current_ITokenProvider(use: current.ITokenProvider);
+use_current_ITokenProvider(get_old_ITokenProvider());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ITokenProvider": {"backCompat": false}
-declare function set_old_ITokenProvider(set: old.ITokenProvider);
 declare function get_current_ITokenProvider(): current.ITokenProvider;
-set_old_ITokenProvider(get_current_ITokenProvider());
+declare function use_old_ITokenProvider(use: old.ITokenProvider);
+use_old_ITokenProvider(get_current_ITokenProvider());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ITokenService": {"forwardCompat": false}
-declare function set_current_ITokenService(set: current.ITokenService);
 declare function get_old_ITokenService(): old.ITokenService;
-set_current_ITokenService(get_old_ITokenService());
+declare function use_current_ITokenService(use: current.ITokenService);
+use_current_ITokenService(get_old_ITokenService());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ITokenService": {"backCompat": false}
-declare function set_old_ITokenService(set: old.ITokenService);
 declare function get_current_ITokenService(): current.ITokenService;
-set_old_ITokenService(get_current_ITokenService());
+declare function use_old_ITokenService(use: old.ITokenService);
+use_old_ITokenService(get_current_ITokenService());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ITrace": {"forwardCompat": false}
-declare function set_current_ITrace(set: current.ITrace);
 declare function get_old_ITrace(): old.ITrace;
-set_current_ITrace(get_old_ITrace());
+declare function use_current_ITrace(use: current.ITrace);
+use_current_ITrace(get_old_ITrace());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ITrace": {"backCompat": false}
-declare function set_old_ITrace(set: old.ITrace);
 declare function get_current_ITrace(): current.ITrace;
-set_old_ITrace(get_current_ITrace());
+declare function use_old_ITrace(use: old.ITrace);
+use_old_ITrace(get_current_ITrace());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ITree": {"forwardCompat": false}
-declare function set_current_ITree(set: current.ITree);
 declare function get_old_ITree(): old.ITree;
-set_current_ITree(get_old_ITree());
+declare function use_current_ITree(use: current.ITree);
+use_current_ITree(get_old_ITree());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ITree": {"backCompat": false}
-declare function set_old_ITree(set: old.ITree);
 declare function get_current_ITree(): current.ITree;
-set_old_ITree(get_current_ITree());
+declare function use_old_ITree(use: old.ITree);
+use_old_ITree(get_current_ITree());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ITreeEntry": {"forwardCompat": false}
-declare function set_current_ITreeEntry(set: current.ITreeEntry);
 declare function get_old_ITreeEntry(): old.ITreeEntry;
-set_current_ITreeEntry(get_old_ITreeEntry());
+declare function use_current_ITreeEntry(use: current.ITreeEntry);
+use_current_ITreeEntry(get_old_ITreeEntry());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ITreeEntry": {"backCompat": false}
-declare function set_old_ITreeEntry(set: old.ITreeEntry);
 declare function get_current_ITreeEntry(): current.ITreeEntry;
-set_old_ITreeEntry(get_current_ITreeEntry());
+declare function use_old_ITreeEntry(use: old.ITreeEntry);
+use_old_ITreeEntry(get_current_ITreeEntry());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IUploadedSummaryDetails": {"forwardCompat": false}
-declare function set_current_IUploadedSummaryDetails(set: current.IUploadedSummaryDetails);
 declare function get_old_IUploadedSummaryDetails(): old.IUploadedSummaryDetails;
-set_current_IUploadedSummaryDetails(get_old_IUploadedSummaryDetails());
+declare function use_current_IUploadedSummaryDetails(use: current.IUploadedSummaryDetails);
+use_current_IUploadedSummaryDetails(get_old_IUploadedSummaryDetails());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IUploadedSummaryDetails": {"backCompat": false}
-declare function set_old_IUploadedSummaryDetails(set: old.IUploadedSummaryDetails);
 declare function get_current_IUploadedSummaryDetails(): current.IUploadedSummaryDetails;
-set_old_IUploadedSummaryDetails(get_current_IUploadedSummaryDetails());
+declare function use_old_IUploadedSummaryDetails(use: old.IUploadedSummaryDetails);
+use_old_IUploadedSummaryDetails(get_current_IUploadedSummaryDetails());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IUser": {"forwardCompat": false}
-declare function set_current_IUser(set: current.IUser);
 declare function get_old_IUser(): old.IUser;
-set_current_IUser(get_old_IUser());
+declare function use_current_IUser(use: current.IUser);
+use_current_IUser(get_old_IUser());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IUser": {"backCompat": false}
-declare function set_old_IUser(set: old.IUser);
 declare function get_current_IUser(): current.IUser;
-set_old_IUser(get_current_IUser());
+declare function use_old_IUser(use: old.IUser);
+use_old_IUser(get_current_IUser());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "IVersion": {"forwardCompat": false}
-declare function set_current_IVersion(set: current.IVersion);
 declare function get_old_IVersion(): old.IVersion;
-set_current_IVersion(get_old_IVersion());
+declare function use_current_IVersion(use: current.IVersion);
+use_current_IVersion(get_old_IVersion());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "IVersion": {"backCompat": false}
-declare function set_old_IVersion(set: old.IVersion);
 declare function get_current_IVersion(): current.IVersion;
-set_old_IVersion(get_current_IVersion());
+declare function use_old_IVersion(use: old.IVersion);
+use_old_IVersion(get_current_IVersion());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "MessageType": {"forwardCompat": false}
-declare function set_current_MessageType(set: current.MessageType);
 declare function get_old_MessageType(): old.MessageType;
-set_current_MessageType(get_old_MessageType());
+declare function use_current_MessageType(use: current.MessageType);
+use_current_MessageType(get_old_MessageType());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "MessageType": {"backCompat": false}
-declare function set_old_MessageType(set: old.MessageType);
 declare function get_current_MessageType(): current.MessageType;
-set_old_MessageType(get_current_MessageType());
+declare function use_old_MessageType(use: old.MessageType);
+use_old_MessageType(get_current_MessageType());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "NackErrorType": {"forwardCompat": false}
-declare function set_current_NackErrorType(set: current.NackErrorType);
 declare function get_old_NackErrorType(): old.NackErrorType;
-set_current_NackErrorType(get_old_NackErrorType());
+declare function use_current_NackErrorType(use: current.NackErrorType);
+use_current_NackErrorType(get_old_NackErrorType());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "NackErrorType": {"backCompat": false}
-declare function set_old_NackErrorType(set: old.NackErrorType);
 declare function get_current_NackErrorType(): current.NackErrorType;
-set_old_NackErrorType(get_current_NackErrorType());
+declare function use_old_NackErrorType(use: old.NackErrorType);
+use_old_NackErrorType(get_current_NackErrorType());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "ScopeType": {"forwardCompat": false}
-declare function set_current_ScopeType(set: current.ScopeType);
 declare function get_old_ScopeType(): old.ScopeType;
-set_current_ScopeType(get_old_ScopeType());
+declare function use_current_ScopeType(use: current.ScopeType);
+use_current_ScopeType(get_old_ScopeType());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "ScopeType": {"backCompat": false}
-declare function set_old_ScopeType(set: old.ScopeType);
 declare function get_current_ScopeType(): current.ScopeType;
-set_old_ScopeType(get_current_ScopeType());
+declare function use_old_ScopeType(use: old.ScopeType);
+use_old_ScopeType(get_current_ScopeType());
 
-// validate forward comapt of old type to new type
+// validate forward compat by using old type in place of current type
 // disable in package.json under typeValidation.broken:
 // "TreeEntry": {"forwardCompat": false}
-declare function set_current_TreeEntry(set: current.TreeEntry);
 declare function get_old_TreeEntry(): old.TreeEntry;
-set_current_TreeEntry(get_old_TreeEntry());
+declare function use_current_TreeEntry(use: current.TreeEntry);
+use_current_TreeEntry(get_old_TreeEntry());
 
-// validate backward comapt of new type to old type
+// validate back compat by using current type in place of old type
 // disable in package.json under typeValidation.broken:
 // "TreeEntry": {"backCompat": false}
-declare function set_old_TreeEntry(set: old.TreeEntry);
 declare function get_current_TreeEntry(): current.TreeEntry;
-set_old_TreeEntry(get_current_TreeEntry());
+declare function use_old_TreeEntry(use: old.TreeEntry);
+use_old_TreeEntry(get_current_TreeEntry());

--- a/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
@@ -6,828 +6,1226 @@
 import * as old from "@fluidframework/protocol-definitions-0.1024.0";
 import * as current from "../index";
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ConnectionMode": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ConnectionMode": {"forwardCompat": false}
+*/
 declare function get_old_ConnectionMode(): old.ConnectionMode;
 declare function use_current_ConnectionMode(use: current.ConnectionMode);
 use_current_ConnectionMode(get_old_ConnectionMode());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ConnectionMode": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ConnectionMode": {"backCompat": false}
+*/
 declare function get_current_ConnectionMode(): current.ConnectionMode;
 declare function use_old_ConnectionMode(use: old.ConnectionMode);
 use_old_ConnectionMode(get_current_ConnectionMode());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "FileMode": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "FileMode": {"forwardCompat": false}
+*/
 declare function get_old_FileMode(): old.FileMode;
 declare function use_current_FileMode(use: current.FileMode);
 use_current_FileMode(get_old_FileMode());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "FileMode": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "FileMode": {"backCompat": false}
+*/
 declare function get_current_FileMode(): current.FileMode;
 declare function use_old_FileMode(use: old.FileMode);
 use_old_FileMode(get_current_FileMode());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IActorClient": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IActorClient": {"forwardCompat": false}
+*/
 declare function get_old_IActorClient(): old.IActorClient;
 declare function use_current_IActorClient(use: current.IActorClient);
 use_current_IActorClient(get_old_IActorClient());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IActorClient": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IActorClient": {"backCompat": false}
+*/
 declare function get_current_IActorClient(): current.IActorClient;
 declare function use_old_IActorClient(use: old.IActorClient);
 use_old_IActorClient(get_current_IActorClient());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IApprovedProposal": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IApprovedProposal": {"forwardCompat": false}
+*/
 declare function get_old_IApprovedProposal(): old.IApprovedProposal;
 declare function use_current_IApprovedProposal(use: current.IApprovedProposal);
 use_current_IApprovedProposal(get_old_IApprovedProposal());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IApprovedProposal": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IApprovedProposal": {"backCompat": false}
+*/
 declare function get_current_IApprovedProposal(): current.IApprovedProposal;
 declare function use_old_IApprovedProposal(use: old.IApprovedProposal);
 use_old_IApprovedProposal(get_current_IApprovedProposal());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IAttachment": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IAttachment": {"forwardCompat": false}
+*/
 declare function get_old_IAttachment(): old.IAttachment;
 declare function use_current_IAttachment(use: current.IAttachment);
 use_current_IAttachment(get_old_IAttachment());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IAttachment": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IAttachment": {"backCompat": false}
+*/
 declare function get_current_IAttachment(): current.IAttachment;
 declare function use_old_IAttachment(use: old.IAttachment);
 use_old_IAttachment(get_current_IAttachment());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IBlob": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IBlob": {"forwardCompat": false}
+*/
 declare function get_old_IBlob(): old.IBlob;
 declare function use_current_IBlob(use: current.IBlob);
 use_current_IBlob(get_old_IBlob());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IBlob": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IBlob": {"backCompat": false}
+*/
 declare function get_current_IBlob(): current.IBlob;
 declare function use_old_IBlob(use: old.IBlob);
 use_old_IBlob(get_current_IBlob());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IBranchOrigin": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IBranchOrigin": {"forwardCompat": false}
+*/
 declare function get_old_IBranchOrigin(): old.IBranchOrigin;
 declare function use_current_IBranchOrigin(use: current.IBranchOrigin);
 use_current_IBranchOrigin(get_old_IBranchOrigin());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IBranchOrigin": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IBranchOrigin": {"backCompat": false}
+*/
 declare function get_current_IBranchOrigin(): current.IBranchOrigin;
 declare function use_old_IBranchOrigin(use: old.IBranchOrigin);
 use_old_IBranchOrigin(get_current_IBranchOrigin());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ICapabilities": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ICapabilities": {"forwardCompat": false}
+*/
 declare function get_old_ICapabilities(): old.ICapabilities;
 declare function use_current_ICapabilities(use: current.ICapabilities);
 use_current_ICapabilities(get_old_ICapabilities());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ICapabilities": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ICapabilities": {"backCompat": false}
+*/
 declare function get_current_ICapabilities(): current.ICapabilities;
 declare function use_old_ICapabilities(use: old.ICapabilities);
 use_old_ICapabilities(get_current_ICapabilities());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IClient": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IClient": {"forwardCompat": false}
+*/
 declare function get_old_IClient(): old.IClient;
 declare function use_current_IClient(use: current.IClient);
 use_current_IClient(get_old_IClient());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IClient": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IClient": {"backCompat": false}
+*/
 declare function get_current_IClient(): current.IClient;
 declare function use_old_IClient(use: old.IClient);
 use_old_IClient(get_current_IClient());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IClientConfiguration": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IClientConfiguration": {"forwardCompat": false}
+*/
 declare function get_old_IClientConfiguration(): old.IClientConfiguration;
 declare function use_current_IClientConfiguration(use: current.IClientConfiguration);
 use_current_IClientConfiguration(get_old_IClientConfiguration());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IClientConfiguration": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IClientConfiguration": {"backCompat": false}
+*/
 declare function get_current_IClientConfiguration(): current.IClientConfiguration;
 declare function use_old_IClientConfiguration(use: old.IClientConfiguration);
 use_old_IClientConfiguration(get_current_IClientConfiguration());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IClientDetails": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IClientDetails": {"forwardCompat": false}
+*/
 declare function get_old_IClientDetails(): old.IClientDetails;
 declare function use_current_IClientDetails(use: current.IClientDetails);
 use_current_IClientDetails(get_old_IClientDetails());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IClientDetails": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IClientDetails": {"backCompat": false}
+*/
 declare function get_current_IClientDetails(): current.IClientDetails;
 declare function use_old_IClientDetails(use: old.IClientDetails);
 use_old_IClientDetails(get_current_IClientDetails());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IClientJoin": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IClientJoin": {"forwardCompat": false}
+*/
 declare function get_old_IClientJoin(): old.IClientJoin;
 declare function use_current_IClientJoin(use: current.IClientJoin);
 use_current_IClientJoin(get_old_IClientJoin());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IClientJoin": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IClientJoin": {"backCompat": false}
+*/
 declare function get_current_IClientJoin(): current.IClientJoin;
 declare function use_old_IClientJoin(use: old.IClientJoin);
 use_old_IClientJoin(get_current_IClientJoin());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ICommittedProposal": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ICommittedProposal": {"forwardCompat": false}
+*/
 declare function get_old_ICommittedProposal(): old.ICommittedProposal;
 declare function use_current_ICommittedProposal(use: current.ICommittedProposal);
 use_current_ICommittedProposal(get_old_ICommittedProposal());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ICommittedProposal": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ICommittedProposal": {"backCompat": false}
+*/
 declare function get_current_ICommittedProposal(): current.ICommittedProposal;
 declare function use_old_ICommittedProposal(use: old.ICommittedProposal);
 use_old_ICommittedProposal(get_current_ICommittedProposal());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IConnect": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IConnect": {"forwardCompat": false}
+*/
 declare function get_old_IConnect(): old.IConnect;
 declare function use_current_IConnect(use: current.IConnect);
 use_current_IConnect(get_old_IConnect());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IConnect": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IConnect": {"backCompat": false}
+*/
 declare function get_current_IConnect(): current.IConnect;
 declare function use_old_IConnect(use: old.IConnect);
 use_old_IConnect(get_current_IConnect());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IConnected": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IConnected": {"forwardCompat": false}
+*/
 declare function get_old_IConnected(): old.IConnected;
 declare function use_current_IConnected(use: current.IConnected);
 use_current_IConnected(get_old_IConnected());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IConnected": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IConnected": {"backCompat": false}
+*/
 declare function get_current_IConnected(): current.IConnected;
 declare function use_old_IConnected(use: old.IConnected);
 use_old_IConnected(get_current_IConnected());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ICreateBlobResponse": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ICreateBlobResponse": {"forwardCompat": false}
+*/
 declare function get_old_ICreateBlobResponse(): old.ICreateBlobResponse;
 declare function use_current_ICreateBlobResponse(use: current.ICreateBlobResponse);
 use_current_ICreateBlobResponse(get_old_ICreateBlobResponse());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IDocumentAttributes": {"forwardCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ICreateBlobResponse": {"backCompat": false}
+declare function get_current_ICreateBlobResponse(): current.ICreateBlobResponse;
+declare function use_old_ICreateBlobResponse(use: old.ICreateBlobResponse);
+use_old_ICreateBlobResponse(get_current_ICreateBlobResponse());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IDocumentAttributes": {"forwardCompat": false}
+*/
 declare function get_old_IDocumentAttributes(): old.IDocumentAttributes;
 declare function use_current_IDocumentAttributes(use: current.IDocumentAttributes);
 use_current_IDocumentAttributes(get_old_IDocumentAttributes());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IDocumentAttributes": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IDocumentAttributes": {"backCompat": false}
+*/
 declare function get_current_IDocumentAttributes(): current.IDocumentAttributes;
 declare function use_old_IDocumentAttributes(use: old.IDocumentAttributes);
 use_old_IDocumentAttributes(get_current_IDocumentAttributes());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IDocumentMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IDocumentMessage": {"forwardCompat": false}
+*/
 declare function get_old_IDocumentMessage(): old.IDocumentMessage;
 declare function use_current_IDocumentMessage(use: current.IDocumentMessage);
 use_current_IDocumentMessage(get_old_IDocumentMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IDocumentMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IDocumentMessage": {"backCompat": false}
+*/
 declare function get_current_IDocumentMessage(): current.IDocumentMessage;
 declare function use_old_IDocumentMessage(use: old.IDocumentMessage);
 use_old_IDocumentMessage(get_current_IDocumentMessage());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IDocumentSystemMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IDocumentSystemMessage": {"forwardCompat": false}
+*/
 declare function get_old_IDocumentSystemMessage(): old.IDocumentSystemMessage;
 declare function use_current_IDocumentSystemMessage(use: current.IDocumentSystemMessage);
 use_current_IDocumentSystemMessage(get_old_IDocumentSystemMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IDocumentSystemMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IDocumentSystemMessage": {"backCompat": false}
+*/
 declare function get_current_IDocumentSystemMessage(): current.IDocumentSystemMessage;
 declare function use_old_IDocumentSystemMessage(use: old.IDocumentSystemMessage);
 use_old_IDocumentSystemMessage(get_current_IDocumentSystemMessage());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IHelpMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IHelpMessage": {"forwardCompat": false}
+*/
 declare function get_old_IHelpMessage(): old.IHelpMessage;
 declare function use_current_IHelpMessage(use: current.IHelpMessage);
 use_current_IHelpMessage(get_old_IHelpMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IHelpMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IHelpMessage": {"backCompat": false}
+*/
 declare function get_current_IHelpMessage(): current.IHelpMessage;
 declare function use_old_IHelpMessage(use: old.IHelpMessage);
 use_old_IHelpMessage(get_current_IHelpMessage());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "INack": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "INack": {"forwardCompat": false}
+*/
 declare function get_old_INack(): old.INack;
 declare function use_current_INack(use: current.INack);
 use_current_INack(get_old_INack());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "INack": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "INack": {"backCompat": false}
+*/
 declare function get_current_INack(): current.INack;
 declare function use_old_INack(use: old.INack);
 use_old_INack(get_current_INack());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "INackContent": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "INackContent": {"forwardCompat": false}
+*/
 declare function get_old_INackContent(): old.INackContent;
 declare function use_current_INackContent(use: current.INackContent);
 use_current_INackContent(get_old_INackContent());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "INackContent": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "INackContent": {"backCompat": false}
+*/
 declare function get_current_INackContent(): current.INackContent;
 declare function use_old_INackContent(use: old.INackContent);
 use_old_INackContent(get_current_INackContent());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IPendingProposal": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IPendingProposal": {"forwardCompat": false}
+*/
 declare function get_old_IPendingProposal(): old.IPendingProposal;
 declare function use_current_IPendingProposal(use: current.IPendingProposal);
 use_current_IPendingProposal(get_old_IPendingProposal());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IPendingProposal": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IPendingProposal": {"backCompat": false}
+*/
 declare function get_current_IPendingProposal(): current.IPendingProposal;
 declare function use_old_IPendingProposal(use: old.IPendingProposal);
 use_old_IPendingProposal(get_current_IPendingProposal());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IProcessMessageResult": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IProcessMessageResult": {"forwardCompat": false}
+*/
 declare function get_old_IProcessMessageResult(): old.IProcessMessageResult;
 declare function use_current_IProcessMessageResult(use: current.IProcessMessageResult);
 use_current_IProcessMessageResult(get_old_IProcessMessageResult());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IProcessMessageResult": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IProcessMessageResult": {"backCompat": false}
+*/
 declare function get_current_IProcessMessageResult(): current.IProcessMessageResult;
 declare function use_old_IProcessMessageResult(use: old.IProcessMessageResult);
 use_old_IProcessMessageResult(get_current_IProcessMessageResult());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IProposal": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IProposal": {"forwardCompat": false}
+*/
 declare function get_old_IProposal(): old.IProposal;
 declare function use_current_IProposal(use: current.IProposal);
 use_current_IProposal(get_old_IProposal());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IProposal": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IProposal": {"backCompat": false}
+*/
 declare function get_current_IProposal(): current.IProposal;
 declare function use_old_IProposal(use: old.IProposal);
 use_old_IProposal(get_current_IProposal());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IProtocolState": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IProtocolState": {"forwardCompat": false}
+*/
 declare function get_old_IProtocolState(): old.IProtocolState;
 declare function use_current_IProtocolState(use: current.IProtocolState);
 use_current_IProtocolState(get_old_IProtocolState());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IProtocolState": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IProtocolState": {"backCompat": false}
+*/
 declare function get_current_IProtocolState(): current.IProtocolState;
 declare function use_old_IProtocolState(use: old.IProtocolState);
 use_old_IProtocolState(get_current_IProtocolState());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IQueueMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IQueueMessage": {"forwardCompat": false}
+*/
 declare function get_old_IQueueMessage(): old.IQueueMessage;
 declare function use_current_IQueueMessage(use: current.IQueueMessage);
 use_current_IQueueMessage(get_old_IQueueMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IQueueMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IQueueMessage": {"backCompat": false}
+*/
 declare function get_current_IQueueMessage(): current.IQueueMessage;
 declare function use_old_IQueueMessage(use: old.IQueueMessage);
 use_old_IQueueMessage(get_current_IQueueMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IQuorum": {"backCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IQuorum": {"forwardCompat": false}
+declare function get_old_IQuorum(): old.IQuorum;
+declare function use_current_IQuorum(use: current.IQuorum);
+use_current_IQuorum(get_old_IQuorum());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IQuorum": {"backCompat": false}
+*/
 declare function get_current_IQuorum(): current.IQuorum;
 declare function use_old_IQuorum(use: old.IQuorum);
 use_old_IQuorum(get_current_IQuorum());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IQuorumEvents": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IQuorumEvents": {"forwardCompat": false}
+*/
 declare function get_old_IQuorumEvents(): old.IQuorumEvents;
 declare function use_current_IQuorumEvents(use: current.IQuorumEvents);
 use_current_IQuorumEvents(get_old_IQuorumEvents());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IQuorumEvents": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IQuorumEvents": {"backCompat": false}
+*/
 declare function get_current_IQuorumEvents(): current.IQuorumEvents;
 declare function use_old_IQuorumEvents(use: old.IQuorumEvents);
 use_old_IQuorumEvents(get_current_IQuorumEvents());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISequencedClient": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISequencedClient": {"forwardCompat": false}
+*/
 declare function get_old_ISequencedClient(): old.ISequencedClient;
 declare function use_current_ISequencedClient(use: current.ISequencedClient);
 use_current_ISequencedClient(get_old_ISequencedClient());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISequencedClient": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISequencedClient": {"backCompat": false}
+*/
 declare function get_current_ISequencedClient(): current.ISequencedClient;
 declare function use_old_ISequencedClient(use: old.ISequencedClient);
 use_old_ISequencedClient(get_current_ISequencedClient());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISequencedDocumentAugmentedMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISequencedDocumentAugmentedMessage": {"forwardCompat": false}
+*/
 declare function get_old_ISequencedDocumentAugmentedMessage(): old.ISequencedDocumentAugmentedMessage;
 declare function use_current_ISequencedDocumentAugmentedMessage(use: current.ISequencedDocumentAugmentedMessage);
 use_current_ISequencedDocumentAugmentedMessage(get_old_ISequencedDocumentAugmentedMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISequencedDocumentAugmentedMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISequencedDocumentAugmentedMessage": {"backCompat": false}
+*/
 declare function get_current_ISequencedDocumentAugmentedMessage(): current.ISequencedDocumentAugmentedMessage;
 declare function use_old_ISequencedDocumentAugmentedMessage(use: old.ISequencedDocumentAugmentedMessage);
 use_old_ISequencedDocumentAugmentedMessage(get_current_ISequencedDocumentAugmentedMessage());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISequencedDocumentMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISequencedDocumentMessage": {"forwardCompat": false}
+*/
 declare function get_old_ISequencedDocumentMessage(): old.ISequencedDocumentMessage;
 declare function use_current_ISequencedDocumentMessage(use: current.ISequencedDocumentMessage);
 use_current_ISequencedDocumentMessage(get_old_ISequencedDocumentMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISequencedDocumentMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISequencedDocumentMessage": {"backCompat": false}
+*/
 declare function get_current_ISequencedDocumentMessage(): current.ISequencedDocumentMessage;
 declare function use_old_ISequencedDocumentMessage(use: old.ISequencedDocumentMessage);
 use_old_ISequencedDocumentMessage(get_current_ISequencedDocumentMessage());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISequencedDocumentSystemMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISequencedDocumentSystemMessage": {"forwardCompat": false}
+*/
 declare function get_old_ISequencedDocumentSystemMessage(): old.ISequencedDocumentSystemMessage;
 declare function use_current_ISequencedDocumentSystemMessage(use: current.ISequencedDocumentSystemMessage);
 use_current_ISequencedDocumentSystemMessage(get_old_ISequencedDocumentSystemMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISequencedDocumentSystemMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISequencedDocumentSystemMessage": {"backCompat": false}
+*/
 declare function get_current_ISequencedDocumentSystemMessage(): current.ISequencedDocumentSystemMessage;
 declare function use_old_ISequencedDocumentSystemMessage(use: old.ISequencedDocumentSystemMessage);
 use_old_ISequencedDocumentSystemMessage(get_current_ISequencedDocumentSystemMessage());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISequencedProposal": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISequencedProposal": {"forwardCompat": false}
+*/
 declare function get_old_ISequencedProposal(): old.ISequencedProposal;
 declare function use_current_ISequencedProposal(use: current.ISequencedProposal);
 use_current_ISequencedProposal(get_old_ISequencedProposal());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISequencedProposal": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISequencedProposal": {"backCompat": false}
+*/
 declare function get_current_ISequencedProposal(): current.ISequencedProposal;
 declare function use_old_ISequencedProposal(use: old.ISequencedProposal);
 use_old_ISequencedProposal(get_current_ISequencedProposal());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IServerError": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IServerError": {"forwardCompat": false}
+*/
 declare function get_old_IServerError(): old.IServerError;
 declare function use_current_IServerError(use: current.IServerError);
 use_current_IServerError(get_old_IServerError());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IServerError": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IServerError": {"backCompat": false}
+*/
 declare function get_current_IServerError(): current.IServerError;
 declare function use_old_IServerError(use: old.IServerError);
 use_old_IServerError(get_current_IServerError());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISignalClient": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISignalClient": {"forwardCompat": false}
+*/
 declare function get_old_ISignalClient(): old.ISignalClient;
 declare function use_current_ISignalClient(use: current.ISignalClient);
 use_current_ISignalClient(get_old_ISignalClient());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISignalClient": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISignalClient": {"backCompat": false}
+*/
 declare function get_current_ISignalClient(): current.ISignalClient;
 declare function use_old_ISignalClient(use: old.ISignalClient);
 use_old_ISignalClient(get_current_ISignalClient());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISignalMessage": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISignalMessage": {"forwardCompat": false}
+*/
 declare function get_old_ISignalMessage(): old.ISignalMessage;
 declare function use_current_ISignalMessage(use: current.ISignalMessage);
 use_current_ISignalMessage(get_old_ISignalMessage());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISignalMessage": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISignalMessage": {"backCompat": false}
+*/
 declare function get_current_ISignalMessage(): current.ISignalMessage;
 declare function use_old_ISignalMessage(use: old.ISignalMessage);
 use_old_ISignalMessage(get_current_ISignalMessage());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISnapshotTree": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISnapshotTree": {"forwardCompat": false}
+*/
 declare function get_old_ISnapshotTree(): old.ISnapshotTree;
 declare function use_current_ISnapshotTree(use: current.ISnapshotTree);
 use_current_ISnapshotTree(get_old_ISnapshotTree());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISnapshotTree": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISnapshotTree": {"backCompat": false}
+*/
 declare function get_current_ISnapshotTree(): current.ISnapshotTree;
 declare function use_old_ISnapshotTree(use: old.ISnapshotTree);
 use_old_ISnapshotTree(get_current_ISnapshotTree());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISnapshotTreeEx": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISnapshotTreeEx": {"forwardCompat": false}
+*/
 declare function get_old_ISnapshotTreeEx(): old.ISnapshotTreeEx;
 declare function use_current_ISnapshotTreeEx(use: current.ISnapshotTreeEx);
 use_current_ISnapshotTreeEx(get_old_ISnapshotTreeEx());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISnapshotTreeEx": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISnapshotTreeEx": {"backCompat": false}
+*/
 declare function get_current_ISnapshotTreeEx(): current.ISnapshotTreeEx;
 declare function use_old_ISnapshotTreeEx(use: old.ISnapshotTreeEx);
 use_old_ISnapshotTreeEx(get_current_ISnapshotTreeEx());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryAck": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryAck": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryAck(): old.ISummaryAck;
 declare function use_current_ISummaryAck(use: current.ISummaryAck);
 use_current_ISummaryAck(get_old_ISummaryAck());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryAck": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryAck": {"backCompat": false}
+*/
 declare function get_current_ISummaryAck(): current.ISummaryAck;
 declare function use_old_ISummaryAck(use: old.ISummaryAck);
 use_old_ISummaryAck(get_current_ISummaryAck());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryAuthor": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryAttachment": {"forwardCompat": false}
+declare function get_old_ISummaryAttachment(): old.ISummaryAttachment;
+declare function use_current_ISummaryAttachment(use: current.ISummaryAttachment);
+use_current_ISummaryAttachment(get_old_ISummaryAttachment());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryAttachment": {"backCompat": false}
+declare function get_current_ISummaryAttachment(): current.ISummaryAttachment;
+declare function use_old_ISummaryAttachment(use: old.ISummaryAttachment);
+use_old_ISummaryAttachment(get_current_ISummaryAttachment());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryAuthor": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryAuthor(): old.ISummaryAuthor;
 declare function use_current_ISummaryAuthor(use: current.ISummaryAuthor);
 use_current_ISummaryAuthor(get_old_ISummaryAuthor());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryAuthor": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryAuthor": {"backCompat": false}
+*/
 declare function get_current_ISummaryAuthor(): current.ISummaryAuthor;
 declare function use_old_ISummaryAuthor(use: old.ISummaryAuthor);
 use_old_ISummaryAuthor(get_current_ISummaryAuthor());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryCommitter": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryBlob": {"forwardCompat": false}
+declare function get_old_ISummaryBlob(): old.ISummaryBlob;
+declare function use_current_ISummaryBlob(use: current.ISummaryBlob);
+use_current_ISummaryBlob(get_old_ISummaryBlob());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryBlob": {"backCompat": false}
+declare function get_current_ISummaryBlob(): current.ISummaryBlob;
+declare function use_old_ISummaryBlob(use: old.ISummaryBlob);
+use_old_ISummaryBlob(get_current_ISummaryBlob());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryCommitter": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryCommitter(): old.ISummaryCommitter;
 declare function use_current_ISummaryCommitter(use: current.ISummaryCommitter);
 use_current_ISummaryCommitter(get_old_ISummaryCommitter());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryCommitter": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryCommitter": {"backCompat": false}
+*/
 declare function get_current_ISummaryCommitter(): current.ISummaryCommitter;
 declare function use_old_ISummaryCommitter(use: old.ISummaryCommitter);
 use_old_ISummaryCommitter(get_current_ISummaryCommitter());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryConfiguration": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryConfiguration": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryConfiguration(): old.ISummaryConfiguration;
 declare function use_current_ISummaryConfiguration(use: current.ISummaryConfiguration);
 use_current_ISummaryConfiguration(get_old_ISummaryConfiguration());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryConfiguration": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryConfiguration": {"backCompat": false}
+*/
 declare function get_current_ISummaryConfiguration(): current.ISummaryConfiguration;
 declare function use_old_ISummaryConfiguration(use: old.ISummaryConfiguration);
 use_old_ISummaryConfiguration(get_current_ISummaryConfiguration());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryContent": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryContent": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryContent(): old.ISummaryContent;
 declare function use_current_ISummaryContent(use: current.ISummaryContent);
 use_current_ISummaryContent(get_old_ISummaryContent());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryContent": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryContent": {"backCompat": false}
+*/
 declare function get_current_ISummaryContent(): current.ISummaryContent;
 declare function use_old_ISummaryContent(use: old.ISummaryContent);
 use_old_ISummaryContent(get_current_ISummaryContent());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryNack": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryHandle": {"forwardCompat": false}
+declare function get_old_ISummaryHandle(): old.ISummaryHandle;
+declare function use_current_ISummaryHandle(use: current.ISummaryHandle);
+use_current_ISummaryHandle(get_old_ISummaryHandle());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryHandle": {"backCompat": false}
+declare function get_current_ISummaryHandle(): current.ISummaryHandle;
+declare function use_old_ISummaryHandle(use: old.ISummaryHandle);
+use_old_ISummaryHandle(get_current_ISummaryHandle());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryNack": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryNack(): old.ISummaryNack;
 declare function use_current_ISummaryNack(use: current.ISummaryNack);
 use_current_ISummaryNack(get_old_ISummaryNack());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryNack": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryNack": {"backCompat": false}
+*/
 declare function get_current_ISummaryNack(): current.ISummaryNack;
 declare function use_old_ISummaryNack(use: old.ISummaryNack);
 use_old_ISummaryNack(get_current_ISummaryNack());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryProposal": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryProposal": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryProposal(): old.ISummaryProposal;
 declare function use_current_ISummaryProposal(use: current.ISummaryProposal);
 use_current_ISummaryProposal(get_old_ISummaryProposal());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryProposal": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryProposal": {"backCompat": false}
+*/
 declare function get_current_ISummaryProposal(): current.ISummaryProposal;
 declare function use_old_ISummaryProposal(use: old.ISummaryProposal);
 use_old_ISummaryProposal(get_current_ISummaryProposal());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ISummaryTokenClaims": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryTokenClaims": {"forwardCompat": false}
+*/
 declare function get_old_ISummaryTokenClaims(): old.ISummaryTokenClaims;
 declare function use_current_ISummaryTokenClaims(use: current.ISummaryTokenClaims);
 use_current_ISummaryTokenClaims(get_old_ISummaryTokenClaims());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ISummaryTokenClaims": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryTokenClaims": {"backCompat": false}
+*/
 declare function get_current_ISummaryTokenClaims(): current.ISummaryTokenClaims;
 declare function use_old_ISummaryTokenClaims(use: old.ISummaryTokenClaims);
 use_old_ISummaryTokenClaims(get_current_ISummaryTokenClaims());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ITokenClaims": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ISummaryTree": {"forwardCompat": false}
+declare function get_old_ISummaryTree(): old.ISummaryTree;
+declare function use_current_ISummaryTree(use: current.ISummaryTree);
+use_current_ISummaryTree(get_old_ISummaryTree());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ISummaryTree": {"backCompat": false}
+declare function get_current_ISummaryTree(): current.ISummaryTree;
+declare function use_old_ISummaryTree(use: old.ISummaryTree);
+use_old_ISummaryTree(get_current_ISummaryTree());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ITokenClaims": {"forwardCompat": false}
+*/
 declare function get_old_ITokenClaims(): old.ITokenClaims;
 declare function use_current_ITokenClaims(use: current.ITokenClaims);
 use_current_ITokenClaims(get_old_ITokenClaims());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ITokenClaims": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ITokenClaims": {"backCompat": false}
+*/
 declare function get_current_ITokenClaims(): current.ITokenClaims;
 declare function use_old_ITokenClaims(use: old.ITokenClaims);
 use_old_ITokenClaims(get_current_ITokenClaims());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ITokenProvider": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ITokenProvider": {"forwardCompat": false}
+*/
 declare function get_old_ITokenProvider(): old.ITokenProvider;
 declare function use_current_ITokenProvider(use: current.ITokenProvider);
 use_current_ITokenProvider(get_old_ITokenProvider());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ITokenProvider": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ITokenProvider": {"backCompat": false}
+*/
 declare function get_current_ITokenProvider(): current.ITokenProvider;
 declare function use_old_ITokenProvider(use: old.ITokenProvider);
 use_old_ITokenProvider(get_current_ITokenProvider());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ITokenService": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ITokenService": {"forwardCompat": false}
+*/
 declare function get_old_ITokenService(): old.ITokenService;
 declare function use_current_ITokenService(use: current.ITokenService);
 use_current_ITokenService(get_old_ITokenService());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ITokenService": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ITokenService": {"backCompat": false}
+*/
 declare function get_current_ITokenService(): current.ITokenService;
 declare function use_old_ITokenService(use: old.ITokenService);
 use_old_ITokenService(get_current_ITokenService());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ITrace": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ITrace": {"forwardCompat": false}
+*/
 declare function get_old_ITrace(): old.ITrace;
 declare function use_current_ITrace(use: current.ITrace);
 use_current_ITrace(get_old_ITrace());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ITrace": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ITrace": {"backCompat": false}
+*/
 declare function get_current_ITrace(): current.ITrace;
 declare function use_old_ITrace(use: old.ITrace);
 use_old_ITrace(get_current_ITrace());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ITree": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ITree": {"forwardCompat": false}
+*/
 declare function get_old_ITree(): old.ITree;
 declare function use_current_ITree(use: current.ITree);
 use_current_ITree(get_old_ITree());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ITree": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ITree": {"backCompat": false}
+*/
 declare function get_current_ITree(): current.ITree;
 declare function use_old_ITree(use: old.ITree);
 use_old_ITree(get_current_ITree());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ITreeEntry": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ITreeEntry": {"forwardCompat": false}
+*/
 declare function get_old_ITreeEntry(): old.ITreeEntry;
 declare function use_current_ITreeEntry(use: current.ITreeEntry);
 use_current_ITreeEntry(get_old_ITreeEntry());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ITreeEntry": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ITreeEntry": {"backCompat": false}
+*/
 declare function get_current_ITreeEntry(): current.ITreeEntry;
 declare function use_old_ITreeEntry(use: old.ITreeEntry);
 use_old_ITreeEntry(get_current_ITreeEntry());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IUploadedSummaryDetails": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IUploadedSummaryDetails": {"forwardCompat": false}
+*/
 declare function get_old_IUploadedSummaryDetails(): old.IUploadedSummaryDetails;
 declare function use_current_IUploadedSummaryDetails(use: current.IUploadedSummaryDetails);
 use_current_IUploadedSummaryDetails(get_old_IUploadedSummaryDetails());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IUploadedSummaryDetails": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IUploadedSummaryDetails": {"backCompat": false}
+*/
 declare function get_current_IUploadedSummaryDetails(): current.IUploadedSummaryDetails;
 declare function use_old_IUploadedSummaryDetails(use: old.IUploadedSummaryDetails);
 use_old_IUploadedSummaryDetails(get_current_IUploadedSummaryDetails());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IUser": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IUser": {"forwardCompat": false}
+*/
 declare function get_old_IUser(): old.IUser;
 declare function use_current_IUser(use: current.IUser);
 use_current_IUser(get_old_IUser());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IUser": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IUser": {"backCompat": false}
+*/
 declare function get_current_IUser(): current.IUser;
 declare function use_old_IUser(use: old.IUser);
 use_old_IUser(get_current_IUser());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "IVersion": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "IVersion": {"forwardCompat": false}
+*/
 declare function get_old_IVersion(): old.IVersion;
 declare function use_current_IVersion(use: current.IVersion);
 use_current_IVersion(get_old_IVersion());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "IVersion": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "IVersion": {"backCompat": false}
+*/
 declare function get_current_IVersion(): current.IVersion;
 declare function use_old_IVersion(use: old.IVersion);
 use_old_IVersion(get_current_IVersion());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "MessageType": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "MessageType": {"forwardCompat": false}
+*/
 declare function get_old_MessageType(): old.MessageType;
 declare function use_current_MessageType(use: current.MessageType);
 use_current_MessageType(get_old_MessageType());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "MessageType": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "MessageType": {"backCompat": false}
+*/
 declare function get_current_MessageType(): current.MessageType;
 declare function use_old_MessageType(use: old.MessageType);
 use_old_MessageType(get_current_MessageType());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "NackErrorType": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "NackErrorType": {"forwardCompat": false}
+*/
 declare function get_old_NackErrorType(): old.NackErrorType;
 declare function use_current_NackErrorType(use: current.NackErrorType);
 use_current_NackErrorType(get_old_NackErrorType());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "NackErrorType": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "NackErrorType": {"backCompat": false}
+*/
 declare function get_current_NackErrorType(): current.NackErrorType;
 declare function use_old_NackErrorType(use: old.NackErrorType);
 use_old_NackErrorType(get_current_NackErrorType());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "ScopeType": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "ScopeType": {"forwardCompat": false}
+*/
 declare function get_old_ScopeType(): old.ScopeType;
 declare function use_current_ScopeType(use: current.ScopeType);
 use_current_ScopeType(get_old_ScopeType());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "ScopeType": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "ScopeType": {"backCompat": false}
+*/
 declare function get_current_ScopeType(): current.ScopeType;
 declare function use_old_ScopeType(use: old.ScopeType);
 use_old_ScopeType(get_current_ScopeType());
 
-// validate forward compat by using old type in place of current type
-// disable in package.json under typeValidation.broken:
-// "TreeEntry": {"forwardCompat": false}
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "SummaryObject": {"forwardCompat": false}
+declare function get_old_SummaryObject(): old.SummaryObject;
+declare function use_current_SummaryObject(use: current.SummaryObject);
+use_current_SummaryObject(get_old_SummaryObject());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "SummaryObject": {"backCompat": false}
+declare function get_current_SummaryObject(): current.SummaryObject;
+declare function use_old_SummaryObject(use: old.SummaryObject);
+use_old_SummaryObject(get_current_SummaryObject());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "SummaryTree": {"forwardCompat": false}
+declare function get_old_SummaryTree(): old.SummaryTree;
+declare function use_current_SummaryTree(use: current.SummaryTree);
+use_current_SummaryTree(get_old_SummaryTree());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "SummaryTree": {"backCompat": false}
+declare function get_current_SummaryTree(): current.SummaryTree;
+declare function use_old_SummaryTree(use: old.SummaryTree);
+use_old_SummaryTree(get_current_SummaryTree());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "SummaryType": {"forwardCompat": false}
+declare function get_old_SummaryType(): old.SummaryType;
+declare function use_current_SummaryType(use: current.SummaryType);
+use_current_SummaryType(get_old_SummaryType());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "SummaryType": {"backCompat": false}
+declare function get_current_SummaryType(): current.SummaryType;
+declare function use_old_SummaryType(use: old.SummaryType);
+use_old_SummaryType(get_current_SummaryType());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "SummaryTypeNoHandle": {"forwardCompat": false}
+declare function get_old_SummaryTypeNoHandle(): old.SummaryTypeNoHandle;
+declare function use_current_SummaryTypeNoHandle(use: current.SummaryTypeNoHandle);
+use_current_SummaryTypeNoHandle(get_old_SummaryTypeNoHandle());
+*/
+
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "SummaryTypeNoHandle": {"backCompat": false}
+declare function get_current_SummaryTypeNoHandle(): current.SummaryTypeNoHandle;
+declare function use_old_SummaryTypeNoHandle(use: old.SummaryTypeNoHandle);
+use_old_SummaryTypeNoHandle(get_current_SummaryTypeNoHandle());
+*/
+
+/*
+* validate forward compat by using old type in place of current type
+* disable in package.json under typeValidation.broken:
+* "TreeEntry": {"forwardCompat": false}
+*/
 declare function get_old_TreeEntry(): old.TreeEntry;
 declare function use_current_TreeEntry(use: current.TreeEntry);
 use_current_TreeEntry(get_old_TreeEntry());
 
-// validate back compat by using current type in place of old type
-// disable in package.json under typeValidation.broken:
-// "TreeEntry": {"backCompat": false}
+/*
+* validate back compat by using current type in place of old type
+* disable in package.json under typeValidation.broken:
+* "TreeEntry": {"backCompat": false}
+*/
 declare function get_current_TreeEntry(): current.TreeEntry;
 declare function use_old_TreeEntry(use: old.TreeEntry);
 use_old_TreeEntry(get_current_TreeEntry());

--- a/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
@@ -6,356 +6,828 @@
 import * as old from "@fluidframework/protocol-definitions-0.1024.0";
 import * as current from "../index";
 
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ConnectionMode": {"forwardCompat": false}
+declare function set_current_ConnectionMode(set: current.ConnectionMode);
 declare function get_old_ConnectionMode(): old.ConnectionMode;
-const currentConnectionMode: current.ConnectionMode = get_old_ConnectionMode();
-declare function set_old_ConnectionMode(oldVal: old.ConnectionMode);
-set_old_ConnectionMode(currentConnectionMode);
+set_current_ConnectionMode(get_old_ConnectionMode());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ConnectionMode": {"backCompat": false}
+declare function set_old_ConnectionMode(set: old.ConnectionMode);
+declare function get_current_ConnectionMode(): current.ConnectionMode;
+set_old_ConnectionMode(get_current_ConnectionMode());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "FileMode": {"forwardCompat": false}
+declare function set_current_FileMode(set: current.FileMode);
 declare function get_old_FileMode(): old.FileMode;
-const currentFileMode: current.FileMode = get_old_FileMode();
-declare function set_old_FileMode(oldVal: old.FileMode);
-set_old_FileMode(currentFileMode);
+set_current_FileMode(get_old_FileMode());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "FileMode": {"backCompat": false}
+declare function set_old_FileMode(set: old.FileMode);
+declare function get_current_FileMode(): current.FileMode;
+set_old_FileMode(get_current_FileMode());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IActorClient": {"forwardCompat": false}
+declare function set_current_IActorClient(set: current.IActorClient);
 declare function get_old_IActorClient(): old.IActorClient;
-const currentIActorClient: current.IActorClient = get_old_IActorClient();
-declare function set_old_IActorClient(oldVal: old.IActorClient);
-set_old_IActorClient(currentIActorClient);
+set_current_IActorClient(get_old_IActorClient());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IActorClient": {"backCompat": false}
+declare function set_old_IActorClient(set: old.IActorClient);
+declare function get_current_IActorClient(): current.IActorClient;
+set_old_IActorClient(get_current_IActorClient());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IApprovedProposal": {"forwardCompat": false}
+declare function set_current_IApprovedProposal(set: current.IApprovedProposal);
 declare function get_old_IApprovedProposal(): old.IApprovedProposal;
-const currentIApprovedProposal: current.IApprovedProposal = get_old_IApprovedProposal();
-declare function set_old_IApprovedProposal(oldVal: old.IApprovedProposal);
-set_old_IApprovedProposal(currentIApprovedProposal);
+set_current_IApprovedProposal(get_old_IApprovedProposal());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IApprovedProposal": {"backCompat": false}
+declare function set_old_IApprovedProposal(set: old.IApprovedProposal);
+declare function get_current_IApprovedProposal(): current.IApprovedProposal;
+set_old_IApprovedProposal(get_current_IApprovedProposal());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IAttachment": {"forwardCompat": false}
+declare function set_current_IAttachment(set: current.IAttachment);
 declare function get_old_IAttachment(): old.IAttachment;
-const currentIAttachment: current.IAttachment = get_old_IAttachment();
-declare function set_old_IAttachment(oldVal: old.IAttachment);
-set_old_IAttachment(currentIAttachment);
+set_current_IAttachment(get_old_IAttachment());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IAttachment": {"backCompat": false}
+declare function set_old_IAttachment(set: old.IAttachment);
+declare function get_current_IAttachment(): current.IAttachment;
+set_old_IAttachment(get_current_IAttachment());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IBlob": {"forwardCompat": false}
+declare function set_current_IBlob(set: current.IBlob);
 declare function get_old_IBlob(): old.IBlob;
-const currentIBlob: current.IBlob = get_old_IBlob();
-declare function set_old_IBlob(oldVal: old.IBlob);
-set_old_IBlob(currentIBlob);
+set_current_IBlob(get_old_IBlob());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IBlob": {"backCompat": false}
+declare function set_old_IBlob(set: old.IBlob);
+declare function get_current_IBlob(): current.IBlob;
+set_old_IBlob(get_current_IBlob());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IBranchOrigin": {"forwardCompat": false}
+declare function set_current_IBranchOrigin(set: current.IBranchOrigin);
 declare function get_old_IBranchOrigin(): old.IBranchOrigin;
-const currentIBranchOrigin: current.IBranchOrigin = get_old_IBranchOrigin();
-declare function set_old_IBranchOrigin(oldVal: old.IBranchOrigin);
-set_old_IBranchOrigin(currentIBranchOrigin);
+set_current_IBranchOrigin(get_old_IBranchOrigin());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IBranchOrigin": {"backCompat": false}
+declare function set_old_IBranchOrigin(set: old.IBranchOrigin);
+declare function get_current_IBranchOrigin(): current.IBranchOrigin;
+set_old_IBranchOrigin(get_current_IBranchOrigin());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ICapabilities": {"forwardCompat": false}
+declare function set_current_ICapabilities(set: current.ICapabilities);
 declare function get_old_ICapabilities(): old.ICapabilities;
-const currentICapabilities: current.ICapabilities = get_old_ICapabilities();
-declare function set_old_ICapabilities(oldVal: old.ICapabilities);
-set_old_ICapabilities(currentICapabilities);
+set_current_ICapabilities(get_old_ICapabilities());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ICapabilities": {"backCompat": false}
+declare function set_old_ICapabilities(set: old.ICapabilities);
+declare function get_current_ICapabilities(): current.ICapabilities;
+set_old_ICapabilities(get_current_ICapabilities());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IClient": {"forwardCompat": false}
+declare function set_current_IClient(set: current.IClient);
 declare function get_old_IClient(): old.IClient;
-const currentIClient: current.IClient = get_old_IClient();
-declare function set_old_IClient(oldVal: old.IClient);
-set_old_IClient(currentIClient);
+set_current_IClient(get_old_IClient());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IClient": {"backCompat": false}
+declare function set_old_IClient(set: old.IClient);
+declare function get_current_IClient(): current.IClient;
+set_old_IClient(get_current_IClient());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IClientConfiguration": {"forwardCompat": false}
+declare function set_current_IClientConfiguration(set: current.IClientConfiguration);
 declare function get_old_IClientConfiguration(): old.IClientConfiguration;
-const currentIClientConfiguration: current.IClientConfiguration = get_old_IClientConfiguration();
-declare function set_old_IClientConfiguration(oldVal: old.IClientConfiguration);
-set_old_IClientConfiguration(currentIClientConfiguration);
+set_current_IClientConfiguration(get_old_IClientConfiguration());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IClientConfiguration": {"backCompat": false}
+declare function set_old_IClientConfiguration(set: old.IClientConfiguration);
+declare function get_current_IClientConfiguration(): current.IClientConfiguration;
+set_old_IClientConfiguration(get_current_IClientConfiguration());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IClientDetails": {"forwardCompat": false}
+declare function set_current_IClientDetails(set: current.IClientDetails);
 declare function get_old_IClientDetails(): old.IClientDetails;
-const currentIClientDetails: current.IClientDetails = get_old_IClientDetails();
-declare function set_old_IClientDetails(oldVal: old.IClientDetails);
-set_old_IClientDetails(currentIClientDetails);
+set_current_IClientDetails(get_old_IClientDetails());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IClientDetails": {"backCompat": false}
+declare function set_old_IClientDetails(set: old.IClientDetails);
+declare function get_current_IClientDetails(): current.IClientDetails;
+set_old_IClientDetails(get_current_IClientDetails());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IClientJoin": {"forwardCompat": false}
+declare function set_current_IClientJoin(set: current.IClientJoin);
 declare function get_old_IClientJoin(): old.IClientJoin;
-const currentIClientJoin: current.IClientJoin = get_old_IClientJoin();
-declare function set_old_IClientJoin(oldVal: old.IClientJoin);
-set_old_IClientJoin(currentIClientJoin);
+set_current_IClientJoin(get_old_IClientJoin());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IClientJoin": {"backCompat": false}
+declare function set_old_IClientJoin(set: old.IClientJoin);
+declare function get_current_IClientJoin(): current.IClientJoin;
+set_old_IClientJoin(get_current_IClientJoin());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ICommittedProposal": {"forwardCompat": false}
+declare function set_current_ICommittedProposal(set: current.ICommittedProposal);
 declare function get_old_ICommittedProposal(): old.ICommittedProposal;
-const currentICommittedProposal: current.ICommittedProposal = get_old_ICommittedProposal();
-declare function set_old_ICommittedProposal(oldVal: old.ICommittedProposal);
-set_old_ICommittedProposal(currentICommittedProposal);
+set_current_ICommittedProposal(get_old_ICommittedProposal());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ICommittedProposal": {"backCompat": false}
+declare function set_old_ICommittedProposal(set: old.ICommittedProposal);
+declare function get_current_ICommittedProposal(): current.ICommittedProposal;
+set_old_ICommittedProposal(get_current_ICommittedProposal());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IConnect": {"forwardCompat": false}
+declare function set_current_IConnect(set: current.IConnect);
 declare function get_old_IConnect(): old.IConnect;
-const currentIConnect: current.IConnect = get_old_IConnect();
-declare function set_old_IConnect(oldVal: old.IConnect);
-set_old_IConnect(currentIConnect);
+set_current_IConnect(get_old_IConnect());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IConnect": {"backCompat": false}
+declare function set_old_IConnect(set: old.IConnect);
+declare function get_current_IConnect(): current.IConnect;
+set_old_IConnect(get_current_IConnect());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IConnected": {"forwardCompat": false}
+declare function set_current_IConnected(set: current.IConnected);
 declare function get_old_IConnected(): old.IConnected;
-const currentIConnected: current.IConnected = get_old_IConnected();
-declare function set_old_IConnected(oldVal: old.IConnected);
-set_old_IConnected(currentIConnected);
+set_current_IConnected(get_old_IConnected());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IConnected": {"backCompat": false}
+declare function set_old_IConnected(set: old.IConnected);
+declare function get_current_IConnected(): current.IConnected;
+set_old_IConnected(get_current_IConnected());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ICreateBlobResponse": {"forwardCompat": false}
+declare function set_current_ICreateBlobResponse(set: current.ICreateBlobResponse);
 declare function get_old_ICreateBlobResponse(): old.ICreateBlobResponse;
-export const currentICreateBlobResponse: current.ICreateBlobResponse = get_old_ICreateBlobResponse();
-// declare function set_old_ICreateBlobResponse(oldVal: old.ICreateBlobResponse);
-// set_old_ICreateBlobResponse(currentICreateBlobResponse);
+set_current_ICreateBlobResponse(get_old_ICreateBlobResponse());
 
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IDocumentAttributes": {"forwardCompat": false}
+declare function set_current_IDocumentAttributes(set: current.IDocumentAttributes);
 declare function get_old_IDocumentAttributes(): old.IDocumentAttributes;
-const currentIDocumentAttributes: current.IDocumentAttributes = get_old_IDocumentAttributes();
-declare function set_old_IDocumentAttributes(oldVal: old.IDocumentAttributes);
-set_old_IDocumentAttributes(currentIDocumentAttributes);
+set_current_IDocumentAttributes(get_old_IDocumentAttributes());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IDocumentAttributes": {"backCompat": false}
+declare function set_old_IDocumentAttributes(set: old.IDocumentAttributes);
+declare function get_current_IDocumentAttributes(): current.IDocumentAttributes;
+set_old_IDocumentAttributes(get_current_IDocumentAttributes());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IDocumentMessage": {"forwardCompat": false}
+declare function set_current_IDocumentMessage(set: current.IDocumentMessage);
 declare function get_old_IDocumentMessage(): old.IDocumentMessage;
-const currentIDocumentMessage: current.IDocumentMessage = get_old_IDocumentMessage();
-declare function set_old_IDocumentMessage(oldVal: old.IDocumentMessage);
-set_old_IDocumentMessage(currentIDocumentMessage);
+set_current_IDocumentMessage(get_old_IDocumentMessage());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IDocumentMessage": {"backCompat": false}
+declare function set_old_IDocumentMessage(set: old.IDocumentMessage);
+declare function get_current_IDocumentMessage(): current.IDocumentMessage;
+set_old_IDocumentMessage(get_current_IDocumentMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IDocumentSystemMessage": {"forwardCompat": false}
+declare function set_current_IDocumentSystemMessage(set: current.IDocumentSystemMessage);
 declare function get_old_IDocumentSystemMessage(): old.IDocumentSystemMessage;
-const currentIDocumentSystemMessage: current.IDocumentSystemMessage = get_old_IDocumentSystemMessage();
-declare function set_old_IDocumentSystemMessage(oldVal: old.IDocumentSystemMessage);
-set_old_IDocumentSystemMessage(currentIDocumentSystemMessage);
+set_current_IDocumentSystemMessage(get_old_IDocumentSystemMessage());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IDocumentSystemMessage": {"backCompat": false}
+declare function set_old_IDocumentSystemMessage(set: old.IDocumentSystemMessage);
+declare function get_current_IDocumentSystemMessage(): current.IDocumentSystemMessage;
+set_old_IDocumentSystemMessage(get_current_IDocumentSystemMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IHelpMessage": {"forwardCompat": false}
+declare function set_current_IHelpMessage(set: current.IHelpMessage);
 declare function get_old_IHelpMessage(): old.IHelpMessage;
-const currentIHelpMessage: current.IHelpMessage = get_old_IHelpMessage();
-declare function set_old_IHelpMessage(oldVal: old.IHelpMessage);
-set_old_IHelpMessage(currentIHelpMessage);
+set_current_IHelpMessage(get_old_IHelpMessage());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IHelpMessage": {"backCompat": false}
+declare function set_old_IHelpMessage(set: old.IHelpMessage);
+declare function get_current_IHelpMessage(): current.IHelpMessage;
+set_old_IHelpMessage(get_current_IHelpMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "INack": {"forwardCompat": false}
+declare function set_current_INack(set: current.INack);
 declare function get_old_INack(): old.INack;
-const currentINack: current.INack = get_old_INack();
-declare function set_old_INack(oldVal: old.INack);
-set_old_INack(currentINack);
+set_current_INack(get_old_INack());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "INack": {"backCompat": false}
+declare function set_old_INack(set: old.INack);
+declare function get_current_INack(): current.INack;
+set_old_INack(get_current_INack());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "INackContent": {"forwardCompat": false}
+declare function set_current_INackContent(set: current.INackContent);
 declare function get_old_INackContent(): old.INackContent;
-const currentINackContent: current.INackContent = get_old_INackContent();
-declare function set_old_INackContent(oldVal: old.INackContent);
-set_old_INackContent(currentINackContent);
+set_current_INackContent(get_old_INackContent());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "INackContent": {"backCompat": false}
+declare function set_old_INackContent(set: old.INackContent);
+declare function get_current_INackContent(): current.INackContent;
+set_old_INackContent(get_current_INackContent());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IPendingProposal": {"forwardCompat": false}
+declare function set_current_IPendingProposal(set: current.IPendingProposal);
 declare function get_old_IPendingProposal(): old.IPendingProposal;
-const currentIPendingProposal: current.IPendingProposal = get_old_IPendingProposal();
-declare function set_old_IPendingProposal(oldVal: old.IPendingProposal);
-set_old_IPendingProposal(currentIPendingProposal);
+set_current_IPendingProposal(get_old_IPendingProposal());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IPendingProposal": {"backCompat": false}
+declare function set_old_IPendingProposal(set: old.IPendingProposal);
+declare function get_current_IPendingProposal(): current.IPendingProposal;
+set_old_IPendingProposal(get_current_IPendingProposal());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IProcessMessageResult": {"forwardCompat": false}
+declare function set_current_IProcessMessageResult(set: current.IProcessMessageResult);
 declare function get_old_IProcessMessageResult(): old.IProcessMessageResult;
-const currentIProcessMessageResult: current.IProcessMessageResult = get_old_IProcessMessageResult();
-declare function set_old_IProcessMessageResult(oldVal: old.IProcessMessageResult);
-set_old_IProcessMessageResult(currentIProcessMessageResult);
+set_current_IProcessMessageResult(get_old_IProcessMessageResult());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IProcessMessageResult": {"backCompat": false}
+declare function set_old_IProcessMessageResult(set: old.IProcessMessageResult);
+declare function get_current_IProcessMessageResult(): current.IProcessMessageResult;
+set_old_IProcessMessageResult(get_current_IProcessMessageResult());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IProposal": {"forwardCompat": false}
+declare function set_current_IProposal(set: current.IProposal);
 declare function get_old_IProposal(): old.IProposal;
-const currentIProposal: current.IProposal = get_old_IProposal();
-declare function set_old_IProposal(oldVal: old.IProposal);
-set_old_IProposal(currentIProposal);
+set_current_IProposal(get_old_IProposal());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IProposal": {"backCompat": false}
+declare function set_old_IProposal(set: old.IProposal);
+declare function get_current_IProposal(): current.IProposal;
+set_old_IProposal(get_current_IProposal());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IProtocolState": {"forwardCompat": false}
+declare function set_current_IProtocolState(set: current.IProtocolState);
 declare function get_old_IProtocolState(): old.IProtocolState;
-const currentIProtocolState: current.IProtocolState = get_old_IProtocolState();
-declare function set_old_IProtocolState(oldVal: old.IProtocolState);
-set_old_IProtocolState(currentIProtocolState);
+set_current_IProtocolState(get_old_IProtocolState());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IProtocolState": {"backCompat": false}
+declare function set_old_IProtocolState(set: old.IProtocolState);
+declare function get_current_IProtocolState(): current.IProtocolState;
+set_old_IProtocolState(get_current_IProtocolState());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IQueueMessage": {"forwardCompat": false}
+declare function set_current_IQueueMessage(set: current.IQueueMessage);
 declare function get_old_IQueueMessage(): old.IQueueMessage;
-const currentIQueueMessage: current.IQueueMessage = get_old_IQueueMessage();
-declare function set_old_IQueueMessage(oldVal: old.IQueueMessage);
-set_old_IQueueMessage(currentIQueueMessage);
+set_current_IQueueMessage(get_old_IQueueMessage());
 
-/*
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IQueueMessage": {"backCompat": false}
+declare function set_old_IQueueMessage(set: old.IQueueMessage);
+declare function get_current_IQueueMessage(): current.IQueueMessage;
+set_old_IQueueMessage(get_current_IQueueMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IQuorum": {"forwardCompat": false}
+declare function set_current_IQuorum(set: current.IQuorum);
 declare function get_old_IQuorum(): old.IQuorum;
-const currentIQuorum: current.IQuorum = get_old_IQuorum();
-declare function set_old_IQuorum(oldVal: old.IQuorum);
-set_old_IQuorum(currentIQuorum);
-*/
+set_current_IQuorum(get_old_IQuorum());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IQuorum": {"backCompat": false}
+declare function set_old_IQuorum(set: old.IQuorum);
+declare function get_current_IQuorum(): current.IQuorum;
+set_old_IQuorum(get_current_IQuorum());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IQuorumEvents": {"forwardCompat": false}
+declare function set_current_IQuorumEvents(set: current.IQuorumEvents);
 declare function get_old_IQuorumEvents(): old.IQuorumEvents;
-const currentIQuorumEvents: current.IQuorumEvents = get_old_IQuorumEvents();
-declare function set_old_IQuorumEvents(oldVal: old.IQuorumEvents);
-set_old_IQuorumEvents(currentIQuorumEvents);
+set_current_IQuorumEvents(get_old_IQuorumEvents());
 
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISequencedClient": {"forwardCompat": false}
+declare function set_current_ISequencedClient(set: current.ISequencedClient);
 declare function get_old_ISequencedClient(): old.ISequencedClient;
-const currentISequencedClient: current.ISequencedClient = get_old_ISequencedClient();
-declare function set_old_ISequencedClient(oldVal: old.ISequencedClient);
-set_old_ISequencedClient(currentISequencedClient);
+set_current_ISequencedClient(get_old_ISequencedClient());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISequencedClient": {"backCompat": false}
+declare function set_old_ISequencedClient(set: old.ISequencedClient);
+declare function get_current_ISequencedClient(): current.ISequencedClient;
+set_old_ISequencedClient(get_current_ISequencedClient());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISequencedDocumentAugmentedMessage": {"forwardCompat": false}
+declare function set_current_ISequencedDocumentAugmentedMessage(set: current.ISequencedDocumentAugmentedMessage);
 declare function get_old_ISequencedDocumentAugmentedMessage(): old.ISequencedDocumentAugmentedMessage;
-const currentISequencedDocumentAugmentedMessage: current.ISequencedDocumentAugmentedMessage =
-    get_old_ISequencedDocumentAugmentedMessage();
-declare function set_old_ISequencedDocumentAugmentedMessage(oldVal: old.ISequencedDocumentAugmentedMessage);
-set_old_ISequencedDocumentAugmentedMessage(currentISequencedDocumentAugmentedMessage);
+set_current_ISequencedDocumentAugmentedMessage(get_old_ISequencedDocumentAugmentedMessage());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISequencedDocumentAugmentedMessage": {"backCompat": false}
+declare function set_old_ISequencedDocumentAugmentedMessage(set: old.ISequencedDocumentAugmentedMessage);
+declare function get_current_ISequencedDocumentAugmentedMessage(): current.ISequencedDocumentAugmentedMessage;
+set_old_ISequencedDocumentAugmentedMessage(get_current_ISequencedDocumentAugmentedMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISequencedDocumentMessage": {"forwardCompat": false}
+declare function set_current_ISequencedDocumentMessage(set: current.ISequencedDocumentMessage);
 declare function get_old_ISequencedDocumentMessage(): old.ISequencedDocumentMessage;
-const currentISequencedDocumentMessage: current.ISequencedDocumentMessage = get_old_ISequencedDocumentMessage();
-declare function set_old_ISequencedDocumentMessage(oldVal: old.ISequencedDocumentMessage);
-set_old_ISequencedDocumentMessage(currentISequencedDocumentMessage);
+set_current_ISequencedDocumentMessage(get_old_ISequencedDocumentMessage());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISequencedDocumentMessage": {"backCompat": false}
+declare function set_old_ISequencedDocumentMessage(set: old.ISequencedDocumentMessage);
+declare function get_current_ISequencedDocumentMessage(): current.ISequencedDocumentMessage;
+set_old_ISequencedDocumentMessage(get_current_ISequencedDocumentMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISequencedDocumentSystemMessage": {"forwardCompat": false}
+declare function set_current_ISequencedDocumentSystemMessage(set: current.ISequencedDocumentSystemMessage);
 declare function get_old_ISequencedDocumentSystemMessage(): old.ISequencedDocumentSystemMessage;
-const currentISequencedDocumentSystemMessage: current.ISequencedDocumentSystemMessage =
-    get_old_ISequencedDocumentSystemMessage();
-declare function set_old_ISequencedDocumentSystemMessage(oldVal: old.ISequencedDocumentSystemMessage);
-set_old_ISequencedDocumentSystemMessage(currentISequencedDocumentSystemMessage);
+set_current_ISequencedDocumentSystemMessage(get_old_ISequencedDocumentSystemMessage());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISequencedDocumentSystemMessage": {"backCompat": false}
+declare function set_old_ISequencedDocumentSystemMessage(set: old.ISequencedDocumentSystemMessage);
+declare function get_current_ISequencedDocumentSystemMessage(): current.ISequencedDocumentSystemMessage;
+set_old_ISequencedDocumentSystemMessage(get_current_ISequencedDocumentSystemMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISequencedProposal": {"forwardCompat": false}
+declare function set_current_ISequencedProposal(set: current.ISequencedProposal);
 declare function get_old_ISequencedProposal(): old.ISequencedProposal;
-const currentISequencedProposal: current.ISequencedProposal = get_old_ISequencedProposal();
-declare function set_old_ISequencedProposal(oldVal: old.ISequencedProposal);
-set_old_ISequencedProposal(currentISequencedProposal);
+set_current_ISequencedProposal(get_old_ISequencedProposal());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISequencedProposal": {"backCompat": false}
+declare function set_old_ISequencedProposal(set: old.ISequencedProposal);
+declare function get_current_ISequencedProposal(): current.ISequencedProposal;
+set_old_ISequencedProposal(get_current_ISequencedProposal());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IServerError": {"forwardCompat": false}
+declare function set_current_IServerError(set: current.IServerError);
 declare function get_old_IServerError(): old.IServerError;
-const currentIServerError: current.IServerError = get_old_IServerError();
-declare function set_old_IServerError(oldVal: old.IServerError);
-set_old_IServerError(currentIServerError);
+set_current_IServerError(get_old_IServerError());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IServerError": {"backCompat": false}
+declare function set_old_IServerError(set: old.IServerError);
+declare function get_current_IServerError(): current.IServerError;
+set_old_IServerError(get_current_IServerError());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISignalClient": {"forwardCompat": false}
+declare function set_current_ISignalClient(set: current.ISignalClient);
 declare function get_old_ISignalClient(): old.ISignalClient;
-const currentISignalClient: current.ISignalClient = get_old_ISignalClient();
-declare function set_old_ISignalClient(oldVal: old.ISignalClient);
-set_old_ISignalClient(currentISignalClient);
+set_current_ISignalClient(get_old_ISignalClient());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISignalClient": {"backCompat": false}
+declare function set_old_ISignalClient(set: old.ISignalClient);
+declare function get_current_ISignalClient(): current.ISignalClient;
+set_old_ISignalClient(get_current_ISignalClient());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISignalMessage": {"forwardCompat": false}
+declare function set_current_ISignalMessage(set: current.ISignalMessage);
 declare function get_old_ISignalMessage(): old.ISignalMessage;
-const currentISignalMessage: current.ISignalMessage = get_old_ISignalMessage();
-declare function set_old_ISignalMessage(oldVal: old.ISignalMessage);
-set_old_ISignalMessage(currentISignalMessage);
+set_current_ISignalMessage(get_old_ISignalMessage());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISignalMessage": {"backCompat": false}
+declare function set_old_ISignalMessage(set: old.ISignalMessage);
+declare function get_current_ISignalMessage(): current.ISignalMessage;
+set_old_ISignalMessage(get_current_ISignalMessage());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISnapshotTree": {"forwardCompat": false}
+declare function set_current_ISnapshotTree(set: current.ISnapshotTree);
 declare function get_old_ISnapshotTree(): old.ISnapshotTree;
-const currentISnapshotTree: current.ISnapshotTree = get_old_ISnapshotTree();
-declare function set_old_ISnapshotTree(oldVal: old.ISnapshotTree);
-set_old_ISnapshotTree(currentISnapshotTree);
+set_current_ISnapshotTree(get_old_ISnapshotTree());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISnapshotTree": {"backCompat": false}
+declare function set_old_ISnapshotTree(set: old.ISnapshotTree);
+declare function get_current_ISnapshotTree(): current.ISnapshotTree;
+set_old_ISnapshotTree(get_current_ISnapshotTree());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISnapshotTreeEx": {"forwardCompat": false}
+declare function set_current_ISnapshotTreeEx(set: current.ISnapshotTreeEx);
 declare function get_old_ISnapshotTreeEx(): old.ISnapshotTreeEx;
-const currentISnapshotTreeEx: current.ISnapshotTreeEx = get_old_ISnapshotTreeEx();
-declare function set_old_ISnapshotTreeEx(oldVal: old.ISnapshotTreeEx);
-set_old_ISnapshotTreeEx(currentISnapshotTreeEx);
+set_current_ISnapshotTreeEx(get_old_ISnapshotTreeEx());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISnapshotTreeEx": {"backCompat": false}
+declare function set_old_ISnapshotTreeEx(set: old.ISnapshotTreeEx);
+declare function get_current_ISnapshotTreeEx(): current.ISnapshotTreeEx;
+set_old_ISnapshotTreeEx(get_current_ISnapshotTreeEx());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryAck": {"forwardCompat": false}
+declare function set_current_ISummaryAck(set: current.ISummaryAck);
 declare function get_old_ISummaryAck(): old.ISummaryAck;
-const currentISummaryAck: current.ISummaryAck = get_old_ISummaryAck();
-declare function set_old_ISummaryAck(oldVal: old.ISummaryAck);
-set_old_ISummaryAck(currentISummaryAck);
+set_current_ISummaryAck(get_old_ISummaryAck());
 
-/*
-declare function get_old_ISummaryAttachment(): old.ISummaryAttachment;
-const currentISummaryAttachment: current.ISummaryAttachment = get_old_ISummaryAttachment();
-declare function set_old_ISummaryAttachment(oldVal: old.ISummaryAttachment);
-set_old_ISummaryAttachment(currentISummaryAttachment);
-*/
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryAck": {"backCompat": false}
+declare function set_old_ISummaryAck(set: old.ISummaryAck);
+declare function get_current_ISummaryAck(): current.ISummaryAck;
+set_old_ISummaryAck(get_current_ISummaryAck());
 
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryAuthor": {"forwardCompat": false}
+declare function set_current_ISummaryAuthor(set: current.ISummaryAuthor);
 declare function get_old_ISummaryAuthor(): old.ISummaryAuthor;
-const currentISummaryAuthor: current.ISummaryAuthor = get_old_ISummaryAuthor();
-declare function set_old_ISummaryAuthor(oldVal: old.ISummaryAuthor);
-set_old_ISummaryAuthor(currentISummaryAuthor);
+set_current_ISummaryAuthor(get_old_ISummaryAuthor());
 
-/*
-declare function get_old_ISummaryBlob(): old.ISummaryBlob;
-const currentISummaryBlob: current.ISummaryBlob = get_old_ISummaryBlob();
-declare function set_old_ISummaryBlob(oldVal: old.ISummaryBlob);
-set_old_ISummaryBlob(currentISummaryBlob);
-*/
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryAuthor": {"backCompat": false}
+declare function set_old_ISummaryAuthor(set: old.ISummaryAuthor);
+declare function get_current_ISummaryAuthor(): current.ISummaryAuthor;
+set_old_ISummaryAuthor(get_current_ISummaryAuthor());
 
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryCommitter": {"forwardCompat": false}
+declare function set_current_ISummaryCommitter(set: current.ISummaryCommitter);
 declare function get_old_ISummaryCommitter(): old.ISummaryCommitter;
-const currentISummaryCommitter: current.ISummaryCommitter = get_old_ISummaryCommitter();
-declare function set_old_ISummaryCommitter(oldVal: old.ISummaryCommitter);
-set_old_ISummaryCommitter(currentISummaryCommitter);
+set_current_ISummaryCommitter(get_old_ISummaryCommitter());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryCommitter": {"backCompat": false}
+declare function set_old_ISummaryCommitter(set: old.ISummaryCommitter);
+declare function get_current_ISummaryCommitter(): current.ISummaryCommitter;
+set_old_ISummaryCommitter(get_current_ISummaryCommitter());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryConfiguration": {"forwardCompat": false}
+declare function set_current_ISummaryConfiguration(set: current.ISummaryConfiguration);
 declare function get_old_ISummaryConfiguration(): old.ISummaryConfiguration;
-const currentISummaryConfiguration: current.ISummaryConfiguration = get_old_ISummaryConfiguration();
-declare function set_old_ISummaryConfiguration(oldVal: old.ISummaryConfiguration);
-set_old_ISummaryConfiguration(currentISummaryConfiguration);
+set_current_ISummaryConfiguration(get_old_ISummaryConfiguration());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryConfiguration": {"backCompat": false}
+declare function set_old_ISummaryConfiguration(set: old.ISummaryConfiguration);
+declare function get_current_ISummaryConfiguration(): current.ISummaryConfiguration;
+set_old_ISummaryConfiguration(get_current_ISummaryConfiguration());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryContent": {"forwardCompat": false}
+declare function set_current_ISummaryContent(set: current.ISummaryContent);
 declare function get_old_ISummaryContent(): old.ISummaryContent;
-const currentISummaryContent: current.ISummaryContent = get_old_ISummaryContent();
-declare function set_old_ISummaryContent(oldVal: old.ISummaryContent);
-set_old_ISummaryContent(currentISummaryContent);
+set_current_ISummaryContent(get_old_ISummaryContent());
 
-/*
-declare function get_old_ISummaryHandle(): old.ISummaryHandle;
-const currentISummaryHandle: current.ISummaryHandle = get_old_ISummaryHandle();
-declare function set_old_ISummaryHandle(oldVal: old.ISummaryHandle);
-set_old_ISummaryHandle(currentISummaryHandle);
-*/
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryContent": {"backCompat": false}
+declare function set_old_ISummaryContent(set: old.ISummaryContent);
+declare function get_current_ISummaryContent(): current.ISummaryContent;
+set_old_ISummaryContent(get_current_ISummaryContent());
 
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryNack": {"forwardCompat": false}
+declare function set_current_ISummaryNack(set: current.ISummaryNack);
 declare function get_old_ISummaryNack(): old.ISummaryNack;
-const currentISummaryNack: current.ISummaryNack = get_old_ISummaryNack();
-declare function set_old_ISummaryNack(oldVal: old.ISummaryNack);
-set_old_ISummaryNack(currentISummaryNack);
+set_current_ISummaryNack(get_old_ISummaryNack());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryNack": {"backCompat": false}
+declare function set_old_ISummaryNack(set: old.ISummaryNack);
+declare function get_current_ISummaryNack(): current.ISummaryNack;
+set_old_ISummaryNack(get_current_ISummaryNack());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryProposal": {"forwardCompat": false}
+declare function set_current_ISummaryProposal(set: current.ISummaryProposal);
 declare function get_old_ISummaryProposal(): old.ISummaryProposal;
-const currentISummaryProposal: current.ISummaryProposal = get_old_ISummaryProposal();
-declare function set_old_ISummaryProposal(oldVal: old.ISummaryProposal);
-set_old_ISummaryProposal(currentISummaryProposal);
+set_current_ISummaryProposal(get_old_ISummaryProposal());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryProposal": {"backCompat": false}
+declare function set_old_ISummaryProposal(set: old.ISummaryProposal);
+declare function get_current_ISummaryProposal(): current.ISummaryProposal;
+set_old_ISummaryProposal(get_current_ISummaryProposal());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ISummaryTokenClaims": {"forwardCompat": false}
+declare function set_current_ISummaryTokenClaims(set: current.ISummaryTokenClaims);
 declare function get_old_ISummaryTokenClaims(): old.ISummaryTokenClaims;
-const currentISummaryTokenClaims: current.ISummaryTokenClaims = get_old_ISummaryTokenClaims();
-declare function set_old_ISummaryTokenClaims(oldVal: old.ISummaryTokenClaims);
-set_old_ISummaryTokenClaims(currentISummaryTokenClaims);
+set_current_ISummaryTokenClaims(get_old_ISummaryTokenClaims());
 
-/*
-declare function get_old_ISummaryTree(): old.ISummaryTree;
-const currentISummaryTree: current.ISummaryTree = get_old_ISummaryTree();
-declare function set_old_ISummaryTree(oldVal: old.ISummaryTree);
-set_old_ISummaryTree(currentISummaryTree);
-*/
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ISummaryTokenClaims": {"backCompat": false}
+declare function set_old_ISummaryTokenClaims(set: old.ISummaryTokenClaims);
+declare function get_current_ISummaryTokenClaims(): current.ISummaryTokenClaims;
+set_old_ISummaryTokenClaims(get_current_ISummaryTokenClaims());
 
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ITokenClaims": {"forwardCompat": false}
+declare function set_current_ITokenClaims(set: current.ITokenClaims);
 declare function get_old_ITokenClaims(): old.ITokenClaims;
-const currentITokenClaims: current.ITokenClaims = get_old_ITokenClaims();
-declare function set_old_ITokenClaims(oldVal: old.ITokenClaims);
-set_old_ITokenClaims(currentITokenClaims);
+set_current_ITokenClaims(get_old_ITokenClaims());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ITokenClaims": {"backCompat": false}
+declare function set_old_ITokenClaims(set: old.ITokenClaims);
+declare function get_current_ITokenClaims(): current.ITokenClaims;
+set_old_ITokenClaims(get_current_ITokenClaims());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ITokenProvider": {"forwardCompat": false}
+declare function set_current_ITokenProvider(set: current.ITokenProvider);
 declare function get_old_ITokenProvider(): old.ITokenProvider;
-const currentITokenProvider: current.ITokenProvider = get_old_ITokenProvider();
-declare function set_old_ITokenProvider(oldVal: old.ITokenProvider);
-set_old_ITokenProvider(currentITokenProvider);
+set_current_ITokenProvider(get_old_ITokenProvider());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ITokenProvider": {"backCompat": false}
+declare function set_old_ITokenProvider(set: old.ITokenProvider);
+declare function get_current_ITokenProvider(): current.ITokenProvider;
+set_old_ITokenProvider(get_current_ITokenProvider());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ITokenService": {"forwardCompat": false}
+declare function set_current_ITokenService(set: current.ITokenService);
 declare function get_old_ITokenService(): old.ITokenService;
-const currentITokenService: current.ITokenService = get_old_ITokenService();
-declare function set_old_ITokenService(oldVal: old.ITokenService);
-set_old_ITokenService(currentITokenService);
+set_current_ITokenService(get_old_ITokenService());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ITokenService": {"backCompat": false}
+declare function set_old_ITokenService(set: old.ITokenService);
+declare function get_current_ITokenService(): current.ITokenService;
+set_old_ITokenService(get_current_ITokenService());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ITrace": {"forwardCompat": false}
+declare function set_current_ITrace(set: current.ITrace);
 declare function get_old_ITrace(): old.ITrace;
-const currentITrace: current.ITrace = get_old_ITrace();
-declare function set_old_ITrace(oldVal: old.ITrace);
-set_old_ITrace(currentITrace);
+set_current_ITrace(get_old_ITrace());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ITrace": {"backCompat": false}
+declare function set_old_ITrace(set: old.ITrace);
+declare function get_current_ITrace(): current.ITrace;
+set_old_ITrace(get_current_ITrace());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ITree": {"forwardCompat": false}
+declare function set_current_ITree(set: current.ITree);
 declare function get_old_ITree(): old.ITree;
-const currentITree: current.ITree = get_old_ITree();
-declare function set_old_ITree(oldVal: old.ITree);
-set_old_ITree(currentITree);
+set_current_ITree(get_old_ITree());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ITree": {"backCompat": false}
+declare function set_old_ITree(set: old.ITree);
+declare function get_current_ITree(): current.ITree;
+set_old_ITree(get_current_ITree());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ITreeEntry": {"forwardCompat": false}
+declare function set_current_ITreeEntry(set: current.ITreeEntry);
 declare function get_old_ITreeEntry(): old.ITreeEntry;
-const currentITreeEntry: current.ITreeEntry = get_old_ITreeEntry();
-declare function set_old_ITreeEntry(oldVal: old.ITreeEntry);
-set_old_ITreeEntry(currentITreeEntry);
+set_current_ITreeEntry(get_old_ITreeEntry());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ITreeEntry": {"backCompat": false}
+declare function set_old_ITreeEntry(set: old.ITreeEntry);
+declare function get_current_ITreeEntry(): current.ITreeEntry;
+set_old_ITreeEntry(get_current_ITreeEntry());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IUploadedSummaryDetails": {"forwardCompat": false}
+declare function set_current_IUploadedSummaryDetails(set: current.IUploadedSummaryDetails);
 declare function get_old_IUploadedSummaryDetails(): old.IUploadedSummaryDetails;
-const currentIUploadedSummaryDetails: current.IUploadedSummaryDetails = get_old_IUploadedSummaryDetails();
-declare function set_old_IUploadedSummaryDetails(oldVal: old.IUploadedSummaryDetails);
-set_old_IUploadedSummaryDetails(currentIUploadedSummaryDetails);
+set_current_IUploadedSummaryDetails(get_old_IUploadedSummaryDetails());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IUploadedSummaryDetails": {"backCompat": false}
+declare function set_old_IUploadedSummaryDetails(set: old.IUploadedSummaryDetails);
+declare function get_current_IUploadedSummaryDetails(): current.IUploadedSummaryDetails;
+set_old_IUploadedSummaryDetails(get_current_IUploadedSummaryDetails());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IUser": {"forwardCompat": false}
+declare function set_current_IUser(set: current.IUser);
 declare function get_old_IUser(): old.IUser;
-const currentIUser: current.IUser = get_old_IUser();
-declare function set_old_IUser(oldVal: old.IUser);
-set_old_IUser(currentIUser);
+set_current_IUser(get_old_IUser());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IUser": {"backCompat": false}
+declare function set_old_IUser(set: old.IUser);
+declare function get_current_IUser(): current.IUser;
+set_old_IUser(get_current_IUser());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "IVersion": {"forwardCompat": false}
+declare function set_current_IVersion(set: current.IVersion);
 declare function get_old_IVersion(): old.IVersion;
-const currentIVersion: current.IVersion = get_old_IVersion();
-declare function set_old_IVersion(oldVal: old.IVersion);
-set_old_IVersion(currentIVersion);
+set_current_IVersion(get_old_IVersion());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IVersion": {"backCompat": false}
+declare function set_old_IVersion(set: old.IVersion);
+declare function get_current_IVersion(): current.IVersion;
+set_old_IVersion(get_current_IVersion());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "MessageType": {"forwardCompat": false}
+declare function set_current_MessageType(set: current.MessageType);
 declare function get_old_MessageType(): old.MessageType;
-const currentMessageType: current.MessageType = get_old_MessageType();
-declare function set_old_MessageType(oldVal: old.MessageType);
-set_old_MessageType(currentMessageType);
+set_current_MessageType(get_old_MessageType());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "MessageType": {"backCompat": false}
+declare function set_old_MessageType(set: old.MessageType);
+declare function get_current_MessageType(): current.MessageType;
+set_old_MessageType(get_current_MessageType());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "NackErrorType": {"forwardCompat": false}
+declare function set_current_NackErrorType(set: current.NackErrorType);
 declare function get_old_NackErrorType(): old.NackErrorType;
-const currentNackErrorType: current.NackErrorType = get_old_NackErrorType();
-declare function set_old_NackErrorType(oldVal: old.NackErrorType);
-set_old_NackErrorType(currentNackErrorType);
+set_current_NackErrorType(get_old_NackErrorType());
 
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "NackErrorType": {"backCompat": false}
+declare function set_old_NackErrorType(set: old.NackErrorType);
+declare function get_current_NackErrorType(): current.NackErrorType;
+set_old_NackErrorType(get_current_NackErrorType());
+
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "ScopeType": {"forwardCompat": false}
+declare function set_current_ScopeType(set: current.ScopeType);
 declare function get_old_ScopeType(): old.ScopeType;
-const currentScopeType: current.ScopeType = get_old_ScopeType();
-declare function set_old_ScopeType(oldVal: old.ScopeType);
-set_old_ScopeType(currentScopeType);
+set_current_ScopeType(get_old_ScopeType());
 
-/*
-declare function get_old_SummaryObject(): old.SummaryObject;
-const currentSummaryObject: current.SummaryObject = get_old_SummaryObject();
-declare function set_old_SummaryObject(oldVal: old.SummaryObject);
-set_old_SummaryObject(currentSummaryObject);
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "ScopeType": {"backCompat": false}
+declare function set_old_ScopeType(set: old.ScopeType);
+declare function get_current_ScopeType(): current.ScopeType;
+set_old_ScopeType(get_current_ScopeType());
 
-declare function get_old_SummaryTree(): old.SummaryTree;
-const currentSummaryTree: current.SummaryTree = get_old_SummaryTree();
-declare function set_old_SummaryTree(oldVal: old.SummaryTree);
-set_old_SummaryTree(currentSummaryTree);
-
-declare function get_old_SummaryType(): old.SummaryType;
-const currentSummaryType: current.SummaryType = get_old_SummaryType();
-declare function set_old_SummaryType(oldVal: old.SummaryType);
-set_old_SummaryType(currentSummaryType);
-
-declare function get_old_SummaryTypeNoHandle(): old.SummaryTypeNoHandle;
-const currentSummaryTypeNoHandle: current.SummaryTypeNoHandle = get_old_SummaryTypeNoHandle();
-declare function set_old_SummaryTypeNoHandle(oldVal: old.SummaryTypeNoHandle);
-set_old_SummaryTypeNoHandle(currentSummaryTypeNoHandle);
-*/
-
+// validate forward comapt of old type to new type
+// disable in package.json under typeValidation.broken:
+// "TreeEntry": {"forwardCompat": false}
+declare function set_current_TreeEntry(set: current.TreeEntry);
 declare function get_old_TreeEntry(): old.TreeEntry;
-const currentTreeEntry: current.TreeEntry = get_old_TreeEntry();
-declare function set_old_TreeEntry(oldVal: old.TreeEntry);
-set_old_TreeEntry(currentTreeEntry);
+set_current_TreeEntry(get_old_TreeEntry());
+
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "TreeEntry": {"backCompat": false}
+declare function set_old_TreeEntry(set: old.TreeEntry);
+declare function get_current_TreeEntry(): current.TreeEntry;
+set_old_TreeEntry(get_current_TreeEntry());

--- a/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
@@ -8,7 +8,7 @@ import * as current from "../index";
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ConnectionMode": {"forwardCompat": false}
 */
 declare function get_old_ConnectionMode(): old.ConnectionMode;
@@ -17,7 +17,7 @@ use_current_ConnectionMode(get_old_ConnectionMode());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ConnectionMode": {"backCompat": false}
 */
 declare function get_current_ConnectionMode(): current.ConnectionMode;
@@ -26,7 +26,7 @@ use_old_ConnectionMode(get_current_ConnectionMode());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "FileMode": {"forwardCompat": false}
 */
 declare function get_old_FileMode(): old.FileMode;
@@ -35,7 +35,7 @@ use_current_FileMode(get_old_FileMode());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "FileMode": {"backCompat": false}
 */
 declare function get_current_FileMode(): current.FileMode;
@@ -44,7 +44,7 @@ use_old_FileMode(get_current_FileMode());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IActorClient": {"forwardCompat": false}
 */
 declare function get_old_IActorClient(): old.IActorClient;
@@ -53,7 +53,7 @@ use_current_IActorClient(get_old_IActorClient());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IActorClient": {"backCompat": false}
 */
 declare function get_current_IActorClient(): current.IActorClient;
@@ -62,7 +62,7 @@ use_old_IActorClient(get_current_IActorClient());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IApprovedProposal": {"forwardCompat": false}
 */
 declare function get_old_IApprovedProposal(): old.IApprovedProposal;
@@ -71,7 +71,7 @@ use_current_IApprovedProposal(get_old_IApprovedProposal());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IApprovedProposal": {"backCompat": false}
 */
 declare function get_current_IApprovedProposal(): current.IApprovedProposal;
@@ -80,7 +80,7 @@ use_old_IApprovedProposal(get_current_IApprovedProposal());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IAttachment": {"forwardCompat": false}
 */
 declare function get_old_IAttachment(): old.IAttachment;
@@ -89,7 +89,7 @@ use_current_IAttachment(get_old_IAttachment());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IAttachment": {"backCompat": false}
 */
 declare function get_current_IAttachment(): current.IAttachment;
@@ -98,7 +98,7 @@ use_old_IAttachment(get_current_IAttachment());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IBlob": {"forwardCompat": false}
 */
 declare function get_old_IBlob(): old.IBlob;
@@ -107,7 +107,7 @@ use_current_IBlob(get_old_IBlob());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IBlob": {"backCompat": false}
 */
 declare function get_current_IBlob(): current.IBlob;
@@ -116,7 +116,7 @@ use_old_IBlob(get_current_IBlob());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IBranchOrigin": {"forwardCompat": false}
 */
 declare function get_old_IBranchOrigin(): old.IBranchOrigin;
@@ -125,7 +125,7 @@ use_current_IBranchOrigin(get_old_IBranchOrigin());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IBranchOrigin": {"backCompat": false}
 */
 declare function get_current_IBranchOrigin(): current.IBranchOrigin;
@@ -134,7 +134,7 @@ use_old_IBranchOrigin(get_current_IBranchOrigin());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ICapabilities": {"forwardCompat": false}
 */
 declare function get_old_ICapabilities(): old.ICapabilities;
@@ -143,7 +143,7 @@ use_current_ICapabilities(get_old_ICapabilities());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ICapabilities": {"backCompat": false}
 */
 declare function get_current_ICapabilities(): current.ICapabilities;
@@ -152,7 +152,7 @@ use_old_ICapabilities(get_current_ICapabilities());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClient": {"forwardCompat": false}
 */
 declare function get_old_IClient(): old.IClient;
@@ -161,7 +161,7 @@ use_current_IClient(get_old_IClient());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClient": {"backCompat": false}
 */
 declare function get_current_IClient(): current.IClient;
@@ -170,7 +170,7 @@ use_old_IClient(get_current_IClient());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClientConfiguration": {"forwardCompat": false}
 */
 declare function get_old_IClientConfiguration(): old.IClientConfiguration;
@@ -179,7 +179,7 @@ use_current_IClientConfiguration(get_old_IClientConfiguration());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClientConfiguration": {"backCompat": false}
 */
 declare function get_current_IClientConfiguration(): current.IClientConfiguration;
@@ -188,7 +188,7 @@ use_old_IClientConfiguration(get_current_IClientConfiguration());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClientDetails": {"forwardCompat": false}
 */
 declare function get_old_IClientDetails(): old.IClientDetails;
@@ -197,7 +197,7 @@ use_current_IClientDetails(get_old_IClientDetails());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClientDetails": {"backCompat": false}
 */
 declare function get_current_IClientDetails(): current.IClientDetails;
@@ -206,7 +206,7 @@ use_old_IClientDetails(get_current_IClientDetails());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClientJoin": {"forwardCompat": false}
 */
 declare function get_old_IClientJoin(): old.IClientJoin;
@@ -215,7 +215,7 @@ use_current_IClientJoin(get_old_IClientJoin());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IClientJoin": {"backCompat": false}
 */
 declare function get_current_IClientJoin(): current.IClientJoin;
@@ -224,7 +224,7 @@ use_old_IClientJoin(get_current_IClientJoin());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ICommittedProposal": {"forwardCompat": false}
 */
 declare function get_old_ICommittedProposal(): old.ICommittedProposal;
@@ -233,7 +233,7 @@ use_current_ICommittedProposal(get_old_ICommittedProposal());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ICommittedProposal": {"backCompat": false}
 */
 declare function get_current_ICommittedProposal(): current.ICommittedProposal;
@@ -242,7 +242,7 @@ use_old_ICommittedProposal(get_current_ICommittedProposal());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IConnect": {"forwardCompat": false}
 */
 declare function get_old_IConnect(): old.IConnect;
@@ -251,7 +251,7 @@ use_current_IConnect(get_old_IConnect());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IConnect": {"backCompat": false}
 */
 declare function get_current_IConnect(): current.IConnect;
@@ -260,7 +260,7 @@ use_old_IConnect(get_current_IConnect());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IConnected": {"forwardCompat": false}
 */
 declare function get_old_IConnected(): old.IConnected;
@@ -269,7 +269,7 @@ use_current_IConnected(get_old_IConnected());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IConnected": {"backCompat": false}
 */
 declare function get_current_IConnected(): current.IConnected;
@@ -278,7 +278,7 @@ use_old_IConnected(get_current_IConnected());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ICreateBlobResponse": {"forwardCompat": false}
 */
 declare function get_old_ICreateBlobResponse(): old.ICreateBlobResponse;
@@ -287,7 +287,7 @@ use_current_ICreateBlobResponse(get_old_ICreateBlobResponse());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ICreateBlobResponse": {"backCompat": false}
 declare function get_current_ICreateBlobResponse(): current.ICreateBlobResponse;
 declare function use_old_ICreateBlobResponse(use: old.ICreateBlobResponse);
@@ -296,7 +296,7 @@ use_old_ICreateBlobResponse(get_current_ICreateBlobResponse());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IDocumentAttributes": {"forwardCompat": false}
 */
 declare function get_old_IDocumentAttributes(): old.IDocumentAttributes;
@@ -305,7 +305,7 @@ use_current_IDocumentAttributes(get_old_IDocumentAttributes());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IDocumentAttributes": {"backCompat": false}
 */
 declare function get_current_IDocumentAttributes(): current.IDocumentAttributes;
@@ -314,7 +314,7 @@ use_old_IDocumentAttributes(get_current_IDocumentAttributes());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IDocumentMessage": {"forwardCompat": false}
 */
 declare function get_old_IDocumentMessage(): old.IDocumentMessage;
@@ -323,7 +323,7 @@ use_current_IDocumentMessage(get_old_IDocumentMessage());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IDocumentMessage": {"backCompat": false}
 */
 declare function get_current_IDocumentMessage(): current.IDocumentMessage;
@@ -332,7 +332,7 @@ use_old_IDocumentMessage(get_current_IDocumentMessage());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IDocumentSystemMessage": {"forwardCompat": false}
 */
 declare function get_old_IDocumentSystemMessage(): old.IDocumentSystemMessage;
@@ -341,7 +341,7 @@ use_current_IDocumentSystemMessage(get_old_IDocumentSystemMessage());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IDocumentSystemMessage": {"backCompat": false}
 */
 declare function get_current_IDocumentSystemMessage(): current.IDocumentSystemMessage;
@@ -350,7 +350,7 @@ use_old_IDocumentSystemMessage(get_current_IDocumentSystemMessage());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IHelpMessage": {"forwardCompat": false}
 */
 declare function get_old_IHelpMessage(): old.IHelpMessage;
@@ -359,7 +359,7 @@ use_current_IHelpMessage(get_old_IHelpMessage());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IHelpMessage": {"backCompat": false}
 */
 declare function get_current_IHelpMessage(): current.IHelpMessage;
@@ -368,7 +368,7 @@ use_old_IHelpMessage(get_current_IHelpMessage());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "INack": {"forwardCompat": false}
 */
 declare function get_old_INack(): old.INack;
@@ -377,7 +377,7 @@ use_current_INack(get_old_INack());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "INack": {"backCompat": false}
 */
 declare function get_current_INack(): current.INack;
@@ -386,7 +386,7 @@ use_old_INack(get_current_INack());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "INackContent": {"forwardCompat": false}
 */
 declare function get_old_INackContent(): old.INackContent;
@@ -395,7 +395,7 @@ use_current_INackContent(get_old_INackContent());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "INackContent": {"backCompat": false}
 */
 declare function get_current_INackContent(): current.INackContent;
@@ -404,7 +404,7 @@ use_old_INackContent(get_current_INackContent());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IPendingProposal": {"forwardCompat": false}
 */
 declare function get_old_IPendingProposal(): old.IPendingProposal;
@@ -413,7 +413,7 @@ use_current_IPendingProposal(get_old_IPendingProposal());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IPendingProposal": {"backCompat": false}
 */
 declare function get_current_IPendingProposal(): current.IPendingProposal;
@@ -422,7 +422,7 @@ use_old_IPendingProposal(get_current_IPendingProposal());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IProcessMessageResult": {"forwardCompat": false}
 */
 declare function get_old_IProcessMessageResult(): old.IProcessMessageResult;
@@ -431,7 +431,7 @@ use_current_IProcessMessageResult(get_old_IProcessMessageResult());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IProcessMessageResult": {"backCompat": false}
 */
 declare function get_current_IProcessMessageResult(): current.IProcessMessageResult;
@@ -440,7 +440,7 @@ use_old_IProcessMessageResult(get_current_IProcessMessageResult());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IProposal": {"forwardCompat": false}
 */
 declare function get_old_IProposal(): old.IProposal;
@@ -449,7 +449,7 @@ use_current_IProposal(get_old_IProposal());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IProposal": {"backCompat": false}
 */
 declare function get_current_IProposal(): current.IProposal;
@@ -458,7 +458,7 @@ use_old_IProposal(get_current_IProposal());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IProtocolState": {"forwardCompat": false}
 */
 declare function get_old_IProtocolState(): old.IProtocolState;
@@ -467,7 +467,7 @@ use_current_IProtocolState(get_old_IProtocolState());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IProtocolState": {"backCompat": false}
 */
 declare function get_current_IProtocolState(): current.IProtocolState;
@@ -476,7 +476,7 @@ use_old_IProtocolState(get_current_IProtocolState());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IQueueMessage": {"forwardCompat": false}
 */
 declare function get_old_IQueueMessage(): old.IQueueMessage;
@@ -485,7 +485,7 @@ use_current_IQueueMessage(get_old_IQueueMessage());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IQueueMessage": {"backCompat": false}
 */
 declare function get_current_IQueueMessage(): current.IQueueMessage;
@@ -494,7 +494,7 @@ use_old_IQueueMessage(get_current_IQueueMessage());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IQuorum": {"forwardCompat": false}
 declare function get_old_IQuorum(): old.IQuorum;
 declare function use_current_IQuorum(use: current.IQuorum);
@@ -503,7 +503,7 @@ use_current_IQuorum(get_old_IQuorum());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IQuorum": {"backCompat": false}
 */
 declare function get_current_IQuorum(): current.IQuorum;
@@ -512,7 +512,7 @@ use_old_IQuorum(get_current_IQuorum());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IQuorumEvents": {"forwardCompat": false}
 */
 declare function get_old_IQuorumEvents(): old.IQuorumEvents;
@@ -521,7 +521,7 @@ use_current_IQuorumEvents(get_old_IQuorumEvents());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IQuorumEvents": {"backCompat": false}
 */
 declare function get_current_IQuorumEvents(): current.IQuorumEvents;
@@ -530,7 +530,7 @@ use_old_IQuorumEvents(get_current_IQuorumEvents());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedClient": {"forwardCompat": false}
 */
 declare function get_old_ISequencedClient(): old.ISequencedClient;
@@ -539,7 +539,7 @@ use_current_ISequencedClient(get_old_ISequencedClient());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedClient": {"backCompat": false}
 */
 declare function get_current_ISequencedClient(): current.ISequencedClient;
@@ -548,7 +548,7 @@ use_old_ISequencedClient(get_current_ISequencedClient());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedDocumentAugmentedMessage": {"forwardCompat": false}
 */
 declare function get_old_ISequencedDocumentAugmentedMessage(): old.ISequencedDocumentAugmentedMessage;
@@ -557,7 +557,7 @@ use_current_ISequencedDocumentAugmentedMessage(get_old_ISequencedDocumentAugment
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedDocumentAugmentedMessage": {"backCompat": false}
 */
 declare function get_current_ISequencedDocumentAugmentedMessage(): current.ISequencedDocumentAugmentedMessage;
@@ -566,7 +566,7 @@ use_old_ISequencedDocumentAugmentedMessage(get_current_ISequencedDocumentAugment
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedDocumentMessage": {"forwardCompat": false}
 */
 declare function get_old_ISequencedDocumentMessage(): old.ISequencedDocumentMessage;
@@ -575,7 +575,7 @@ use_current_ISequencedDocumentMessage(get_old_ISequencedDocumentMessage());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedDocumentMessage": {"backCompat": false}
 */
 declare function get_current_ISequencedDocumentMessage(): current.ISequencedDocumentMessage;
@@ -584,7 +584,7 @@ use_old_ISequencedDocumentMessage(get_current_ISequencedDocumentMessage());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedDocumentSystemMessage": {"forwardCompat": false}
 */
 declare function get_old_ISequencedDocumentSystemMessage(): old.ISequencedDocumentSystemMessage;
@@ -593,7 +593,7 @@ use_current_ISequencedDocumentSystemMessage(get_old_ISequencedDocumentSystemMess
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedDocumentSystemMessage": {"backCompat": false}
 */
 declare function get_current_ISequencedDocumentSystemMessage(): current.ISequencedDocumentSystemMessage;
@@ -602,7 +602,7 @@ use_old_ISequencedDocumentSystemMessage(get_current_ISequencedDocumentSystemMess
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedProposal": {"forwardCompat": false}
 */
 declare function get_old_ISequencedProposal(): old.ISequencedProposal;
@@ -611,7 +611,7 @@ use_current_ISequencedProposal(get_old_ISequencedProposal());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISequencedProposal": {"backCompat": false}
 */
 declare function get_current_ISequencedProposal(): current.ISequencedProposal;
@@ -620,7 +620,7 @@ use_old_ISequencedProposal(get_current_ISequencedProposal());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IServerError": {"forwardCompat": false}
 */
 declare function get_old_IServerError(): old.IServerError;
@@ -629,7 +629,7 @@ use_current_IServerError(get_old_IServerError());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IServerError": {"backCompat": false}
 */
 declare function get_current_IServerError(): current.IServerError;
@@ -638,7 +638,7 @@ use_old_IServerError(get_current_IServerError());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISignalClient": {"forwardCompat": false}
 */
 declare function get_old_ISignalClient(): old.ISignalClient;
@@ -647,7 +647,7 @@ use_current_ISignalClient(get_old_ISignalClient());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISignalClient": {"backCompat": false}
 */
 declare function get_current_ISignalClient(): current.ISignalClient;
@@ -656,7 +656,7 @@ use_old_ISignalClient(get_current_ISignalClient());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISignalMessage": {"forwardCompat": false}
 */
 declare function get_old_ISignalMessage(): old.ISignalMessage;
@@ -665,7 +665,7 @@ use_current_ISignalMessage(get_old_ISignalMessage());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISignalMessage": {"backCompat": false}
 */
 declare function get_current_ISignalMessage(): current.ISignalMessage;
@@ -674,7 +674,7 @@ use_old_ISignalMessage(get_current_ISignalMessage());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISnapshotTree": {"forwardCompat": false}
 */
 declare function get_old_ISnapshotTree(): old.ISnapshotTree;
@@ -683,7 +683,7 @@ use_current_ISnapshotTree(get_old_ISnapshotTree());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISnapshotTree": {"backCompat": false}
 */
 declare function get_current_ISnapshotTree(): current.ISnapshotTree;
@@ -692,7 +692,7 @@ use_old_ISnapshotTree(get_current_ISnapshotTree());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISnapshotTreeEx": {"forwardCompat": false}
 */
 declare function get_old_ISnapshotTreeEx(): old.ISnapshotTreeEx;
@@ -701,7 +701,7 @@ use_current_ISnapshotTreeEx(get_old_ISnapshotTreeEx());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISnapshotTreeEx": {"backCompat": false}
 */
 declare function get_current_ISnapshotTreeEx(): current.ISnapshotTreeEx;
@@ -710,7 +710,7 @@ use_old_ISnapshotTreeEx(get_current_ISnapshotTreeEx());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryAck": {"forwardCompat": false}
 */
 declare function get_old_ISummaryAck(): old.ISummaryAck;
@@ -719,7 +719,7 @@ use_current_ISummaryAck(get_old_ISummaryAck());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryAck": {"backCompat": false}
 */
 declare function get_current_ISummaryAck(): current.ISummaryAck;
@@ -728,7 +728,7 @@ use_old_ISummaryAck(get_current_ISummaryAck());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryAttachment": {"forwardCompat": false}
 declare function get_old_ISummaryAttachment(): old.ISummaryAttachment;
 declare function use_current_ISummaryAttachment(use: current.ISummaryAttachment);
@@ -737,7 +737,7 @@ use_current_ISummaryAttachment(get_old_ISummaryAttachment());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryAttachment": {"backCompat": false}
 declare function get_current_ISummaryAttachment(): current.ISummaryAttachment;
 declare function use_old_ISummaryAttachment(use: old.ISummaryAttachment);
@@ -746,7 +746,7 @@ use_old_ISummaryAttachment(get_current_ISummaryAttachment());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryAuthor": {"forwardCompat": false}
 */
 declare function get_old_ISummaryAuthor(): old.ISummaryAuthor;
@@ -755,7 +755,7 @@ use_current_ISummaryAuthor(get_old_ISummaryAuthor());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryAuthor": {"backCompat": false}
 */
 declare function get_current_ISummaryAuthor(): current.ISummaryAuthor;
@@ -764,7 +764,7 @@ use_old_ISummaryAuthor(get_current_ISummaryAuthor());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryBlob": {"forwardCompat": false}
 declare function get_old_ISummaryBlob(): old.ISummaryBlob;
 declare function use_current_ISummaryBlob(use: current.ISummaryBlob);
@@ -773,7 +773,7 @@ use_current_ISummaryBlob(get_old_ISummaryBlob());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryBlob": {"backCompat": false}
 declare function get_current_ISummaryBlob(): current.ISummaryBlob;
 declare function use_old_ISummaryBlob(use: old.ISummaryBlob);
@@ -782,7 +782,7 @@ use_old_ISummaryBlob(get_current_ISummaryBlob());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryCommitter": {"forwardCompat": false}
 */
 declare function get_old_ISummaryCommitter(): old.ISummaryCommitter;
@@ -791,7 +791,7 @@ use_current_ISummaryCommitter(get_old_ISummaryCommitter());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryCommitter": {"backCompat": false}
 */
 declare function get_current_ISummaryCommitter(): current.ISummaryCommitter;
@@ -800,7 +800,7 @@ use_old_ISummaryCommitter(get_current_ISummaryCommitter());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryConfiguration": {"forwardCompat": false}
 */
 declare function get_old_ISummaryConfiguration(): old.ISummaryConfiguration;
@@ -809,7 +809,7 @@ use_current_ISummaryConfiguration(get_old_ISummaryConfiguration());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryConfiguration": {"backCompat": false}
 */
 declare function get_current_ISummaryConfiguration(): current.ISummaryConfiguration;
@@ -818,7 +818,7 @@ use_old_ISummaryConfiguration(get_current_ISummaryConfiguration());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryContent": {"forwardCompat": false}
 */
 declare function get_old_ISummaryContent(): old.ISummaryContent;
@@ -827,7 +827,7 @@ use_current_ISummaryContent(get_old_ISummaryContent());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryContent": {"backCompat": false}
 */
 declare function get_current_ISummaryContent(): current.ISummaryContent;
@@ -836,7 +836,7 @@ use_old_ISummaryContent(get_current_ISummaryContent());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryHandle": {"forwardCompat": false}
 declare function get_old_ISummaryHandle(): old.ISummaryHandle;
 declare function use_current_ISummaryHandle(use: current.ISummaryHandle);
@@ -845,7 +845,7 @@ use_current_ISummaryHandle(get_old_ISummaryHandle());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryHandle": {"backCompat": false}
 declare function get_current_ISummaryHandle(): current.ISummaryHandle;
 declare function use_old_ISummaryHandle(use: old.ISummaryHandle);
@@ -854,7 +854,7 @@ use_old_ISummaryHandle(get_current_ISummaryHandle());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryNack": {"forwardCompat": false}
 */
 declare function get_old_ISummaryNack(): old.ISummaryNack;
@@ -863,7 +863,7 @@ use_current_ISummaryNack(get_old_ISummaryNack());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryNack": {"backCompat": false}
 */
 declare function get_current_ISummaryNack(): current.ISummaryNack;
@@ -872,7 +872,7 @@ use_old_ISummaryNack(get_current_ISummaryNack());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryProposal": {"forwardCompat": false}
 */
 declare function get_old_ISummaryProposal(): old.ISummaryProposal;
@@ -881,7 +881,7 @@ use_current_ISummaryProposal(get_old_ISummaryProposal());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryProposal": {"backCompat": false}
 */
 declare function get_current_ISummaryProposal(): current.ISummaryProposal;
@@ -890,7 +890,7 @@ use_old_ISummaryProposal(get_current_ISummaryProposal());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryTokenClaims": {"forwardCompat": false}
 */
 declare function get_old_ISummaryTokenClaims(): old.ISummaryTokenClaims;
@@ -899,7 +899,7 @@ use_current_ISummaryTokenClaims(get_old_ISummaryTokenClaims());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryTokenClaims": {"backCompat": false}
 */
 declare function get_current_ISummaryTokenClaims(): current.ISummaryTokenClaims;
@@ -908,7 +908,7 @@ use_old_ISummaryTokenClaims(get_current_ISummaryTokenClaims());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryTree": {"forwardCompat": false}
 declare function get_old_ISummaryTree(): old.ISummaryTree;
 declare function use_current_ISummaryTree(use: current.ISummaryTree);
@@ -917,7 +917,7 @@ use_current_ISummaryTree(get_old_ISummaryTree());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ISummaryTree": {"backCompat": false}
 declare function get_current_ISummaryTree(): current.ISummaryTree;
 declare function use_old_ISummaryTree(use: old.ISummaryTree);
@@ -926,7 +926,7 @@ use_old_ISummaryTree(get_current_ISummaryTree());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITokenClaims": {"forwardCompat": false}
 */
 declare function get_old_ITokenClaims(): old.ITokenClaims;
@@ -935,7 +935,7 @@ use_current_ITokenClaims(get_old_ITokenClaims());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITokenClaims": {"backCompat": false}
 */
 declare function get_current_ITokenClaims(): current.ITokenClaims;
@@ -944,7 +944,7 @@ use_old_ITokenClaims(get_current_ITokenClaims());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITokenProvider": {"forwardCompat": false}
 */
 declare function get_old_ITokenProvider(): old.ITokenProvider;
@@ -953,7 +953,7 @@ use_current_ITokenProvider(get_old_ITokenProvider());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITokenProvider": {"backCompat": false}
 */
 declare function get_current_ITokenProvider(): current.ITokenProvider;
@@ -962,7 +962,7 @@ use_old_ITokenProvider(get_current_ITokenProvider());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITokenService": {"forwardCompat": false}
 */
 declare function get_old_ITokenService(): old.ITokenService;
@@ -971,7 +971,7 @@ use_current_ITokenService(get_old_ITokenService());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITokenService": {"backCompat": false}
 */
 declare function get_current_ITokenService(): current.ITokenService;
@@ -980,7 +980,7 @@ use_old_ITokenService(get_current_ITokenService());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITrace": {"forwardCompat": false}
 */
 declare function get_old_ITrace(): old.ITrace;
@@ -989,7 +989,7 @@ use_current_ITrace(get_old_ITrace());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITrace": {"backCompat": false}
 */
 declare function get_current_ITrace(): current.ITrace;
@@ -998,7 +998,7 @@ use_old_ITrace(get_current_ITrace());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITree": {"forwardCompat": false}
 */
 declare function get_old_ITree(): old.ITree;
@@ -1007,7 +1007,7 @@ use_current_ITree(get_old_ITree());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITree": {"backCompat": false}
 */
 declare function get_current_ITree(): current.ITree;
@@ -1016,7 +1016,7 @@ use_old_ITree(get_current_ITree());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITreeEntry": {"forwardCompat": false}
 */
 declare function get_old_ITreeEntry(): old.ITreeEntry;
@@ -1025,7 +1025,7 @@ use_current_ITreeEntry(get_old_ITreeEntry());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ITreeEntry": {"backCompat": false}
 */
 declare function get_current_ITreeEntry(): current.ITreeEntry;
@@ -1034,7 +1034,7 @@ use_old_ITreeEntry(get_current_ITreeEntry());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IUploadedSummaryDetails": {"forwardCompat": false}
 */
 declare function get_old_IUploadedSummaryDetails(): old.IUploadedSummaryDetails;
@@ -1043,7 +1043,7 @@ use_current_IUploadedSummaryDetails(get_old_IUploadedSummaryDetails());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IUploadedSummaryDetails": {"backCompat": false}
 */
 declare function get_current_IUploadedSummaryDetails(): current.IUploadedSummaryDetails;
@@ -1052,7 +1052,7 @@ use_old_IUploadedSummaryDetails(get_current_IUploadedSummaryDetails());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IUser": {"forwardCompat": false}
 */
 declare function get_old_IUser(): old.IUser;
@@ -1061,7 +1061,7 @@ use_current_IUser(get_old_IUser());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IUser": {"backCompat": false}
 */
 declare function get_current_IUser(): current.IUser;
@@ -1070,7 +1070,7 @@ use_old_IUser(get_current_IUser());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IVersion": {"forwardCompat": false}
 */
 declare function get_old_IVersion(): old.IVersion;
@@ -1079,7 +1079,7 @@ use_current_IVersion(get_old_IVersion());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "IVersion": {"backCompat": false}
 */
 declare function get_current_IVersion(): current.IVersion;
@@ -1088,7 +1088,7 @@ use_old_IVersion(get_current_IVersion());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "MessageType": {"forwardCompat": false}
 */
 declare function get_old_MessageType(): old.MessageType;
@@ -1097,7 +1097,7 @@ use_current_MessageType(get_old_MessageType());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "MessageType": {"backCompat": false}
 */
 declare function get_current_MessageType(): current.MessageType;
@@ -1106,7 +1106,7 @@ use_old_MessageType(get_current_MessageType());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "NackErrorType": {"forwardCompat": false}
 */
 declare function get_old_NackErrorType(): old.NackErrorType;
@@ -1115,7 +1115,7 @@ use_current_NackErrorType(get_old_NackErrorType());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "NackErrorType": {"backCompat": false}
 */
 declare function get_current_NackErrorType(): current.NackErrorType;
@@ -1124,7 +1124,7 @@ use_old_NackErrorType(get_current_NackErrorType());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ScopeType": {"forwardCompat": false}
 */
 declare function get_old_ScopeType(): old.ScopeType;
@@ -1133,7 +1133,7 @@ use_current_ScopeType(get_old_ScopeType());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "ScopeType": {"backCompat": false}
 */
 declare function get_current_ScopeType(): current.ScopeType;
@@ -1142,7 +1142,7 @@ use_old_ScopeType(get_current_ScopeType());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryObject": {"forwardCompat": false}
 declare function get_old_SummaryObject(): old.SummaryObject;
 declare function use_current_SummaryObject(use: current.SummaryObject);
@@ -1151,7 +1151,7 @@ use_current_SummaryObject(get_old_SummaryObject());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryObject": {"backCompat": false}
 declare function get_current_SummaryObject(): current.SummaryObject;
 declare function use_old_SummaryObject(use: old.SummaryObject);
@@ -1160,7 +1160,7 @@ use_old_SummaryObject(get_current_SummaryObject());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryTree": {"forwardCompat": false}
 declare function get_old_SummaryTree(): old.SummaryTree;
 declare function use_current_SummaryTree(use: current.SummaryTree);
@@ -1169,7 +1169,7 @@ use_current_SummaryTree(get_old_SummaryTree());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryTree": {"backCompat": false}
 declare function get_current_SummaryTree(): current.SummaryTree;
 declare function use_old_SummaryTree(use: old.SummaryTree);
@@ -1178,7 +1178,7 @@ use_old_SummaryTree(get_current_SummaryTree());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryType": {"forwardCompat": false}
 declare function get_old_SummaryType(): old.SummaryType;
 declare function use_current_SummaryType(use: current.SummaryType);
@@ -1187,7 +1187,7 @@ use_current_SummaryType(get_old_SummaryType());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryType": {"backCompat": false}
 declare function get_current_SummaryType(): current.SummaryType;
 declare function use_old_SummaryType(use: old.SummaryType);
@@ -1196,7 +1196,7 @@ use_old_SummaryType(get_current_SummaryType());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryTypeNoHandle": {"forwardCompat": false}
 declare function get_old_SummaryTypeNoHandle(): old.SummaryTypeNoHandle;
 declare function use_current_SummaryTypeNoHandle(use: current.SummaryTypeNoHandle);
@@ -1205,7 +1205,7 @@ use_current_SummaryTypeNoHandle(get_old_SummaryTypeNoHandle());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "SummaryTypeNoHandle": {"backCompat": false}
 declare function get_current_SummaryTypeNoHandle(): current.SummaryTypeNoHandle;
 declare function use_old_SummaryTypeNoHandle(use: old.SummaryTypeNoHandle);
@@ -1214,7 +1214,7 @@ use_old_SummaryTypeNoHandle(get_current_SummaryTypeNoHandle());
 
 /*
 * validate forward compat by using old type in place of current type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "TreeEntry": {"forwardCompat": false}
 */
 declare function get_old_TreeEntry(): old.TreeEntry;
@@ -1223,7 +1223,7 @@ use_current_TreeEntry(get_old_TreeEntry());
 
 /*
 * validate back compat by using current type in place of old type
-* disable in package.json under typeValidation.broken:
+* to disable, add in package.json under typeValidation.broken:
 * "TreeEntry": {"backCompat": false}
 */
 declare function get_current_TreeEntry(): current.TreeEntry;

--- a/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
@@ -377,13 +377,6 @@ declare function set_old_IQueueMessage(set: old.IQueueMessage);
 declare function get_current_IQueueMessage(): current.IQueueMessage;
 set_old_IQueueMessage(get_current_IQueueMessage());
 
-// validate forward comapt of old type to new type
-// disable in package.json under typeValidation.broken:
-// "IQuorum": {"forwardCompat": false}
-declare function set_current_IQuorum(set: current.IQuorum);
-declare function get_old_IQuorum(): old.IQuorum;
-set_current_IQuorum(get_old_IQuorum());
-
 // validate backward comapt of new type to old type
 // disable in package.json under typeValidation.broken:
 // "IQuorum": {"backCompat": false}
@@ -397,6 +390,13 @@ set_old_IQuorum(get_current_IQuorum());
 declare function set_current_IQuorumEvents(set: current.IQuorumEvents);
 declare function get_old_IQuorumEvents(): old.IQuorumEvents;
 set_current_IQuorumEvents(get_old_IQuorumEvents());
+
+// validate backward comapt of new type to old type
+// disable in package.json under typeValidation.broken:
+// "IQuorumEvents": {"backCompat": false}
+declare function set_old_IQuorumEvents(set: old.IQuorumEvents);
+declare function get_current_IQuorumEvents(): current.IQuorumEvents;
+set_old_IQuorumEvents(get_current_IQuorumEvents());
 
 // validate forward comapt of old type to new type
 // disable in package.json under typeValidation.broken:

--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -12,13 +12,25 @@ export type PackageDetails ={
     readonly minorVersion: number;
     readonly patchVersion: string;
     readonly oldVersions: readonly string[];
+    readonly broken: BrokenCompatTypes;
 }
+
+export interface BrokenCompatSettings{
+    backCompat?: false;
+    forwardCompat?: false;
+}
+
+export type BrokenCompatTypes = Partial<Record<string, BrokenCompatSettings>>;
+
 
 interface PackageJson{
     name:string,
     version: string,
     devDependencies: Record<string, string>;
-    typeValidationVersion: string,
+    typeValidation?: {
+        version: string,
+        broken: BrokenCompatTypes,
+    },
 }
 
 function createSortedObject<T>(obj:Record<string,T>): Record<string,T>{
@@ -39,14 +51,17 @@ export function getPackageDetails(packageDir: string): PackageDetails {
 
     const pkgJson: PackageJson = JSON.parse(fs.readFileSync(packagePath).toString());
 
-    if(pkgJson.version !== pkgJson.typeValidationVersion){
-        if(pkgJson.typeValidationVersion !== undefined){
-            pkgJson.devDependencies[`${pkgJson.name}-${pkgJson.typeValidationVersion}`] =
-                `npm:${pkgJson.name}@${pkgJson.typeValidationVersion}`;
+    if(pkgJson.version !== pkgJson.typeValidation?.version){
+        if(pkgJson.typeValidation !== undefined){
+            pkgJson.devDependencies[`${pkgJson.name}-${pkgJson.typeValidation}`] =
+                `npm:${pkgJson.name}@${pkgJson.typeValidation}`;
 
             pkgJson.devDependencies = createSortedObject(pkgJson.devDependencies);
         }
-        pkgJson.typeValidationVersion = pkgJson.version;
+        pkgJson.typeValidation = {
+            version: pkgJson.version,
+            broken: {}
+        }
         fs.writeFileSync(packagePath, JSON.stringify(pkgJson, undefined, 2));
     }
 
@@ -63,6 +78,7 @@ export function getPackageDetails(packageDir: string): PackageDetails {
         majorVersion,
         minorVersion,
         patchVersion: versionParts[2],
-        oldVersions
+        oldVersions,
+        broken: pkgJson.typeValidation.broken
     }
 }

--- a/tools/build-tools/src/typeValidator/testGeneration.ts
+++ b/tools/build-tools/src/typeValidator/testGeneration.ts
@@ -31,19 +31,33 @@ import * as current from "../index";
                 const oldType = `old.${type.name}`
                 const currentType = `current.${type.name}`
 
+                testString.push(`/*`)
+                testString.push(`* validate forward compat by using old type in place of current type`);
+                testString.push(`* disable in package.json under typeValidation.broken:`);
+                testString.push(`* "${type.name}": {"forwardCompat": false}`);
+                const forwarCompatCase = buildTestCase(oldType, currentType);
                 if(currentTypeData.packageDetails.broken[type.name]?.forwardCompat !== false){
-                    testString.push(`// validate forward compat by using old type in place of current type`);
-                    testString.push(`// disable in package.json under typeValidation.broken:`);
-                    testString.push(`// "${type.name}": {"forwardCompat": false}`);
-                    testString.push(... buildTestCase(oldType, currentType))
+                    testString.push("*/");
+                    testString.push(... forwarCompatCase);
+                }else{
+                    testString.push(... forwarCompatCase);
+                    testString.push("*/");
                 }
+                testString.push("");
 
+                testString.push(`/*`)
+                testString.push(`* validate back compat by using current type in place of old type`);
+                testString.push(`* disable in package.json under typeValidation.broken:`);
+                testString.push(`* "${type.name}": {"backCompat": false}`);
+                const backCompatCase = buildTestCase(currentType, oldType);
                 if(currentTypeData.packageDetails.broken[type.name]?.backCompat !== false){
-                    testString.push(`// validate back compat by using current type in place of old type`);
-                    testString.push(`// disable in package.json under typeValidation.broken:`);
-                    testString.push(`// "${type.name}": {"backCompat": false}`);
-                    testString.push(... buildTestCase(currentType, oldType))
+                    testString.push("*/");
+                    testString.push(... backCompatCase)
+                }else{
+                    testString.push(... backCompatCase);
+                    testString.push("*/");
                 }
+                testString.push("");
 
             }
         }
@@ -59,6 +73,5 @@ function buildTestCase(getAsType:string, useType:string){
     testString.push(`declare function ${getSig}(): ${getAsType};`);
     testString.push(`declare function ${useSig}(use: ${useType});`);
     testString.push(`${useSig}(${getSig}());`)
-    testString.push("");
     return testString
 }

--- a/tools/build-tools/src/typeValidator/testGeneration.ts
+++ b/tools/build-tools/src/typeValidator/testGeneration.ts
@@ -27,22 +27,38 @@ import * as current from "../index";
         for(const type of currentTypeData.typeData){
             const typeString = type.name.replace(".","");
             // no need to test new types
-            if(!type.internal && oldTypes.some((t)=>t.name.replace(".","") == typeString)){
+            if(oldTypes.some((t)=>t.name.replace(".","") == typeString)){
                 const oldType = `old.${type.name}`
                 const currentType = `current.${type.name}`
 
+                if(currentTypeData.packageDetails.broken[type.name]?.forwardCompat !== false){
+                    testString.push(`// validate forward comapt of old type to new type`);
+                    testString.push(`// disable in package.json under typeValidation.broken:`);
+                    testString.push(`// "${type.name}": {"forwardCompat": false}`);
+                    testString.push(... buildTestCase(oldType, currentType))
+                }
 
-                const getOldSig =`get_old_${typeString}`;
-                const setOldSig =`set_old_${typeString}`;
-                testString.push(`declare function ${getOldSig}(): ${oldType};`);
-                const testGet = [`const current${typeString}: ${currentType} =`,`${getOldSig}();`];
-                testString.push(`${testGet[0]}${ testGet[0].length + testGet[1].length > 125 ?"\n    " : " "}${testGet[1]}`)
-                testString.push()
-                testString.push(`declare function ${setOldSig}(oldVal: ${oldType});`);
-                testString.push(`${setOldSig}(current${typeString});`)
-                testString.push("");
+                if(currentTypeData.packageDetails.broken[type.name]?.backCompat !== false){
+                    testString.push(`// validate backward comapt of new type to old type`);
+                    testString.push(`// disable in package.json under typeValidation.broken:`);
+                    testString.push(`// "${type.name}": {"backCompat": false}`);
+                    testString.push(... buildTestCase(currentType, oldType))
+                }
+
             }
         }
         fs.writeFileSync(`${packageDir}/src/test/validate${oldDetails.packageDetails.version}.ts`, testString.join("\n"));
     }
+}
+
+
+function buildTestCase(getType:string, setType:string){
+    const setSig =`set_${setType.replace(".","_")}`;
+    const getSig =`get_${getType.replace(".","_")}`;
+    const testString: string[] =[];
+    testString.push(`declare function ${setSig}(set: ${setType});`);
+    testString.push(`declare function ${getSig}(): ${getType};`);
+    testString.push(`${setSig}(${getSig}());`)
+    testString.push("");
+    return testString
 }

--- a/tools/build-tools/src/typeValidator/testGeneration.ts
+++ b/tools/build-tools/src/typeValidator/testGeneration.ts
@@ -32,14 +32,14 @@ import * as current from "../index";
                 const currentType = `current.${type.name}`
 
                 if(currentTypeData.packageDetails.broken[type.name]?.forwardCompat !== false){
-                    testString.push(`// validate forward comapt of old type to new type`);
+                    testString.push(`// validate forward compat by using old type in place of current type`);
                     testString.push(`// disable in package.json under typeValidation.broken:`);
                     testString.push(`// "${type.name}": {"forwardCompat": false}`);
                     testString.push(... buildTestCase(oldType, currentType))
                 }
 
                 if(currentTypeData.packageDetails.broken[type.name]?.backCompat !== false){
-                    testString.push(`// validate backward comapt of new type to old type`);
+                    testString.push(`// validate back compat by using current type in place of old type`);
                     testString.push(`// disable in package.json under typeValidation.broken:`);
                     testString.push(`// "${type.name}": {"backCompat": false}`);
                     testString.push(... buildTestCase(currentType, oldType))
@@ -52,13 +52,13 @@ import * as current from "../index";
 }
 
 
-function buildTestCase(getType:string, setType:string){
-    const setSig =`set_${setType.replace(".","_")}`;
-    const getSig =`get_${getType.replace(".","_")}`;
+function buildTestCase(getAsType:string, useType:string){
+    const getSig =`get_${getAsType.replace(".","_")}`;
+    const useSig =`use_${useType.replace(".","_")}`;
     const testString: string[] =[];
-    testString.push(`declare function ${setSig}(set: ${setType});`);
-    testString.push(`declare function ${getSig}(): ${getType};`);
-    testString.push(`${setSig}(${getSig}());`)
+    testString.push(`declare function ${getSig}(): ${getAsType};`);
+    testString.push(`declare function ${useSig}(use: ${useType});`);
+    testString.push(`${useSig}(${getSig}());`)
     testString.push("");
     return testString
 }

--- a/tools/build-tools/src/typeValidator/testGeneration.ts
+++ b/tools/build-tools/src/typeValidator/testGeneration.ts
@@ -33,7 +33,7 @@ import * as current from "../index";
 
                 testString.push(`/*`)
                 testString.push(`* validate forward compat by using old type in place of current type`);
-                testString.push(`* disable in package.json under typeValidation.broken:`);
+                testString.push(`* to disable, add in package.json under typeValidation.broken:`);
                 testString.push(`* "${type.name}": {"forwardCompat": false}`);
                 const forwarCompatCase = buildTestCase(oldType, currentType);
                 if(currentTypeData.packageDetails.broken[type.name]?.forwardCompat !== false){
@@ -47,7 +47,7 @@ import * as current from "../index";
 
                 testString.push(`/*`)
                 testString.push(`* validate back compat by using current type in place of old type`);
-                testString.push(`* disable in package.json under typeValidation.broken:`);
+                testString.push(`* to disable, add in package.json under typeValidation.broken:`);
                 testString.push(`* "${type.name}": {"backCompat": false}`);
                 const backCompatCase = buildTestCase(currentType, oldType);
                 if(currentTypeData.packageDetails.broken[type.name]?.backCompat !== false){


### PR DESCRIPTION
This change modifies the format of the tests by removing variables, and making the back and forward compact portions independent. In addition, it adds the ability to specify breaking changes in the package.json directly.

Note. this change does not introduce any breaks. it simply adds entries for existing breaks