### PR TITLE
Remove NackWithNoReconnect event

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1039,14 +1039,6 @@ export class DeltaManager
             ? getNackReconnectInfo(message.content) :
             createGenericNetworkError(`Nack: unknown reason`, true);
 
-        if (this.reconnectMode !== ReconnectMode.Enabled) {
-            this.logger.sendErrorEvent({
-                eventName: "NackWithNoReconnect",
-                reason: reconnectInfo.message,
-                mode: this.connectionMode,
-            });
-        }
-
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.reconnectOnError(
             "write",


### PR DESCRIPTION
I was going through errors in our telemetry and that event pops to the top.
But when I looked at the code, I do not see a reason for its existence:
- nacks are not special, if we care about these things, similar event should fire on error/disconnect paths
- reconnectOnError() does reasonable job here in terms of closing container without error if container is not allowed to reconnected (like summarizer) or not logging any error of container is in manual reconnection mode.

So I do not see the value of this error - errors should be fixed or removed from telemetry :)