### PR TITLE
Draft: Consume BufferEncoding type change

### DIFF
--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/garbage-collector": "^0.49.0",
     "@fluidframework/protocol-base": "^0.1031.0-37526",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/runtime-definitions": "^0.49.0"
   },
   "devDependencies": {

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -300,7 +300,7 @@ export function convertSummaryTreeToITree(summaryTree: ISummaryTree): ITree {
         switch (value.type) {
             case SummaryType.Blob: {
                 let parsedContent: string;
-                let encoding: string = "utf-8";
+                let encoding: BufferEncoding = "utf-8";
                 if (typeof value.content === "string") {
                     parsedContent = value.content;
                 } else {

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -39,7 +39,7 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
     public async createBlob(content: ArrayBufferLike): Promise<ICreateBlobResponse> {
         const id = this.size.toString();
         this.blobs.set(id, content);
-        return { id, url: "" };
+        return { id };
     }
 
     public async readBlob(blobId: string): Promise<ArrayBufferLike> {

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -329,9 +329,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {
@@ -602,9 +602,9 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1025.0-23979",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
-      "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
+      "version": "0.1031.0-38246",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1031.0-38246.tgz",
+      "integrity": "sha512-DTSkWproPdJPZiRANAkPnkkO1FBQpLVytDvIJWEMl6Y0Ygqd6aX6C3Yy/TYPKurIeu15uCnwSyFtV+aHUh/TnQ=="
     },
     "@fluidframework/protocol-base": {
       "version": "0.1025.0-23979",
@@ -631,6 +631,11 @@
             "lodash": "^4.17.21",
             "sha.js": "^2.4.11"
           }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1025.0-23979",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
+          "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
         }
       }
     },
@@ -825,6 +830,11 @@
             "sha.js": "^2.4.11"
           }
         },
+        "@fluidframework/gitresources": {
+          "version": "0.1025.0-23979",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
+          "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -860,6 +870,11 @@
             "lodash": "^4.17.21",
             "sha.js": "^2.4.11"
           }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1025.0-23979",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
+          "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
         }
       }
     },

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.31.0-0",
-    "@fluidframework/gitresources": "^0.1025.0-0",
+    "@fluidframework/gitresources": "^0.1031.0-38246",
     "@fluidframework/server-services": "^0.1025.0-0",
     "@fluidframework/server-services-client": "^0.1025.0-0",
     "@fluidframework/server-services-core": "^0.1025.0-0",

--- a/server/gitrest/src/routes/git/blobs.ts
+++ b/server/gitrest/src/routes/git/blobs.ts
@@ -11,7 +11,7 @@ import * as utils from "../../utils";
 /**
  * Validates that the input encoding is valid
  */
-function validateEncoding(encoding: string): encoding is BufferEncoding {
+function validateEncoding(encoding: BufferEncoding): boolean {
     return encoding === "utf-8" || encoding === "base64";
 }
 

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -109,7 +109,7 @@ export class BlobTreeEntry {
      * @param contents - blob contents
      * @param encoding - encoding of contents; defaults to utf-8
      */
-    constructor(public readonly path: string, contents: string, encoding: string = "utf-8") {
+    constructor(public readonly path: string, contents: string, encoding: BufferEncoding = "utf-8") {
         this.value = { contents, encoding };
     }
 }

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
     "@fluidframework/protocol-base": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "axios": "^0.21.1",
     "debug": "^4.1.1",
     "jsrsasign": "^10.2.0",

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -257,7 +257,7 @@ export class GitManager implements IGitManager {
                         entryAsBlob.contents = this.translateSymlink(entryAsBlob.contents, depth);
                     }
 
-                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding as BufferEncoding);
+                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding);
                     entriesP.push(blobP);
                     break;
 

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -218,9 +218,9 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
-      "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+      "version": "0.1031.0-38246",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1031.0-38246.tgz",
+      "integrity": "sha512-DTSkWproPdJPZiRANAkPnkkO1FBQpLVytDvIJWEMl6Y0Ygqd6aX6C3Yy/TYPKurIeu15uCnwSyFtV+aHUh/TnQ=="
     },
     "@fluidframework/mocha-test-setup": {
       "version": "0.27.9",
@@ -237,21 +237,29 @@
         "@fluidframework/gitresources": "^0.1028.1",
         "@fluidframework/protocol-definitions": "^0.1024.0",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1024.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0.tgz",
-      "integrity": "sha512-ksbjiihicwMbbX3fPkVOxsl8QDDiuc20T7t4Y7vq7aMkzPh4FAwoomjjreDSf71N6zAoz30HEzPPl0OwvPi0xw==",
+      "version": "0.1025.0-38244",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38244.tgz",
+      "integrity": "sha512-YcPZfyZu09IGQ7V0GwAsxrnOTMQllxZ9zKj72rYpHHpnJMU1wqAlMr/4BaKDeNp7Mb+ncCLnqLaDd4h/0Oa69w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
-      },
-      "dependencies": {
-        "@fluidframework/common-definitions": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0.tgz",
-          "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
-        }
       }
     },
     "@fluidframework/server-lambdas": {
@@ -276,6 +284,21 @@
         "semver": "^6.3.0",
         "sha.js": "^2.4.11",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-local-server": {
@@ -293,6 +316,16 @@
         "@fluidframework/server-test-utils": "^0.1028.1",
         "jsrsasign": "^10.2.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-memory-orderer": {
@@ -317,6 +350,16 @@
         "moniker": "^0.1.2",
         "uuid": "^8.3.1",
         "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-services-client": {
@@ -335,6 +378,21 @@
         "jwt-decode": "^3.0.0",
         "sillyname": "0.1.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-services-core": {
@@ -350,6 +408,21 @@
         "@types/node": "^12.19.0",
         "debug": "^4.1.1",
         "nconf": "^0.11.0"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-services-shared": {
@@ -377,6 +450,19 @@
         "winston": "^3.3.3"
       },
       "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        },
         "@types/cors": {
           "version": "2.8.12",
           "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -510,6 +596,16 @@
         "sillyname": "0.1.0",
         "uuid": "^8.3.1",
         "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-test-utils": {
@@ -528,6 +624,21 @@
         "lodash": "^4.17.21",
         "string-hash": "^1.1.3",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@microsoft/api-extractor": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -29,9 +29,9 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/gitresources": "^0.1028.1",
+    "@fluidframework/gitresources": "^0.1031.0-38246",
     "@fluidframework/protocol-base": "^0.1028.1",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-lambdas": "^0.1028.1",
     "@fluidframework/server-local-server": "^0.1028.1",
     "@fluidframework/server-memory-orderer": "^0.1028.1",

--- a/server/tinylicious/src/routes/storage/git/blobs.ts
+++ b/server/tinylicious/src/routes/storage/git/blobs.ts
@@ -15,7 +15,7 @@ export async function createBlob(
     authorization: string,
     body: ICreateBlobParams,
 ): Promise<ICreateBlobResponse> {
-    const buffer = Buffer.from(body.content, body.encoding as BufferEncoding);
+    const buffer = Buffer.from(body.content, body.encoding);
 
     const sha = await git.writeObject({
         dir: utils.getGitDir(store, tenantId),


### PR DESCRIPTION
Use pre-release gitresources and protocol-definitions packages with types updated from string to BufferEncoding.