### PR TITLE
Ops caching broken: disabled feature, bugs

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -158,9 +158,9 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
             if (this.snapshotOps !== undefined && this.snapshotOps.length !== 0) {
                 const messages = this.snapshotOps.filter((op) =>
                     op.sequenceNumber >= from && op.sequenceNumber < to);
+                this.validateMessages("cached", messages, from);
                 if (messages.length > 0 && messages[0].sequenceNumber === from) {
                     this.snapshotOps = this.snapshotOps.filter((op) => op.sequenceNumber >= to);
-                    this.validateMessages("cached", messages, from);
                     opsFromSnapshot = messages.length;
                     return { messages, partialResult: true };
                 }
@@ -174,8 +174,8 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
             // This saves a bit of processing time
             if (from < this.firstCacheMiss) {
                 const messagesFromCache = await this.getCached(from, to);
+                this.validateMessages("cached", messagesFromCache, from);
                 if (messagesFromCache.length !== 0) {
-                    this.validateMessages("cached", messagesFromCache, from);
                     opsFromCache += messagesFromCache.length;
                     return {
                         messages: messagesFromCache,

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -391,10 +391,10 @@ export class OdspDocumentService implements IDocumentService {
                 write: async (key: string, opsData: string) => {
                     return this.cache.persistedCache.put({...opsKey, key}, opsData);
                 },
-                read: async (batch: string) => undefined,
+                read: async (key: string) => this.cache.persistedCache.get({...opsKey, key}),
                 remove: () => { this.cache.persistedCache.removeEntries().catch(() => {}); },
             },
-            this.hostPolicy.opsCaching?.batchSize ?? 100,
+            batchSize,
             this.hostPolicy.opsCaching?.timerGranularity ?? 5000,
             this.hostPolicy.opsCaching?.totalOpsToCache ?? 5000,
         );

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -117,38 +117,43 @@ export class OpsCache {
         }
     }
 
-    public async get(from: number, to?: number): Promise<IMessage[]> {
+    private async getCore(from: number, to?: number): Promise<IMessage[]> {
         const messages: IMessage[] = [];
         let batchNumber = this.getBatchNumber(from);
-        const start = performance.now();
         // eslint-disable-next-line no-constant-condition
         while (true) {
             const res = await this.cache.read(`${this.batchSize}_${batchNumber}`);
             if (res === undefined) {
-                break;
+                return messages;
             }
             const result: CacheEntry = JSON.parse(res);
             for (const op of result) {
                 // Note that we write out undefined, but due to JSON.stringify, it turns into null!
                 if (op) {
                     if (to !== undefined && op.sequenceNumber >= to) {
-                        break;
+                        return messages;
                     }
                     if (messages.length === 0) {
                         if (op.sequenceNumber > from) {
-                            break;
+                            return messages;
                         } else if (op.sequenceNumber < from) {
                             continue;
                         }
                     }
                     messages.push(op);
                 } else if (messages.length !== 0) {
-                    break;
+                    return messages;
                 }
             }
 
             batchNumber++;
         }
+    }
+
+    public async get(from: number, to?: number): Promise<IMessage[]> {
+        const start = performance.now();
+
+        const messages = await this.getCore(from, to);
 
         const duration = performance.now() - start;
         if (messages.length > 0 || duration > 1000) {

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -119,7 +119,7 @@ export class OpsCache {
 
     public async get(from: number, to?: number): Promise<IMessage[]> {
         const messages: IMessage[] = [];
-        let batchNumber = this.getBatchNumber(from + 1);
+        let batchNumber = this.getBatchNumber(from);
         const start = performance.now();
         // eslint-disable-next-line no-constant-condition
         while (true) {
@@ -135,9 +135,9 @@ export class OpsCache {
                         break;
                     }
                     if (messages.length === 0) {
-                        if (op.sequenceNumber > from + 1) {
+                        if (op.sequenceNumber > from) {
                             break;
-                        } else if (op.sequenceNumber <= from) {
+                        } else if (op.sequenceNumber < from) {
                             continue;
                         }
                     }

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -48,7 +48,8 @@ class MockCache implements ICache {
 async function validate(
     mockCache: MockCache,
     expected: { [key: number]: (MyDataInput | undefined)[]; },
-    cache: OpsCache, initialSeq: number)
+    cache: OpsCache,
+    initialSeq: number)
 {
     assert.deepEqual(mockCache.data, JSON.parse(JSON.stringify(expected)));
 
@@ -61,22 +62,22 @@ async function validate(
         }
     }
 
-    let result = await cache.get(initialSeq, undefined);
+    let result = await cache.get(initialSeq + 1, undefined);
     assert.deepEqual(result, expectedArr);
 
     if (initialSeq >= 10) {
-        result = await cache.get(0, 10);
+        result = await cache.get(1, 10);
         assert(result.length === 0);
     }
 
     // Asking for one too early should result in empty result, as hit miss should result in no ops.
     if (initialSeq > 0) {
-        result = await cache.get(initialSeq - 1, undefined);
+        result = await cache.get(initialSeq, undefined);
         assert(result.length === 0);
     }
 
     if (expectedArr.length > 0) {
-        const last = expectedArr[expectedArr.length - 1].sequenceNumber;
+        const last = expectedArr[expectedArr.length - 1].sequenceNumber + 1;
 
         result = await cache.get(last, undefined);
         assert(result.length === 0);
@@ -84,11 +85,14 @@ async function validate(
         result = await cache.get(last + 10, undefined);
         assert(result.length === 0);
 
-        result = await cache.get(initialSeq + 1, last);
-        assert.deepEqual(result, expectedArr.slice(1, -1));
-
-        result = await cache.get(initialSeq + 1, last + 100000);
+        result = await cache.get(initialSeq + 2, last);
         assert.deepEqual(result, expectedArr.slice(1));
+
+        result = await cache.get(initialSeq + 2, last + 100000);
+        assert.deepEqual(result, expectedArr.slice(1));
+
+        result = await cache.get(initialSeq + 2, last - 1);
+        assert.deepEqual(result, expectedArr.slice(1, -1));
     }
 }
 


### PR DESCRIPTION
Breaking out PR #7422 into smaller chunks.
All of the code switched to using inclusive left ("from") & exclusive right ("to") boundaries.
But not ops caching code, which results in bug - not returning right ops.
Fixing bug and appropriate UTs, but also sprinkling asserts in layers that use this layer to ensure that ops are always returned sequentially, no duplicates, with right start & end.