### PR TITLE
[bump] package version for build-common (patch)

### DIFF
--- a/common/build/build-common/package-lock.json
+++ b/common/build/build-common/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@fluidframework/build-common",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 1
 }

--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/build-common",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Package containing common configs",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -159,9 +159,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions-0.20.0": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/common-definitions-0.20.0": "npm:@fluidframework/common-definitions@0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -401,9 +401,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -77,7 +77,7 @@
     "sha.js": "^2.4.11"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/base64-js": "^1.3.0",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/protocol-definitions": "^0.1024.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-definitions-0.39.8": "npm:@fluidframework/container-definitions@0.39.8",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/protocol-definitions": "^0.1025.0-0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/common-definitions": "^0.20.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/protocol-definitions-0.1024.0": "npm:@fluidframework/protocol-definitions@0.1024.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/examples/agents/intelligence-runner-agent/package.json
+++ b/examples/agents/intelligence-runner-agent/package.json
@@ -31,7 +31,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@types/request": "^2.47.1",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -46,7 +46,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -59,7 +59,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -43,7 +43,7 @@
     "vue": "^2.6.12"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -69,7 +69,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/debug": "^4.1.5",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -55,7 +55,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/benchmark": "^2.1.0",

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -38,7 +38,7 @@
     "fluid-framework": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -27,7 +27,7 @@
     "webpack:dev": "webpack --env.development"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^12.19.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -46,7 +46,7 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/babel__core": "^7",
     "@types/node": "^12.19.0",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@types/orderedmap": "^1",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/async": "^3.2.6",
     "@types/lodash": "^4.14.118",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^12.19.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",
     "@types/jest": "22.2.3",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/marked": "^2.0.2",
     "@types/node": "^12.19.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -60,7 +60,7 @@
     "debug": "^4.1.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/runtime-utils": "^0.47.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -47,7 +47,7 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/node": "^12.19.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/runtime-utils": "^0.47.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/fluid-static": "^0.47.0",
     "@fluidframework/test-tools": "^0.2.3074",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -40,7 +40,7 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/core-interfaces": "^0.39.7"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -37,7 +37,7 @@
     "semver": "^7.3.4"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/semver": "^7.3.6",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -52,7 +52,7 @@
     "comlink": "^4.3.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -31,7 +31,7 @@
     "source-map-loader": "^0.2.4"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@mixer/webpack-bundle-compare": "^0.1.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/view-adapters": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -48,7 +48,7 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",
     "@fluidframework/test-utils": "^0.47.0",
     "@types/jest": "22.2.3",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -62,7 +62,7 @@
     "traverse": "0.6.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^8.2.2",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluid-experimental/property-common": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/driver-definitions": "^0.39.6",
     "@fluidframework/eslint-config-fluid": "^0.23.0",

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -52,7 +52,7 @@
     "@fluid-experimental/property-dds": "^0.47.0",
     "@fluid-experimental/property-properties": "^0.47.0",
     "@fluid-experimental/property-proxy": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@hig/fonts": "^1.0.2",
     "@material-ui/core": "^4.0.0",
     "@material-ui/lab": "^4.0.0-alpha.16",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -62,7 +62,7 @@
     "traverse": "0.6.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "chai": "^4.2.0",
     "concurrently": "^5.2.0",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -45,7 +45,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-loader": "^0.47.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -62,7 +62,7 @@
     "use-resize-observer": "^7.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-tools": "^0.2.3074",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/map": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -39,7 +39,7 @@
     "jsonwebtoken": "^8.4.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/mocha": "^8.2.2",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/shared-summary-block": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -33,7 +33,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/experimental/framework/react/package.json
+++ b/experimental/framework/react/package.json
@@ -39,7 +39,7 @@
     "react": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1875,9 +1875,9 @@
 			}
 		},
 		"@fluidframework/build-common": {
-			"version": "0.23.0-36574",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-			"integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg=="
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
 			"version": "0.2.35662",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/shared-object-base": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -64,7 +64,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/telemetry-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/gitresources": "^0.1030.0-0",
     "@fluidframework/mocha-test-setup": "^0.47.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -42,7 +42,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/shared-object-base": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/shared-object-base": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -36,7 +36,7 @@
     "jsonschema": "^1.2.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/telemetry-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/replay-driver": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/odsp-driver-definitions": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -39,7 +39,7 @@
     "comlink": "^4.3.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -68,7 +68,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/driver-definitions": "^0.39.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -73,7 +73,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/odsp-driver-definitions": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/telemetry-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -72,7 +72,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -35,7 +35,7 @@
     "axios": "^0.21.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -39,7 +39,7 @@
     "nconf": "^0.11.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -37,7 +37,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -76,7 +76,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -50,7 +50,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -67,7 +67,7 @@
     "@fluidframework/shared-object-base": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/sequence": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/sequence": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/runtime-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/core-interfaces": "^0.39.7"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/datastore": "^0.47.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/sequence": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^16.10.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/react": "^16.9.15",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -31,7 +31,7 @@
     "@fluidframework/core-interfaces": "^0.39.7"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/react": "^16.9.15",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -70,7 +70,7 @@
     "style-loader": "^1.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -72,7 +72,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-loader-utils": "^0.47.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/telemetry-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -66,7 +66,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/runtime-utils": "^0.47.0",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -36,7 +36,7 @@
     "comlink": "^4.3.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/protocol-definitions": "^0.1024.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -33,7 +33,7 @@
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -59,7 +59,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",

--- a/packages/runtime/client-api/package.json
+++ b/packages/runtime/client-api/package.json
@@ -71,7 +71,7 @@
     "jwt-decode": "^2.2.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/jwt-decode": "^2.2.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^12.19.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -75,7 +75,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^12.19.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -74,7 +74,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@fluidframework/test-runtime-utils": "^0.47.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/runtime-definitions": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^12.19.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -68,7 +68,7 @@
     "@fluidframework/runtime-definitions": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -67,7 +67,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -52,7 +52,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-loader": "^0.47.0",
     "@fluidframework/container-runtime": "^0.47.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.47.0",
     "@fluidframework/base-host": "^0.47.0",
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.47.0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.39.8",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -55,7 +55,7 @@
     "mocha": "^8.4.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/test-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -53,7 +53,7 @@
     "applicationinsights": "^2.1.5"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -57,7 +57,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -71,7 +71,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -110,7 +110,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -50,7 +50,7 @@
     "random-js": "^1.0.8"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -87,7 +87,7 @@
     "random-js": "^1.0.8"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -73,7 +73,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/diff": "^3.5.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -72,7 +72,7 @@
     "semver": "^7.3.4"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-runtime-definitions": "^0.47.0",
     "@fluidframework/container-utils": "^0.47.0",
     "@fluidframework/datastore": "^0.47.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/tool-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/sequence": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/tool-utils": "^0.47.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -86,7 +86,7 @@
     "webpack-dev-server": "^3.8.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -63,7 +63,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@types/mocha": "^8.2.2",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -66,7 +66,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -66,7 +66,7 @@
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.47.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -327,9 +327,9 @@
 			}
 		},
 		"@fluidframework/build-common": {
-			"version": "0.23.0-36574",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-			"integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg=="
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
 			"version": "0.2.34654",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^12.19.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -55,7 +55,7 @@
     "moniker": "^0.1.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1030.0",
     "@types/async": "^3.2.6",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -68,7 +68,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1030.0",
     "@types/async": "^3.2.6",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -65,7 +65,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^8.2.2",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -70,7 +70,7 @@
     "ws": "^7.4.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/mocha": "^8.2.2",
     "@types/uuid": "^8.3.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -80,7 +80,7 @@
     "ws": "^7.4.6"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-local-server": "^0.1030.0",
     "@fluidframework/server-test-utils": "^0.1030.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -60,7 +60,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-local-server": "^0.1030.0",
     "@fluidframework/server-test-utils": "^0.1030.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -63,7 +63,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/debug": "^4.1.5",
     "@types/jsrsasign": "^8.0.8",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -34,7 +34,7 @@
     "nconf": "^0.11.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -31,7 +31,7 @@
     "nconf": "^0.11.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1030.0",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -32,7 +32,7 @@
     "node-rdkafka": "^2.10.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1030.0",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -28,7 +28,7 @@
     "zookeeper": "4.8.2"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1030.0",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -48,7 +48,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/debug": "^4.1.5",
     "@types/formidable": "1.2.3",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -53,7 +53,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/node": "^12.19.0",
     "@types/supertest": "^2.0.5",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -62,7 +62,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1030.0",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -68,7 +68,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/server-test-utils": "^0.1030.0",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -59,7 +59,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^8.2.2",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -169,9 +169,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -65,7 +65,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -392,9 +392,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -34,7 +34,7 @@
     "mocha": "^8.4.0"
   },
   "devDependencies": {
-    "@fluidframework/build-common": "^0.23.0-0",
+    "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/mocha-test-setup": "^0.41.0",
     "@microsoft/api-extractor": "^7.16.1",


### PR DESCRIPTION
            @fluidframework/build-common:     0.23.0 -> 0.23.1
     @fluidframework/eslint-config-fluid:     0.24.0 (unchanged)
      @fluidframework/common-definitions:     0.21.0 (unchanged)
            @fluidframework/common-utils:     0.33.0 (unchanged)
   @fluidframework/container-definitions:     0.40.0 (unchanged)
         @fluidframework/core-interfaces:     0.40.0 (unchanged)
      @fluidframework/driver-definitions:     0.40.0 (unchanged)
    @fluidframework/protocol-definitions:   0.1025.0 (unchanged)
                                  Server:   0.1030.0 (unchanged)
                                  Client:     0.47.0 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for build-common
            @fluidframework/build-common -> ^0.23.0