### PR TITLE
enableWholeSummaryUpload for azure-client

### DIFF
--- a/packages/framework/azure-client/src/AzureClient.ts
+++ b/packages/framework/azure-client/src/AzureClient.ts
@@ -38,6 +38,7 @@ export class AzureClient {
     constructor(private readonly props: AzureClientProps) {
         this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
             this.props.connection.tokenProvider,
+            { enableWholeSummaryUpload: true },
         );
     }
 


### PR DESCRIPTION
This enables support for the new version Azure Fluid Relay being deployed for Public Preview.