### PR TITLE
Substituting utf8 by utf-8  by  in services-client

### DIFF
--- a/server/routerlicious/packages/services-client/src/storageContracts.ts
+++ b/server/routerlicious/packages/services-client/src/storageContracts.ts
@@ -107,7 +107,7 @@ export interface IWholeFlatSummaryTree {
 
 export interface IWholeFlatSummaryBlob {
     content: string;
-    encoding: "base64" | "utf8";
+    encoding: "base64" | "utf-8";
     id: string;
     size: number;
 }

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -171,7 +171,7 @@ export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(
     const blobs = new Map<string, ArrayBuffer>();
     if (flatSummary.blobs) {
         flatSummary.blobs.forEach((blob) => {
-            blobs.set(blob.id, stringToBuffer(blob.content, blob.encoding ?? "utf8"));
+            blobs.set(blob.id, stringToBuffer(blob.content, blob.encoding ?? "utf-8"));
         });
     }
     const flatSummaryTree = flatSummary.trees && flatSummary.trees[0];


### PR DESCRIPTION
In `IWholeSummaryBlob` we use `utf-8`, so making `IWholeFlatSummaryBlob` also use that instead of `utf8`