### PR TITLE
Website: update recipes to point to fluid examples

### DIFF
--- a/docs/content/docs/recipes/react.md
+++ b/docs/content/docs/recipes/react.md
@@ -9,7 +9,7 @@ In this tutorial, you'll learn about using the Fluid Framework by building a sim
 
 To jump ahead into the finished demo, check out the [Create React App demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/cra-demo).
 
-The following image shows the time stamp application open in four browsers. Each has a button labelled **click** and beside it a UNIX Epoch time. The same time in all four. The cursor is on the button in one browser.
+The following image shows the time stamp application open in four browsers. Each has a button labeled **click** and beside it a Unix epoch time. The same time is in all four. The cursor is on the button in one browser.
 
 ![Four browsers with the Timestamp app open in them.](https://fluidframework.blob.core.windows.net/static/images/Four-clients-1.PNG)
 

--- a/docs/content/docs/recipes/react.md
+++ b/docs/content/docs/recipes/react.md
@@ -5,7 +5,11 @@ aliases:
   - "/start/react-tutorial/"
 ---
 
-In this tutorial, you'll learn about using the Fluid Framework by building a simple application that enables every client of the application to change a dynamic time stamp on itself and all other clients almost instantly. You'll also learn how to connect the Fluid data layer with a view layer made in [React](https://reactjs.org/). The following image shows the time stamp application open in four browsers. Each has a button labelled **click** and beside it a UNIX Epoch time. The same time in all four. The cursor is on the button in one browser.
+In this tutorial, you'll learn about using the Fluid Framework by building a simple application that enables every client of the application to change a dynamic time stamp on itself and all other clients almost instantly. You'll also learn how to connect the Fluid data layer with a view layer made in [React](https://reactjs.org/).
+
+To jump ahead into the finished demo, check out the [Create React App demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/cra-demo).
+
+The following image shows the time stamp application open in four browsers. Each has a button labelled **click** and beside it a UNIX Epoch time. The same time in all four. The cursor is on the button in one browser.
 
 ![Four browsers with the Timestamp app open in them.](https://fluidframework.blob.core.windows.net/static/images/Four-clients-1.PNG)
 
@@ -221,6 +225,7 @@ Paste the URL of the application into the address bar of another tab or even ano
 - Try extending the demo with more key/value pairs and a more complex UI.
 - Consider using the [Fluent UI React controls](https://aka.ms/fluentui/) to give the application the look and feel of Microsoft 365. To install them in your project run the following in the command prompt: `npm install @fluentui/react`.
 - Try changing the container schema to use a different shared data object type or specify multiple objects in `initialObjects`.
+- For an example that will scale to larger applications and larger teams, check out the [Fluid React Starter in the FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/fluid-react-starter).
 
 {{< callout tip >}}
 

--- a/docs/content/docs/recipes/vue.md
+++ b/docs/content/docs/recipes/vue.md
@@ -1,6 +1,7 @@
 ---
 title: Using Fluid with Vue
 menuPosition: 2
-status: unwritten
 discussion: 5463
 ---
+
+The Fluid Framework is view framework agnostic and works well with most view frameworks. Visit the [FluidExamples repo](https://github.com/microsoft/FluidExamples/blob/main/multi-framework-diceroller/src/view/vueView.js) to see how [Vue.js](https://vuejs.org/) can be used render the dice roller from the [QuickStart]({{< relref "quick-start.md" >}}).

--- a/docs/content/docs/recipes/web-components.md
+++ b/docs/content/docs/recipes/web-components.md
@@ -1,6 +1,7 @@
 ---
 title: Using Fluid with Web Components
 menuPosition: 2
-status: unwritten
 discussion: 5465
 ---
+
+The Fluid Framework is view framework agnostic and works well with most view frameworks. Visit the [FluidExamples repo](https://github.com/microsoft/FluidExamples/blob/main/multi-framework-diceroller/src/view/wcView.js) to see how [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) can be used render the dice roller from the [QuickStart]({{< relref "quick-start.md" >}}).


### PR DESCRIPTION
Replace "coming soon" verbage of vue and web components with text directing user to our multi-view demo in our examples repo. Also added links to cra-demo and fluid-react-starter to the react tutorial. 