### PR TITLE
Change type to BufferEncoding

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -47,7 +47,7 @@ export interface IBlob {
     // (undocumented)
     contents: string;
     // (undocumented)
-    encoding: string;
+    encoding: BufferEncoding;
 }
 
 // @public

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -485,6 +485,12 @@
         "z-schema": "~3.18.3"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
+          "dev": true
+        },
         "resolve": {
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -548,9 +554,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-      "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
+      "version": "12.20.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -39,6 +39,7 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/protocol-definitions-0.1024.0": "npm:@fluidframework/protocol-definitions@0.1024.0",
     "@microsoft/api-extractor": "^7.16.1",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",
@@ -94,6 +95,15 @@
       "TypeAliasDeclaration_SummaryTypeNoHandle": {
         "forwardCompat": false,
         "backCompat": false
+      },
+      "InterfaceDeclaration_IBlob": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_ITree": {
+        "forwardCompat": false
+      },
+      "TypeAliasDeclaration_ITreeEntry": {
+        "forwardCompat": false
       }
     }
   }

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -41,7 +41,7 @@ export interface IBlob {
     contents: string;
 
     // The encoding of the contents string (utf-8 or base64)
-    encoding: string;
+    encoding: BufferEncoding;
 }
 
 export interface IAttachment {

--- a/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/validate0.1024.0.ts
@@ -133,13 +133,13 @@ use_old_InterfaceDeclaration_IAttachment(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IBlob": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IBlob():
     old.IBlob;
 declare function use_current_InterfaceDeclaration_IBlob(
     use: current.IBlob);
 use_current_InterfaceDeclaration_IBlob(
     get_old_InterfaceDeclaration_IBlob());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -1309,13 +1309,13 @@ use_old_InterfaceDeclaration_ITrace(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ITree": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_ITree():
     old.ITree;
 declare function use_current_InterfaceDeclaration_ITree(
     use: current.ITree);
 use_current_InterfaceDeclaration_ITree(
     get_old_InterfaceDeclaration_ITree());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -1333,13 +1333,13 @@ use_old_InterfaceDeclaration_ITree(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_ITreeEntry": {"forwardCompat": false}
-*/
 declare function get_old_TypeAliasDeclaration_ITreeEntry():
     old.ITreeEntry;
 declare function use_current_TypeAliasDeclaration_ITreeEntry(
     use: current.ITreeEntry);
 use_current_TypeAliasDeclaration_ITreeEntry(
     get_old_TypeAliasDeclaration_ITreeEntry());
+*/
 
 /*
 * validate back compat by using current type in place of old type

--- a/common/lib/protocol-definitions/tsconfig.json
+++ b/common/lib/protocol-definitions/tsconfig.json
@@ -6,7 +6,8 @@
     ],
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "types": ["node"]
     },
     "include": [
         "src/**/*"

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/server/routerlicious/packages/gitresources/src/resources.ts
+++ b/server/routerlicious/packages/gitresources/src/resources.ts
@@ -97,7 +97,7 @@ export interface ICreateBlobParams {
     content: string;
 
     // The encoding of the content. Either utf8 or base64.
-    encoding: string;
+    encoding: BufferEncoding;
 }
 
 /**

--- a/server/routerlicious/packages/gitresources/tsconfig.json
+++ b/server/routerlicious/packages/gitresources/tsconfig.json
@@ -6,7 +6,8 @@
     ],
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./dist"
+        "outDir": "./dist",
+        "types": ["node"]
     },
     "include": [
         "src/**/*"

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -257,7 +257,7 @@ export class GitManager implements IGitManager {
                         entryAsBlob.contents = this.translateSymlink(entryAsBlob.contents, depth);
                     }
 
-                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding);
+                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding as BufferEncoding);
                     entriesP.push(blobP);
                     break;
 

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -119,7 +119,7 @@ export class GitManager implements IGitManager {
         return this.historian.getContent(path, commit);
     }
 
-    public createBlob(content: string, encoding: string): Promise<resources.ICreateBlobResponse> {
+    public createBlob(content: string, encoding: BufferEncoding): Promise<resources.ICreateBlobResponse> {
         const blob: resources.ICreateBlobParams = {
             content,
             encoding,

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { ParsedUrlQueryInput } from "querystring";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import { RestWrapper, BasicRestWrapper } from "./restWrapper";
@@ -31,8 +32,7 @@ export const getAuthorizationTokenFromCredentials = (credentials: ICredentials):
  * Implementation of the IHistorian interface that calls out to a REST interface
  */
 export class Historian implements IHistorian {
-    private readonly defaultQueryString: Record<string, string | number | boolean | readonly string[] |
-        readonly number[] | readonly boolean[] | undefined | null> = {};
+    private readonly defaultQueryString: ParsedUrlQueryInput = {};
     private readonly cacheBust: boolean;
 
     constructor(
@@ -164,8 +164,7 @@ export class Historian implements IHistorian {
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
-    private getQueryString(queryString?: {}): Record<string, string | number | boolean | readonly string[] |
-        readonly number[] | readonly boolean[] | undefined | null> {
+    private getQueryString(queryString?: {}): ParsedUrlQueryInput {
         if (this.cacheBust) {
             return {
                 cacheBust: Date.now(),

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -31,7 +31,8 @@ export const getAuthorizationTokenFromCredentials = (credentials: ICredentials):
  * Implementation of the IHistorian interface that calls out to a REST interface
  */
 export class Historian implements IHistorian {
-    private readonly defaultQueryString: Record<string, unknown> = {};
+    private readonly defaultQueryString: Record<string, string | number | boolean | readonly string[] |
+        readonly number[] | readonly boolean[] | undefined | null> = {};
     private readonly cacheBust: boolean;
 
     constructor(
@@ -163,7 +164,8 @@ export class Historian implements IHistorian {
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
-    private getQueryString(queryString?: {}): Record<string, unknown> {
+    private getQueryString(queryString?: {}): Record<string, string | number | boolean | readonly string[] |
+        readonly number[] | readonly boolean[] | undefined | null> {
         if (this.cacheBust) {
             return {
                 cacheBust: Date.now(),

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -11,7 +11,8 @@ import { debug } from "./debug";
 export abstract class RestWrapper {
     constructor(
         protected readonly baseurl?: string,
-        protected defaultQueryString: Record<string, unknown> = {},
+        protected defaultQueryString: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null> = {},
         protected readonly maxBodyLength = 1000 * 1024 * 1024,
         protected readonly maxContentLength = 1000 * 1024 * 1024,
     ) {
@@ -19,8 +20,10 @@ export abstract class RestWrapper {
 
     public async get<T>(
         url: string,
-        queryString?: Record<string, unknown>,
-        headers?: Record<string, unknown>,
+        queryString?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
+        headers?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -36,8 +39,10 @@ export abstract class RestWrapper {
     public async post<T>(
         url: string,
         requestBody: any,
-        queryString?: Record<string, unknown>,
-        headers?: Record<string, unknown>,
+        queryString?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
+        headers?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -53,8 +58,10 @@ export abstract class RestWrapper {
 
     public async delete<T>(
         url: string,
-        queryString?: Record<string, unknown>,
-        headers?: Record<string, unknown>,
+        queryString?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
+        headers?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -70,8 +77,10 @@ export abstract class RestWrapper {
     public async patch<T>(
         url: string,
         requestBody: any,
-        queryString?: Record<string, unknown>,
-        headers?: Record<string, unknown>,
+        queryString?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
+        headers?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -87,7 +96,8 @@ export abstract class RestWrapper {
 
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 
-    protected generateQueryString(queryStringValues: Record<string, unknown>) {
+    protected generateQueryString(queryStringValues: Record<string, string | number | boolean |
+            readonly string[] | readonly number[] | readonly boolean[] | undefined | null>) {
         if (this.defaultQueryString || queryStringValues) {
             const queryStringMap = { ...this.defaultQueryString, ...queryStringValues };
 
@@ -104,13 +114,17 @@ export abstract class RestWrapper {
 export class BasicRestWrapper extends RestWrapper {
     constructor(
         baseurl?: string,
-        defaultQueryString: Record<string, unknown> = {},
+        defaultQueryString: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null> = {},
         maxBodyLength = 1000 * 1024 * 1024,
         maxContentLength = 1000 * 1024 * 1024,
-        private defaultHeaders: Record<string, unknown> = {},
+        private defaultHeaders: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null> = {},
         private readonly axios: AxiosInstance = Axios,
-        private readonly refreshDefaultQueryString?: () => Record<string, unknown>,
-        private readonly refreshDefaultHeaders?: () => Record<string, unknown>,
+        private readonly refreshDefaultQueryString?: () => Record<string, string | number | boolean |
+            readonly string[] | readonly number[] | readonly boolean[] | undefined | null>,
+        private readonly refreshDefaultHeaders?: () => Record<string, string | number | boolean |
+            readonly string[] | readonly number[] | readonly boolean[] | undefined | null>,
         private readonly getCorrelationId?: () => string | undefined,
     ) {
         super(baseurl, defaultQueryString, maxBodyLength, maxContentLength);
@@ -157,9 +171,11 @@ export class BasicRestWrapper extends RestWrapper {
     }
 
     private generateHeaders(
-        headers?: Record<string, unknown>,
+        headers?: Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null>,
         fallbackCorrelationId?: string,
-    ): Record<string, unknown> {
+    ): Record<string, string | number | boolean | readonly string[] |
+            readonly number[] | readonly boolean[] | undefined | null> {
         let result = headers ?? {};
         if (this.defaultHeaders) {
             result = { ...this.defaultHeaders, ...headers };

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -11,8 +11,7 @@ import { debug } from "./debug";
 export abstract class RestWrapper {
     constructor(
         protected readonly baseurl?: string,
-        protected defaultQueryString: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null> = {},
+        protected defaultQueryString: querystring.ParsedUrlQueryInput = {},
         protected readonly maxBodyLength = 1000 * 1024 * 1024,
         protected readonly maxContentLength = 1000 * 1024 * 1024,
     ) {
@@ -20,10 +19,8 @@ export abstract class RestWrapper {
 
     public async get<T>(
         url: string,
-        queryString?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
-        headers?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
+        queryString?: querystring.ParsedUrlQueryInput,
+        headers?: querystring.ParsedUrlQueryInput,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -39,10 +36,8 @@ export abstract class RestWrapper {
     public async post<T>(
         url: string,
         requestBody: any,
-        queryString?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
-        headers?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
+        queryString?: querystring.ParsedUrlQueryInput,
+        headers?: querystring.ParsedUrlQueryInput,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -58,10 +53,8 @@ export abstract class RestWrapper {
 
     public async delete<T>(
         url: string,
-        queryString?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
-        headers?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
+        queryString?: querystring.ParsedUrlQueryInput,
+        headers?: querystring.ParsedUrlQueryInput,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -77,10 +70,8 @@ export abstract class RestWrapper {
     public async patch<T>(
         url: string,
         requestBody: any,
-        queryString?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
-        headers?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
+        queryString?: querystring.ParsedUrlQueryInput,
+        headers?: querystring.ParsedUrlQueryInput,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -96,8 +87,7 @@ export abstract class RestWrapper {
 
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 
-    protected generateQueryString(queryStringValues: Record<string, string | number | boolean |
-            readonly string[] | readonly number[] | readonly boolean[] | undefined | null>) {
+    protected generateQueryString(queryStringValues: querystring.ParsedUrlQueryInput) {
         if (this.defaultQueryString || queryStringValues) {
             const queryStringMap = { ...this.defaultQueryString, ...queryStringValues };
 
@@ -114,17 +104,13 @@ export abstract class RestWrapper {
 export class BasicRestWrapper extends RestWrapper {
     constructor(
         baseurl?: string,
-        defaultQueryString: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null> = {},
+        defaultQueryString: querystring.ParsedUrlQueryInput = {},
         maxBodyLength = 1000 * 1024 * 1024,
         maxContentLength = 1000 * 1024 * 1024,
-        private defaultHeaders: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null> = {},
+        private defaultHeaders: querystring.ParsedUrlQueryInput = {},
         private readonly axios: AxiosInstance = Axios,
-        private readonly refreshDefaultQueryString?: () => Record<string, string | number | boolean |
-            readonly string[] | readonly number[] | readonly boolean[] | undefined | null>,
-        private readonly refreshDefaultHeaders?: () => Record<string, string | number | boolean |
-            readonly string[] | readonly number[] | readonly boolean[] | undefined | null>,
+        private readonly refreshDefaultQueryString?: () => querystring.ParsedUrlQueryInput,
+        private readonly refreshDefaultHeaders?: () => querystring.ParsedUrlQueryInput,
         private readonly getCorrelationId?: () => string | undefined,
     ) {
         super(baseurl, defaultQueryString, maxBodyLength, maxContentLength);
@@ -171,11 +157,9 @@ export class BasicRestWrapper extends RestWrapper {
     }
 
     private generateHeaders(
-        headers?: Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null>,
+        headers?: querystring.ParsedUrlQueryInput,
         fallbackCorrelationId?: string,
-    ): Record<string, string | number | boolean | readonly string[] |
-            readonly number[] | readonly boolean[] | undefined | null> {
+    ): querystring.ParsedUrlQueryInput {
         let result = headers ?? {};
         if (this.defaultHeaders) {
             result = { ...this.defaultHeaders, ...headers };

--- a/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
+++ b/tools/build-tools/src/repoPolicyCheck/repoPolicyCheck.ts
@@ -153,7 +153,7 @@ lineReader.once("close",()=>{
 
 
 process.on("beforeExit", () => {
-    writeOutLine(`Statitisics: ${processed} processed, ${count - processed} excluded, ${count} total`);
+    writeOutLine(`Statistics: ${processed} processed, ${count - processed} excluded, ${count} total`);
     handlerActionPerf.forEach((handlerPerf, action)=>{
         writeOutLine(`Performance for "${action}":`);
         handlerPerf.forEach((dur, handler)=>{


### PR DESCRIPTION
Change encoding type from string to BufferEncoding in gitresources and protocol-definitions, which is what it really is and ends up being cast to.

This is the first in a series of PRs to eventually consume this breaking change. Full set of changes are viewable here: #7490.