### PR TITLE
Add exports required for creating a token provider to azure-client

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -11,8 +11,11 @@ import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
+import { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { ITokenResponse } from '@fluidframework/routerlicious-driver';
+import { IUser } from '@fluidframework/protocol-definitions';
+import { ScopeType } from '@fluidframework/protocol-definitions';
 import { ServiceAudience } from '@fluidframework/fluid-static';
 
 // @public (undocumented)
@@ -76,6 +79,16 @@ export type IAzureAudience = IServiceAudience<AzureMember>;
 export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
+
+export { ITokenClaims }
+
+export { ITokenProvider }
+
+export { ITokenResponse }
+
+export { IUser }
+
+export { ScopeType }
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/framework/azure-client/src/index.ts
+++ b/packages/framework/azure-client/src/index.ts
@@ -7,3 +7,6 @@ export * from "./AzureAudience";
 export * from "./AzureClient";
 export * from "./AzureFunctionTokenProvider";
 export * from "./interfaces";
+
+export { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+export { ScopeType, ITokenClaims, IUser } from "@fluidframework/protocol-definitions";


### PR DESCRIPTION
This PR adds in the necessary interface a developer would require if they were setting up their own `ITokenProvider` instance. With this, they would only require the `@fluidframework/azure-client` import for both fetching the client itself as well as providing the necessary parameters to instantiate it