### PR TITLE
TaskManager API docs cleanup

### DIFF
--- a/api-report/task-manager.api.md
+++ b/api-report/task-manager.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AttachState } from '@fluidframework/container-definitions';
-import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
@@ -74,32 +73,31 @@ export class OldestClientObserver extends TypedEventEmitter<IOldestClientObserve
 
 // @public
 export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITaskManager {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    // (undocumented)
     abandon(taskId: string): void;
-    // (undocumented)
-    applyStashedOp(): void;
+    // @internal (undocumented)
+    protected applyStashedOp(): void;
+    // @internal
     static create(runtime: IFluidDataStoreRuntime, id?: string): TaskManager;
+    // @internal
     static getFactory(): IChannelFactory;
-    // (undocumented)
-    _getTaskQueues(): Map<string, string[]>;
-    // (undocumented)
+    // @internal
+    protected _getTaskQueues(): Map<string, string[]>;
     haveTaskLock(taskId: string): boolean;
-    // (undocumented)
+    // @internal (undocumented)
     protected initializeLocalCore(): void;
-    // (undocumented)
+    // @internal (undocumented)
     protected loadCore(storage: IChannelStorageService): Promise<void>;
-    // (undocumented)
     lockTask(taskId: string): Promise<void>;
-    // (undocumented)
+    // @internal (undocumented)
     protected onDisconnect(): void;
+    // @internal
     protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    // (undocumented)
     queued(taskId: string): boolean;
-    // (undocumented)
+    // @internal (undocumented)
     protected registerCore(): void;
-    // (undocumented)
+    // @internal
     protected reSubmitCore(): void;
+    // @internal
     protected snapshotCore(serializer: IFluidSerializer): ITree;
     }
 

--- a/packages/dds/task-manager/src/taskManagerFactory.ts
+++ b/packages/dds/task-manager/src/taskManagerFactory.ts
@@ -33,6 +33,9 @@ export class TaskManagerFactory implements IChannelFactory {
         return TaskManagerFactory.Attributes;
     }
 
+    constructor(private readonly newTaskManager:
+        (id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes) => TaskManager) {}
+
     /**
      * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.load}
      */
@@ -41,13 +44,13 @@ export class TaskManagerFactory implements IChannelFactory {
         id: string,
         services: IChannelServices,
         attributes: IChannelAttributes): Promise<ITaskManager> {
-        const taskQueue = new TaskManager(id, runtime, attributes);
+        const taskQueue = this.newTaskManager(id, runtime, attributes);
         await taskQueue.load(services);
         return taskQueue;
     }
 
     public create(document: IFluidDataStoreRuntime, id: string): ITaskManager {
-        const taskQueue = new TaskManager(id, document, this.attributes);
+        const taskQueue = this.newTaskManager(id, document, this.attributes);
         taskQueue.initializeLocal();
         return taskQueue;
     }


### PR DESCRIPTION
Since TaskManager is experimental and doesn't have a publicly exposed factory class I felt that it was a good candidate to do an initial run on. I don't think we will be able to be this aggressive with more widely used DDSes such as SharedMap.

One thing to note is that @internal does not prevent it being in intellisense or for the developer to find it. This is maybe okay but could be confusing. Intellisense does show the @internal marking.

Notes:
- constructor is not private. Can only create through `create` method or factory.
- All protected APIs are marked @internal to remove them from the API docs
- create docs are removed since create for 3P and internal differ
- TaskManager instance API matches ITaskManager