### PR TITLE
add configureHistorianLogging() helper to historian-base

### DIFF
--- a/server/historian/packages/historian-base/src/index.ts
+++ b/server/historian/packages/historian-base/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export * from "./logger";
 export * from "./routes";
 export * from "./services";
 export * from "./runnerFactory";

--- a/server/historian/packages/historian-base/src/logger.ts
+++ b/server/historian/packages/historian-base/src/logger.ts
@@ -24,15 +24,15 @@ export function configureHistorianLogging(configOrPath: Provider | string) {
         ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory")
         : configOrPath;
 
-        const genevaConfig = config.get("lumberjack");
+        const lumberjackConfig = config.get("lumberjack");
         const engineList =
-            genevaConfig && genevaConfig.engineList ?
-            genevaConfig.engineList as ILumberjackEngine[] :
+            lumberjackConfig && lumberjackConfig.engineList ?
+            lumberjackConfig.engineList as ILumberjackEngine[] :
             [new WinstonLumberjackEngine()];
 
         const schemaValidatorList =
-            genevaConfig && genevaConfig.schemaValidator ?
-            genevaConfig.schemaValidator as ILumberjackSchemaValidator[] :
+            lumberjackConfig && lumberjackConfig.schemaValidator ?
+            lumberjackConfig.schemaValidator as ILumberjackSchemaValidator[] :
             undefined;
 
         Lumberjack.setup(engineList, schemaValidatorList);

--- a/server/historian/packages/historian-base/src/logger.ts
+++ b/server/historian/packages/historian-base/src/logger.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import nconf, { Provider } from "nconf";
+import { WinstonLumberjackEngine } from "@fluidframework/server-services-utils";
+import { ILumberjackEngine, ILumberjackSchemaValidator, Lumberjack } from "@fluidframework/server-services-telemetry";
+
+/**
+ * Helps to avoid package version mismatch issues with usage of global Lumberjack instance.
+ * Configures the default behavior of the Winston and Lumberjack loggers based on the provided config.
+ *
+ * IMPORTANT: call this after `configureLogging` has been called, if calling both, so that Lumberjack is not
+ * setup twice, which will throw an error. `configureLogging` does not do a safety check when setting up Lumberjack.
+ */
+export function configureHistorianLogging(configOrPath: Provider | string) {
+    // if package versions are not mismatched, this check will ensure this function does nothing.
+    if (!Lumberjack.isSetupCompleted()) {
+        // TODO: this is duplicate code from `@fluidframework/server-services-utils` configureLogging()
+        // to avoid adding duplicate transports to the global `winston` instance. This should just call
+        // configureLogging() once global winston usage is removed in favor of Lumberjack.
+        const config = typeof configOrPath === "string"
+        ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory")
+        : configOrPath;
+
+        const genevaConfig = config.get("lumberjack");
+        const engineList =
+            genevaConfig && genevaConfig.engineList ?
+            genevaConfig.engineList as ILumberjackEngine[] :
+            [new WinstonLumberjackEngine()];
+
+        const schemaValidatorList =
+            genevaConfig && genevaConfig.schemaValidator ?
+            genevaConfig.schemaValidator as ILumberjackSchemaValidator[] :
+            undefined;
+
+        Lumberjack.setup(engineList, schemaValidatorList);
+    }
+}


### PR DESCRIPTION
In FRS, we consume historian-base and run it with services-shared's runService method after configuring different telemetry. If historian-base depends on a different version of r11s packages than FRS, the global Lumberjack instance used within Historian cannot be setup using the version of services-utils that FRS has access to.

This PR adds a helper method that lets us configure the version of Lumberjack that Historian's source code depends on regardless of what version FRS depends on.