### PR TITLE
[patch 0.46] Add telemetry property dataStoreId w/ packageData tag for "Duplicate data store created with existing ID"

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -149,9 +149,9 @@ export class DataStores implements IDisposable {
                     ...extractSafePropertiesFromMessage(message),
                     dataStoreId: {
                         value: attachMessage.id,
-                        tag: TelemetryDataTag.PackageData
+                        tag: TelemetryDataTag.PackageData,
                     },
-                }
+                },
             );
             throw error;
         }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -143,6 +143,7 @@ export class DataStores implements IDisposable {
 
          // If a non-local operation then go and create the object, otherwise mark it as officially attached.
         if (this.contexts.has(attachMessage.id)) {
+            // TODO: dataStoreId may require a different tag from PackageData #7488
             const error = new DataCorruptionError(
                 "Duplicate data store created with existing ID",
                 {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -145,11 +145,11 @@ export class DataStores implements IDisposable {
         if (this.contexts.has(attachMessage.id)) {
             const error = new DataCorruptionError(
                 "Duplicate data store created with existing ID",
-                { 
+                {
                     ...extractSafePropertiesFromMessage(message),
                     dataStoreId: {
                         value: attachMessage.id,
-                        tag: TelemetryDataTag.PackageData,
+                        tag: TelemetryDataTag.PackageData
                     },
                 }
             );

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -34,7 +34,7 @@ import {
      responseToException,
      SummaryTreeBuilder,
 } from "@fluidframework/runtime-utils";
-import { ChildLogger } from "@fluidframework/telemetry-utils";
+import { ChildLogger, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { BlobCacheStorageService, buildSnapshotTree } from "@fluidframework/driver-utils";
 import { assert, Lazy } from "@fluidframework/common-utils";
@@ -145,7 +145,13 @@ export class DataStores implements IDisposable {
         if (this.contexts.has(attachMessage.id)) {
             const error = new DataCorruptionError(
                 "Duplicate data store created with existing ID",
-                extractSafePropertiesFromMessage(message),
+                { 
+                    ...extractSafePropertiesFromMessage(message),
+                    dataStoreId: {
+                        value: attachMessage.id,
+                        tag: TelemetryDataTag.PackageData,
+                    },
+                }
             );
             throw error;
         }

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -169,7 +169,10 @@ export class RemoteChannelContext implements IChannelContext {
                 // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError("Channel type not available", {
                     channelId: this.id,
-                    dataStoreId: this.dataStoreContext.id,
+                    dataStoreId: {
+                        value: this.dataStoreContext.id,
+                        tag: TelemetryDataTag.PackageData,
+                    },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                 });
             }
@@ -178,7 +181,10 @@ export class RemoteChannelContext implements IChannelContext {
                 // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError(`Channel Factory ${this.attachMessageType} for attach not registered`, {
                     channelId: this.id,
-                    dataStoreId: this.dataStoreContext.id,
+                    dataStoreId: {
+                        value: this.dataStoreContext.id,
+                        tag: TelemetryDataTag.PackageData,
+                    },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                     channelFactoryType: this.attachMessageType,
                 });
@@ -190,7 +196,10 @@ export class RemoteChannelContext implements IChannelContext {
                 // TODO: Strip out potential PII content #1920
                 throw new DataCorruptionError(`Channel Factory ${attributes.type} not registered`, {
                     channelId: this.id,
-                    dataStoreId: this.dataStoreContext.id,
+                    dataStoreId: {
+                        value: this.dataStoreContext.id,
+                        tag: TelemetryDataTag.PackageData,
+                    },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                     channelFactoryType: attributes.type,
                 });

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -166,7 +166,7 @@ export class RemoteChannelContext implements IChannelContext {
         // this as long as we support old attach messages
         if (attributes === undefined) {
             if (this.attachMessageType === undefined) {
-                 // TODO: dataStoreId may require a different tag from PackageData #7488
+                // TODO: dataStoreId may require a different tag from PackageData #7488
                 throw new DataCorruptionError("Channel type not available", {
                     channelId: this.id,
                     dataStoreId: {

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -166,7 +166,7 @@ export class RemoteChannelContext implements IChannelContext {
         // this as long as we support old attach messages
         if (attributes === undefined) {
             if (this.attachMessageType === undefined) {
-                // TODO: Strip out potential PII content #1920
+                 // TODO: dataStoreId may require a different tag from PackageData #7488
                 throw new DataCorruptionError("Channel type not available", {
                     channelId: this.id,
                     dataStoreId: {
@@ -178,7 +178,7 @@ export class RemoteChannelContext implements IChannelContext {
             }
             factory = this.registry.get(this.attachMessageType);
             if (factory === undefined) {
-                // TODO: Strip out potential PII content #1920
+                // TODO: dataStoreId may require a different tag from PackageData #7488
                 throw new DataCorruptionError(`Channel Factory ${this.attachMessageType} for attach not registered`, {
                     channelId: this.id,
                     dataStoreId: {
@@ -193,7 +193,7 @@ export class RemoteChannelContext implements IChannelContext {
         } else {
             factory = this.registry.get(attributes.type);
             if (factory === undefined) {
-                // TODO: Strip out potential PII content #1920
+                // TODO: dataStoreId may require a different tag from PackageData #7488
                 throw new DataCorruptionError(`Channel Factory ${attributes.type} not registered`, {
                     channelId: this.id,
                     dataStoreId: {

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -171,7 +171,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: {
                         value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData,
+                        tag: TelemetryDataTag.PackageData
                     },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                 });
@@ -183,7 +183,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: {
                         value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData,
+                        tag: TelemetryDataTag.PackageData
                     },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                     channelFactoryType: this.attachMessageType,
@@ -198,7 +198,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: {
                         value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData,
+                        tag: TelemetryDataTag.PackageData
                     },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                     channelFactoryType: attributes.type,

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -171,7 +171,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: {
                         value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData
+                        tag: TelemetryDataTag.PackageData,
                     },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                 });
@@ -183,7 +183,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: {
                         value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData
+                        tag: TelemetryDataTag.PackageData,
                     },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                     channelFactoryType: this.attachMessageType,
@@ -198,7 +198,7 @@ export class RemoteChannelContext implements IChannelContext {
                     channelId: this.id,
                     dataStoreId: {
                         value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData
+                        tag: TelemetryDataTag.PackageData,
                     },
                     dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
                     channelFactoryType: attributes.type,


### PR DESCRIPTION
Adding in additional telemetry to record the dataStoreId when we report the DataCorruptionError for duplicate data stores