### PR TITLE
Remove example dependency from tinyliciousclient

### DIFF
--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -48,7 +48,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluid-example/diceroller": "^0.48.0",
+    "@fluidframework/aqueduct": "^0.48.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",

--- a/packages/framework/tinylicious-client/src/test/DiceRoller.ts
+++ b/packages/framework/tinylicious-client/src/test/DiceRoller.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DataObject, DataObjectFactory, IDataObjectProps } from "@fluidframework/aqueduct";
+import { IEvent } from "@fluidframework/common-definitions";
+
+export class DiceRoller extends DataObject {
+    public static get Name() { return "@fluid-example/dice-roller"; }
+
+    public static readonly factory = new DataObjectFactory<DiceRoller, undefined, undefined, IEvent>
+    (
+        DiceRoller.Name,
+        DiceRoller,
+        [],
+        {},
+    );
+
+    public constructor(props: IDataObjectProps) {
+        super(props);
+    }
+}

--- a/packages/framework/tinylicious-client/src/test/TestDataObject.ts
+++ b/packages/framework/tinylicious-client/src/test/TestDataObject.ts
@@ -6,13 +6,13 @@
 import { DataObject, DataObjectFactory, IDataObjectProps } from "@fluidframework/aqueduct";
 import { IEvent } from "@fluidframework/common-definitions";
 
-export class DiceRoller extends DataObject {
-    public static get Name() { return "@fluid-example/dice-roller"; }
+export class TestDataObject extends DataObject {
+    public static get Name() { return "@fluid-example/test-data-object"; }
 
-    public static readonly factory = new DataObjectFactory<DiceRoller, undefined, undefined, IEvent>
+    public static readonly factory = new DataObjectFactory<TestDataObject, undefined, undefined, IEvent>
     (
-        DiceRoller.Name,
-        DiceRoller,
+        TestDataObject.Name,
+        TestDataObject,
         [],
         {},
     );

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -8,7 +8,7 @@ import { AttachState } from "@fluidframework/container-definitions";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { TinyliciousClient } from "..";
-import { DiceRoller } from "./DiceRoller";
+import { TestDataObject } from "./TestDataObject";
 
 describe("TinyliciousClient", () => {
     let tinyliciousClient: TinyliciousClient;
@@ -214,7 +214,7 @@ describe("TinyliciousClient", () => {
             initialObjects: {
                 map1: SharedMap,
             },
-            dynamicObjectTypes: [DiceRoller],
+            dynamicObjectTypes: [TestDataObject],
         };
 
         const createFluidContainer = (await tinyliciousClient.createContainer(dynamicSchema)).container;
@@ -224,7 +224,7 @@ describe("TinyliciousClient", () => {
             });
         });
 
-        const newPair = await createFluidContainer.create(DiceRoller);
+        const newPair = await createFluidContainer.create(TestDataObject);
         assert.ok(newPair?.handle);
 
         const map1 = createFluidContainer.initialObjects.map1 as SharedMap;

--- a/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/framework/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import { strict as assert } from "assert";
-import { DiceRoller } from "@fluid-example/diceroller";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { TinyliciousClient } from "..";
+import { DiceRoller } from "./DiceRoller";
 
 describe("TinyliciousClient", () => {
     let tinyliciousClient: TinyliciousClient;


### PR DESCRIPTION
Remove the dependency of @fluid-example/diceroller from @fluidframework/tinylicious-client
Define the object with test itself.