### PR TITLE
Fix some FlushMode/BatchManager related issues

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -76,7 +76,7 @@ export class DocumentDeltaConnection extends TypedEventEmitter<IDocumentDeltaCon
     protected readonly socket: SocketIOClient.Socket;
     submit(messages: IDocumentMessage[]): void;
     // (undocumented)
-    protected submitCore(type: string, messages: IDocumentMessage[]): void;
+    protected submitCore(type: string, messages: IDocumentMessage[], immediate?: boolean): void;
     // (undocumented)
     protected readonly submitManager: BatchManager<IDocumentMessage[]>;
     submitSignal(message: IDocumentMessage): void;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -267,6 +267,7 @@ export class DocumentDeltaConnection
         }
     }
 
+    // to be removed #7365
     private static get disabledBatchManagerFeatureGate() {
         try {
             return localStorage !== undefined
@@ -276,11 +277,20 @@ export class DocumentDeltaConnection
         return false;
     }
 
-    protected submitCore(type: string, messages: IDocumentMessage[]) {
+    protected submitCore(type: string, messages: IDocumentMessage[], immediate: boolean = false) {
         if (this.isBatchManagerDisabled) {
-            this.emitMessages(type, [messages]);
-        } else {
-            this.submitManager.add(type, messages);
+            setTimeout(
+                () => {
+                    this.emitMessages(type, [messages]);
+                },
+                0);
+            return;
+        }
+
+        // to be removed #7365
+        this.submitManager.add(type, messages);
+        if (immediate) {
+            this.submitManager.drain();
         }
     }
 

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -62,15 +62,6 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
           super(socket, documentId, new TelemetryNullLogger());
     }
 
-    protected submitCore(type: string, messages: IDocumentMessage[]) {
-        if (this.isBatchManagerDisabled) {
-            this.emitMessages(type, [messages]);
-        } else {
-            this.submitManager.add(type, messages);
-            this.submitManager.drain();
-        }
-    }
-
     /**
      * Submits a new delta operation to the server
      */
@@ -78,7 +69,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
         // We use a promise resolve to force a turn break given message processing is sync
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         Promise.resolve().then(() => {
-            this.submitCore("submitOp", messages);
+            this.submitCore("submitOp", messages, true /* immediate */);
         });
     }
 
@@ -86,7 +77,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
      * Submits a new signal to the server
      */
     public submitSignal(message: any): void {
-        this.submitCore("submitSignal", [message]);
+        this.submitCore("submitSignal", [message], true /* immediate */);
     }
 
     /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -789,6 +789,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     /** The message in the metadata of the base summary this container is loaded from. */
     private readonly baseSummaryMessage: ISummaryMetadataMessage | undefined;
 
+    // To be removed. Default FlushMode should be TurnBased. See #7365
     private static get defaultFlushMode(): FlushMode {
         return getLocalStorageFeatureGate(turnBasedFlushModeKey) ? FlushMode.TurnBased : FlushMode.Immediate;
     }


### PR DESCRIPTION
- Removing the BatchManager added a regression as message emission was issued synchronously. Fixing this by yielding a turn before calling `emit`.
- Remove/refactor `submitCore` from `LocalDocumentDeltaConnection`