### PR TITLE
Container Fails to Serialize and Rehydrate Multiple Times

### DIFF
--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -5,6 +5,7 @@
 
 import {
     assert,
+    bufferToString,
     fromBase64ToUtf8,
     IsoBuffer,
     Uint8ArrayToString,
@@ -266,11 +267,11 @@ export function convertSnapshotTreeToSummaryTree(
 
     const builder = new SummaryTreeBuilder();
     for (const [path, id] of Object.entries(snapshot.blobs)) {
-        let decoded: string | Uint8Array | undefined;
+        let decoded: string | undefined;
         if ((snapshot as any).blobsContents !== undefined) {
             const content: ArrayBufferLike = (snapshot as any).blobsContents[id];
             if (content !== undefined) {
-                decoded = new Uint8Array(content);
+                decoded = bufferToString(content, "utf-8");
             }
         // 0.44 back-compat We still put contents in same blob for back-compat so need to add blob
         // only for blobPath -> blobId mapping and not for blobId -> blob value contents.

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -80,7 +80,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
             assert.strictEqual(sparseMatrix.id, sparseMatrixId, "Sparse matrix should exist!!");
         });
 
-        it.skip(`Rehydrate container from ${filenameShort} round trip serialize/deserialize${
+        it(`Rehydrate container from ${filenameShort} round trip serialize/deserialize${
             disableIsolatedChannels ? " (disable isolated channels)" : ""}`, async () => {
             const snapshotTree = fs.readFileSync(filename, "utf8");
 

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -314,14 +314,14 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
         it("Rehydrate container multiple times round trip serialize/deserialize", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();
-            const snapshotTree1 = container.serialize();
-            const container1 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree1);
-
-            const snapshotTree2 = container1.serialize();
-            const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree2);
+            let container1 = container;
+            for (let i = 0; i < 5; ++i) {
+                const snapshotTree1 = container1.serialize();
+                container1 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree1);
+            }
 
             // Check for default data store
-            const response = await container2.request({ url: "/" });
+            const response = await container1.request({ url: "/" });
             assert.strictEqual(response.status, 200, `Component should exist!! ${response.value}`);
             const defaultDataStore = response.value as TestFluidObject;
             assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -311,6 +311,44 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             assert.strictEqual(sparseMatrix.id, sparseMatrixId, "Sparse matrix should exist!!");
         });
 
+        it("Rehydrate container multiple times round trip serialize/deserialize", async () => {
+            const { container } =
+                await createDetachedContainerAndGetRootDataStore();
+            const snapshotTree1 = container.serialize();
+            const container1 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree1);
+
+            const snapshotTree2 = container1.serialize();
+            const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree2);
+
+            // Check for default data store
+            const response = await container2.request({ url: "/" });
+            assert.strictEqual(response.status, 200, `Component should exist!! ${response.value}`);
+            const defaultDataStore = response.value as TestFluidObject;
+            assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
+
+            // Check for dds
+            const sharedMap = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
+            const sharedDir = await defaultDataStore.getSharedObject<SharedDirectory>(sharedDirectoryId);
+            const sharedString = await defaultDataStore.getSharedObject<SharedString>(sharedStringId);
+            const sharedCell = await defaultDataStore.getSharedObject<SharedCell>(sharedCellId);
+            const sharedCounter = await defaultDataStore.getSharedObject<SharedCounter>(sharedCounterId);
+            const crc = await defaultDataStore.getSharedObject<ConsensusRegisterCollection<string>>(crcId);
+            const coc = await defaultDataStore.getSharedObject<ConsensusOrderedCollection>(cocId);
+            const ink = await defaultDataStore.getSharedObject<Ink>(sharedInkId);
+            const sharedMatrix = await defaultDataStore.getSharedObject<SharedMatrix>(sharedMatrixId);
+            const sparseMatrix = await defaultDataStore.getSharedObject<SparseMatrix>(sparseMatrixId);
+            assert.strictEqual(sharedMap.id, sharedMapId, "Shared map should exist!!");
+            assert.strictEqual(sharedDir.id, sharedDirectoryId, "Shared directory should exist!!");
+            assert.strictEqual(sharedString.id, sharedStringId, "Shared string should exist!!");
+            assert.strictEqual(sharedCell.id, sharedCellId, "Shared cell should exist!!");
+            assert.strictEqual(sharedCounter.id, sharedCounterId, "Shared counter should exist!!");
+            assert.strictEqual(crc.id, crcId, "CRC should exist!!");
+            assert.strictEqual(coc.id, cocId, "COC should exist!!");
+            assert.strictEqual(ink.id, sharedInkId, "Shared ink should exist!!");
+            assert.strictEqual(sharedMatrix.id, sharedMatrixId, "Shared matrix should exist!!");
+            assert.strictEqual(sparseMatrix.id, sparseMatrixId, "Sparse matrix should exist!!");
+        });
+
         it("Storage in detached container", async () => {
             const { container } =
                 await createDetachedContainerAndGetRootDataStore();


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/7362
This was a recent change where if the content is in UnintArray then we stopped converting it to string while deserializing a container. But it is harmful as the Uint8Array loses it shapes on JSON stringifying and parsing and end up just an "object" type instead of Uint8Array, so then at rehydrating the container fails to load.