### PR TITLE
Support legacy container create flow

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -64,7 +64,15 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         if (!parsedUrl.pathname) {
             throw new Error("Parsed url should contain tenant and doc Id!!");
         }
-        const [, tenantId] = parsedUrl.pathname.split("/");
+        // extract tenant and document IDs from the parsed URL.
+        const [, tenantId, newDocumentId] = parsedUrl.pathname.split("/");
+        // TODO: This logic to determine ID helps with back-compat of the legacy container create flow.
+        // Will ignore the new document ID provided by the application as r11s will not honor it.
+        // The literal "new" document ID interpreted as a request to generate the ID
+        // by the server and therefore is replaced with `undefined` value.
+        // Any other value will be transmitted as-is to support the legacy container create flow.
+        const id = newDocumentId !== "new" ? newDocumentId : undefined;
+
         const protocolSummary = createNewSummary.tree[".protocol"] as ISummaryTree;
         const appSummary = createNewSummary.tree[".app"] as ISummaryTree;
         if (!(protocolSummary && appSummary)) {
@@ -77,16 +85,18 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
         const ordererRestWrapper = await RouterliciousOrdererRestWrapper.load(
             tenantId,
-            undefined,
+            id,
             this.tokenProvider,
             logger2,
             rateLimiter,
             this.driverPolicies.enableRestLess,
             resolvedUrl.endpoints.ordererUrl,
         );
+        // the backend responds with the actual document ID associated with the new container.
         const documentId = await ordererRestWrapper.post<string>(
             `/documents/${tenantId}`,
             {
+                id,
                 summary: convertSummaryToCreateNewSummary(appSummary),
                 sequenceNumber: documentAttributes.sequenceNumber,
                 values: quorumValues,


### PR DESCRIPTION
Partial revert of #7337.

Before enforcing the new container create flow in r11s/t8s we need to refactor the webpack loader and some legacy example applications. Hence, we've decided to support both container create flows, with or without ID provided by an app. The restriction will be reinstated in the next version prior to FRS Public Preview.