### PR TITLE
Website: fix docs refering to create/load container APIs

### DIFF
--- a/docs/content/docs/build/audience.md
+++ b/docs/content/docs/build/audience.md
@@ -13,9 +13,9 @@ This document will explain how to use the audience APIs and then provide example
 When creating a container, your app is also provided a container services object which holds the audience.  This audience is backed by that same container. The following is an example. Note that `client` is an object of a type that is provided by a service-specific client library.
 
 ```js
-const { fluidContainer, containerServices } =
-    await client.createContainer(serviceConfig, containerSchema);
-const audience = containerServices.audience;
+const { container, services } =
+    await client.createContainer(containerSchema);
+const audience = services.audience;
 ```
 
 ### The IMember

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -30,7 +30,6 @@ This example schema defines two initial objects, `layout` and `text`, and declar
 
 ```typescript
 const schema = {
-    name: "example-container",
     initialObjects: {
         layout: SharedMap,
         text: SharedString
@@ -44,7 +43,7 @@ const schema = {
 Containers are created from the service-specific client's `createContainer` function. Your code must provide a configuration that is specific to the service and a schema object that defines the container schema. About this code note:
 
 - `client` represents an object defined by the service-specific client library. See the documentation for the service you are using for more details about how to use its service-specific client library.
-- It is a good practice to deconstruct the object that is returned by `createContainer` into its two main parts; `container` and `containerServices`. For an example of the use of the latter, see [Working with the audience]({{< relref "audience.md#working-with-the-audience" >}}).
+- It is a good practice to deconstruct the object that is returned by `createContainer` into its two main parts; `container` and `services`. For an example of the use of the latter, see [Working with the audience]({{< relref "audience.md#working-with-the-audience" >}}).
 
 ```typescript {linenos=inline,hl_lines=[7,8]}
 const schema = {
@@ -150,7 +149,6 @@ These shared objects are exposed via the `initialObjects` property on the contai
 
 ```typescript {linenos=inline}
 const schema = {
-    name: "example-container",
     initialObjects: {
         layout: SharedMap,
         text: SharedString

--- a/docs/content/docs/build/data-modeling.md
+++ b/docs/content/docs/build/data-modeling.md
@@ -61,7 +61,7 @@ const schema = {
     dynamicObjectTypes: [ SharedCell, SharedMap ],
 }
 
-const { container, services } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(id, schema);
 
 const newCell = await container.create(SharedCell); // Create a new SharedCell
 const newMap = await container.create(SharedMap); // Create a new SharedMap

--- a/docs/content/docs/build/data-modeling.md
+++ b/docs/content/docs/build/data-modeling.md
@@ -100,7 +100,7 @@ const schema = {
     dynamicObjectTypes: [ SharedCell ],
 }
 
-const { container, services } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(id, schema);
 const map = container.initialObjects.map;
 
 const newCell = await container.create(SharedCell); // Create a new SharedCell

--- a/docs/content/docs/build/data-modeling.md
+++ b/docs/content/docs/build/data-modeling.md
@@ -25,22 +25,21 @@ The example below creates a new container with a `SharedMap` and a `SharedCell` 
 
 - `client` represents an object defined by the service-specific client library. See the documentation for the service you are using for more details about how to use its service-specific client library.
 - The placeholder `/*service config*/` stands for a service-specific configuration object.
-- It is a good practice to deconstruct the object that is returned by `createContainer` into its two main parts; `container` and `containerServices`. For an example of the use of the latter, see [Working with the audience]({{< relref "audience.md#working-with-the-audience" >}}).
+- It is a good practice to deconstruct the object that is returned by `createContainer` into its two main parts; `container` and `services`. For an example of the use of the latter, see [Working with the audience]({{< relref "audience.md#working-with-the-audience" >}}).
 
 ```typescript
 const schema = {
-    name: "example-container",
     initialObjects: {
         customMap: SharedMap,
         "custom-cell": SharedCell,
     }
 }
 
-const { fluidContainer, containerServices } = await client.createContainer(/*service config*/, schema);
+const { container, services } = await client.createContainer(schema);
 
-const initialObjects = fluidContainer.initialObjects;
-const map = fluidContainer.initialObjects.customMap;
-const cell = fluidContainer.initialObjects["custom-cell"];
+const initialObjects = container.initialObjects;
+const map = container.initialObjects.customMap;
+const cell = container.initialObjects["custom-cell"];
 ```
 
 ## Dynamic objects
@@ -62,10 +61,10 @@ const schema = {
     dynamicObjectTypes: [ SharedCell, SharedMap ],
 }
 
-const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(/*service config*/, schema);
 
-const newCell = await fluidContainer.create(SharedCell); // Create a new SharedCell
-const newMap = await fluidContainer.create(SharedMap); // Create a new SharedMap
+const newCell = await container.create(SharedCell); // Create a new SharedCell
+const newMap = await container.create(SharedMap); // Create a new SharedMap
 ```
 
 {{% callout tip %}}
@@ -95,17 +94,16 @@ using the handle. It also demonstrates retrieving the `SharedCell` object from t
 
 ```typescript
 const schema = {
-    name: "example-container",
     initialObjects: {
         map: SharedMap,
     },
     dynamicObjectTypes: [ SharedCell ],
 }
 
-const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
-const map = fluidContainer.initialObjects.map;
+const { container, services } = await client.getContainer(/*service config*/, schema);
+const map = container.initialObjects.map;
 
-const newCell = await fluidContainer.create(SharedCell); // Create a new SharedCell
+const newCell = await container.create(SharedCell); // Create a new SharedCell
 map.set("cell-id", newCell.handle); // Attach the new SharedCell
 
 // ...

--- a/docs/content/docs/data-structures/map.md
+++ b/docs/content/docs/data-structures/map.md
@@ -49,7 +49,7 @@ const schema = {
     }
 }
 
-const { container, services } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(id, schema);
 
 const map = container.initialObjects.customMap;
 ```
@@ -62,7 +62,7 @@ const schema = {
     dynamicObjectTypes: [ SharedMap ]
 }
 
-const { container, services } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(id, schema);
 
 const newMap = await container.create(SharedMap); // Create a new SharedMap
 ```
@@ -312,7 +312,7 @@ const schema = {
 Now, you can dynamically create additional `SharedMap` instances and store their handles into the initial map that is always provided in the container.
 
 ```javascript
-const { container, services } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(id, schema);
 
 const initialMap = container.initialObjects.initialMap;
 
@@ -415,7 +415,7 @@ const schema = {
     dynamicObjectTypes: [SharedMap]
 }
 
-const { container, services } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(id, schema);
 
 const initialMap = container.initialObjects.initialMap;
 

--- a/docs/content/docs/data-structures/map.md
+++ b/docs/content/docs/data-structures/map.md
@@ -28,15 +28,14 @@ The following example loads a `SharedMap` as part of the initial roster of objec
 
 ```javascript
 const schema = {
-    name: "example-container",
     initialObjects: {
         customMap: SharedMap,
     }
 }
 
-const { fluidContainer, containerServices } = await client.createContainer(/*service config*/, schema);
+const { container, services } = await client.createContainer(schema);
 
-const map = fluidContainer.initialObjects.customMap;
+const map = container.initialObjects.customMap;
 ```
 
 At this point, you can directly start using the `map` object within your application. Including the `SharedMap` as part of initial objects ensures that the DDS is available the moment the async call to `createContainer` finishes.
@@ -45,15 +44,14 @@ Similarly, if you are loading an existing container, the process stays largely i
 
 ```javascript
 const schema = {
-    name: "example-container",
     initialObjects: {
         customMap: SharedMap,
     }
 }
 
-const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(/*service config*/, schema);
 
-const map = fluidContainer.initialObjects.customMap;
+const map = container.initialObjects.customMap;
 ```
 
 Finally, if you'd like to dynamically create `SharedMap` instances as part of the application lifecycle (i.e. if there are user interactions in the applications that require a new DDS to be created at runtime), you can add the `SharedMap` type to the `dynamicObjectTypes` field in the schema and call the container's `create` function.
@@ -64,7 +62,7 @@ const schema = {
     dynamicObjectTypes: [ SharedMap ]
 }
 
-const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(/*service config*/, schema);
 
 const newMap = await container.create(SharedMap); // Create a new SharedMap
 ```
@@ -108,7 +106,7 @@ If client A and client B are both updating the same `SharedMap` and client B tri
 Consider the following example where you have a label and a button. When clicked, the button updates the label contents to be a random number.
 
 ```javascript
-const map = fluidContainer.initialObjects.customMap;
+const map = container.initialObjects.customMap;
 const dataKey = "data";
 const button = document.createElement('button');
 button.textContent = "Randomize!";
@@ -137,7 +135,7 @@ In the code above, whenever a user clicks the button, it sets a new random value
 Your event listener can be more sophisticated by using the additional information provided in the arguments listed above in the `valueChanged` event's `listener` signature.
 
 ```javascript {linenos=inline,hl_lines=["14-15"]}
-const map = fluidContainer.initialObjects.customMap;
+const map = container.initialObjects.customMap;
 const dataKey = "data";
 const button = document.createElement('button');
 button.textContent = "Randomize!";
@@ -304,7 +302,6 @@ The following example demonstrates nesting DDSes using `SharedMap`. You specify 
 
 ```javascript
 const schema = {
-    name: "example-container",
     initialObjects: {
         initialMap: SharedMap,
     },
@@ -315,12 +312,12 @@ const schema = {
 Now, you can dynamically create additional `SharedMap` instances and store their handles into the initial map that is always provided in the container.
 
 ```javascript
-const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(/*service config*/, schema);
 
-const initialMap = fluidContainer.initialObjects.initialMap;
+const initialMap = container.initialObjects.initialMap;
 
 // Create a SharedMap dynamically at runtime
-const newSharedMap = await fluidContainer.create(SharedMap);
+const newSharedMap = await container.create(SharedMap);
 
 // BAD: This call won't work; you must store the handle, not the SharedMap itself.
 // initialMap.set("newSharedMapKey", newSharedMap);
@@ -412,18 +409,17 @@ Whenever a new task is created, you can call `container.create` to create a new 
 
 ```javascript
 const schema = {
-    name: "example-container",
     initialObjects: {
         initialMap: SharedMap,
     },
     dynamicObjectTypes: [SharedMap]
 }
 
-const { fluidContainer, containerServices } = await client.getContainer(/*service config*/, schema);
+const { container, services } = await client.getContainer(/*service config*/, schema);
 
-const initialMap = fluidContainer.initialObjects.initialMap;
+const initialMap = container.initialObjects.initialMap;
 
-const newTask = await fluidContainer.create(SharedMap);
+const newTask = await container.create(SharedMap);
 const newTaskId = uuid();
 
 initialMap.set(newTaskId, newTask.handle);

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -78,15 +78,14 @@ The `AzureClient` API exposes `createContainer` and `getContainer` functions to 
 
 ```javascript
 const schema = {
-    name: "my-container",
     initialObjects: {
         /* ... */
     },
     dynamicObjectTypes: [ /*...*/ ],
 }
 const azureClient = new AzureClient(config);
-await azureClient.createContainer({ id: "_unique-id_" }, schema);
-const { fluidContainer, containerServices } = await azureClient.getContainer({ id: "_unique-id_" }, schema);
+await azureClient.createContainer(schema);
+const { container, services } = await azureClient.getContainer("_unique-id_", schema);
 ```
 
 The `id` being passed into the container config is a unique identifier to a container instance. Any client that wants to join the same collaborative session needs to call `getContainer` with the same container `id`.
@@ -97,16 +96,16 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 ## Getting audience details
 
-Calls to `createContainer` and `getContainer` return an `AzureResources` object that contains a `FluidContainer` -- described above -- and a `containerServices` object.
+Calls to `createContainer` and `getContainer` return an `AzureResources` object that contains a `FluidContainer` -- described above -- and a `services` object.
 
 The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the shared objects within the Fluid container can be reused when moving to using `FrsClient`.
 
-The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
+The `services` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 
 Let's take a look at how you can use the `audience` object to maintain an updated view of all the members currently in a container.
 
 ``` javascript
-const { audience } = containerServices;
+const { audience } = services;
 const audienceDiv = document.createElement("div");
 
 const onAudienceChanged = () => {

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -78,14 +78,15 @@ The `AzureClient` API exposes `createContainer` and `getContainer` functions to 
 
 ```javascript
 const schema = {
+    name: "my-container",
     initialObjects: {
         /* ... */
     },
     dynamicObjectTypes: [ /*...*/ ],
 }
 const azureClient = new AzureClient(config);
-await azureClient.createContainer(schema);
-const { container, services } = await azureClient.getContainer("_unique-id_", schema);
+await azureClient.createContainer({ id: "_unique-id_" }, schema);
+const { fluidContainer, containerServices } = await azureClient.getContainer({ id: "_unique-id_" }, schema);
 ```
 
 The `id` being passed into the container config is a unique identifier to a container instance. Any client that wants to join the same collaborative session needs to call `getContainer` with the same container `id`.
@@ -96,16 +97,16 @@ The container being fetched back will hold the `initialObjects` as defined in th
 
 ## Getting audience details
 
-Calls to `createContainer` and `getContainer` return an `AzureResources` object that contains a `FluidContainer` -- described above -- and a `services` object.
+Calls to `createContainer` and `getContainer` return an `AzureResources` object that contains a `FluidContainer` -- described above -- and a `containerServices` object.
 
 The `FluidContainer` contains the Fluid data model and is service-agnostic. Any code you write against this container object returned by the `FrsClient` is reusable with the client for another service. An example of this is if you prototyped your scenario using `TinyliciousClient`, then all of your code interacting with the shared objects within the Fluid container can be reused when moving to using `FrsClient`.
 
-The `services` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
+The `containerServices` object contains data that is specific to the Azure Fluid Relay service. This object contains an `audience` value that can be used to manage the roster of users that are currently connected to the container.
 
 Let's take a look at how you can use the `audience` object to maintain an updated view of all the members currently in a container.
 
 ``` javascript
-const { audience } = services;
+const { audience } = containerServices;
 const audienceDiv = document.createElement("div");
 
 const onAudienceChanged = () => {

--- a/docs/content/docs/testing/telemetry.md
+++ b/docs/content/docs/testing/telemetry.md
@@ -18,9 +18,7 @@ be implemented and passed into the service client's constructor via the `props` 
 All Fluid service clients (for example, `AzureClient` and `TinyliciousClient`) allow passing a `logger?: ITelemetryBaseLogger`
 into the service client props. Both `createContainer()` and `getContainer()` methods will then create an instance of the `logger`.
 
-`TinyliciousClientProps`
-interface definition takes an optional parameter `logger`. (The definition is similar to
-`AzureClientProps` interface)
+`TinyliciousClientProps` interface definition takes an optional parameter `logger`.
 
 ```ts
 const loader = new Loader({
@@ -239,20 +237,20 @@ This custom logger should be provided in the service client constructor. Fluid w
 async function start(): Promise<void> {
   // Create a custom ITelemetryBaseLogger object to pass into the Tinylicious container
   // and hook to the Telemetry system
-  const azureConfig = {
-      connection: connectionProps,
-      logger: new ConsoleLogger(),
-  };
-  const client = new AzureClient(azureConfig);
+  const client = new TinyliciousClient({logger: new ConsoleLogger()});
   let container: FluidContainer;
-  let services: AzureContainerServices;
+  let services: TinyliciousContainerServices;
 
   // Get or create the document depending if we are running through the create new flow
   const createNew = !location.hash;
   if (createNew) {
       // The client will create a new detached container using the schema
       // A detached container will enable the app to modify the container before attaching it to the client
-      {container, services} = await client.createContainer(containerSchema);
+      ({container, services} = await client.createContainer(containerSchema));
+
+      // Assign the returned ID to the URL hash for subsequent load flow
+      const id = await container.attach();
+      location.hash = id;
   }
 ```
 

--- a/docs/content/docs/testing/testing.md
+++ b/docs/content/docs/testing/testing.md
@@ -101,12 +101,13 @@ describe("ClientTest", () => {
     });
 
     it("can create Azure container successfully", async () => {
-        const containerConfig: AzureContainerConfig = { id: documentId };
         const schema: ContainerSchema = {
-            name: documentId,
+            initialObjects: {
+              customMap: SharedMap
+            },
         };
 
-        const containerAndServices  = await client.createContainer(containerConfig, schema);
+        const containerAndServices  = await client.createContainer(schema);
     });
 });
 


### PR DESCRIPTION
We have a lot of legacy docs with references to old APIs