### PR TITLE
Change error messages to camelCase

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -416,7 +416,7 @@ export class DocumentDeltaConnection
 
             // Give extra 2 seconds for handshake on top of socket connection timeout
             this.socketConnectionTimeout = setTimeout(() => {
-                fail(false, this.createErrorObject("timeoutWaitingForHandshakeFromOrderingService"));
+                fail(false, this.createErrorObject("orderingServiceHandshakeTimeout"));
             }, timeout + 2000);
         });
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -285,7 +285,7 @@ export class DocumentDeltaConnection
     public dispose() {
         this.disposeCore(
             false, // socketProtocolError
-            createGenericNetworkError("client closing connection", true /* canRetry */));
+            createGenericNetworkError("clientClosingConnection", true /* canRetry */));
     }
 
     // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
@@ -333,12 +333,12 @@ export class DocumentDeltaConnection
 
             // Listen for connection issues
             this.addConnectionListener("connect_error", (error) => {
-                fail(true, this.createErrorObject("connect_error", error));
+                fail(true, this.createErrorObject("connectError", error));
             });
 
             // Listen for timeouts
             this.addConnectionListener("connect_timeout", () => {
-                fail(true, this.createErrorObject("connect_timeout"));
+                fail(true, this.createErrorObject("connectTimeout"));
             });
 
             this.addConnectionListener("connect_document_success", (response: IConnected) => {
@@ -358,7 +358,7 @@ export class DocumentDeltaConnection
                     // In this case we will get "read", even if we requested "write"
                     if (actualMode !== requestedMode) {
                         fail(false, this.createErrorObject(
-                            "connect_document_success",
+                            "connectDocumentSuccess",
                             "Connected in a different mode than was requested",
                             false,
                         ));
@@ -367,7 +367,7 @@ export class DocumentDeltaConnection
                 } else {
                     if (actualMode === "write") {
                         fail(false, this.createErrorObject(
-                            "connect_document_success",
+                            "connectDocumentSuccess",
                             "Connected in write mode without write permissions",
                             false,
                         ));
@@ -409,14 +409,14 @@ export class DocumentDeltaConnection
 
                 // This is not an socket.io error - it's Fluid protocol error.
                 // In this case fail connection and indicate that we were unable to create connection
-                fail(false, this.createErrorObject("connect_document_error", error));
+                fail(false, this.createErrorObject("connectDocumentError", error));
             }));
 
             this.socket.emit("connect_document", connectMessage);
 
             // Give extra 2 seconds for handshake on top of socket connection timeout
             this.socketConnectionTimeout = setTimeout(() => {
-                fail(false, this.createErrorObject("Timeout waiting for handshake from ordering service"));
+                fail(false, this.createErrorObject("timeoutWaitingForHandshakeFromOrderingService"));
             }, timeout + 2000);
         });
 
@@ -488,13 +488,12 @@ export class DocumentDeltaConnection
         // - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
         // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
         //   over it.
-        let message = `socket.io: ${handler}`;
-        if (typeof error === "string") {
-            message = `${message}: ${error}`;
-        }
+        const message = `socket.io: ${handler}`;
         const errorObj = createGenericNetworkError(
             message,
             canRetry,
+            undefined,
+            { error: typeof error === "string" ? Object(error) : "" },
         );
 
         return errorObj;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -495,7 +495,6 @@ export class DocumentDeltaConnection
         const errorObj = createGenericNetworkError(
             message,
             canRetry,
-            undefined,
         );
 
         return errorObj;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -488,12 +488,14 @@ export class DocumentDeltaConnection
         // - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
         // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
         //   over it.
-        const message = `socket.io: ${handler}`;
+        let message = `socket.io: ${handler}`;
+        if (typeof error === "string") {
+            message = `${message}: ${error}`;
+        }
         const errorObj = createGenericNetworkError(
             message,
             canRetry,
             undefined,
-            { error: typeof error === "string" ? Object(error) : "" },
         );
 
         return errorObj;

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -61,7 +61,7 @@ export async function createNewFluidFile(
 ): Promise<IOdspResolvedUrl> {
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
-        throwOdspNetworkError("Invalid filename. Please try again.", invalidFileNameStatusCode);
+        throwOdspNetworkError("invalidFilename", invalidFileNameStatusCode);
     }
 
     let itemId: string;
@@ -132,7 +132,7 @@ export async function createNewEmptyFluidFile(
 
                 const content = fetchResponse.content;
                 if (!content || !content.id) {
-                    throwOdspNetworkError("Could not parse item from Vroom response", fetchIncorrectResponse);
+                    throwOdspNetworkError("couldNotParseItemFromVroomResponse", fetchIncorrectResponse);
                 }
                 event.end({
                     headers: Object.keys(headers).length !== 0 ? true : undefined,
@@ -186,7 +186,7 @@ export async function createNewFluidFileFromSummary(
 
                 const content = fetchResponse.content;
                 if (!content || !content.itemId) {
-                    throwOdspNetworkError("Could not parse item from Vroom response", fetchIncorrectResponse);
+                    throwOdspNetworkError("couldNotParseItemFromVroomResponse", fetchIncorrectResponse);
                 }
                 event.end({
                     headers: Object.keys(headers).length !== 0 ? true : undefined,

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -282,7 +282,7 @@ export class EpochTracker implements IPersistedFileCache {
         // initializes this value. Sometimes response does not contain epoch as it is still in
         // implementation phase at server side. In that case also, don't compare it with our epoch value.
         if (this.fluidEpoch && epochFromResponse && (this.fluidEpoch !== epochFromResponse)) {
-            throwOdspNetworkError(message ?? "Epoch Mismatch", fluidEpochMismatchError);
+            throwOdspNetworkError(message ?? "epochMismatch", fluidEpochMismatchError);
         }
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -268,7 +268,7 @@ export class OdspDocumentService implements IDocumentService {
 
             const finalWebsocketToken = websocketToken ?? (websocketEndpoint.socketToken || null);
             if (finalWebsocketToken === null) {
-                throwOdspNetworkError("Push Token is null", fetchTokenErrorCode);
+                throwOdspNetworkError("pushTokenIsNull", fetchTokenErrorCode);
             }
             try {
                 const connection = await this.connectToDeltaStreamWithRetry(

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -485,10 +485,10 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             );
             const versionsResponse = response.content;
             if (!versionsResponse) {
-                throwOdspNetworkError("getVersions returned no response", 400);
+                throwOdspNetworkError("getVersionsReturnedNoResponse", 400);
             }
             if (!Array.isArray(versionsResponse.value)) {
-                throwOdspNetworkError("getVersions returned non-array response", 400);
+                throwOdspNetworkError("getVersionsReturnedNonArrayResponse", 400);
             }
             return versionsResponse.value.map((version) => {
                 // Parse the date from the message
@@ -660,19 +660,19 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     private checkSnapshotUrl() {
         if (!this.snapshotUrl) {
-            throwOdspNetworkError("Method not supported because no snapshotUrl was provided", 400);
+            throwOdspNetworkError("methodNotSupportedBecauseNoSnapshotUrlWasProvided", 400);
         }
     }
 
     private checkAttachmentPOSTUrl() {
         if (!this.attachmentPOSTUrl) {
-            throwOdspNetworkError("Method not supported because no attachmentPOSTUrl was provided", 400);
+            throwOdspNetworkError("methodNotSupportedBecauseNoAttachmentPOSTUrlWasProvided", 400);
         }
     }
 
     private checkAttachmentGETUrl() {
         if (!this.attachmentGETUrl) {
-            throwOdspNetworkError("Method not supported because no attachmentGETUrl was provided", 400);
+            throwOdspNetworkError("methodNotSupportedBecauseNoAttachmentGETUrlWasProvided", 400);
         }
     }
 

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -157,7 +157,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
                 { eventName: "GetSharingLinkToken" },
                 async (event) => tokenFetcher(options).then((tokenResponse) => {
                     if (tokenResponse === null) {
-                        throwOdspNetworkError("Share link Token is null", fetchTokenErrorCode);
+                        throwOdspNetworkError("shareLinkTokenIsNull", fetchTokenErrorCode);
                     }
                     event.end({ fromCache: isTokenFromCache(tokenResponse) });
                     return tokenResponse;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -109,12 +109,7 @@ export async function fetchHelper(
         }
         if (!response.ok || response.status < 200 || response.status >= 300) {
             throwOdspNetworkError(
-                "errorResponseNotOk",
-                response.status,
-                response,
-                await response.text(),
-                { responseStatus: response.status },
-            );
+                `Error ${response.status}`, response.status, response, await response.text());
         }
 
         const headers = headersToMap(response.headers);

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -154,7 +154,8 @@ describe("Tests for snapshot fetch", () => {
         );
         } catch (error) {
             isCaught = true;
-            assert.strictEqual(error.message, "Error 404 (undefined)", "incorrect error message");
+            assert.strictEqual(error.message, "errorResponseNotOk (undefined)", "incorrect error message");
+            assert.strictEqual(error.responseStatus, 404, "Response status does not match");
         }
         // making sure network fetch did throw and catch block was executed
         assert(isCaught, "catch block was not executed");
@@ -185,7 +186,7 @@ describe("Tests for snapshot fetch", () => {
             );
         } catch (error) {
             isCaught = true;
-            assert.strictEqual(error.message, "Error 404 (undefined)", "incorrect error message");
+            assert.strictEqual(error.message, "errorResponseNotOk (undefined)", "incorrect error message");
         }
         // making sure network fetch did throw and catch block was executed
         assert(isCaught, "catch block was not executed");

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -154,8 +154,7 @@ describe("Tests for snapshot fetch", () => {
         );
         } catch (error) {
             isCaught = true;
-            assert.strictEqual(error.message, "errorResponseNotOk (undefined)", "incorrect error message");
-            assert.strictEqual(error.responseStatus, 404, "Response status does not match");
+            assert.strictEqual(error.message, "Error 404 (undefined)", "incorrect error message");
         }
         // making sure network fetch did throw and catch block was executed
         assert(isCaught, "catch block was not executed");
@@ -186,7 +185,7 @@ describe("Tests for snapshot fetch", () => {
             );
         } catch (error) {
             isCaught = true;
-            assert.strictEqual(error.message, "errorResponseNotOk (undefined)", "incorrect error message");
+            assert.strictEqual(error.message, "Error 404 (undefined)", "incorrect error message");
         }
         // making sure network fetch did throw and catch block was executed
         assert(isCaught, "catch block was not executed");

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -132,7 +132,7 @@ describe("Odsp Create Container Test", () => {
             assert.strictEqual(error.statusCode, fetchIncorrectResponse, "Wrong error code");
             assert.strictEqual(error.errorType, DriverErrorType.incorrectServerResponse,
                 "Error type should be correct");
-            assert.strictEqual(error.message, "Could not parse item from Vroom response", "Message should be correct");
+            assert.strictEqual(error.message, "couldNotParseItemFromVroomResponse", "Message should be correct");
         }
     });
 });

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1022,7 +1022,7 @@ export class DeltaManager
         // check message.content for Back-compat with old service.
         const reconnectInfo = message.content !== undefined
             ? getNackReconnectInfo(message.content) :
-            createGenericNetworkError(`Nack: unknown reason`, true);
+            createGenericNetworkError("nack:UnknownReason", true);
 
         if (this.reconnectMode !== ReconnectMode.Enabled) {
             this.logger.sendErrorEvent({
@@ -1402,7 +1402,7 @@ export class DeltaManager
                     const message2 = this.comparableMessagePayload(message);
                     if (message1 !== message2) {
                         const error = new NonRetryableError(
-                            "Two messages with same seq# and different payload!",
+                            "twoMessagesWithSameSeqNumAndDifferentPayload",
                             DriverErrorType.fileOverwrittenInStorage,
                             {
                                 clientId: this.connection?.clientId,

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -399,7 +399,7 @@ async function getSingleOpBatch(
                 // ops to storage quick enough, and possibly waiting for summaries, while summarizer can't get
                 // current as it can't get ops.
                 throw createGenericNetworkError(
-                    "Failed to retrieve ops from storage: too many retries",
+                    "failedToRetrieveOpsFromStorage:TooManyRetries",
                     false /* canRetry */,
                     undefined /* retryAfterSeconds */,
                     {

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -101,7 +101,7 @@ export async function fetchTokens(
     const refreshToken = tokens.refresh_token;
 
     if (accessToken === undefined || refreshToken === undefined) {
-        throwOdspNetworkError("Unable to get access token.", tokens.error === "invalid_grant" ? 401 : result.status);
+        throwOdspNetworkError("unableToGetAccessToken", tokens.error === "invalid_grant" ? 401 : result.status);
     }
     return { accessToken, refreshToken };
 }

--- a/packages/utils/odsp-doclib-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDrives.ts
@@ -124,7 +124,7 @@ export async function getChildrenByDriveItem(
     do {
         const response = await getAsync(url, authRequestInfo);
         if (response.status !== 200) {
-            throwOdspNetworkError("Unable to get children", response.status, response);
+            throwOdspNetworkError("unableToGetChildren", response.status, response);
         }
         const getChildrenResult = await response.json();
         children = children.concat(getChildrenResult.value);
@@ -142,19 +142,19 @@ async function getDriveItem(
     let response = await getAsync(getDriveItemUrl, authRequestInfo);
     if (response.status !== 200) {
         if (!create) {
-            throwOdspNetworkError("Unable to get drive/item id from path", response.status, response);
+            throwOdspNetworkError("unableToGetDriveItemIdFromPath", response.status, response);
         }
 
         // Try creating the file
         const contentUri = `${getDriveItemUrl}/content`;
         const createResultResponse = await putAsync(contentUri, authRequestInfo);
         if (createResultResponse.status !== 201) {
-            throwOdspNetworkError("Failed to create file.", createResultResponse.status, createResultResponse);
+            throwOdspNetworkError("failedToCreateFile", createResultResponse.status, createResultResponse);
         }
 
         response = await getAsync(getDriveItemUrl, authRequestInfo);
         if (response.status !== 200) {
-            throwOdspNetworkError("Unable to get drive/item id from path", response.status, response);
+            throwOdspNetworkError("unableToGetDriveItemIdFromPath", response.status, response);
         }
     }
     const getDriveItemResult = await response.json();
@@ -212,7 +212,7 @@ async function getDriveResponse(
     const getDriveUrl = `https://${server}${accountPath}/_api/v2.1/${routeTail}`;
     const response = await getAsync(getDriveUrl, authRequestInfo);
     if (response.status !== 200) {
-        throwOdspNetworkError(`Failed to get ${routeTail}.`, response.status, response);
+        throwOdspNetworkError("failedToGetDriveResponse", response.status, response, undefined, { route: routeTail });
     }
     return response;
 }

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -252,13 +252,15 @@ export function throwOdspNetworkError(
     statusCode: number,
     response?: Response,
     responseText?: string,
+    props?: ITelemetryProperties,
 ): never {
     const networkError = createOdspNetworkError(
         response && response.statusText !== "" ? `${errorMessage} (${response.statusText})` : errorMessage,
         statusCode,
         response ? numberFromHeader(response.headers.get("retry-after")) : undefined, /* retryAfterSeconds */
         response,
-        responseText);
+        responseText,
+        props);
 
     throw networkError;
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/6754
As per Mark proposal, we replaced some of the errors to have fluidErrorCodes which will be in cacmelCase. So replacing others classes to use the same camelCase fluidErrorCode.
Also puts any variables in separate telemetry props so that we can use static fluidErrorCodes and errorType to classify errors.