### PR TITLE
roll back server protocol-definitions dependencies to 1024

### DIFF
--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -467,9 +467,9 @@
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1025.0-35619",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-35619.tgz",
-			"integrity": "sha512-vN73ykRT655VMaUfgBgOfLYpbtfMtUZyQ7+jUs13neaEMFaVKZHxQQQASVPKKFtpJxl4rC/JGTZwKBNt1s85lA==",
+			"version": "0.1024.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0.tgz",
+			"integrity": "sha512-ksbjiihicwMbbX3fPkVOxsl8QDDiuc20T7t4Y7vq7aMkzPh4FAwoomjjreDSf71N6zAoz30HEzPPl0OwvPi0xw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0"
 			}

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-core": "^0.1030.0",
     "@types/node": "^12.19.0"
   },

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
     "@fluidframework/protocol-base": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas-driver": "^0.1030.0",
     "@fluidframework/server-services-client": "^0.1030.0",
     "@fluidframework/server-services-core": "^0.1030.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1030.0",
     "@fluidframework/server-memory-orderer": "^0.1030.0",
     "@fluidframework/server-services-client": "^0.1030.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-base": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1030.0",
     "@fluidframework/server-services-client": "^0.1030.0",
     "@fluidframework/server-services-core": "^0.1030.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-kafka-orderer": "^0.1030.0",
     "@fluidframework/server-lambdas": "^0.1030.0",
     "@fluidframework/server-lambdas-driver": "^0.1030.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-kafka-orderer": "^0.1030.0",
     "@fluidframework/server-lambdas": "^0.1030.0",
     "@fluidframework/server-lambdas-driver": "^0.1030.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
     "@fluidframework/protocol-base": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "axios": "^0.21.1",
     "debug": "^4.1.1",
     "jsrsasign": "^10.2.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1030.0",
     "@types/nconf": "^0.10.0",
     "@types/node": "^12.19.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
     "@fluidframework/protocol-base": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1030.0",
     "@fluidframework/server-services-core": "^0.1030.0",
     "@socket.io/redis-adapter": "^7.0.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1030.0",
     "@fluidframework/server-services-core": "^0.1030.0",
     "@fluidframework/server-services-telemetry": "^0.1030.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1030.0",
     "@fluidframework/server-services-core": "^0.1030.0",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1030.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1030.0",
     "@fluidframework/protocol-base": "^0.1030.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0",
+    "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-services-client": "^0.1030.0",
     "@fluidframework/server-services-core": "^0.1030.0",
     "@fluidframework/server-services-telemetry": "^0.1030.0",


### PR DESCRIPTION
fix #7374
It looks like this was bumped but not consumed, so I didn't get build breaks after rolling back