### PR TITLE
Temporary filter out too much telemetry from r11s driver

### DIFF
--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -11,6 +11,11 @@ import { pkgName } from "./packageVersion";
 const _global: any = global;
 class TestLogger implements ITelemetryBufferedLogger {
     send(event: ITelemetryBaseEvent) {
+        // TODO: Remove when issue #7061 is resolved.
+        // Don't log this event as we generate too much.
+        if (event.eventName === "fluid:telemetry:RouterliciousDriver:readBlob_end") {
+            return;
+        }
         if (this.testName !== undefined) {
             event.testName = this.testName;
         }

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -97,7 +97,7 @@ stages:
         poolBuild: Lite
         testPackage: "@fluidframework/test-end-to-end-tests"
         testWorkspace: ${{ variables.testWorkspace }}
-        timeoutInMinutes: 120
+        timeoutInMinutes: 240
         testSteps:
         - task: Npm@1
           displayName: '[end-to-end tests] npm run test:realsvc:frs:report'


### PR DESCRIPTION
Temporary fix for #7061

Also increase timeout for frs e2e tests.