### PR TITLE
Remove existing check from Alfred

### DIFF
--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -16,7 +16,6 @@ import * as core from "@fluidframework/server-services-core";
 
 export class KafkaOrdererConnection implements core.IOrdererConnection {
     public static async create(
-        existing: boolean,
         producer: core.IProducer,
         tenantId: string,
         documentId: string,
@@ -27,7 +26,6 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
     ): Promise<KafkaOrdererConnection> {
         // Create the connection
         return new KafkaOrdererConnection(
-            existing,
             producer,
             tenantId,
             documentId,
@@ -38,7 +36,6 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
     }
 
     constructor(
-        public readonly existing: boolean,
         private readonly producer: core.IProducer,
         public readonly tenantId: string,
         public readonly documentId: string,
@@ -162,8 +159,6 @@ export class KafkaOrderer implements core.IOrderer {
         return new KafkaOrderer(producer, tenantId, documentId, maxMessageSize, serviceConfiguration);
     }
 
-    private existing: boolean | undefined;
-
     constructor(
         private readonly producer: core.IProducer,
         private readonly tenantId: string,
@@ -176,11 +171,8 @@ export class KafkaOrderer implements core.IOrderer {
     public async connect(
         socket: core.IWebSocket,
         clientId: string,
-        client: IClient,
-        details: core.IDocumentDetails): Promise<core.IOrdererConnection> {
-        this.existing = details.existing;
+        client: IClient): Promise<core.IOrdererConnection> {
         const connection = KafkaOrdererConnection.create(
-            this.existing,
             this.producer,
             this.tenantId,
             this.documentId,
@@ -188,9 +180,6 @@ export class KafkaOrderer implements core.IOrderer {
             this.maxMessageSize,
             clientId,
             this.serviceConfiguration);
-
-        // Document is now existing regardless of the original value
-        this.existing = true;
 
         return connection;
     }

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -80,6 +80,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
             // Lookup the last sequence number stored
             // TODO - is this storage specific to the orderer in place? Or can I generalize the output context?
             dbObject = await this.collection.findOne({ documentId, tenantId });
+            // Check if the document was deleted prior.
         } catch (error) {
             const errMsg = "Deli lambda creation failed";
             context.log?.error(`${errMsg}. Exception: ${inspect(error)}`, { messageMetaData });
@@ -121,7 +122,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
                     // the sequence number is 'n' rather than '0'.
                     lastCheckpoint.logOffset = -1;
                     lastCheckpoint.epoch = leaderEpoch;
-                    context.log?.info(`Deli checkpoint from summary: 
+                    context.log?.info(`Deli checkpoint from summary:
                         ${ JSON.stringify(lastCheckpoint)}`, { messageMetaData });
                 }
             } else {

--- a/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
+++ b/server/routerlicious/packages/local-server/src/test/localDeltaConnectionServer.spec.ts
@@ -123,7 +123,7 @@ describe("LocalDeltaConnectionServer", () => {
 
         // Wait for the first client to be connected and joined.
         const connected1 = await connected1P;
-        assert.equal(connected1.existing, false, "The document should not be existing for the first client");
+        assert.equal(connected1.existing, true, "The document should be existing for the first client");
 
         const join1 = await join1P;
         assert.equal(

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -195,7 +195,7 @@ export class LocalNode extends EventEmitter implements IConcreteNode {
                         // Emit connected message
                         const connected: IConnectedMessage = {
                             clientId: connection.clientId,
-                            existing: connection.existing,
+                            existing: true,
                             maxMessageSize: this.maxMessageSize,
                             serviceConfiguration: DefaultServiceConfiguration,
                         };

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
@@ -129,7 +129,7 @@ describe("Routerlicious", () => {
                     const connectMessage: IConnect = {
                         client: undefined,
                         id,
-                        mode: "read",
+                        mode: "write",
                         tenantId,
                         token,
                         versions: ["^0.3.0", "^0.2.0", "^0.1.0"],
@@ -240,7 +240,7 @@ describe("Routerlicious", () => {
                         // There is no ack for the disconnect, but the message will be ordered with future messages.
                         await connectToServer(testId, testTenantId, testSecret, webSocketServer.createConnection());
 
-                        assert.equal(deliKafka.getRawMessages().length, 2);
+                        assert.equal(deliKafka.getRawMessages().length, 3);
                         const message = deliKafka.getMessage(1);
                         assert.equal(message.documentId, testId);
                         const systemLeaveMessage = message.operation as ISequencedDocumentSystemMessage;

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
@@ -170,7 +170,7 @@ describe("Routerlicious", () => {
                         const socket = webSocketServer.createConnection();
                         const connectMessage = await connectToServer(testId, testTenantId, testSecret, socket);
                         assert.ok(connectMessage.clientId);
-                        assert.equal(connectMessage.existing, false);
+                        assert.equal(connectMessage.existing, true);
 
                         // Verify a connection message was sent
                         const message = deliKafka.getLastMessage();
@@ -182,12 +182,12 @@ describe("Routerlicious", () => {
                         assert.equal(JoinMessage.clientId, connectMessage.clientId);
                     });
 
-                    it("Should connect to and set existing flag to true when connecting to an existing document",
+                    it("Should support multiple connections to an existing document",
                         async () => {
                             const firstSocket = webSocketServer.createConnection();
                             const firstConnectMessage = await connectToServer(
                                 testId, testTenantId, testSecret, firstSocket);
-                            assert.equal(firstConnectMessage.existing, false);
+                            assert.equal(firstConnectMessage.existing, true);
 
                             const secondSocket = webSocketServer.createConnection();
                             const secondConnectMessage = await connectToServer(
@@ -202,7 +202,7 @@ describe("Routerlicious", () => {
                             const socket = webSocketServer.createConnection();
                             const connectMessage = await connectToServer(id, testTenantId, testSecret, socket);
                             assert.ok(connectMessage.clientId);
-                            assert.equal(connectMessage.existing, false);
+                            assert.equal(connectMessage.existing, true);
 
                             // Verify a connection message was sent
                             const message = deliKafka.getLastMessage();

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -5,7 +5,6 @@
 
 import { IClient, IDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IServiceConfiguration } from "./configuration";
-import { IDocumentDetails } from "./document";
 import { IWebSocket } from "./http";
 
 /**
@@ -32,10 +31,6 @@ export interface IOrdererConnection {
     readonly tenantId: string;
 
     readonly documentId: string;
-
-    // TODO - this can probably be phased out in favor of an explicit create of the ordering context
-    // For now it maps to whether the connection is to an existing ordering context or a new one
-    readonly existing: boolean;
 
     readonly maxMessageSize: number;
 
@@ -67,8 +62,7 @@ export interface IOrderer {
     connect(
         socket: IWebSocket,
         clientId: string,
-        client: IClient,
-        details: IDocumentDetails): Promise<IOrdererConnection>;
+        client: IClient): Promise<IOrdererConnection>;
 
     close(): Promise<void>;
 }


### PR DESCRIPTION
Currently, Alfred checks the existence of document before establishing connection with client. The only purpose of this check is to send existing flag back to client. However, with detached creation, this check is no longer necessary since the document is guaranteed to be present during creation. In addition, client has already removed all dependencies on "existing" flag ( #6033 ).

This PR removes the DB check and saves one additional network call per connection. In case any scenario needs to perform a similar check, deli can be leveraged since it also reads from the same DB.