### PR TITLE
Allow --baseVersion flag to set the base version for the e2e test to target against

### DIFF
--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -18,7 +18,7 @@ import {
 } from "@fluidframework/test-utils";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { FluidTestDriverConfig, createFluidTestDriver } from "@fluidframework/test-drivers";
-
+import { pkgVersion } from "./packageVersion";
 import { getLoaderApi, getContainerRuntimeApi, getDataRuntimeApi, getDriverApi } from "./testApi";
 
 export const TestDataObjectType = "@fluid-example/test-dataStore";
@@ -74,16 +74,18 @@ function createGetDataStoreFactoryFunction(api: ReturnType<typeof getDataRuntime
     };
 }
 
-export const getDataStoreFactory = createGetDataStoreFactoryFunction(getDataRuntimeApi());
+// Only support current version, not baseVersion support
+export const getDataStoreFactory = createGetDataStoreFactoryFunction(getDataRuntimeApi(pkgVersion));
 
 export async function createVersionedFluidTestDriver(
+    baseVersion: string,
     driverConfig?: {
         type?: TestDriverTypes,
         config?: FluidTestDriverConfig,
         version?: number | string,
     },
 ) {
-    const driverApi = getDriverApi(driverConfig?.version);
+    const driverApi = getDriverApi(baseVersion,driverConfig?.version);
     return createFluidTestDriver(
         driverConfig?.type ?? "local",
         driverConfig?.config,
@@ -92,6 +94,7 @@ export async function createVersionedFluidTestDriver(
 }
 
 export async function getVersionedTestObjectProvider(
+    baseVersion: string,
     loaderVersion?: number | string,
     driverConfig?: {
         type?: TestDriverTypes,
@@ -101,10 +104,10 @@ export async function getVersionedTestObjectProvider(
     runtimeVersion?: number | string,
     dataRuntimeVersion?: number | string,
 ): Promise<ITestObjectProvider> {
-    const loaderApi = getLoaderApi(loaderVersion);
-    const containerRuntimeApi = getContainerRuntimeApi(runtimeVersion);
-    const dataRuntimeApi = getDataRuntimeApi(dataRuntimeVersion);
-    const driver = await createVersionedFluidTestDriver(driverConfig);
+    const loaderApi = getLoaderApi(baseVersion, loaderVersion);
+    const containerRuntimeApi = getContainerRuntimeApi(baseVersion, runtimeVersion);
+    const dataRuntimeApi = getDataRuntimeApi(baseVersion, dataRuntimeVersion);
+    const driver = await createVersionedFluidTestDriver(baseVersion, driverConfig);
 
     const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(dataRuntimeApi);
     const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -85,7 +85,7 @@ export async function createVersionedFluidTestDriver(
         version?: number | string,
     },
 ) {
-    const driverApi = getDriverApi(baseVersion,driverConfig?.version);
+    const driverApi = getDriverApi(baseVersion, driverConfig?.version);
     return createFluidTestDriver(
         driverConfig?.type ?? "local",
         driverConfig?.config,

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -50,7 +50,8 @@ const packageList = [
 ];
 
 export const ensurePackageInstalled =
-    async (version: number | string, force: boolean) => ensureInstalled(getRequestedRange(version), packageList, force);
+    async (baseVersion: string, version: number | string, force: boolean) =>
+        ensureInstalled(getRequestedRange(baseVersion, version), packageList, force);
 
 // Current versions of the APIs
 const LoaderApi = {
@@ -83,8 +84,8 @@ const DataRuntimeApi = {
     },
 };
 
-export function getLoaderApi(requested?: number | string): typeof LoaderApi {
-    const requestedStr = getRequestedRange(requested);
+export function getLoaderApi(baseVersion: string, requested?: number | string): typeof LoaderApi {
+    const requestedStr = getRequestedRange(baseVersion, requested);
 
     // If the current version satisfies the range, use it.
     if (semver.satisfies(pkgVersion, requestedStr)) {
@@ -98,8 +99,11 @@ export function getLoaderApi(requested?: number | string): typeof LoaderApi {
     };
 }
 
-export function getContainerRuntimeApi(requested?: number | string): typeof ContainerRuntimeApi {
-    const requestedStr = getRequestedRange(requested);
+export function getContainerRuntimeApi(
+    baseVersion: string,
+    requested?: number | string,
+): typeof ContainerRuntimeApi {
+    const requestedStr = getRequestedRange(baseVersion, requested);
     if (semver.satisfies(pkgVersion, requestedStr)) {
         return ContainerRuntimeApi;
     }
@@ -112,8 +116,11 @@ export function getContainerRuntimeApi(requested?: number | string): typeof Cont
     };
 }
 
-export function getDataRuntimeApi(requested?: number | string): typeof DataRuntimeApi {
-    const requestedStr = getRequestedRange(requested);
+export function getDataRuntimeApi(
+    baseVersion: string,
+    requested?: number | string,
+): typeof DataRuntimeApi {
+    const requestedStr = getRequestedRange(baseVersion, requested);
     if (semver.satisfies(pkgVersion, requestedStr)) {
         return DataRuntimeApi;
     }
@@ -140,8 +147,8 @@ export function getDataRuntimeApi(requested?: number | string): typeof DataRunti
     };
 }
 
-export function getDriverApi(requested?: number | string): typeof DriverApi {
-    const requestedStr = getRequestedRange(requested);
+export function getDriverApi(baseVersion: string, requested?: number | string): typeof DriverApi {
+    const requestedStr = getRequestedRange(baseVersion, requested);
 
     // If the current version satisfies the range, use it.
     if (semver.satisfies(pkgVersion, requestedStr)) {

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -91,7 +91,7 @@ async function removeInstalled(version: string) {
     }
 }
 
-function resolveVersion(requested: string, installed: boolean) {
+export function resolveVersion(requested: string, installed: boolean) {
     const cachedVersion = resolutionCache.get(requested);
     if (cachedVersion) { return cachedVersion; }
     if (semver.valid(requested)) {
@@ -146,6 +146,7 @@ async function ensureModulePath(version: string, modulePath: string) {
 }
 
 export async function ensureInstalled(requested: string, packageList: string[], force: boolean) {
+    if (requested === pkgVersion) { return; }
     const version = resolveVersion(requested, false);
     const modulePath = getModulePath(version);
 
@@ -215,10 +216,10 @@ export const loadPackage = (modulePath: string, pkg: string) =>
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-require-imports
     require(path.join(modulePath, "node_modules", pkg));
 
-export function getRequestedRange(requested?: number | string): string {
-    if (requested === undefined || requested === 0) { return pkgVersion; }
+export function getRequestedRange(baseVersion: string, requested?: number | string): string {
+    if (requested === undefined || requested === 0) { return baseVersion; }
     if (typeof requested === "string") { return requested; }
-    const version = new semver.SemVer(pkgVersion);
+    const version = new semver.SemVer(baseVersion);
     // ask for prerelease in case we just bumpped the version and haven't release the previous version yet.
     return `^${version.major}.${version.minor + requested}.0-0`;
 }


### PR DESCRIPTION
Instead of the current version (which continues to be the default), add the `--baseVersion` flag that allow a version (or version range) to be specified to be ran the test against.