### PR TITLE
Bump runtime-defintions version for sequence

### DIFF
--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/gitresources": "^0.1024.0",
     "@fluidframework/mocha-test-setup": "^0.39.9",
-    "@fluidframework/runtime-definitions": "^0.39.8",
+    "@fluidframework/runtime-definitions": "^0.39.9",
     "@fluidframework/server-services-client": "^0.1024.0",
     "@fluidframework/test-runtime-utils": "^0.39.9",
     "@microsoft/api-extractor": "^7.13.1",


### PR DESCRIPTION
Runtime-definitions dependency version needs to be 0.39.9 in order for the bump-version script to run