### PR TITLE
Add documentation for event interfaces in the fluid-static package

### DIFF
--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -125,7 +125,7 @@ export interface RootDataObjectProps {
     initialObjects: LoadableObjectClassRecord;
 }
 
-// @public (undocumented)
+// @public
 export abstract class ServiceAudience<M extends IMember = IMember> extends TypedEventEmitter<IServiceAudienceEvents<M>> implements IServiceAudience<M> {
     constructor(container: Container);
     // (undocumented)

--- a/docs/content/docs/build/audience.md
+++ b/docs/content/docs/build/audience.md
@@ -122,6 +122,8 @@ In some cases, the user data could be generated locally or fetched from an exter
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/build/auth.md
+++ b/docs/content/docs/build/auth.md
@@ -137,6 +137,8 @@ Relay service.
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -212,6 +212,8 @@ references to useful services you can use to build richer apps. An example of a 
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/build/data-modeling.md
+++ b/docs/content/docs/build/data-modeling.md
@@ -149,6 +149,8 @@ An example where this is useful is building a collaborative storyboarding applic
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/build/dds.md
+++ b/docs/content/docs/build/dds.md
@@ -209,6 +209,8 @@ These DDSes are used for storing sequential data. They are all optimistic.
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/concepts/handles.md
+++ b/docs/content/docs/concepts/handles.md
@@ -86,6 +86,8 @@ console.log(text === text2) // true
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/concepts/tob.md
+++ b/docs/content/docs/concepts/tob.md
@@ -87,6 +87,8 @@ Fluid objects' data structures will be summarized.
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/data-structures/overview.md
+++ b/docs/content/docs/data-structures/overview.md
@@ -151,6 +151,8 @@ DDS will be available over time.
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/deep/dataobject-aqueduct.md
+++ b/docs/content/docs/deep/dataobject-aqueduct.md
@@ -273,6 +273,8 @@ We use custom handlers to build the Container Services pattern.
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/deep/feature-detection-iprovide.md
+++ b/docs/content/docs/deep/feature-detection-iprovide.md
@@ -104,6 +104,8 @@ object of the correct type or `undefined`.
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/deep/hosts.md
+++ b/docs/content/docs/deep/hosts.md
@@ -129,6 +129,8 @@ As the Fluid Framework expands, we intend to make further use of these responses
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/deployment/azure-frs.md
+++ b/docs/content/docs/deployment/azure-frs.md
@@ -209,6 +209,8 @@ fetched back user details for the members in your collaborative session!
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/recipes/react.md
+++ b/docs/content/docs/recipes/react.md
@@ -245,6 +245,8 @@ When you make changes to the code the project will automatically rebuild and the
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/docs/content/docs/start/tutorial.md
+++ b/docs/content/docs/start/tutorial.md
@@ -181,6 +181,8 @@ The [full code for this application is available](https://github.com/microsoft/F
 [ContainerRuntimeFactoryWithDefaultDataStore]: {{< relref "containerruntimefactorywithdefaultdatastore.md" >}}
 [DataObject]: {{< relref "dataobject.md" >}}
 [DataObjectFactory]: {{< relref "dataobjectfactory.md" >}}
+[FluidContainer]: {{< relref "fluidcontainer.md" >}}
+[IFluidContainer]: {{< relref "ifluidcontainer.md" >}}
 [PureDataObject]: {{< relref "puredataobject.md" >}}
 [PureDataObjectFactory]: {{< relref "puredataobjectfactory.md" >}}
 [SharedCounter]: {{< relref "/docs/data-structures/counter.md" >}}

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -6,6 +6,6 @@
 /* eslint-disable import/export */
 
 export * from "./containerDefinitions";
-export * from  "./fluidStatic";
-export * from  "./map";
-export * from  "./sequence";
+export * from "./fluidStatic";
+export * from "./map";
+export * from "./sequence";

--- a/packages/framework/fluid-framework/src/map.ts
+++ b/packages/framework/fluid-framework/src/map.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from  "@fluidframework/map";
+export * from "@fluidframework/map";

--- a/packages/framework/fluid-framework/src/sequence.ts
+++ b/packages/framework/fluid-framework/src/sequence.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export * from  "@fluidframework/sequence";
+export * from "@fluidframework/sequence";

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -12,6 +12,36 @@ import { RootDataObject } from "./rootDataObject";
 
 /**
  * Events emitted from IFluidContainer.
+ *
+ * ### "connected"
+ *
+ * The connected event is emitted when the `IFluidContainer` completes connecting to the Fluid service.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * () => void;
+ * ```
+ *
+ * ### "dispose"
+ *
+ * The dispose event is emitted when the `IFluidContainer` is disposed, which permanently disables it.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * () => void;
+ * ```
+ *
+ * ### "disconnected"
+ *
+ * The disconnected event is emitted when the `IFluidContainer` becomes disconnected from the Fluid service.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * () => void;
+ * ```
  */
 export interface IFluidContainerEvents extends IEvent {
     (event: "connected" | "dispose" | "disconnected", listener: () => void): void;

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -9,9 +9,12 @@ import { Container } from "@fluidframework/container-loader";
 import { IClient } from "@fluidframework/protocol-definitions";
 import { IServiceAudience, IServiceAudienceEvents, IMember } from "./types";
 
-// Base class for providing audience information for sessions interacting with FluidContainer
-// This can be extended by different service-specific client packages to additional parameters to
-// the user and client details returned in IMember
+/**
+ * Base class for providing audience information for sessions interacting with FluidContainer
+ * This can be extended by different service-specific client packages to additional parameters to
+ * the user and client details returned in IMember
+ * @typeParam M - A service-specific member type.
+ */
 export abstract class ServiceAudience<M extends IMember = IMember>
   extends TypedEventEmitter<IServiceAudienceEvents<M>>
   implements IServiceAudience<M> {

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -69,6 +69,43 @@ export interface ContainerSchema {
  * Events that trigger when the roster of members in the Fluid session change.
  * Only changes that would be reflected in the returned map of IServiceAudience's getMembers method
  * will emit events.
+ *
+ * ### "membersChanged"
+ *
+ * The membersChanged event is emitted when a member is either added or removed.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * () => void;
+ * ```
+ *
+ * ### "memberAdded"
+ *
+ * The memberAdded event is emitted when a member joins the audience.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * (clientId: string, member: M) => void;
+ * ```
+ * - `clientId` - A unique identifier for the client
+ *
+ * - `member` - The service-specific member object for the client
+ *
+ * ### "memberRemoved"
+ *
+ * The memberRemoved event is emitted when a member leaves the audience.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * (clientId: string, member: M) => void;
+ * ```
+ * - `clientId` - A unique identifier for the client
+ *
+ * - `member` - The service-specific member object for the client
+ * @typeParam M - A service-specific member type.
  */
 export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
     (event: "membersChanged", listener: () => void): void;
@@ -78,7 +115,7 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
 /**
  * Base interface to be implemented to fetch each service's audience. The generic M allows consumers to further
  * extend the client object with service-specific details about the connecting client, such as device information,
- * environme
+ * environment, or a username.
  */
 export interface IServiceAudience<M extends IMember> extends IEventProvider<IServiceAudienceEvents<M>> {
     /**


### PR DESCRIPTION
Taking a stab at documenting the event interfaces in the fluid-static package.  Since we don't have extraction of the events working in the api-documenter currently, this just takes the approach of using a class comment.

If/when we get automatic extraction working, the English should still be relevant/useful.

Output looks like this:
![image](https://user-images.githubusercontent.com/4276348/134086271-c2aa529d-2814-4723-ae6f-0624affe8968.png)
