### PR TITLE
r11s-driver: fix 401 retry

### DIFF
--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -86,9 +86,9 @@ export class RouterliciousRestWrapper extends RestWrapper {
         const correlationId = requestHeaders?.["x-correlation-id"] || uuid();
 
         return {
+            ...requestHeaders,
             "x-correlation-id": correlationId,
             "Authorization": this.authorizationHeader,
-            ...requestHeaders,
         };
     }
 }


### PR DESCRIPTION
The logic for 401 retries in r11s driver are broken. This fixes it such that authorization header in the request is always up to date