### PR TITLE
Make sendTelemetryEvent always use category = "generic" to keep caller in full control

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -17,6 +17,7 @@ import { ITelemetryGenericEvent } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { ITelemetryPerformanceEvent } from '@fluidframework/common-definitions';
 import { ITelemetryProperties } from '@fluidframework/common-definitions';
+import { TelemetryEventCategory } from '@fluidframework/common-definitions';
 import { TelemetryEventPropertyType } from '@fluidframework/common-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
@@ -203,6 +204,9 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     sendErrorEvent(event: ITelemetryErrorEvent, error?: any): void;
     sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void;
     sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any): void;
+    protected sendTelemetryEventCore(event: ITelemetryGenericEvent & {
+        category: TelemetryEventCategory;
+    }, error?: any): void;
 }
 
 // @public

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -204,7 +204,6 @@ export function wrapErrorAndLog<T extends IFluidErrorBase>(
     logger.sendTelemetryEvent({
         eventName: "WrapError",
         wrappedByErrorInstanceId,
-        category: "generic", // avoids it being an "error" category due to  supplied error
     }, innerError);
 
     return newError;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1044,7 +1044,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         this.logger.sendTelemetryEvent({
             eventName: "ContainerRuntimeDisposed",
-            category: "generic",
             isDirty: this.isDirty,
             lastSequenceNumber: this.deltaManager.lastSequenceNumber,
             attachState: this.attachState,

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -340,7 +340,7 @@ export class SummaryGenerator {
                 const retryAfterSeconds = summaryNack?.retryAfter;
 
                 const error = new LoggingError(`summaryNack: ${message}`, { retryAfterSeconds });
-                logger.sendTelemetryEvent(
+                logger.sendErrorEvent(
                     { eventName: "SummaryNack", ...generateTelemetryProps, retryAfterSeconds }, error);
                 assert(getRetryDelaySecondsFromError(error) === retryAfterSeconds, "retryAfterSeconds");
                 // This will only set resultsBuilder.receivedSummaryAckOrNack, as other promises are already set.

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -186,7 +186,6 @@ export function decodeSummary(
                             if (newEarliestSeq <= latestSeq) {
                                 logger.sendTelemetryEvent({
                                     eventName:"DuplicateOutstandingOps",
-                                    category: "generic",
                                     // eslint-disable-next-line max-len
                                     message: `newEarliestSeq <= latestSeq in decodeSummary: ${newEarliestSeq} <= ${latestSeq}`,
                                 });

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -494,7 +494,7 @@ export class ReplayTool {
                         this.documentsFromStorageSnapshots.push(doc);
                     }
                 } catch (error) {
-                    doc.logger.sendTelemetryEvent({ eventName: "FailedToLoadSnapshot" }, error);
+                    doc.logger.sendErrorEvent({ eventName: "FailedToLoadSnapshot" }, error);
                 }
             }
             this.documentsFromStorageSnapshots.sort((a: Document, b: Document) => a.fromOp > b.fromOp ? 1 : -1);

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -137,10 +137,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
         event: ITelemetryGenericEvent & { category: TelemetryEventCategory },
         error?: any)
     {
-        const newEvent: ITelemetryBaseEvent = {
-            ...event,
-            category: event.category ?? (error === undefined ?  "generic" : "error"),
-        };
+        const newEvent = { ...event };
         if (error !== undefined) {
             TelemetryLogger.prepareErrorObject(newEvent, error, false);
         }

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -13,6 +13,7 @@ import {
     ITelemetryProperties,
     TelemetryEventPropertyType,
     ITaggedTelemetryPropertyType,
+    TelemetryEventCategory,
 } from "@fluidframework/common-definitions";
 import { BaseTelemetryNullLogger, performance } from "@fluidframework/common-utils";
 import {
@@ -123,6 +124,19 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param error - optional error object to log
      */
     public sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any) {
+        this.sendTelemetryEventCore({ ...event, category: "generic"}, error);
+    }
+
+    /**
+     * Send a telemetry event with the logger
+     *
+     * @param event - the event to send
+     * @param error - optional error object to log
+     */
+     protected sendTelemetryEventCore(
+        event: ITelemetryGenericEvent & { category: TelemetryEventCategory },
+        error?: any)
+    {
         const newEvent: ITelemetryBaseEvent = {
             ...event,
             category: event.category ?? (error === undefined ?  "generic" : "error"),
@@ -146,7 +160,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param error - optional error object to log
      */
     public sendErrorEvent(event: ITelemetryErrorEvent, error?: any) {
-        this.sendTelemetryEvent({ ...event, category: "error" }, error);
+        this.sendTelemetryEventCore({ ...event, category: "error" }, error);
     }
 
     /**
@@ -156,12 +170,12 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param error - optional error object to log
      */
     public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {
-        const perfEvent: ITelemetryGenericEvent = {
+        const perfEvent = {
             ...event,
             category: event.category ? event.category : "performance",
         };
 
-        this.sendTelemetryEvent(perfEvent, error);
+        this.sendTelemetryEventCore(perfEvent, error);
     }
 
     protected prepareEvent(event: ITelemetryBaseEvent): ITelemetryBaseEvent {


### PR DESCRIPTION
Found another place in code where intention was to use "generic" category but it ended up being "error" due to error passed in. So instead of keep patching these by caller overwriting (default) category, make it more deterministic on what category is used.