### PR TITLE
Fix rebase bug, add test

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -614,7 +614,7 @@ export class SharedPropertyTree extends SharedObject {
 
 	getRebasedChanges(startGuid: string, endGuid?: string) {
 		const startIndex = _.findIndex(this.remoteChanges, (c) => c.guid === startGuid);
-		if (endGuid) {
+		if (endGuid !== undefined) {
 			const endIndex = _.findIndex(this.remoteChanges, (c) => c.guid === endGuid);
 			return this.remoteChanges.slice(startIndex + 1, endIndex + 1);
 		}

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -246,6 +246,15 @@ describe("PropertyTree", () => {
 
 				expect(count).to.equal(1);
 			});
+
+            it("getRebasedChanges should return empty array empty guid as start & end", async () => {
+                await opProcessingController.pauseProcessing();
+                sharedPropertyTree1.root.insert("test", PropertyFactory.create("String", undefined, "Magic"));
+				sharedPropertyTree1.commit();
+                await opProcessingController.process(container1.deltaManager, container2.deltaManager);
+                const result = sharedPropertyTree1.getRebasedChanges("", "");
+                expect(result.length).to.equal(0);
+            });
 		});
 	});
 });


### PR DESCRIPTION
This addresses an issue when sending a lot of ops without waiting for an ack. 

When Property DDS integrates the remote change into its commit chain it will do a rebase if necessary. Due to a bug in `getRebasedChanges` if we try to rebase from an guid A to guid A the expectation is that the returned changes is an empty array. If the guid A="" which can happen if you start committing a lot of ops without any previous commits. The function will instead return the whole chain of commits and therefore will try to rebase a chain on itself which can cause rebase conflicts where none were.

Example:

`
(guid=R). <-(remoteHead:Guid: R, guid: A, insert P) <- (remoteHead:Guid: R,  guid: A, modify P) `

we will try to rebase this chain from remote head guid (e.g. the last commit we have seen when we send these ops) to the current head guid R in this case no other op was send therefore we rebase from R to R e.g. a noop.
if R="" the function will instead return the whole chain. of changes which will cause a conflict  if we try to rebase the modify operation on to the insert operation.