### PR TITLE
Single `props` for initializing a TinyliciousClient

### DIFF
--- a/api-report/tinylicious-client.api.md
+++ b/api-report/tinylicious-client.api.md
@@ -9,8 +9,13 @@ import { FluidContainer } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
+import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ServiceAudience } from '@fluidframework/fluid-static';
+
+export { ITelemetryBaseEvent }
+
+export { ITelemetryBaseLogger }
 
 // @public (undocumented)
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
@@ -23,7 +28,7 @@ export class TinyliciousAudience extends ServiceAudience<TinyliciousMember> impl
 
 // @public
 class TinyliciousClient {
-    constructor(serviceConnectionConfig?: TinyliciousConnectionConfig, logger?: ITelemetryBaseLogger | undefined);
+    constructor(props?: TinyliciousClientProps | undefined);
     createContainer(containerSchema: ContainerSchema): Promise<{
         container: FluidContainer;
         services: TinyliciousContainerServices;
@@ -38,11 +43,15 @@ export { TinyliciousClient }
 
 export default TinyliciousClient;
 
-// @public (undocumented)
+// @public
+export interface TinyliciousClientProps {
+    connection?: TinyliciousConnectionConfig;
+    logger?: ITelemetryBaseLogger;
+}
+
+// @public
 export interface TinyliciousConnectionConfig {
-    // (undocumented)
     domain?: string;
-    // (undocumented)
     port?: number;
 }
 

--- a/packages/framework/tinylicious-client/README.md
+++ b/packages/framework/tinylicious-client/README.md
@@ -19,7 +19,7 @@ In the example below we are connecting to a locally running instance of our Tiny
 ```javascript
 import { TinyliciousClient, TinyliciousConnectionConfig } from "@fluidframework/tinylicious-client";
 
-const clientProps = { connection: { port: 7070 }};
+const clientProps = { connection: { port: 7070 } };
 const tinyliciousClient = new TinyliciousClient(clientProps);
 ```
 

--- a/packages/framework/tinylicious-client/README.md
+++ b/packages/framework/tinylicious-client/README.md
@@ -19,8 +19,8 @@ In the example below we are connecting to a locally running instance of our Tiny
 ```javascript
 import { TinyliciousClient, TinyliciousConnectionConfig } from "@fluidframework/tinylicious-client";
 
-const config: TinyliciousConnectionConfig = { port: 7070 };
-const tinyliciousClient = new TinyliciousClient(config);
+const clientProps = { connection: { port: 7070 }};
+const tinyliciousClient = new TinyliciousClient(clientProps);
 ```
 
 ## Fluid Containers
@@ -56,7 +56,7 @@ Using the default `TinyliciousClient` object the developer can create and get Fl
 ```javascript
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 
-const tinyliciousClient = new TinyliciousClient(config);
+const tinyliciousClient = new TinyliciousClient(props);
 const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema);
 ```
 

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -14,7 +14,6 @@ import {
     InsecureTinyliciousTokenProvider,
     InsecureTinyliciousUrlResolver,
 } from "@fluidframework/tinylicious-driver";
-import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import {
     ContainerSchema,
     DOProviderContainerRuntimeFactory,
@@ -22,7 +21,7 @@ import {
     RootDataObject,
 } from "@fluidframework/fluid-static";
 import {
-    TinyliciousConnectionConfig,
+    TinyliciousClientProps,
     TinyliciousContainerServices,
 } from "./interfaces";
 import { TinyliciousAudience } from "./TinyliciousAudience";
@@ -36,17 +35,13 @@ export class TinyliciousClient {
 
     /**
      * Creates a new client instance using configuration parameters.
-     * @param connectionConfig - Optional. Configuration parameters to override default connection settings.
-     * @param logger - Optional. A logger instance to receive diagnostic messages.
+     * @param props - Properties for initializing a new TinyliciousClient instance
      */
-    constructor(
-        serviceConnectionConfig?: TinyliciousConnectionConfig,
-        private readonly logger?: ITelemetryBaseLogger,
-    ) {
+    constructor(private readonly props?: TinyliciousClientProps) {
         const tokenProvider = new InsecureTinyliciousTokenProvider();
         this.urlResolver = new InsecureTinyliciousUrlResolver(
-            serviceConnectionConfig?.port,
-            serviceConnectionConfig?.domain,
+            this.props?.connection?.port,
+            this.props?.connection?.domain,
         );
         this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
             tokenProvider,
@@ -69,7 +64,7 @@ export class TinyliciousClient {
     }
 
     /**
-     * Acesses the existing container given its unique ID in the tinylicious server.
+     * Accesses the existing container given its unique ID in the tinylicious server.
      * @param id - Unique ID of the container.
      * @param containerSchema - Container schema used to access data objects in the container.
      * @returns Existing container instance along with associated services.
@@ -120,7 +115,7 @@ export class TinyliciousClient {
             urlResolver: this.urlResolver,
             documentServiceFactory: this.documentServiceFactory,
             codeLoader,
-            logger: this.logger,
+            logger: this.props?.logger,
         });
 
         let container: Container;

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -35,7 +35,7 @@ export class TinyliciousClient {
 
     /**
      * Creates a new client instance using configuration parameters.
-     * @param props - Properties for initializing a new TinyliciousClient instance
+     * @param props - Optional. Properties for initializing a new TinyliciousClient instance
      */
     constructor(private readonly props?: TinyliciousClientProps) {
         const tokenProvider = new InsecureTinyliciousTokenProvider();

--- a/packages/framework/tinylicious-client/src/interfaces.ts
+++ b/packages/framework/tinylicious-client/src/interfaces.ts
@@ -2,10 +2,42 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { IMember, IServiceAudience } from "@fluidframework/fluid-static";
 
+// Re-export so developers can build loggers without pulling in common-definitions
+export {
+    ITelemetryBaseEvent,
+    ITelemetryBaseLogger,
+} from "@fluidframework/common-definitions";
+
+/**
+ * Props for initializing a TinyliciousClient
+ */
+export interface TinyliciousClientProps {
+    /**
+     * Optional. Configuration for establishing a connection with the Tinylicious.
+     */
+    connection?: TinyliciousConnectionConfig,
+    /**
+     * Optional. A logger instance to receive diagnostic messages.
+     */
+    logger?: ITelemetryBaseLogger,
+}
+
+/**
+ * Parameters for establishing a connection with the a Tinylicious service.
+ */
 export interface TinyliciousConnectionConfig {
+    /**
+     * Optional. Override of the port
+     * @defaultValue - 7070
+     */
     port?: number;
+    /**
+     * Optional. Override of the domain
+     * @defaultValue - http://localhost
+     */
     domain?: string
 }
 

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -45,7 +45,7 @@ describe("TinyliciousClient", () => {
      * be returned.
      */
     it("can create a container successfully with port number specification", async () => {
-        const clientProps = { connection: { port: 7070 }};
+        const clientProps = { connection: { port: 7070 } };
         const clientWithPort = new TinyliciousClient(clientProps);
 
         const containerAndServicesP = clientWithPort.createContainer(schema);

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -8,10 +8,7 @@ import { DiceRoller } from "@fluid-example/diceroller";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
-import {
-    TinyliciousClient,
-    TinyliciousConnectionConfig,
-} from "..";
+import { TinyliciousClient } from "..";
 
 describe("TinyliciousClient", () => {
     let tinyliciousClient: TinyliciousClient;
@@ -48,8 +45,8 @@ describe("TinyliciousClient", () => {
      * be returned.
      */
     it("can create a container successfully with port number specification", async () => {
-        const clientConfig: TinyliciousConnectionConfig = { port: 7070 };
-        const clientWithPort = new TinyliciousClient(clientConfig);
+        const clientProps = { connection: { port: 7070 }};
+        const clientWithPort = new TinyliciousClient(clientProps);
 
         const containerAndServicesP = clientWithPort.createContainer(schema);
 


### PR DESCRIPTION
Have a single props for initializing a TinyliciousClient provides better extensibility for future settings and configurations.

This change also exports ITelemetryBaseEvent and ITelemetryBaseLogger from "@fluidframework/common-definitions" that enables building a logger without pulling in common-definitions.