### PR TITLE
Add config to enforce server-generated doc id in R11s

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -89,7 +89,8 @@ data:
             "socketIoAdapter" : {
                 "enableCustomSocketIoAdapter": {{ .Values.alfred.socketIoAdapter.enableCustomSocketIoAdapter }},
                 "shouldDisableDefaultNamespace": {{ .Values.alfred.socketIoAdapter.shouldDisableDefaultNamespace }}
-            }
+            },
+            "enforceServerGeneratedDocumentId": {{ .Values.alfred.enforceServerGeneratedDocumentId }}
         },
         "client": {
             "type": "browser",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -35,6 +35,7 @@ alfred:
   socketIoAdapter:
     enableCustomSocketIoAdapter: true
     shouldDisableDefaultNamespace: false
+  enforceServerGeneratedDocumentId: false
 storage:
   enableWholeSummaryUpload: false
 deli:

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -26,6 +26,9 @@ export function create(
     tenantManager: ITenantManager): Router {
     const router: Router = Router();
 
+    // Whether to enforce server-generated document ids in create doc flow
+    const enforceServerGeneratedDocumentId: boolean = config.get("alfred:enforceServerGeneratedDocumentId") ?? false;
+
     const commonThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
         throttleIdPrefix: (req) => getParam(req.params, "tenantId") || appTenants[0].id,
         throttleIdSuffix: Constants.alfredRestThrottleIdSuffix,
@@ -62,7 +65,10 @@ export function create(
         (request, response, next) => {
             // Tenant and document
             const tenantId = getParam(request.params, "tenantId");
-            const id = request.body.id as string || uuid();
+            // If enforcing server generated document id, ignore id parameter
+            const id = enforceServerGeneratedDocumentId
+                ? uuid()
+                : request.body.id as string || uuid();
 
             // Summary information
             const summary = request.body.summary;

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -83,10 +83,11 @@
                 "key": "create-new-tenants-if-going-to-production"
             }
         ],
-        "socketIoAdapter" : {
+        "socketIoAdapter": {
             "enableCustomSocketIoAdapter": true,
             "shouldDisableDefaultNamespace": false
-        }
+        },
+        "enforceServerGeneratedDocumentId": false
     },
     "client": {
         "type": "browser",
@@ -157,11 +158,28 @@
     },
     "foreman": {
         "alfred": "http://alfred:3000",
-        "queues": ["paparazziQueue", "augloopQueue", "headlessQueue"],
+        "queues": [
+            "paparazziQueue",
+            "augloopQueue",
+            "headlessQueue"
+        ],
         "permissions": {
-            "paparazziQueue": ["snapshot", "spell", "intel", "translation"],
-            "augloopQueue": ["augmentation"],
-            "headlessQueue": ["chain-snapshot", "chain-intel", "chain-translation", "chain-spell", "chain-cache"]
+            "paparazziQueue": [
+                "snapshot",
+                "spell",
+                "intel",
+                "translation"
+            ],
+            "augloopQueue": [
+                "augmentation"
+            ],
+            "headlessQueue": [
+                "chain-snapshot",
+                "chain-intel",
+                "chain-translation",
+                "chain-spell",
+                "chain-cache"
+            ]
         }
     },
     "paparazzi": {
@@ -187,14 +205,23 @@
     },
     "error": {
         "track": false,
-        "endpoint" : ""
+        "endpoint": ""
     },
     "worker": {
         "alfredUrl": "http://alfred:3003",
         "serverUrl": "http://localhost:3003",
         "blobStorageUrl": "http://historian:3000",
         "internalBlobStorageUrl": "http://historian:3000",
-        "permission": ["snapshot", "spell", "intel", "translation", "chain-snapshot", "chain-spell", "chain-intel", "chain-translation"]
+        "permission": [
+            "snapshot",
+            "spell",
+            "intel",
+            "translation",
+            "chain-snapshot",
+            "chain-spell",
+            "chain-intel",
+            "chain-translation"
+        ]
     },
     "tenantConfig": [
         {


### PR DESCRIPTION
In FRS, we want to enforce server-generated doc ids in certain environments. If "enforceServerGeneratedDocumentId" is true, we will always ignore the documentId being passed to the server from the client.