### PR TITLE
Yangg/frs whole summary

### DIFF
--- a/api-report/test-drivers.api.md
+++ b/api-report/test-drivers.api.md
@@ -153,7 +153,7 @@ export type RouterliciousDriverApiType = typeof RouterliciousDriverApi;
 
 // @public (undocumented)
 export class RouterliciousTestDriver implements ITestDriver {
-    constructor(tenantId: string, tenantSecret: string, serviceEndpoints: IServiceEndpoint, api?: RouterliciousDriverApiType, endpointName?: string | undefined);
+    constructor(tenantId: string, tenantSecret: string, serviceEndpoints: IServiceEndpoint, useWholeSummary: boolean, api?: RouterliciousDriverApiType, endpointName?: string | undefined);
     // (undocumented)
     createContainerUrl(testId: string): Promise<string>;
     // (undocumented)

--- a/api-report/test-drivers.api.md
+++ b/api-report/test-drivers.api.md
@@ -13,6 +13,7 @@ import { ILocalDeltaConnectionServer } from '@fluidframework/server-local-server
 import { InsecureTinyliciousUrlResolver } from '@fluidframework/tinylicious-driver';
 import { InsecureUrlResolver } from '@fluidframework/test-runtime-utils';
 import { IRequest } from '@fluidframework/core-interfaces';
+import { IRouterliciousDriverPolicies } from '@fluidframework/routerlicious-driver';
 import { ITestDriver } from '@fluidframework/test-driver-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { LocalDocumentServiceFactory } from '@fluidframework/local-driver';
@@ -153,7 +154,7 @@ export type RouterliciousDriverApiType = typeof RouterliciousDriverApi;
 
 // @public (undocumented)
 export class RouterliciousTestDriver implements ITestDriver {
-    constructor(tenantId: string, tenantSecret: string, serviceEndpoints: IServiceEndpoint, useWholeSummary: boolean, api?: RouterliciousDriverApiType, endpointName?: string | undefined);
+    constructor(tenantId: string, tenantSecret: string, serviceEndpoints: IServiceEndpoint, api: RouterliciousDriverApiType, driverPolicies: IRouterliciousDriverPolicies | undefined, endpointName?: string | undefined);
     // (undocumented)
     createContainerUrl(testId: string): Promise<string>;
     // (undocumented)

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -25,6 +25,7 @@ const dockerConfig = {
     },
     tenantId: "fluid",
     tenantSecret: "create-new-tenants-if-going-to-production",
+    useWholeSummary: false,
 };
 
 function getConfig(fluidHost?: string, tenantId?: string, tenantSecret?: string, useWholeSummary: boolean = false) {

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -27,7 +27,7 @@ const dockerConfig = {
     tenantSecret: "create-new-tenants-if-going-to-production",
 };
 
-function getConfig(fluidHost?: string, tenantId?: string, tenantSecret?: string) {
+function getConfig(fluidHost?: string, tenantId?: string, tenantSecret?: string, useWholeSummary: boolean = false) {
     assert(fluidHost, "Missing Fluid host");
     assert(tenantId, "Missing tenantId");
     assert(tenantSecret, "Missing tenant secret");
@@ -39,6 +39,7 @@ function getConfig(fluidHost?: string, tenantId?: string, tenantSecret?: string)
         },
         tenantId,
         tenantSecret,
+        useWholeSummary,
     };
 }
 
@@ -57,7 +58,7 @@ function getEndpointConfigFromEnv(r11sEndpointName: string) {
     }
     assert(configStr, `Missing config for ${r11sEndpointName}`);
     const config = JSON.parse(configStr);
-    return getConfig(config.host, config.tenantId, config.tenantSecret);
+    return getConfig(config.host, config.tenantId, config.tenantSecret, config.useWholeSummary);
 }
 
 function getConfigFromEnv(r11sEndpointName?: string) {
@@ -76,11 +77,12 @@ export class RouterliciousTestDriver implements ITestDriver {
     public static createFromEnv(config?: { r11sEndpointName?: string },
         api: RouterliciousDriverApiType = RouterliciousDriverApi,
     ) {
-        const { serviceEndpoint, tenantId, tenantSecret } = getConfigFromEnv(config?.r11sEndpointName);
+        const { serviceEndpoint, tenantId, tenantSecret, useWholeSummary } = getConfigFromEnv(config?.r11sEndpointName);
         return new RouterliciousTestDriver(
             tenantId,
             tenantSecret,
             serviceEndpoint,
+            useWholeSummary,
             api,
             config?.r11sEndpointName,
         );
@@ -92,6 +94,7 @@ export class RouterliciousTestDriver implements ITestDriver {
         private readonly tenantId: string,
         private readonly tenantSecret: string,
         private readonly serviceEndpoints: IServiceEndpoint,
+        private readonly useWholeSummary: boolean,
         private readonly api: RouterliciousDriverApiType = RouterliciousDriverApi,
         public readonly endpointName?: string,
     ) {
@@ -111,6 +114,7 @@ export class RouterliciousTestDriver implements ITestDriver {
 
         return new this.api.RouterliciousDocumentServiceFactory(
             tokenProvider,
+            { enableWholeSummaryUpload: this.useWholeSummary },
         );
     }
 


### PR DESCRIPTION
Update RouterliciousTestDriver to enable the whole summary when running tests against FRS.