### PR TITLE
fix location for type declaration

### DIFF
--- a/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
@@ -5,15 +5,15 @@
 
 import { EventEmitter } from "events";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { IFluidHandle , IRequest, IResponse} from "@fluidframework/core-interfaces";
+import { IFluidHandle, IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { SharedPropertyTree, PropertyTreeFactory } from "@fluid-experimental/property-dds";
 import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
 
 import { LazyLoadedDataObject, LazyLoadedDataObjectFactory } from "@fluidframework/data-object-base";
-import { BaseProperty } from "@fluid-experimental/property-properties";
+import { BaseProperty, NodeProperty } from "@fluid-experimental/property-properties";
 
 export interface IPropertyTree extends EventEmitter {
-    pset: any;
+    pset: NodeProperty;
     tree: SharedPropertyTree;
 
     on(event: "changeSetModified" | "commit", listener: (CS: any) => void): this;
@@ -76,7 +76,7 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
         this.emit("commit");
     }
 
-    resolvePath(path: string, options: any): BaseProperty|undefined {
+    resolvePath(path: string, options: any): BaseProperty | undefined {
         return this.tree.root.resolvePath(path, options);
     }
     public static getFactory(): IFluidDataStoreFactory { return PropertyTreeInstantiationFactory; }

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/Field.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/Field.tsx
@@ -13,73 +13,75 @@ import { StringView } from './PropertyViews/String';
 import { Utils } from './typeUtils';
 
 function onInlineEditEnd(val: string | number | boolean, props: IEditableValueCellProps) {
-  const {rowData} = props;
-  // Convert to number if it is possible and the type is not an integer with 64 bits.
-  if (rowData.typeid !== 'Uint64' && rowData.typeid !== 'Int64' && rowData.typeid !== 'String') {
-    val = !isNaN(+val) ? +val : val;
-  }
-
-  const proxiedParent = PropertyProxy.proxify(rowData.parent!);
-  const parentContext = rowData.parent!.getContext();
-  try {
-    if (parentContext === 'single' || parentContext === 'array') {
-      // TODO: Temporary workaround, as enum arrays currently are not considered primitive.
-      if (Utils.isEnumArrayProperty(rowData.parent!)) {
-        (rowData.parent! as any).set(parseInt(rowData.name, 10), val);
-      } else {
-        proxiedParent[rowData.name] = val;
-      }
-    } else if (parentContext === 'map') {
-      (proxiedParent as ProxifiedMapProperty).set(rowData.name, val);
-    } else if (parentContext === 'set') {
-      (rowData.parent! as SetProperty).get(rowData.name)!.value = val;
+    const { rowData } = props;
+    // Convert to number if it is possible and the type is not an integer with 64 bits.
+    if (rowData.typeid !== 'Uint64' && rowData.typeid !== 'Int64' && rowData.typeid !== 'String') {
+        val = !isNaN(+val) ? +val : val;
     }
-    rowData.parent!.getRoot().getWorkspace()!.commit();
-  } catch (error) {
-    console.error(error);
-  }
+
+    const proxiedParent = PropertyProxy.proxify(rowData.parent!);
+    const parentContext = rowData.parent!.getContext();
+    try {
+        if (parentContext === 'single' || parentContext === 'array') {
+            // TODO: Temporary workaround, as enum arrays currently are not considered primitive.
+            if (Utils.isEnumArrayProperty(rowData.parent!)) {
+                (rowData.parent! as any).set(parseInt(rowData.name, 10), val);
+            } else {
+                proxiedParent[rowData.name] = val;
+            }
+        } else if (parentContext === 'map') {
+            // This is safe since we know the input property in PropertyProxy.proxify was of type MapProperty
+            // since the parents context was of type "map"
+            (proxiedParent as unknown as ProxifiedMapProperty).set(rowData.name, val);
+        } else if (parentContext === 'set') {
+            (rowData.parent! as SetProperty).get(rowData.name)!.value = val;
+        }
+        rowData.parent!.getRoot().getWorkspace()!.commit();
+    } catch (error) {
+        console.error(error);
+    }
 }
 
-export const Field: React.FunctionComponent<IEditableValueCellProps> = ({rowData, ...restProps}) => {
-  const parent = rowData.parent!;
-  let typeid = rowData.typeid;
-  let property;
+export const Field: React.FunctionComponent<IEditableValueCellProps> = ({ rowData, ...restProps }) => {
+    const parent = rowData.parent!;
+    let typeid = rowData.typeid;
+    let property;
 
-  try {
-    property = (rowData.parent! as ContainerProperty).get(rowData.name);
-  } catch {
-    typeid = 'Reference';
-  }
-  if (Utils.isEnumProperty(property) || Utils.isEnumArrayProperty(parent!)) {
-    typeid = 'enum';
-  }
+    try {
+        property = (rowData.parent! as ContainerProperty).get(rowData.name);
+    } catch {
+        typeid = 'Reference';
+    }
+    if (Utils.isEnumProperty(property) || Utils.isEnumArrayProperty(parent!)) {
+        typeid = 'enum';
+    }
 
-  const ViewComponent: React.ComponentType<any> = typeToViewMap.hasOwnProperty(typeid)
-    ? typeToViewMap[typeid]
-    : StringView;
+    const ViewComponent: React.ComponentType<any> = typeToViewMap.hasOwnProperty(typeid)
+        ? typeToViewMap[typeid]
+        : StringView;
 
-  return (
-    <ViewComponent
-      onSubmit={onInlineEditEnd}
-      rowData={rowData}
-      {...restProps}
-    />
-  );
+    return (
+        <ViewComponent
+            onSubmit={onInlineEditEnd}
+            rowData={rowData}
+            {...restProps}
+        />
+    );
 };
 
 const typeToViewMap = {
-  Bool: BooleanView,
-  String: StringView,
-  enum: EnumView,
+    Bool: BooleanView,
+    String: StringView,
+    enum: EnumView,
 
-  Float32: NumberView,
-  Float64: NumberView,
-  Int16: NumberView,
-  Int32: NumberView,
-  Int64: NumberView,
-  Int8: NumberView,
-  Uint16: NumberView,
-  Uint32: NumberView,
-  Uint64: NumberView,
-  Uint8: NumberView,
+    Float32: NumberView,
+    Float64: NumberView,
+    Int16: NumberView,
+    Int32: NumberView,
+    Int64: NumberView,
+    Int8: NumberView,
+    Uint16: NumberView,
+    Uint32: NumberView,
+    Uint64: NumberView,
+    Uint8: NumberView,
 };

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "author": "Microsoft and contributors",
   "main": "dist/index.js",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "index.d.ts"


### PR DESCRIPTION
The location for the type declaration file was not updated in the migration to TS , importing  the proxy like

```typescript
import { PropertyProxy } from "@fluid-experimental/property-proxy";
```
will cause an error along the lines of 
```bash
[tsl] ERROR in /path/to/file.ts
      TS7016: Could not find a declaration file for module '@fluid-experimental/property-proxy'. '[...]/node_modules/@fluid-experimental/property-proxy/dist/index.js' implicitly has an 'any' type.
```

a workaround is to import it through the dist folder which contains the type file

```typescript
import { PropertyProxy } from "@fluid-experimental/property-proxy/dist";
```