### PR TITLE
Moved mock-logger package from devDependencies to dependencies

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -64,6 +64,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluid-internal/mock-logger": "^0.48.0",
     "@fluidframework/agent-scheduler": "^0.48.0",
     "@fluidframework/aqueduct": "^0.48.0",
     "@fluidframework/base-host": "^0.48.0",
@@ -110,7 +111,6 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@fluid-internal/mock-logger": "^0.48.0",
     "@fluidframework/build-common": "^0.23.0-0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/eslint-config-fluid": "^0.23.0",


### PR DESCRIPTION
The service tests are failing after the `@fluid-internal/mock-logger` package was added because the service tests were not installing this package - https://dev.azure.com/fluidframework/internal/_build/results?buildId=37423&view=logs&j=498afae4-24f0-5535-7222-a274fe302077&t=0f713e44-8f0a-592c-ec26-8a324518faa9

Moving this package to dependencies so that it is installed.