### PR TITLE
Fix scribe failures after restart

### DIFF
--- a/.github/code_owners.yml
+++ b/.github/code_owners.yml
@@ -79,6 +79,7 @@ server/**:
 - anthony-murphy
 - GaryWilber
 - hedasilv
+- pradeepvairamani
 
 # examples
 examples/**:

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -132,6 +132,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             }
         } else {
             lastCheckpoint = JSON.parse(document.scribe);
+            context.log?.info(`Restoring checkpoint from db. Seq no: ${lastCheckpoint.sequenceNumber}`);
         }
 
         // Filter and keep ops after protocol state
@@ -181,7 +182,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             protocolHandler,
             latestSummary.term,
             latestSummary.protocolHead,
-            opMessages,
+            opsSinceLastSummary,
             scribeSessionMetric);
 
         await this.sendLambdaStartResult(tenantId, documentId, {lambdaName: LambdaName.Scribe, success: true});


### PR DESCRIPTION
Scribe had a bug which effectively made all the documents that were created before a scribe restart run without generating summaries.

Steps to repro the bug and test the fix:

Start C1
Start C2
Click up
-> Client summary @ 35
Close C1
Close C2
-> Server summary @ 53
Stop scribe
Start C3
click up
Restart scribe

At this point, we were running into the error `Protocol state is not moving sequentially.` since the messages from the pending queue were being replayed. The fix is to filter out the messages before the protocol state while creating scribe lambda in the factory.