### PR TITLE
Change no join op recovery to telemetry only

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -44,6 +44,7 @@ import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
+import { ITelemetryErrorEvent } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { ITelemetryProperties } from '@fluidframework/common-definitions';
 import { IThrottlingWarning } from '@fluidframework/container-definitions';
@@ -181,6 +182,7 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     get lastMessage(): ISequencedDocumentMessage | undefined;
     // (undocumented)
     get lastSequenceNumber(): number;
+    logConnectionIssue(event: ITelemetryErrorEvent): void;
     // (undocumented)
     get maxMessageSize(): number;
     // (undocumented)
@@ -212,8 +214,6 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     submit(type: MessageType, contents: any, batch?: boolean, metadata?: any): number;
     // (undocumented)
     submitSignal(content: any): void;
-    // (undocumented)
-    triggerConnectionRecovery(reason: string, props: ITelemetryProperties): void;
     // (undocumented)
     get version(): string;
 }

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -102,7 +102,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
             if (this.joinOpTimer.hasTimer) {
                 this.stopJoinOpTimer();
             } else {
-                // timer has already fired, meaning it too too long to get join on.
+                // timer has already fired, meaning it took too long to get join on.
                 // Record how long it actually took to recover.
                 this.handler.logConnectionIssue("ReceivedJoinOp");
             }

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -17,7 +17,7 @@ export interface IConnectionStateHandler {
         (value: ConnectionState, oldState: ConnectionState, reason?: string | undefined) => void,
     shouldClientJoinWrite: () => boolean,
     maxClientLeaveWaitTime: number | undefined,
-    triggerConnectionRecovery: (reason: string) => void,
+    logConnectionIssue: (eventName: string) => void,
 }
 
 export interface ILocalSequencedClient extends ISequencedClient {
@@ -30,6 +30,8 @@ export interface ILocalSequencedClient extends ISequencedClient {
 export interface IConnectionStateHandlerEvents extends IEvent {
     (event: "connectionStateChanged", listener: () => void);
 }
+
+const JoinOpTimer = 45000;
 
 export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConnectionStateHandlerEvents> {
     private _connectionState = ConnectionState.Disconnected;
@@ -73,12 +75,12 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         // timing out ops fetches. So attempt recovery infrequently. Also fetch uses 30 second timeout, so
         // if retrying fixes the problem, we should not see these events.
         this.joinOpTimer = new Timer(
-            45000,
+            JoinOpTimer,
             () => {
                 // I've observed timer firing within couple ms from disconnect event, looks like
                 // queued timer callback is not cancelled if timer is cancelled while callback sits in the queue.
-                if (this.connectionState !== ConnectionState.Disconnected) {
-                    this.handler.triggerConnectionRecovery("NoJoinOp");
+                if (this.connectionState === ConnectionState.Connecting) {
+                    this.handler.logConnectionIssue("NoJoinOp");
                 }
             },
         );
@@ -89,7 +91,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
         this.joinOpTimer.start();
     }
 
-    private stopJoinOpTimer(reason: string) {
+    private stopJoinOpTimer() {
         assert(this.joinOpTimer.hasTimer, 0x235 /* "no joinOpTimer" */);
         this.joinOpTimer.clear();
     }
@@ -97,7 +99,13 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
     public receivedAddMemberEvent(clientId: string) {
         // This is the only one that requires the pending client ID
         if (clientId === this.pendingClientId) {
-            this.stopJoinOpTimer("joinOp");
+            if (this.joinOpTimer.hasTimer) {
+                this.stopJoinOpTimer();
+            } else {
+                // timer has already fired, meaning it too too long to get join on.
+                // Record how long it actually took to recover.
+                this.handler.logConnectionIssue("ReceivedJoinOp");
+            }
             // Start the event in case we are waiting for leave or timeout.
             if (this.prevClientLeftTimer.hasTimer) {
                 this.waitEvent = PerformanceEvent.start(this.logger, {
@@ -147,7 +155,7 @@ export class ConnectionStateHandler extends EventEmitterWithErrorHandling<IConne
 
     public receivedDisconnectEvent(reason: string) {
         if (this.joinOpTimer.hasTimer) {
-            this.stopJoinOpTimer(`disconnect: ${reason}`);
+            this.stopJoinOpTimer();
         }
         this.setConnectionState(ConnectionState.Disconnected, reason);
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -656,15 +656,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
                 shouldClientJoinWrite: () => this._deltaManager.shouldJoinWrite(),
                 maxClientLeaveWaitTime: this.loader.services.options.maxClientLeaveWaitTime,
-                triggerConnectionRecovery: (reason: string) => {
+                logConnectionIssue: (eventName: string) => {
                     // We get here when socket does not receive any ops on "write" connection, including
                     // its own join op. Attempt recovery option.
-                    this._deltaManager.triggerConnectionRecovery(
-                        reason,
-                        {
-                            duration: performance.now() - this.connectionTransitionTimes[this.connectionState],
-                        },
-                    );
+                    this._deltaManager.logConnectionIssue({
+                        eventName,
+                        duration: performance.now() - this.connectionTransitionTimes[ConnectionState.Connecting],
+                        loaded: this.loaded,
+                    });
                 },
             },
             this.logger,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -10,6 +10,7 @@ import {
     ITelemetryLogger,
     IEventProvider,
     ITelemetryProperties,
+    ITelemetryErrorEvent,
 } from "@fluidframework/common-definitions";
 import {
     IConnectionDetails,
@@ -452,18 +453,32 @@ export class DeltaManager
         }
     }
 
-    public triggerConnectionRecovery(reason: string, props: ITelemetryProperties) {
-            assert(this.connection !== undefined, 0x238 /* "called only in connected state" */);
-            this.logger.sendErrorEvent({
-                eventName: "ConnectionRecovery",
-                reason,
-                // This directly tells us if fetching ops is in flight, and thus likely the reason of
-                // stalled op processing
-                fetchReason: this.fetchReason,
-                ...props,
-            });
-            this.disconnectFromDeltaStream(reason);
-            this.triggerConnect({ reason, mode: "read", fetchOpsFromStorage: false });
+    /**
+     * Log error event with a bunch of internal to DeltaManager information about state of op processing
+     * Used to diagnose connectivity issues related to op processing (i.e. cases where for some reason
+     * we stop processing ops that results in no processing join op and thus moving to connected state)
+     * @param event - Event to log.
+     */
+    public logConnectionIssue(event: ITelemetryErrorEvent) {
+        assert(this.connection !== undefined, 0x238 /* "called only in connected state" */);
+
+        const pendingSorted = this.pending.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+        this.logger.sendErrorEvent({
+            ...event,
+            // This directly tells us if fetching ops is in flight, and thus likely the reason of
+            // stalled op processing
+            fetchReason: this.fetchReason,
+            // A bunch of useful sequence numbers to understand if we are holding some ops from processing
+            lastQueuedSequenceNumber: this.lastQueuedSequenceNumber, // last sequential op
+            lastProcessedSequenceNumber: this.lastProcessedSequenceNumber, // same as above, but after processing
+            lastObserved: this.lastObservedSeqNumber, // last sequence we ever saw; may have gaps with above.
+            // connection info
+            ...this.connectionStateProps,
+            pendingOps: this.pending.length, // Do we have any pending ops?
+            pendingFirst: pendingSorted[0]?.sequenceNumber, // is the first pending op the one that we are missing?
+            haveHandler: this.handler !== undefined, // do we have handler installed
+            closed: this.closed,
+        });
     }
 
     private set_readonlyPermissions(readonly: boolean) {
@@ -1536,7 +1551,7 @@ export class DeltaManager
         }
 
         if (this.closed) {
-            this.logger.sendTelemetryEvent({ eventName: "fetchMissingDeltasClosedConnection" });
+            this.logger.sendTelemetryEvent({ eventName: "fetchMissingDeltasClosedConnection", reason });
             return;
         }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -476,7 +476,7 @@ export class DeltaManager
             ...this.connectionStateProps,
             pendingOps: this.pending.length, // Do we have any pending ops?
             pendingFirst: pendingSorted[0]?.sequenceNumber, // is the first pending op the one that we are missing?
-            haveHandler: this.handler !== undefined, // do we have handler installed
+            haveHandler: this.handler !== undefined, // do we have handler installed?
             closed: this.closed,
         });
     }

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -75,7 +75,7 @@ describe("ConnectionStateHandler Tests", () => {
                 maxClientLeaveWaitTime: expectedTimeout,
                 protocolHandler: () => protocolHandler,
                 shouldClientJoinWrite: () => shouldClientJoinWrite,
-                triggerConnectionRecovery: (reason: string) => { throw new Error("triggerConnectionRecovery"); },
+                logConnectionIssue: (eventName: string) => { throw new Error("logConnectionIssue"); },
             },
             new TelemetryNullLogger(),
         );


### PR DESCRIPTION
Issue #7312: fluid:telemetry:DeltaManager:ConnectionRecovery is hit in production and ODSP scalability tests

I've been going around this area for quite a while, both trying to better understand it, but also try various recovery options.
Unfortunately none of the recovery options tried so far does not really work. So removing it and switching to only logging more data to keep understanding problem better.

With that, it's worth also provide a bit more info on what I've learned so far: Big part of these issues, at least in stress tests, is the fact that we boot container with "write" connection, and connection is established before container is loaded. As result, because load may take a while, we are not processing ops for very long time.
I'll attempt to solve this in separate PR, but adding DeltaManager.handler & Container.loaded properties to payload is super valuable, as well as learning that we do sit on ton of unprocessed ops.
