### PR TITLE
Better telemetry and recovery

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -578,9 +578,7 @@ export class DeltaManager
         // If so, it's time to process any accumulated ops, as there might be no other event that
         // will force these pending ops to be processed.
         // Or request OPs from snapshot / or point zero (if we have no ops at all)
-        if (this.pending.length > 0) {
-            this.processPendingOps("DocumentOpen");
-        }
+        this.processPendingOps("DocumentOpen");
     }
 
     public async preFetchOps(cacheOnly: boolean) {
@@ -1603,12 +1601,38 @@ export class DeltaManager
      * Sorts pending ops and attempts to apply them
      */
     private processPendingOps(reason?: string): void {
-        if (this.handler !== undefined) {
-            const pendingSorted = this.pending.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
-            this.pending = [];
-            // Given that we do not track where these ops came from any more, it's not very
-            // actionably to report gaps in this range.
-            this.enqueueMessages(pendingSorted, `${reason}_pending`, true /* allowGaps */);
+        if (this.handler === undefined) {
+            return;
+        }
+
+        const pendingSorted = this.pending.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+        this.pending = [];
+        // Given that we do not track where these ops came from any more, it's not very
+        // actionably to report gaps in this range.
+        this.enqueueMessages(pendingSorted, `${reason}_pending`, true /* allowGaps */);
+
+        // Re-entrancy is ignored by fetchMissingDeltas, execution will come here when it's over
+        if (this.fetchReason === undefined) {
+            // See issue #7312 for more details
+            // We observe cases where client gets into situation where it is not aware of missing ops
+            // (i.e. client being behind), and as such, does not attempt to fetch them.
+            // In some cases client may not have enough signal (example - "read" connection that is silent -
+            // there is no easy way for client to realize it's behind, see a bit of commentary / logic at the
+            // end of setupNewSuccessfulConnection). In other cases it should be able to learn that info ("write"
+            // connection, learn by receiving its own join op), but data suggest it does not happen.
+            // In 50% of these cases we do know we are behind through checkpointSequenceNumber on connection object
+            // and thus can leverage that to trigger recovery. But this is not going to solve all the problems
+            // (the other 50%), and thus these errors below should be looked at even if code below results in
+            // recovery.
+            if (this.lastQueuedSequenceNumber < this.lastObservedSeqNumber) {
+                // connectionMode === "read" case is too noisy, so not log it.
+                // It happens because fetch in setupNewSuccessfulConnection get cancelled due to other fetch, and we
+                // never retry (other than here)
+                if (this.connectionMode === "write") {
+                    this.logConnectionIssue({ eventName: "OpsBehind" });
+                }
+                this.fetchMissingDeltas("OpsBehind", this.lastQueuedSequenceNumber);
+            }
         }
     }
 


### PR DESCRIPTION
Breaking out PR #7422 into smaller chunks.

Please see issue #7312 for more details.
This change does two things:
- It adds telemetry to detect cases where we know that we are behind, but we are not actively trying to catch up. We do not fully understand these problems, but this telemetry (along with other PRs that add telemetry data points in various places) will help us better understand the problem.
- It also engages recovery for such cases.

We know for sure how we can get into such cases with "read" connections. These are normal (expected) workflows.
"write" connections are much more mysterious, as service (PUSH for ODSP) guarantees that join op should not be missed and should be delivered to client quickly after connection. But telemetry shows that we may be in position where join op is not processed for minutes, and it's not clear at the moment if that's a bug on client or server.

Semi-related PRs that together helps us move in right direction here:
PR #7428
PR #7427
PR #7429
