### PR TITLE
More telemetry, asserts and some recovery for cases where client is not up to date

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -432,18 +432,26 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
             // If so, there it most likely does not need these ops (otherwise it already asked for them)
             if (data !== undefined) {
                 this.getOpsMap.delete(result.nonce);
+                const common = {
+                    eventName: "GetOps",
+                    code: result.code,
+                    from: data.from,
+                    to: data.to,
+                    duration: performance.now() - data.start,
+                };
                 if (messages !== undefined && messages.length > 0) {
                     this.logger.sendPerformanceEvent({
-                        eventName: "GetOps",
+                        ...common,
                         first: messages[0].sequenceNumber,
                         last: messages[messages.length - 1].sequenceNumber,
-                        code: result.code,
-                        from: data.from,
-                        to: data.to,
-                        duration: performance.now() - data.start,
                         length: messages.length,
                     });
                     this.emit("op", this.documentId, messages);
+                } else {
+                    this.logger.sendPerformanceEvent({
+                        ...common,
+                        length: 0,
+                    });
                 }
             }
         });

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -135,9 +135,9 @@ export class OpsCache {
                         break;
                     }
                     if (messages.length === 0) {
-                        if (op.sequenceNumber > from + 1) {
+                        if (op.sequenceNumber > from) {
                             break;
-                        } else if (op.sequenceNumber <= from) {
+                        } else if (op.sequenceNumber < from) {
                             continue;
                         }
                     }

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -119,7 +119,7 @@ export class OpsCache {
 
     public async get(from: number, to?: number): Promise<IMessage[]> {
         const messages: IMessage[] = [];
-        let batchNumber = this.getBatchNumber(from + 1);
+        let batchNumber = this.getBatchNumber(from);
         const start = performance.now();
         // eslint-disable-next-line no-constant-condition
         while (true) {

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -48,7 +48,8 @@ class MockCache implements ICache {
 async function validate(
     mockCache: MockCache,
     expected: { [key: number]: (MyDataInput | undefined)[]; },
-    cache: OpsCache, initialSeq: number)
+    cache: OpsCache,
+    initialSeq: number)
 {
     assert.deepEqual(mockCache.data, JSON.parse(JSON.stringify(expected)));
 
@@ -61,22 +62,22 @@ async function validate(
         }
     }
 
-    let result = await cache.get(initialSeq, undefined);
+    let result = await cache.get(initialSeq + 1, undefined);
     assert.deepEqual(result, expectedArr);
 
     if (initialSeq >= 10) {
-        result = await cache.get(0, 10);
+        result = await cache.get(1, 10);
         assert(result.length === 0);
     }
 
     // Asking for one too early should result in empty result, as hit miss should result in no ops.
     if (initialSeq > 0) {
-        result = await cache.get(initialSeq - 1, undefined);
+        result = await cache.get(initialSeq, undefined);
         assert(result.length === 0);
     }
 
     if (expectedArr.length > 0) {
-        const last = expectedArr[expectedArr.length - 1].sequenceNumber;
+        const last = expectedArr[expectedArr.length - 1].sequenceNumber + 1;
 
         result = await cache.get(last, undefined);
         assert(result.length === 0);
@@ -84,11 +85,14 @@ async function validate(
         result = await cache.get(last + 10, undefined);
         assert(result.length === 0);
 
-        result = await cache.get(initialSeq + 1, last);
-        assert.deepEqual(result, expectedArr.slice(1, -1));
-
-        result = await cache.get(initialSeq + 1, last + 100000);
+        result = await cache.get(initialSeq + 2, last);
         assert.deepEqual(result, expectedArr.slice(1));
+
+        result = await cache.get(initialSeq + 2, last + 100000);
+        assert.deepEqual(result, expectedArr.slice(1));
+
+        result = await cache.get(initialSeq + 2, last - 1);
+        assert.deepEqual(result, expectedArr.slice(1, -1));
     }
 }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1256,19 +1256,19 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 if (loadMode.deltaConnection !== "none") {
                     // Start prefetch, but not set opsBeforeReturnP - boot is not blocked by it!
                     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    this._deltaManager.preFetchOps(false);
+                    this._deltaManager.preFetchOps(false /* cacheOnly */);
                 }
                 break;
             case "cached":
-                opsBeforeReturnP = this._deltaManager.preFetchOps(true);
+                opsBeforeReturnP = this._deltaManager.preFetchOps(true /* cacheOnly */);
                 // Keep going with fetching ops from storage once we have all cached ops in.
                 // Ops processing will start once cached ops are in and and will stop when queue is empty
                 // (which in most cases will happen when we are done processing cached ops)
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                opsBeforeReturnP.then(async () => this._deltaManager.preFetchOps(false));
+                opsBeforeReturnP.then(async () => this._deltaManager.preFetchOps(false /* cacheOnly */));
                 break;
             case "all":
-                opsBeforeReturnP = this._deltaManager.preFetchOps(false);
+                opsBeforeReturnP = this._deltaManager.preFetchOps(false /* cacheOnly */);
                 break;
             default:
                 unreachableCase(loadMode.opsBeforeReturn);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -645,6 +645,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     dmLastMsqSeqNumber: () => this.deltaManager?.lastMessage?.sequenceNumber,
                     dmLastMsqSeqTimestamp: () => this.deltaManager?.lastMessage?.timestamp,
                     dmLastMsqSeqClientId: () => this.deltaManager?.lastMessage?.clientId,
+                    connectionState: () => ConnectionState[this.connectionState],
+                    connectionStateDuration:
+                        () => performance.now() - this.connectionTransitionTimes[this.connectionState],
                 },
             });
 
@@ -972,8 +975,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     public setAutoReconnect(reconnect: boolean) {
-        if (reconnect && this.closed) {
-            throw new Error("Attempting to setAutoReconnect() a closed DeltaManager");
+        if (this.closed) {
+            throw new Error("Attempting to setAutoReconnect() a closed Container");
         }
 
         this._deltaManager.setAutomaticReconnect(reconnect);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -380,13 +380,17 @@ export class DeltaManager
      * about current or last connection (if there is no connection at the moment)
     */
     public connectionProps(): ITelemetryProperties {
+        const common = {
+            connectionMode: this.connectionMode,
+        };
         if (this.connection !== undefined) {
             return {
-                sequenceNumber: this.lastSequenceNumber,
+                ...common,
                 connectionMode: this.connectionMode,
             };
         } else {
             return {
+                ...common,
                 // Report how many ops this client sent in last disconnected session
                 sentOps: this.clientSequenceNumber,
             };
@@ -578,15 +582,13 @@ export class DeltaManager
         // If so, it's time to process any accumulated ops, as there might be no other event that
         // will force these pending ops to be processed.
         // Or request OPs from snapshot / or point zero (if we have no ops at all)
-        if (this.pending.length > 0) {
-            this.processPendingOps("DocumentOpen");
-        }
+        this.processPendingOps("DocumentOpen");
     }
 
     public async preFetchOps(cacheOnly: boolean) {
         // Note that might already got connected to delta stream by now.
         // If we did, then we proactively fetch ops at the end of setupNewSuccessfulConnection to ensure
-        if (this.connection === undefined) {
+        if (this.connection === undefined && !this.closed) {
             return this.fetchMissingDeltasCore("DocumentOpen", cacheOnly, this.lastQueuedSequenceNumber, undefined);
         }
     }
@@ -664,7 +666,7 @@ export class DeltaManager
             this.handler !== undefined || !fetchOpsFromStorage,
             this.logger,
             "CantFetchWithoutBaseline"); // can't fetch if no baseline
-        if (fetchOpsFromStorage && this.handler !== undefined) {
+        if (fetchOpsFromStorage) {
             this.fetchMissingDeltas(args.reason, this.lastQueuedSequenceNumber);
         }
 
@@ -1539,8 +1541,9 @@ export class DeltaManager
      * Retrieves the missing deltas between the given sequence numbers
      */
      private fetchMissingDeltas(reasonArg: string, lastKnowOp: number, to?: number) {
-         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-         this.fetchMissingDeltasCore(reasonArg, false /* cacheOnly */, lastKnowOp, to);
+         this.fetchMissingDeltasCore(reasonArg, false /* cacheOnly */, lastKnowOp, to).catch((error) => {
+             this.logger.sendErrorEvent({ eventName: "fetchMissingDeltasException" }, error);
+         });
      }
 
      /**
@@ -1559,6 +1562,12 @@ export class DeltaManager
 
         if (this.closed) {
             this.logger.sendTelemetryEvent({ eventName: "fetchMissingDeltasClosedConnection", reason });
+            return;
+        }
+
+        if (this.handler === undefined) {
+            // We do not poses yet any information
+            assert(lastKnowOp === 0, "initial state");
             return;
         }
 
@@ -1603,12 +1612,37 @@ export class DeltaManager
      * Sorts pending ops and attempts to apply them
      */
     private processPendingOps(reason?: string): void {
-        if (this.handler !== undefined) {
-            const pendingSorted = this.pending.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
-            this.pending = [];
-            // Given that we do not track where these ops came from any more, it's not very
-            // actionably to report gaps in this range.
-            this.enqueueMessages(pendingSorted, `${reason}_pending`, true /* allowGaps */);
+        if (this.closed) {
+            return;
+        }
+
+        assert(this.handler !== undefined, "handler should be installed");
+
+        const pendingSorted = this.pending.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+        this.pending = [];
+        // Given that we do not track where these ops came from any more, it's not very
+        // actionably to report gaps in this range.
+        this.enqueueMessages(pendingSorted, `${reason}_pending`, true /* allowGaps */);
+
+        // See issue #7312 for more details
+        // We observe cases where client gets into situation where it is not aware of missing ops
+        // (i.e. client being behind), and as such, does not attempt to fetch them.
+        // In some cases client may not have enough signal (example - "read" connection that is silent -
+        // there is no easy way for client to realize it's behind, see a bit of commentary / logic at the
+        // end of setupNewSuccessfulConnection). In other cases it should be able to learn that info ("write"
+        // connection, learn by receiving its own join op), but data suggest it does not happen.
+        // In 50% of these cases we do know we are behind through checkpointSequenceNumber on connection object
+        // and thus can leverage that to trigger recovery. But this is not going to solve all the problems
+        // (the other 50%), and thus these errors below should be looked at even if code below results in
+        // recovery.
+        if (this.fetchReason === undefined && this.lastQueuedSequenceNumber < this.lastObservedSeqNumber) {
+            // connectionMode === "read" case is too noisy, so not log it.
+            // It happens because fetch in setupNewSuccessfulConnection get cancelled due to other fetch, and we
+            // never retry (other than here)
+            if (this.connectionMode === "write") {
+                this.logConnectionIssue({ eventName: "OpsBehind" });
+            }
+            this.fetchMissingDeltas("OpsBehind", this.lastQueuedSequenceNumber);
         }
     }
 

--- a/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IContainer } from "@fluidframework/container-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import {
     createLocalResolverCreateNewRequest,
@@ -63,7 +63,12 @@ describe("No Delta Stream", () => {
         if (!storageOnly) {
             loaderContainerTracker.add(loader);
         }
-        const container = await loader.resolve({ url: documentLoadUrl });
+
+        // See issue #7426 - need better long term solution
+        const container = await loader.resolve({
+            url: documentLoadUrl,
+            headers: { [LoaderHeader.loadMode]: { opsBeforeReturn: "all" }},
+        });
         await loaderContainerTracker.ensureSynchronized();
         return container;
     }


### PR DESCRIPTION
More progress on understanding Issue #7312:
1. A bunch of asserts to ensure correctness, mostly around fetching ops and getting sequential, no duplicate results.
2. More telemetry around where we fetch ops ("GetOps") and also when we get into trouble with not being current.
3. Smallish bug in ops caching that might have result in returning result without first requested op.
4. Changed where we short-circuit code when dealing with closed & no-handler conditions - pushed it out for most of the code to not care.
5. Biggest change is in processPendingOps() to detect that client is behind, and fetch ops proactively.