### PR TITLE
Handle leading slash in summary object handle

### DIFF
--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -77,7 +77,11 @@ export function convertSummaryTreeToWholeSummaryTree(
                     if (!parentHandle) {
                         throw Error("Parent summary does not exist to reference by handle.");
                     }
-                    id = `${parentHandle}/${summaryObject.handle}`;
+                    let handlePath = summaryObject.handle;
+                    if (handlePath.length > 0 && !handlePath.startsWith("/")) {
+                        handlePath = `/${handlePath}`;
+                    }
+                    id = `${parentHandle}${handlePath}`;
                 }
                 break;
             }


### PR DESCRIPTION
Sometimes, summaryObject.handle has a leading slash, which can lead to a "//" in the id. We don't want that.