### PR TITLE
Update FRS docs to match the latest client API

### DIFF
--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -4,9 +4,6 @@ menuPosition: 2
 ---
 
 Azure Fluid Relay service is a cloud-hosted Fluid service. You can connect your Fluid application to an Azure Fluid Relay instance using the `AzureClient` in the `@fluidframework/azure-client` package. `AzureClient` handles the logic of connecting your [Fluid container]({{< relref "containers.md" >}}) to the service while keeping the container object itself service-agnostic. You can use one instance of this client to manage multiple containers.
-Relay instance using the `AzureClient` in the `@fluidframework/azure-client` package. `AzureClient` handles the logic of
-connecting your [Fluid container][] to the service while keeping the container object itself service-agnostic. You can
-use one instance of this client to manage multiple containers.
 
 The sections below will explain how to use `AzureClient` in your own application.
 
@@ -20,50 +17,64 @@ To connect to an Azure Fluid Relay instance you first need to create an `AzureCl
 The `InsecureTokenProvider` should only be used for development purposes because **using it exposes the tenant key secret in your client-side code bundle.** This must be replaced with an implementation of `ITokenProvider` that fetches the token from your own backend service that is responsible for signing it with the tenant key.
 {{< /callout >}}
 
-
 ```javascript
 const config = {
-    tenantId: "myTenantId",
-    tokenProvider: new InsecureTokenProvider("myTenantKey", { id: "UserId", name: "Test User" }),
-    orderer: "https://myOrdererUrl",
-    storage: "https://myStorageUrl",
-}
+  tenantId: "myTenantId",
+  tokenProvider: new InsecureTokenProvider("myTenantKey", {
+    id: "userId",
+    name: "Test User",
+  }),
+  orderer: "https://myOrdererUrl",
+  storage: "https://myStorageUrl",
+};
 
-const client = new AzureClient(config);
+const clientProps = {
+  connection: config,
+};
+
+const client = new AzureClient(clientProps);
 ```
 
 Now that you have an instance of `AzureClient`, you can start using it to create or load Fluid containers!
 
 ### Token providers
 
-The [AzureFunctionTokenProvider](https://github.com/microsoft/FluidFramework/blob/main/packages/framework/azure-client/src/AzureFunctionTokenProvider.ts) is an implementation of `ITokenProvider` which ensures your tenant key secret is not exposed in your client-side bundle code. The `AzureFunctionTokenProvider` takes in your Azure Function URL appended by `/api/GetAzureToken` along with the current user object. Later on, it makes a `GET` request to your Azure Function by passing in the tenantID, documentId and userID/userName as optional parameters.
+The [AzureFunctionTokenProvider](https://github.com/microsoft/FluidFramework/blob/main/packages/framework/azure-client/src/AzureFunctionTokenProvider.ts) is an implementation of `ITokenProvider` which ensures your tenant key secret is not exposed in your client-side bundle code. The `AzureFunctionTokenProvider` takes in your Azure Function URL appended by `/api/GetAzureToken` along with the current user object. Later on, it makes a `GET` request to your Azure Function by passing in the tenantId, documentId and userId/userName as optional parameters.
 
 ```javascript
 const config = {
-    tenantId: "myTenantId",
-    tokenProvider: new AzureFunctionTokenProvider("myAzureFunctionUrl"+"/api/GetAzureToken", { userId:
-    "UserId", userName: "Test User"}),
-    orderer: "https://myOrdererUrl",
-    storage: "https://myStorageUrl",
+  tenantId: "myTenantId",
+  tokenProvider: new AzureFunctionTokenProvider(
+    "myAzureFunctionUrl" + "/api/GetAzureToken",
+    { userId: "userId", userName: "Test User" }
+  ),
+  orderer: "https://myOrdererUrl",
+  storage: "https://myStorageUrl",
 };
 
-const client = new AzureClient(config);
+const clientProps = {
+  connection: config,
+};
+
+const client = new AzureClient(clientProps);
 ```
 
 The user object can also hold optional additional user details. For example:
 
 ```javascript
-cont userDetails: ICustomUserDetails = {
+const userDetails: ICustomUserDetails = {
   email: "xyz@outlook.com",
   address: "Redmond",
 };
 
 const config = {
-    tenantId: "myTenantId",
-    tokenProvider: new AzureFunctionTokenProvider("myAzureFunctionUrl"+"/api/GetAzureToken", { userId:
-    "UserId", userName: "Test User", additionalDetails: userDetails}),
-    orderer: "https://myOrdererUrl",
-    storage: "https://myStorageUrl",
+  tenantId: "myTenantId",
+  tokenProvider: new AzureFunctionTokenProvider(
+    "myAzureFunctionUrl" + "/api/GetAzureToken",
+    { userId: "UserId", userName: "Test User", additionalDetails: userDetails }
+  ),
+  orderer: "https://myOrdererUrl",
+  storage: "https://myStorageUrl",
 };
 ```
 
@@ -71,25 +82,39 @@ Your Azure Function will generate the token for the given user that is signed us
 
 ## Managing containers
 
-The `AzureClient` API exposes `createContainer` and `getContainer` functions to create and get containers respectively. Both functions take in the below two properties:
+The `AzureClient` API exposes `createContainer` and `getContainer` functions to create and get containers respectively. Both functions take in a _container schema_ that defines the container data model. For the
+`getContainer` function, there is an additional parameter for the container `id` of the container you wish to
+fetch.
 
-* A *container config* that defines the ID of the container and an optional entry point for logging.
-* A *container schema* that defines the container data model.
+In the container creation scenario, you can use the following pattern:
 
 ```javascript
 const schema = {
-    name: "my-container",
-    initialObjects: {
-        /* ... */
-    },
-    dynamicObjectTypes: [ /*...*/ ],
-}
-const azureClient = new AzureClient(config);
-await azureClient.createContainer({ id: "_unique-id_" }, schema);
-const { fluidContainer, containerServices } = await azureClient.getContainer({ id: "_unique-id_" }, schema);
+  name: "my-container",
+  initialObjects: {
+    /* ... */
+  },
+  dynamicObjectTypes: [
+    /*...*/
+  ],
+};
+const azureClient = new AzureClient(clientProps);
+const { fluidContainer, containerServices } = await azureClient.createContainer(
+  schema
+);
+const id = await fluidContainer.attach();
 ```
 
-The `id` being passed into the container config is a unique identifier to a container instance. Any client that wants to join the same collaborative session needs to call `getContainer` with the same container `id`.
+The `container.attach()` call is when the container actually becomes connected to the service and is recorded in its blob storage. It returns an `id` which is the unique identifier to this container instance.
+
+Any client that wants to join the same collaborative session needs to call `getContainer` with the same container `id`.
+
+```javascript
+const { fluidContainer, containerServices } = await azureClient.getContainer(
+  id,
+  schema
+);
+```
 
 For the further information on how to start recording logs being emitted by Fluid, see [Telemetry]({{< relref "telemetry.md" >}}).
 
@@ -97,49 +122,49 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 ## Getting audience details
 
-Calls to `createContainer` and `getContainer` return an `AzureResources` object that contains a `FluidContainer` -- described above -- and a `containerServices` object.
+Calls to `createContainer` and `getContainer` return two values: a `FluidContainer` -- described above -- and a `containerServices` object.
 
-The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the shared objects within the Fluid container can be reused when moving to using `FrsClient`.
+The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `AzureClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the shared objects within the Fluid container can be reused when moving to using `AzureClient`.
 
 The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 
 Let's take a look at how you can use the `audience` object to maintain an updated view of all the members currently in a container.
 
-``` javascript
+```javascript
 const { audience } = containerServices;
 const audienceDiv = document.createElement("div");
 
 const onAudienceChanged = () => {
-        const members = audience.getMembers();
-        const self = audience.getMyself();
-        const memberStrings: string[] = [];
-        const useAzure = process.env.FLUID_CLIENT === "azure";
+  const members = audience.getMembers();
+  const self = audience.getMyself();
+  const memberStrings: string[] = [];
+  const useAzure = process.env.FLUID_CLIENT === "azure";
 
-        members.forEach((member: AzureMember<ICustomUserDetails>) => {
-            if (member.userId !== self?.userId) {
-                if (useAzure) {
-                    const memberString = `${member.userName}: {Email: ${member.additionalDetails?.email},
+  members.forEach((member: AzureMember<ICustomUserDetails>) => {
+    if (member.userId !== self?.userId) {
+      if (useAzure) {
+        const memberString = `${member.userName}: {Email: ${member.additionalDetails?.email},
                         Address: ${member.additionalDetails?.address}}`;
-                    memberStrings.push(memberString);
-                } else {
-                    memberStrings.push(member.userName);
-                }
-            }
-        });
-        audienceDiv.innerHTML = `
+        memberStrings.push(memberString);
+      } else {
+        memberStrings.push(member.userName);
+      }
+    }
+  });
+  audienceDiv.innerHTML = `
             Current User: ${self?.userName} <br />
             Other Users: ${memberStrings.join(", ")}
         `;
-    };
+};
 
-    onAudienceChanged();
-    audience.on("membersChanged", onAudienceChanged);
+onAudienceChanged();
+audience.on("membersChanged", onAudienceChanged);
 ```
 
 `audience` provides two functions that will return `AzureMember` objects that have a user ID and user name:
 
-* `getMembers` returns a map of all the users connected to the container. These values will change anytime a member joins or leaves the container.
-* `getMyself` returns the current user on this client.
+- `getMembers` returns a map of all the users connected to the container. These values will change anytime a member joins or leaves the container.
+- `getMyself` returns the current user on this client.
 
 `audience` also emits events for when the roster of members changes. `membersChanged` will fire for any roster changes, whereas `memberAdded` and `memberRemoved` will fire for their respective changes with the `clientId` and `member` values that have been modified. After any of these events fire, a new call to `getMembers` will return the updated member roster.
 
@@ -160,8 +185,8 @@ A sample `AzureMember` object looks like the following:
     }
   ],
   "additionalDetails": {
-      "email": "xyz@outlook.com",
-      "address": "Redmond",
+    "email": "xyz@outlook.com",
+    "address": "Redmond"
   }
 }
 ```

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -122,7 +122,7 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 ## Getting audience details
 
-Calls to `createContainer` and `getContainer` return two values: a `FluidContainer` -- described above -- and a `containerServices` object.
+Calls to `createContainer` and `getContainer` return two values: a `container` -- described above -- and a `services` object.
 
 The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `AzureClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the shared objects within the Fluid container can be reused when moving to using `AzureClient`.
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -90,7 +90,6 @@ In the container creation scenario, you can use the following pattern:
 
 ```javascript
 const schema = {
-  name: "my-container",
   initialObjects: {
     /* ... */
   },
@@ -118,7 +117,7 @@ const { container, services } = await azureClient.getContainer(
 
 For the further information on how to start recording logs being emitted by Fluid, see [Telemetry]({{< relref "telemetry.md" >}}).
 
-The container being fetched back will hold the `initialObjects` as defined in the container schema. See [Data modeling]({{< relref "data-modeling.md" >}}) to learn more about how to establish the schema and use the `FluidContainer` object.
+The container being fetched back will hold the `initialObjects` as defined in the container schema. See [Data modeling]({{< relref "data-modeling.md" >}}) to learn more about how to establish the schema and use the `container` object.
 
 ## Getting audience details
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -102,7 +102,7 @@ const azureClient = new AzureClient(clientProps);
 const { container, services } = await azureClient.createContainer(
   schema
 );
-const id = await fluidContainer.attach();
+const id = await container.attach();
 ```
 
 The `container.attach()` call is when the container actually becomes connected to the service and is recorded in its blob storage. It returns an `id` which is the unique identifier to this container instance.

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -99,7 +99,7 @@ const schema = {
   ],
 };
 const azureClient = new AzureClient(clientProps);
-const { fluidContainer, containerServices } = await azureClient.createContainer(
+const { container, services } = await azureClient.createContainer(
   schema
 );
 const id = await fluidContainer.attach();

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -124,7 +124,7 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 Calls to `createContainer` and `getContainer` return two values: a `container` -- described above -- and a `services` object.
 
-The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `AzureClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the shared objects within the Fluid container can be reused when moving to using `AzureClient`.
+The `container` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `AzureClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the shared objects within the Fluid container can be reused when moving to using `AzureClient`.
 
 The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -110,7 +110,7 @@ The `container.attach()` call is when the container actually becomes connected t
 Any client that wants to join the same collaborative session needs to call `getContainer` with the same container `id`.
 
 ```javascript
-const { fluidContainer, containerServices } = await azureClient.getContainer(
+const { container, services } = await azureClient.getContainer(
   id,
   schema
 );

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -41,7 +41,7 @@ const azureUser = {
     additionalDetails: userDetails,
 };
 
-const connectionProps: AzureConnectionConfig = useAzure ? {
+const connectionConfig: AzureConnectionConfig = useAzure ? {
     tenantId: "",
     tokenProvider: new AzureFunctionTokenProvider("", azureUser),
     orderer: "",
@@ -77,10 +77,10 @@ async function initializeNewContainer(container: IFluidContainer): Promise<void>
 async function start(): Promise<void> {
     // Create a custom ITelemetryBaseLogger object to pass into the Tinylicious container
     // and hook to the Telemetry system
-    const azureConfig = {
-        connection: connectionProps,
+    const clientProps = {
+        connection: connectionConfig,
     };
-    const client = new AzureClient(azureConfig);
+    const client = new AzureClient(clientProps);
     let container: IFluidContainer;
     let services: AzureContainerServices;
     let id: string;


### PR DESCRIPTION
0.47 had a number of changes to the `AzureClient` API. This updates the doc to match those changes along with fixing a number of grammatical, spacing, and other nit issues