### PR TITLE
Improve layer check against client-api and base-host

### DIFF
--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -145,8 +145,7 @@
                     "@fluidframework/base-host"
                 ],
                 "deps": [
-                    "Loader",
-                    "Framework-Utils"
+                    "Loader"
                 ]
             },
             "HostUtils": {
@@ -195,6 +194,7 @@
                     "packages/framework/"
                 ],
                 "deps": [
+                    "Framework-Utils",
                     "Hosts",
                     "Runtime"
                 ]

--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -140,7 +140,7 @@
                     "Container-Utils"
                 ]
             },
-            "Hosts": {
+            "BaseHost": {
                 "packages": [
                     "@fluidframework/base-host"
                 ],
@@ -195,7 +195,7 @@
                 ],
                 "deps": [
                     "Framework-Utils",
-                    "Hosts",
+                    "Loader",
                     "Runtime"
                 ]
             },
@@ -219,7 +219,6 @@
                 ],
                 "deps": [
                     "Framework",
-                    "Hosts",
                     "Runtime"
                 ]
             },

--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -178,9 +178,17 @@
                     "Container-Utils"
                 ]
             },
+            "ClientApi": {
+                "packages": [
+                    "@fluid-internal/client-api"
+                ],
+                "deps": [
+                    "Framework",
+                    "Runtime"
+                ]
+            },
             "Framework": {
                 "packages": [
-                    "@fluid-internal/client-api",
                     "@fluid-experimental/data-objects",
                     "@fluidframework/fluid-static"
                 ],

--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -164,9 +164,6 @@
                 ]
             },
             "Runtime": {
-                "packages": [
-                    "@fluidframework/agent-scheduler"
-                ],
                 "dirs": [
                     "experimental/dds/",
                     "packages/dds/",


### PR DESCRIPTION
Currently client-api and base-host dependencies are permitted in the relatively high profile Framework layer and anything above it.  This change pulls them off to the side such that any usage would need to be made explicit.