### PR TITLE
Lumberjack improvements

### DIFF
--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
+    "json-stringify-safe": "^5.0.1",
     "path-browserify": "^1.0.1",
     "uuid": "^8.3.1"
   },

--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -145,7 +145,7 @@ export class Lumber<T extends string = LumberEventName> {
         if (exception instanceof Error) {
             this._exception = exception;
         } else if (exception !== undefined) { // We want to log the exception even if its value is `false`
-            this._exception = new Error (safeStringify(exception));
+            this._exception = new Error(safeStringify(exception));
         }
 
         this._durationInMs = performance.now() - this._startTime;

--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import safeStringify from "json-stringify-safe";
 import { v4 as uuid } from "uuid";
 import { performance } from "@fluidframework/common-utils";
 import { LumberEventName } from "./lumberEventNames";
@@ -101,7 +102,7 @@ export class Lumber<T extends string = LumberEventName> {
 
     public error(
         message: string,
-        exception?: Error,
+        exception?: any,
         logLevel: LogLevel = LogLevel.Error) {
         this.emit(message, logLevel, false, exception);
     }
@@ -114,7 +115,7 @@ export class Lumber<T extends string = LumberEventName> {
         message: string,
         logLevel: LogLevel,
         successful: boolean,
-        exception: Error | undefined) {
+        exception: any | undefined) {
         if (this._completed) {
             handleError(
                 LumberEventName.LumberjackError,
@@ -140,7 +141,13 @@ export class Lumber<T extends string = LumberEventName> {
         this._message = message;
         this._logLevel = logLevel;
         this._successful = successful;
-        this._exception = exception;
+
+        if (exception instanceof Error) {
+            this._exception = exception;
+        } else if (exception !== undefined) { // We want to log the exception even if its value is `false`
+            this._exception = new Error (safeStringify(exception));
+        }
+
         this._durationInMs = performance.now() - this._startTime;
 
         this._engineList.forEach((engine) => engine.emit(this));

--- a/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
@@ -58,8 +58,43 @@ export class Lumberjack {
         message: string,
         level: LogLevel,
         properties?: Map<string, any> | Record<string, any>,
-        exception?: Error) {
+        exception?: any) {
         this.instance.log(message, level, properties, exception);
+    }
+
+    public static debug(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.instance.log(message, LogLevel.Debug, properties, exception);
+    }
+
+    public static verbose(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.instance.log(message, LogLevel.Verbose, properties, exception);
+    }
+
+    public static info(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.instance.log(message, LogLevel.Info, properties, exception);
+    }
+
+    public static warning(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.instance.log(message, LogLevel.Warning, properties, exception);
+    }
+
+    public static error(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.instance.log(message, LogLevel.Error, properties, exception);
     }
 
     public setup(
@@ -101,7 +136,7 @@ export class Lumberjack {
         message: string,
         level: LogLevel,
         properties?: Map<string, any> | Record<string, any>,
-        exception?: Error) {
+        exception?: any) {
         this.errorOnIncompleteSetup();
         const lumber = new Lumber<string>(
             this.getLogCallerInfo(),
@@ -115,6 +150,41 @@ export class Lumberjack {
         } else {
             lumber.success(message, level);
         }
+    }
+
+    public debug(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.log(message, LogLevel.Debug, properties, exception);
+    }
+
+    public verbose(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.log(message, LogLevel.Verbose, properties, exception);
+    }
+
+    public info(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.log(message, LogLevel.Info, properties, exception);
+    }
+
+    public warning(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.log(message, LogLevel.Warning, properties, exception);
+    }
+
+    public error(
+        message: string,
+        properties?: Map<string, any> | Record<string, any>,
+        exception?: any) {
+        this.log(message, LogLevel.Error, properties, exception);
     }
 
     /**
@@ -131,9 +201,10 @@ export class Lumberjack {
         const defaultStackTracePreparer = Error.prepareStackTrace;
         try {
             Error.prepareStackTrace = (_, structuredStackTrace) => {
-                // Since we have a static log() and an instance log(), we should discard the first entry
-                // in the call stack in case the static log() called the singleton's instance log()
-                if (structuredStackTrace[0].getFileName() === __filename) {
+                // Since we have a static log() and an instance log(), as well as convenience
+                // methods such as info(), error(), etc, we should discard the first entry
+                // in the call stack while it points to this Lumberjack file.
+                while (structuredStackTrace[0].getFileName() === __filename) {
                     structuredStackTrace.shift();
                 }
                 const caller = structuredStackTrace[0];

--- a/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
@@ -64,23 +64,20 @@ export class Lumberjack {
 
     public static debug(
         message: string,
-        properties?: Map<string, any> | Record<string, any>,
-        exception?: any) {
-        this.instance.log(message, LogLevel.Debug, properties, exception);
+        properties?: Map<string, any> | Record<string, any>) {
+        this.instance.log(message, LogLevel.Debug, properties);
     }
 
     public static verbose(
         message: string,
-        properties?: Map<string, any> | Record<string, any>,
-        exception?: any) {
-        this.instance.log(message, LogLevel.Verbose, properties, exception);
+        properties?: Map<string, any> | Record<string, any>) {
+        this.instance.log(message, LogLevel.Verbose, properties);
     }
 
     public static info(
         message: string,
-        properties?: Map<string, any> | Record<string, any>,
-        exception?: any) {
-        this.instance.log(message, LogLevel.Info, properties, exception);
+        properties?: Map<string, any> | Record<string, any>) {
+        this.instance.log(message, LogLevel.Info, properties);
     }
 
     public static warning(
@@ -154,23 +151,20 @@ export class Lumberjack {
 
     public debug(
         message: string,
-        properties?: Map<string, any> | Record<string, any>,
-        exception?: any) {
-        this.log(message, LogLevel.Debug, properties, exception);
+        properties?: Map<string, any> | Record<string, any>) {
+        this.log(message, LogLevel.Debug, properties);
     }
 
     public verbose(
         message: string,
-        properties?: Map<string, any> | Record<string, any>,
-        exception?: any) {
-        this.log(message, LogLevel.Verbose, properties, exception);
+        properties?: Map<string, any> | Record<string, any>) {
+        this.log(message, LogLevel.Verbose, properties);
     }
 
     public info(
         message: string,
-        properties?: Map<string, any> | Record<string, any>,
-        exception?: any) {
-        this.log(message, LogLevel.Info, properties, exception);
+        properties?: Map<string, any> | Record<string, any>) {
+        this.log(message, LogLevel.Info, properties);
     }
 
     public warning(

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -48,6 +48,9 @@ export enum CommonProperties {
     maxOpsSinceLastSummary = "maxOpsSinceLastSummary",
     lastSummarySequenceNumber = "lastSummarySequenceNumber",
 
+    // Request properties
+    statusCode = "statusCode",
+
     // Miscellaneous properties
     restart = "restart",
     telemetryGroupName = "telemetryGroupName",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -57,6 +57,7 @@
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^8.4.0",
     "nconf": "^0.11.0",
+    "serialize-error": "^8.1.0",
     "sillyname": "0.1.0",
     "uuid": "^8.3.1",
     "winston": "^3.3.3"

--- a/server/routerlicious/packages/services-utils/src/winstonLumberjackEngine.ts
+++ b/server/routerlicious/packages/services-utils/src/winstonLumberjackEngine.ts
@@ -5,28 +5,33 @@
 
 import { ILumberjackEngine, LogLevel, Lumber, LumberType } from "@fluidframework/server-services-telemetry";
 import winston from "winston";
+import { serializeError } from "serialize-error";
 
 // Lumberjack engine based on Winston. It processes the data
 // captured in a Lumber instance and sends it through Winston.
 export class WinstonLumberjackEngine implements ILumberjackEngine {
     public emit(lumber: Lumber<string>) {
-        const propObj: { [key: string]: any } = {};
-        lumber.properties.forEach((value, key) => { propObj[key] = value; });
-        const obj = {
-            eventName: lumber.eventName,
-            id: lumber.id,
-            properties: JSON.stringify(propObj),
-            type: LumberType[lumber.type],
-            timestamp: new Date(lumber.timestamp).toISOString(),
-            durationInMs: lumber.durationInMs,
-            successful: lumber.successful,
-            exception: lumber.exception?.message,
-        };
+        try {
+            const propObj: { [key: string]: any } = {};
+            lumber.properties.forEach((value, key) => { propObj[key] = value; });
+            const obj = {
+                eventName: lumber.eventName,
+                id: lumber.id,
+                properties: JSON.stringify(propObj),
+                type: LumberType[lumber.type],
+                timestamp: new Date(lumber.timestamp).toISOString(),
+                durationInMs: lumber.durationInMs,
+                successful: lumber.successful,
+                exception: serializeError(lumber.exception),
+            };
 
-        const level = this.getLogLevelToWinstonMapping(lumber.logLevel);
-        const message = lumber.message ?? "No message provided.";
+            const level = this.getLogLevelToWinstonMapping(lumber.logLevel);
+            const message = lumber.message ?? "No message provided.";
 
-        winston.log(level, message, obj);
+            winston.log(level, message, obj);
+        } catch (err) {
+            winston.error(`WinstonLumberjackEngine: error when emitting Lumber object. Error: ${err}`);
+        }
     }
 
     private getLogLevelToWinstonMapping(level: LogLevel | undefined) {

--- a/server/routerlicious/packages/services-utils/src/winstonLumberjackEngine.ts
+++ b/server/routerlicious/packages/services-utils/src/winstonLumberjackEngine.ts
@@ -15,12 +15,12 @@ export class WinstonLumberjackEngine implements ILumberjackEngine {
         const obj = {
             eventName: lumber.eventName,
             id: lumber.id,
-            properties: propObj,
+            properties: JSON.stringify(propObj),
             type: LumberType[lumber.type],
             timestamp: new Date(lumber.timestamp).toISOString(),
             durationInMs: lumber.durationInMs,
             successful: lumber.successful,
-            exception: lumber.exception,
+            exception: lumber.exception?.message,
         };
 
         const level = this.getLogLevelToWinstonMapping(lumber.logLevel);


### PR DESCRIPTION
1. Adding log-related convenience methods such as `error()`, `info()` and `warning()`, allowing user to avoid importing `LogLevel` which is required in the generic `log()` method.
2. Allowing `exception` parameters to be of any type, since some error handlers throughout the code do not guarantee the error would be of type `Error` (example: Redis client code). Then, we internally convert the `any` type into an `Error` if necessary.
3. Other minor fixes such as properly formatting data in the `WinstonLumberjackEngine` and correctly obtaining the caller file name/function name for `Lumberjack`.