### PR TITLE
Don't count nacks for deli op events

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -288,13 +288,13 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                         };
                     }
                 }
+
+                sequencedMessageCount++;
             }
 
             // Update the msn last sent.
             this.lastSentMSN = ticketedMessage.msn;
             this.lastSendP = this.sendToScriptorium(ticketedMessage.message);
-
-            sequencedMessageCount++;
         }
 
         kafkaCheckpointMessage = this.getKafkaCheckpointMessage(rawMessage);


### PR DESCRIPTION
`sequencedMessageCount` was being incremented for non-sequenced messages (nacks). We shouldn't be doing that. This was causing some opEvents to be fired even though no actual ops were created.