### PR TITLE
Export DDSes in namespaced way in fluid-framework

### DIFF
--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -5,13 +5,17 @@
 ```ts
 
 import { AttachState } from '@fluidframework/container-definitions';
+import * as map from '@fluidframework/map';
+import * as sequence from '@fluidframework/sequence';
 
 export { AttachState }
 
+export { map }
+
+export { sequence }
+
 
 export * from "@fluidframework/fluid-static";
-export * from "@fluidframework/map";
-export * from "@fluidframework/sequence";
 
 // (No @packageDocumentation comment for this package)
 

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -11,12 +11,13 @@ import {
 import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
 import {
     IFluidContainer,
-    SharedMap,
+    map,
 } from "fluid-framework";
 import { v4 as uuid } from "uuid";
 import { DiceRollerController } from "./controller";
 import { makeAppView } from "./view";
 
+// const SharedMap = map.SharedMap;
 export interface ICustomUserDetails {
     gender: string;
     email: string;
@@ -59,15 +60,15 @@ const connectionProps: AzureConnectionConfig = useAzure ? {
 const containerSchema = {
     initialObjects: {
         /* [id]: DataObject */
-        map1: SharedMap,
-        map2: SharedMap,
+        map1: map.SharedMap,
+        map2: map.SharedMap,
     },
 };
 
 async function initializeNewContainer(container: IFluidContainer): Promise<void> {
     // Initialize both of our SharedMaps for usage with a DiceRollerController
-    const sharedMap1 = container.initialObjects.map1 as SharedMap;
-    const sharedMap2 = container.initialObjects.map2 as SharedMap;
+    const sharedMap1 = container.initialObjects.map1 as map.SharedMap;
+    const sharedMap2 = container.initialObjects.map2 as map.SharedMap;
     await Promise.all([
         DiceRollerController.initializeModel(sharedMap1),
         DiceRollerController.initializeModel(sharedMap2),
@@ -109,8 +110,8 @@ async function start(): Promise<void> {
     document.title = id;
 
     // Here we are guaranteed that the maps have already been initialized for use with a DiceRollerController
-    const sharedMap1 = container.initialObjects.map1 as SharedMap;
-    const sharedMap2 = container.initialObjects.map2 as SharedMap;
+    const sharedMap1 = container.initialObjects.map1 as map.SharedMap;
+    const sharedMap2 = container.initialObjects.map2 as map.SharedMap;
     const diceRollerController1 = new DiceRollerController(sharedMap1);
     const diceRollerController2 = new DiceRollerController(sharedMap2);
 

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -17,7 +17,6 @@ import { v4 as uuid } from "uuid";
 import { DiceRollerController } from "./controller";
 import { makeAppView } from "./view";
 
-// const SharedMap = map.SharedMap;
 export interface ICustomUserDetails {
     gender: string;
     email: string;

--- a/examples/hosts/app-integration/external-controller/src/controller.ts
+++ b/examples/hosts/app-integration/external-controller/src/controller.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from "events";
-import { IValueChanged } from "fluid-framework";
+import { map } from "fluid-framework";
 
 /**
  * IDiceRoller describes the public API surface for our dice roller data object.
@@ -32,8 +32,8 @@ const diceValueKey = "diceValue";
 interface DiceRollerControllerProps {
     get: (key: string) => any;
     set: (key: string, value: any) => void;
-    on(event: "valueChanged", listener: (args: IValueChanged) => void): this;
-    off(event: "valueChanged", listener: (args: IValueChanged) => void): this;
+    on(event: "valueChanged", listener: (args: map.IValueChanged) => void): this;
+    off(event: "valueChanged", listener: (args: map.IValueChanged) => void): this;
 }
 
 /**

--- a/examples/hosts/app-integration/external-controller/tests/index.ts
+++ b/examples/hosts/app-integration/external-controller/tests/index.ts
@@ -7,7 +7,7 @@
 
 import { DOProviderContainerRuntimeFactory, FluidContainer } from "@fluidframework/fluid-static";
 import { getSessionStorageContainer } from "@fluid-experimental/get-container";
-import { SharedMap } from "fluid-framework";
+import { map } from "fluid-framework";
 
 import { DiceRollerController } from "../src/controller";
 import { makeAppView } from "../src/view";
@@ -25,15 +25,15 @@ export const containerConfig = {
     name: "dice-roller-container",
     initialObjects: {
         /* [id]: DataObject */
-        map1: SharedMap,
-        map2: SharedMap,
+        map1: map.SharedMap,
+        map2: map.SharedMap,
     },
 };
 
 async function initializeNewContainer(container: FluidContainer): Promise<void> {
     // We now get the first SharedMap from the container
-    const sharedMap1 = container.initialObjects.map1 as SharedMap;
-    const sharedMap2 = container.initialObjects.map2 as SharedMap;
+    const sharedMap1 = container.initialObjects.map1 as map.SharedMap;
+    const sharedMap2 = container.initialObjects.map2 as map.SharedMap;
     await Promise.all([
         DiceRollerController.initializeModel(sharedMap1),
         DiceRollerController.initializeModel(sharedMap2),
@@ -59,8 +59,8 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement,
         await initializeNewContainer(fluidContainer);
     }
 
-    const sharedMap1 = fluidContainer.initialObjects.map1 as SharedMap;
-    const sharedMap2 = fluidContainer.initialObjects.map2 as SharedMap;
+    const sharedMap1 = fluidContainer.initialObjects.map1 as map.SharedMap;
+    const sharedMap2 = fluidContainer.initialObjects.map2 as map.SharedMap;
     const diceRollerController = new DiceRollerController(sharedMap1);
     const diceRollerController2 = new DiceRollerController(sharedMap2);
 

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -5,7 +5,14 @@
 
 /* eslint-disable import/export */
 
+// Can't use the more compact syntax due to https://github.com/microsoft/rushstack/issues/2780
+// import { map } from "./map";
+// import { sequence } from "./sequence";
+
 export * from "./containerDefinitions";
-export * from  "./fluidStatic";
-export * from  "./map";
-export * from  "./sequence";
+export * from "./fluidStatic";
+
+import * as map from "@fluidframework/map";
+import * as sequence from "@fluidframework/sequence";
+
+export { map, sequence };

--- a/packages/framework/fluid-framework/src/map.ts
+++ b/packages/framework/fluid-framework/src/map.ts
@@ -1,6 +1,9 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
+// /*!
+//  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+//  * Licensed under the MIT License.
+//  */
 
-export * from  "@fluidframework/map";
+// export * as map from "@fluidframework/map";
+// // import * as map from "@fluidframework/map";
+
+// // export { map };

--- a/packages/framework/fluid-framework/src/sequence.ts
+++ b/packages/framework/fluid-framework/src/sequence.ts
@@ -1,6 +1,8 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
+// /*!
+//  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+//  * Licensed under the MIT License.
+//  */
 
-export * from  "@fluidframework/sequence";
+// import * as sequence from "@fluidframework/sequence";
+
+// export { sequence };


### PR DESCRIPTION
This PR is an experiment in namespacing (i don't know if that's the right technical term here) the contents of fluid-framework, especially the DDSes. This change is straightforward, but it does require downstream consumers to update their code to use the namespaces.