### PR TITLE
Remove Aqueduct from fluid-framework package

### DIFF
--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 
-export * from "@fluidframework/aqueduct";
 export * from "@fluidframework/fluid-static";
 export * from "@fluidframework/map";
 export * from "@fluidframework/sequence";

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -27,7 +27,6 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/aqueduct": "^0.47.0",
     "@fluidframework/fluid-static": "^0.47.0",
     "@fluidframework/map": "^0.47.0",
     "@fluidframework/sequence": "^0.47.0"

--- a/packages/framework/fluid-framework/src/aqueduct.ts
+++ b/packages/framework/fluid-framework/src/aqueduct.ts
@@ -1,6 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export * from  "@fluidframework/aqueduct";

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable import/export */
 
-export * from  "./aqueduct";
 export * from  "./fluidStatic";
 export * from  "./map";
 export * from  "./sequence";


### PR DESCRIPTION
Generally speaking, Aqueduct is only needed by developers who want to build their own data objects or write their own container code.  With the consumption-centric approach, e.g. used by Brainstorm and external-controller, the DO's and container code are already provided.  For now, let's scope the fluid-framework package to be the set required for the consumption approach, and if we choose to expand it to support custom data objects and container code in the future we can revisit.