### PR TITLE
Add attach-related APIs to IFluidContainer, and prefer IFluidContainer over FluidContainer in usage

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -5,8 +5,8 @@
 ```ts
 
 import { ContainerSchema } from '@fluidframework/fluid-static';
-import { FluidContainer } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
+import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
@@ -25,11 +25,11 @@ export class AzureAudience extends ServiceAudience<AzureMember> implements IAzur
 export class AzureClient {
     constructor(props: AzureClientProps);
     createContainer(containerSchema: ContainerSchema): Promise<{
-        container: FluidContainer;
+        container: IFluidContainer;
         services: AzureContainerServices;
     }>;
     getContainer(id: string, containerSchema: ContainerSchema): Promise<{
-        container: FluidContainer;
+        container: IFluidContainer;
         services: AzureContainerServices;
     }>;
     }

--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -4,6 +4,10 @@
 
 ```ts
 
+import { AttachState } from '@fluidframework/container-definitions';
+
+export { AttachState }
+
 
 export * from "@fluidframework/fluid-static";
 export * from "@fluidframework/map";

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -45,7 +45,6 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
     constructor(container: Container, rootDataObject: RootDataObject, attachCallback: () => Promise<string>);
     attach(): Promise<string>;
-    // (undocumented)
     get attachState(): AttachState;
     get connected(): boolean;
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
@@ -65,6 +64,7 @@ export interface IConnection {
 // @public
 export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
     attach(): Promise<string>;
+    readonly attachState: AttachState;
     readonly connected: boolean;
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
     dispose(): void;

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -44,7 +44,6 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
     constructor(container: Container, rootDataObject: RootDataObject, attachCallback: () => Promise<string>);
-    // (undocumented)
     attach(): Promise<string>;
     // (undocumented)
     get attachState(): AttachState;
@@ -65,6 +64,7 @@ export interface IConnection {
 
 // @public
 export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
+    attach(): Promise<string>;
     readonly connected: boolean;
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
     dispose(): void;

--- a/api-report/tinylicious-client.api.md
+++ b/api-report/tinylicious-client.api.md
@@ -5,8 +5,8 @@
 ```ts
 
 import { ContainerSchema } from '@fluidframework/fluid-static';
-import { FluidContainer } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
+import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
@@ -30,11 +30,11 @@ export class TinyliciousAudience extends ServiceAudience<TinyliciousMember> impl
 class TinyliciousClient {
     constructor(props?: TinyliciousClientProps | undefined);
     createContainer(containerSchema: ContainerSchema): Promise<{
-        container: FluidContainer;
+        container: IFluidContainer;
         services: TinyliciousContainerServices;
     }>;
     getContainer(id: string, containerSchema: ContainerSchema): Promise<{
-        container: FluidContainer;
+        container: IFluidContainer;
         services: TinyliciousContainerServices;
     }>;
     }

--- a/examples/data-objects/focus-tracker/src/FocusTracker.ts
+++ b/examples/data-objects/focus-tracker/src/FocusTracker.ts
@@ -6,7 +6,7 @@
 import { IEvent } from "@fluidframework/common-definitions";
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {
-    FluidContainer,
+    IFluidContainer,
     IMember,
     IServiceAudience,
     SignalManager,
@@ -43,7 +43,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
     };
 
     public constructor(
-        container: FluidContainer,
+        container: IFluidContainer,
         public readonly audience: IServiceAudience<IMember>,
         private readonly signalManager: SignalManager,
     ) {

--- a/examples/data-objects/focus-tracker/src/app.ts
+++ b/examples/data-objects/focus-tracker/src/app.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-    FluidContainer,
+    IFluidContainer,
     ContainerSchema,
     SignalManager,
 } from "fluid-framework";
@@ -50,7 +50,7 @@ function renderFocusPresence(focusTracker: FocusTracker, div: HTMLDivElement) {
 async function start(): Promise<void> {
     // Get or create the document depending if we are running through the create new flow
     const client = new TinyliciousClient();
-    let container: FluidContainer;
+    let container: IFluidContainer;
     let services: TinyliciousContainerServices;
     let containerId: string;
 

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -10,7 +10,7 @@ import {
 } from "@fluidframework/azure-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 import {
-    FluidContainer,
+    IFluidContainer,
     SharedMap,
 } from "fluid-framework";
 import { v4 as uuid } from "uuid";
@@ -65,7 +65,7 @@ const containerSchema = {
     },
 };
 
-async function initializeNewContainer(container: FluidContainer): Promise<void> {
+async function initializeNewContainer(container: IFluidContainer): Promise<void> {
     // Initialize both of our SharedMaps for usage with a DiceRollerController
     const sharedMap1 = container.initialObjects.map1 as SharedMap;
     const sharedMap2 = container.initialObjects.map2 as SharedMap;
@@ -83,7 +83,7 @@ async function start(): Promise<void> {
         logger: new ConsoleLogger(),
     };
     const client = new AzureClient(azureConfig);
-    let container: FluidContainer;
+    let container: IFluidContainer;
     let services: AzureContainerServices;
     let id: string;
 

--- a/packages/framework/azure-client/src/AzureClient.ts
+++ b/packages/framework/azure-client/src/AzureClient.ts
@@ -11,6 +11,7 @@ import {
     ContainerSchema,
     DOProviderContainerRuntimeFactory,
     FluidContainer,
+    IFluidContainer,
     RootDataObject,
 } from "@fluidframework/fluid-static";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
@@ -47,7 +48,7 @@ export class AzureClient {
      */
     public async createContainer(
         containerSchema: ContainerSchema,
-    ): Promise<{ container: FluidContainer; services: AzureContainerServices }> {
+    ): Promise<{ container: IFluidContainer; services: AzureContainerServices }> {
         const loader = this.createLoader(containerSchema);
         const container = await loader.createDetachedContainer({
             package: "no-dynamic-package",
@@ -68,7 +69,7 @@ export class AzureClient {
     public async getContainer(
         id: string,
         containerSchema: ContainerSchema,
-    ): Promise<{ container: FluidContainer; services: AzureContainerServices }> {
+    ): Promise<{ container: IFluidContainer; services: AzureContainerServices }> {
         const loader = this.createLoader(containerSchema);
         const container = await loader.resolve({ url: id });
         return this.getFluidContainerAndServices(id, container);
@@ -78,13 +79,13 @@ export class AzureClient {
     private async getFluidContainerAndServices(
         id: string,
         container: Container,
-    ): Promise<{ container: FluidContainer; services: AzureContainerServices }> {
+    ): Promise<{ container: IFluidContainer; services: AzureContainerServices }> {
         const attach = async () => {
             await container.attach({ url: id });
             return id;
         };
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
-        const fluidContainer: FluidContainer = new FluidContainer(container, rootDataObject, attach);
+        const fluidContainer: IFluidContainer = new FluidContainer(container, rootDataObject, attach);
         const services: AzureContainerServices = this.getContainerServices(container);
         return { container: fluidContainer, services };
     }

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -27,6 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
+    "@fluidframework/container-definitions": "^0.39.8",
     "@fluidframework/fluid-static": "^0.48.0",
     "@fluidframework/map": "^0.48.0",
     "@fluidframework/sequence": "^0.48.0"

--- a/packages/framework/fluid-framework/src/containerDefinitions.ts
+++ b/packages/framework/fluid-framework/src/containerDefinitions.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { AttachState } from "@fluidframework/container-definitions";

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -5,6 +5,7 @@
 
 /* eslint-disable import/export */
 
+export * from "./containerDefinitions";
 export * from  "./fluidStatic";
 export * from  "./map";
 export * from  "./sequence";

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -39,6 +39,11 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
     readonly initialObjects: LoadableObjectRecord;
 
     /**
+     * The current attachment state of the container.  Once a container has been attached, it remains attached.
+     * When loading an existing container, it will already be attached.
+     */
+    readonly attachState: AttachState;
+    /**
      * A newly created container starts detached from the collaborative service.  Calling attach() uploads the
      * new container to the service and connects to the collaborative service.
      * @returns A promise which resolves when the attach is complete, with the string identifier of the container.
@@ -78,6 +83,9 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
         container.on("disconnected", this.disconnectedHandler);
     }
 
+    /**
+     * {@inheritDoc IFluidContainer.attachState}
+     */
     public get attachState(): AttachState {
         return this.container.attachState;
     }
@@ -108,6 +116,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
      */
     public async attach() {
         if (this.attachState === AttachState.Detached) {
+            // Consider -- should we emit an attached event after the callback completes?
             return this.attachCallback();
         } else {
             throw new Error("Cannot attach container. Container is not in detached state");

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -43,6 +43,7 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
      * When loading an existing container, it will already be attached.
      */
     readonly attachState: AttachState;
+
     /**
      * A newly created container starts detached from the collaborative service.  Calling attach() uploads the
      * new container to the service and connects to the collaborative service.

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -39,6 +39,13 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
     readonly initialObjects: LoadableObjectRecord;
 
     /**
+     * A newly created container starts detached from the collaborative service.  Calling attach() uploads the
+     * new container to the service and connects to the collaborative service.
+     * @returns A promise which resolves when the attach is complete, with the string identifier of the container.
+     */
+    attach(): Promise<string>;
+
+    /**
      * Create a new data object or DDS of the specified type.  In order to share the data object or DDS with other
      * collaborators and retrieve it later, store its handle in a collection like a SharedDirectory from your
      * initialObjects.
@@ -96,6 +103,9 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
         return this.rootDataObject.initialObjects;
     }
 
+    /**
+     * {@inheritDoc IFluidContainer.attach}
+     */
     public async attach() {
         if (this.attachState === AttachState.Detached) {
             return this.attachCallback();

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -18,6 +18,7 @@ import {
     ContainerSchema,
     DOProviderContainerRuntimeFactory,
     FluidContainer,
+    IFluidContainer,
     RootDataObject,
 } from "@fluidframework/fluid-static";
 import {
@@ -55,7 +56,7 @@ export class TinyliciousClient {
      */
     public async createContainer(
         containerSchema: ContainerSchema,
-    ): Promise<{container: FluidContainer; services: TinyliciousContainerServices}> {
+    ): Promise<{container: IFluidContainer; services: TinyliciousContainerServices}> {
         // temporarily we'll generate the new container ID here
         // until container ID changes are settled in lower layers.
         const id = uuid();
@@ -72,7 +73,7 @@ export class TinyliciousClient {
     public async getContainer(
         id: string,
         containerSchema: ContainerSchema,
-    ): Promise<{container: FluidContainer; services: TinyliciousContainerServices}> {
+    ): Promise<{container: IFluidContainer; services: TinyliciousContainerServices}> {
         const container = await this.getContainerCore(id, containerSchema, false);
         return this.getFluidContainerAndServices(id, container);
     }
@@ -81,13 +82,13 @@ export class TinyliciousClient {
     private async getFluidContainerAndServices(
         id: string,
         container: Container,
-    ): Promise<{container: FluidContainer; services: TinyliciousContainerServices}> {
+    ): Promise<{container: IFluidContainer; services: TinyliciousContainerServices}> {
         const rootDataObject = await requestFluidObject<RootDataObject>(container, "/");
         const attach = async () => {
             await container.attach({ url: id });
             return id;
         };
-        const fluidContainer: FluidContainer = new FluidContainer(container, rootDataObject, attach);
+        const fluidContainer: IFluidContainer = new FluidContainer(container, rootDataObject, attach);
         const services: TinyliciousContainerServices = this.getContainerServices(container);
         return { container: fluidContainer, services };
     }


### PR DESCRIPTION
This change does three main things:
1. `attach()` and `attachState` were missing from `IFluidContainer`, I've added those.
2. Since we use the `AttachState` type for `attachState`, I've re-exported it from the `fluid-framework` package as well.
3. Wherever it made sense to use `IFluidContainer` over `FluidContainer` I've done so, most notably in the client packages.