### PR TITLE
Fix PR #7383 - node 12 compat in gen_version.js

### DIFF
--- a/common/build/build-common/gen_version.js
+++ b/common/build/build-common/gen_version.js
@@ -23,7 +23,7 @@ const pkgName = pkg.name;
 // For test builds, the package version starts with 0.0.0.  Code need to know the original version.
 // CI build create one with original version prefix is emitted into the environment for code logic to be used here.
 // See tools/pipelines/scripts/build-version.js
-const pkgVersion = process.env.SETVERSION_CODEVERSION ?? pkg.version;
+const pkgVersion = process.env.SETVERSION_CODEVERSION ? process.env.SETVERSION_CODEVERSION : pkg.version;
 
 // Make sure the output directory exists
 if (!fs.existsSync(outDir)) {


### PR DESCRIPTION
Node 12 doesn't support `??` operator yet.  

