### PR TITLE
Test variant logging, extend timeout, and restore type 

### DIFF
--- a/api-report/test-drivers.api.md
+++ b/api-report/test-drivers.api.md
@@ -23,7 +23,7 @@ import { RouterliciousDocumentServiceFactory } from '@fluidframework/routerlicio
 import { TestDriverTypes } from '@fluidframework/test-driver-definitions';
 
 // @public (undocumented)
-export function createFluidTestDriver(fluidTestDriverType?: TestDriverTypes, config?: FluidTestDriverConfig, api?: DriverApiType): Promise<ITestDriver>;
+export function createFluidTestDriver(fluidTestDriverType?: TestDriverTypes, config?: FluidTestDriverConfig, api?: DriverApiType): Promise<LocalServerTestDriver | TinyliciousTestDriver | RouterliciousTestDriver | OdspTestDriver>;
 
 // @public (undocumented)
 export type CreateFromEnvConfigParam<T extends (config: any, ...args: any) => any> = T extends (config: infer P, ...args: any) => any ? P : never;

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -348,9 +348,9 @@
           "dev": true
         },
         "@fluidframework/protocol-definitions": {
-          "version": "0.1024.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0.tgz",
-          "integrity": "sha512-ksbjiihicwMbbX3fPkVOxsl8QDDiuc20T7t4Y7vq7aMkzPh4FAwoomjjreDSf71N6zAoz30HEzPPl0OwvPi0xw==",
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
           "dev": true,
           "requires": {
             "@fluidframework/common-definitions": "^0.20.0"

--- a/examples/data-objects/table-document/src/test/.mocharc.js
+++ b/examples/data-objects/table-document/src/test/.mocharc.js
@@ -7,6 +7,6 @@
 
 const packageDir = `${__dirname}/../..`;
 
-const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common.js");
-const config = getFluidTestMochaConfig(packageDir, ["@fluidframework/test-version-utils"]);
+const common = require("@fluidframework/mocha-test-setup/mocharc-common.js");
+const config = common.getFluidTestMochaConfig(packageDir, ["@fluidframework/test-version-utils"]);
 module.exports = config;

--- a/examples/data-objects/webflow/src/test/.mocharc.js
+++ b/examples/data-objects/webflow/src/test/.mocharc.js
@@ -7,8 +7,8 @@
 
 const packageDir = `${__dirname}/../..`;
 
-const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common.js");
-const config = getFluidTestMochaConfig(packageDir,
+const common = require("@fluidframework/mocha-test-setup/mocharc-common.js");
+const config = common.getFluidTestMochaConfig(packageDir,
     [
         "@fluidframework/test-version-utils",
         "ignore-styles",

--- a/experimental/dds/tree/src/test/.mocharc.js
+++ b/experimental/dds/tree/src/test/.mocharc.js
@@ -7,6 +7,6 @@
 
 const packageDir = `${__dirname}/../..`;
 
-const getFluidTestMochaConfig = require('@fluidframework/mocha-test-setup/mocharc-common.js');
-const config = getFluidTestMochaConfig(packageDir);
+const common = require('@fluidframework/mocha-test-setup/mocharc-common.js');
+const config = common.getFluidTestMochaConfig(packageDir);
 module.exports = config;

--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -8,12 +8,16 @@
 const { existsSync } = require("fs");
 const path = require("path");
 
-function getFluidTestMochaConfig(packageDir, additionalRequiredModules) {
-
+function getFluidTestVariant() {
     const testDriver = process.env.fluid__test__driver ? process.env.fluid__test__driver : "local";
     const r11sEndpointName = process.env.fluid__test__r11sEndpointName;
     const testVariant = (testDriver === "r11s" || testDriver === "routerlicious")
         && (r11sEndpointName !== undefined && r11sEndpointName !== "r11s") ? `r11s-${r11sEndpointName}` : testDriver;
+    return testVariant;
+}
+
+function getFluidTestMochaConfig(packageDir, additionalRequiredModules) {
+
     const moduleDir = `${packageDir}/node_modules`;
 
     const requiredModules = [
@@ -52,6 +56,7 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules) {
     }
 
     if (process.env.FLUID_TEST_REPORT === "1") {
+        const testVariant = getFluidTestVariant();
         const packageJson = require(`${packageDir}/package.json`);
         config["reporter"] = `xunit`;
         config["reporter-options"] = [
@@ -63,4 +68,4 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules) {
     return config;
 }
 
-module.exports = getFluidTestMochaConfig;
+module.exports = { getFluidTestMochaConfig, getFluidTestVariant };

--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -6,7 +6,10 @@
 import { ITelemetryBufferedLogger } from "@fluidframework/test-driver-definitions";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { Context } from "mocha";
+import { getFluidTestVariant } from "../mocharc-common";
 import { pkgName } from "./packageVersion";
+
+const testVariant = getFluidTestVariant();
 
 const _global: any = global;
 class TestLogger implements ITelemetryBufferedLogger {
@@ -19,6 +22,7 @@ class TestLogger implements ITelemetryBufferedLogger {
         if (this.testName !== undefined) {
             event.testName = this.testName;
         }
+        event.testVariant = testVariant;
         event.hostName = pkgName;
         this.parentLogger.send(event);
     }
@@ -67,6 +71,7 @@ export const mochaHooks = {
             category: "generic",
             eventName: "fluid:telemetry:Test_start",
             testName: currentTestName,
+            testVariant,
         });
     },
     afterEach() {
@@ -78,6 +83,7 @@ export const mochaHooks = {
             testName: currentTestName,
             state: context.currentTest?.state,
             duration: context.currentTest?.duration,
+            testVariant,
         });
 
         console.log = log;

--- a/packages/test/test-drivers/src/factory.ts
+++ b/packages/test/test-drivers/src/factory.ts
@@ -6,7 +6,7 @@
 import http from "http";
 import * as path from "path";
 import Axios from "axios";
-import { ITestDriver, TestDriverTypes } from "@fluidframework/test-driver-definitions";
+import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { unreachableCase } from "@fluidframework/common-utils";
 import { LocalServerTestDriver } from "./localServerTestDriver";
 import { TinyliciousTestDriver } from "./tinyliciousTestDriver";
@@ -62,7 +62,7 @@ export async function createFluidTestDriver(
     fluidTestDriverType: TestDriverTypes = "local",
     config?: FluidTestDriverConfig,
     api: DriverApiType = DriverApi,
-): Promise<ITestDriver> {
+): Promise<LocalServerTestDriver | TinyliciousTestDriver | RouterliciousTestDriver | OdspTestDriver> {
     switch (fluidTestDriverType) {
         case "local":
             return new LocalServerTestDriver(api.LocalDriverApi);

--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.js
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.js
@@ -7,8 +7,8 @@
 
 const packageDir = `${__dirname}/../..`;
 
-const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common.js");
-const config = getFluidTestMochaConfig(packageDir, [
+const common = require("@fluidframework/mocha-test-setup/mocharc-common.js");
+const config = common.getFluidTestMochaConfig(packageDir, [
     "@fluidframework/test-version-utils"
 ]);
 module.exports = config;

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -4,7 +4,7 @@
  */
 
 import commander from "commander";
-import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
+import { ITestDriver, TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import random from "random-js";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
@@ -129,7 +129,7 @@ async function runnerProcess(
         const loaderOptions = generateLoaderOptions(seed);
         const containerOptions = generateRuntimeOptions(seed);
 
-        const testDriver = await createTestDriver(driver, seed, runConfig.runId);
+        const testDriver: ITestDriver = await createTestDriver(driver, seed, runConfig.runId);
         const baseLogger = await loggerP;
         const logger = ChildLogger.create(baseLogger, undefined,
             {

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -97,7 +97,7 @@ stages:
         poolBuild: Lite
         testPackage: "@fluidframework/test-end-to-end-tests"
         testWorkspace: ${{ variables.testWorkspace }}
-        timeoutInMinutes: 240
+        timeoutInMinutes: 360
         testSteps:
         - task: Npm@1
           displayName: '[end-to-end tests] npm run test:realsvc:frs:report'
@@ -120,7 +120,7 @@ stages:
         poolBuild: Lite
         testPackage: "@fluidframework/test-end-to-end-tests"
         testWorkspace: ${{ variables.testWorkspace }}
-        timeoutInMinutes: 240
+        timeoutInMinutes: 360
         testSteps:
         - task: Npm@1
           displayName: '[end-to-end tests] npm run test:realsvc:odsp:report'


### PR DESCRIPTION
- Restore the typing for createFluidTestDriver because it broke type narrowing in PR #7319 , but that means we need to force the type of the variable to `ITestDriver` in `test-service-load/src/runner.ts`.
- extend timeout (for now) to make e2e test pass.  Long term, we need to break the test into stages. (and investigate why it takes so long)
- Add `testVariant` to the `Test_start`/`Test_end` events.