### PR TITLE
Added cotainer runtime option to turn GC sweep phase on / off

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -188,6 +188,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         trackState?: boolean;
         runGC?: boolean;
         fullGC?: boolean;
+        runSweep?: boolean;
     }): Promise<ISummaryTreeWithStats>;
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
@@ -332,6 +333,7 @@ export interface IGCRuntimeOptions {
     disableGC?: boolean;
     gcAllowed?: boolean;
     runFullGC?: boolean;
+    runSweep?: boolean;
 }
 
 // @public

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -284,7 +284,7 @@ const runGCKey = "FluidRunGC";
 // Local storage key to turn GC test mode on / off.
 const gcTestModeKey = "FluidGCTestMode";
 // Local storage key to turn GC sweep on / off.
-const runSweep = "FluidRunSweep";
+const runSweepKey = "FluidRunSweep";
 // Local storage key to set the default flush mode to TurnBased
 const turnBasedFlushModeKey = "FluidFlushModeTurnBased";
 
@@ -857,7 +857,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // Whether GC sweep phase should run or not. If this is false, only GC mark phase is run. Can override with
         // localStorage flag.
         this.shouldRunSweep = this.shouldRunGC &&
-            (getLocalStorageFeatureGate(runSweep) ?? this.runtimeOptions.gcOptions.runSweep === true);
+            (getLocalStorageFeatureGate(runSweepKey) ?? this.runtimeOptions.gcOptions.runSweep === true);
 
         // Default to false (enabled).
         this.disableIsolatedChannels = this.runtimeOptions.summaryOptions.disableIsolatedChannels ?? false;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -216,6 +216,12 @@ export interface IGCRuntimeOptions {
     runFullGC?: boolean;
 
     /**
+     * Flag that if true, will run sweep which may delete unused objects that meet certain criteria. Only takes
+     * effect if GC is enabled.
+     */
+    runSweep?: boolean;
+
+    /**
      * Allows additional GC options to be passed.
      */
     [key: string]: any;
@@ -277,6 +283,8 @@ interface IRuntimeMessageMetadata {
 const runGCKey = "FluidRunGC";
 // Local storage key to turn GC test mode on / off.
 const gcTestModeKey = "FluidGCTestMode";
+// Local storage key to turn GC sweep on / off.
+const runSweep = "FluidRunSweep";
 // Local storage key to set the default flush mode to TurnBased
 const turnBasedFlushModeKey = "FluidFlushModeTurnBased";
 
@@ -780,6 +788,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private latestSummaryGCVersion: GCVersion;
     // This is the source of truth for whether GC is enabled or not.
     private readonly shouldRunGC: boolean;
+    // This is the source of truth for whether GC sweep phase should run or not.
+    private readonly shouldRunSweep: boolean;
     /**
      * True if generating summaries with isolated channels is
      * explicitly disabled. This only affects how summaries are written,
@@ -836,13 +846,18 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.latestSummaryGCVersion = prevSummaryGCVersion ??
             (this.runtimeOptions.gcOptions.gcAllowed === true ? this.currentGCVersion : 0);
 
-        // Can override with localStorage flag.
+        // Whether GC should run or not. Can override with localStorage flag.
         this.shouldRunGC = getLocalStorageFeatureGate(runGCKey) ?? (
             // GC must be enabled for the document.
             this.gcEnabled
             // Must not be disabled by runtime option.
             && !this.runtimeOptions.gcOptions.disableGC
         );
+
+        // Whether GC sweep phase should run or not. If this is false, only GC mark phase is run. Can override with
+        // localStorage flag.
+        this.shouldRunSweep = this.shouldRunGC &&
+            (getLocalStorageFeatureGate(runSweep) ?? this.runtimeOptions.gcOptions.runSweep === true);
 
         // Default to false (enabled).
         this.disableIsolatedChannels = this.runtimeOptions.summaryOptions.disableIsolatedChannels ?? false;
@@ -1736,6 +1751,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         runGC?: boolean,
         /** True to generate full GC data; defaults to false */
         fullGC?: boolean,
+        /** True to run GC sweep phase after the mark phase; defaults to false */
+        runSweep?: boolean,
     }): Promise<ISummaryTreeWithStats> {
         const { summaryLogger, fullTree = false, trackState = true, runGC = true, fullGC = false } = options;
 
@@ -1840,6 +1857,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     trackState: true,
                     runGC: this.shouldRunGC,
                     fullGC: this.runtimeOptions.gcOptions.runFullGC || forceRegenerateData,
+                    runSweep: this.shouldRunSweep,
                 });
             } catch (error) {
                 return { stage: "base", referenceSequenceNumber: summaryRefSeqNum, error };

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -34,6 +34,7 @@ const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
     disableGC: booleanCases,
     gcAllowed: booleanCases,
     runFullGC: booleanCases,
+    runSweep: [false],
 };
 
 export function generateRuntimeOptions(seed: number) {


### PR DESCRIPTION
Fixes #7202

Staging for GC sweep phase: Added option to turn sweep on / off in container runtime options. It can be overridden via local storage flags.