### PR TITLE
Summarizer improvements: Reduce number of errors in telemetry

### DIFF
--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -329,9 +329,6 @@ export class RunningSummarizer implements IDisposable {
         cancellationToken = this.cancellationToken): void
     {
         if (this.summarizingLock !== undefined) {
-            // This should not happen often, if at all (depends on how on-demand and enqueues summaries are used)
-            // Log an error to learn about these cases and assess if we need to change anything.
-            this.logger.sendTelemetryEvent({ eventName: "ConcurrentSummaryAttempt", reason: summarizeReason });
             // lockedSummaryAction() will retry heuristic-based summary at the end of current attempt
             // if it's still needed
             this.tryWhileSummarizing = true;

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -230,7 +230,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
             // summarizer container loosing connection while load.
             // Not worth reporting such errors as errors. That said, we might miss some real errors if
             // we ignore blindly, so try to narrow signature we are looking for - skip logging
-            // error only if interactive container should no longer be summarizer (which in practice
+            // error only if this client should no longer be a summarizer (which in practice
             // means it also lost connection), and error happened on load (we do not have summarizer).
             // We could add error.fluidErrorCode !== "containerClosedWithoutErrorDuringLoad" check to narrow it down,
             // but that does not seem to be necessary.

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -226,11 +226,13 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
                 async () => summarizer.run(clientId, this.summarizerOptions),
             );
         }).catch((error) => {
-            // Most of exceptions happen due to container being closed while loading it.
-            // Not worth reporting such errors. That said, we might miss some real errors if
+            // Most of exceptions happen due to container being closed while loading it, due to
+            // summarizer container loosing connection while load.
+            // Not worth reporting such errors as errors. That said, we might miss some real errors if
             // we ignore blindly, so try to narrow signature we are looking for - skip logging
-            // error only if interactive container also is disconnected (or went through reconnection),
-            // we do not have summarizer. We could add error.fluidErrorCode !== "containerClosedWithoutErrorDuringLoad",
+            // error only if interactive container should no longer be summarizer (which in practice
+            // means it also lost connection), and error happened on load (we do not have summarizer).
+            // We could add error.fluidErrorCode !== "containerClosedWithoutErrorDuringLoad" check to narrow it down,
             // but that does not seem to be necessary.
             if (this.getShouldSummarizeState().shouldSummarize || this.summarizer !== undefined) {
                 this.logger.sendErrorEvent({ eventName: "SummarizerException" }, error);


### PR DESCRIPTION
Changes based on going through latest ODSP Stress logs:
1. ConcurrentSummaryAttempt that was added by me recently as result of PR feedback generates too much noise. The reason for that - SummarizeHeuristicRunner calls RunningSummarizer.trySummarize whenever it wants (basically when time-based or op-based triggers fire). So it naturally runs into asking for new summary when previous summary is still running, as it does not wait with releasing its wishes until previous wish is over. I do not think it's worth complicating code here - it's fine to ignore these cases.
2. I've added a bunch of asserts to ensure consistency of state / easier to follow code. I got it wrong with 0x265 - we can get there if summarization process cancels before it even fully started.
3. The errors due to summarizer container being closed due to it losing connection before it even fully booted always happened, but these are now at the top of the list, so worth address them. Do not log any error if main container also disconnected and error was while creating summarizer - that is very good indication that both containers disconnected at the same time and that's the reason for error. This might miss some other errors, but we will see them outside of this condition (at scale), so it does not feel like big deal (especially that we know that we should not be summarizing anyway, so moving to exit silently is Ok).