### PR TITLE
More documentation for fluid-framework exports

### DIFF
--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -18,7 +18,7 @@ import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
-// @public (undocumented)
+// @public
 export interface ContainerSchema {
     dynamicObjectTypes?: LoadableObjectClass<any>[];
     initialObjects: LoadableObjectClassRecord;
@@ -98,13 +98,13 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
 // @public
 export type LoadableObjectClass<T extends IFluidLoadable> = DataObjectClass<T> | SharedObjectClass<T>;
 
-// @public (undocumented)
+// @public
 export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>;
 
 // @public
 export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) => T;
 
-// @public (undocumented)
+// @public
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
 // @public (undocumented)

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -50,9 +50,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
 
 // @public
 export interface IConnection {
-    // (undocumented)
     id: string;
-    // (undocumented)
     mode: "write" | "read";
 }
 
@@ -75,9 +73,7 @@ export interface IFluidContainerEvents extends IEvent {
 
 // @public
 export interface IMember {
-    // (undocumented)
     connections: IConnection[];
-    // (undocumented)
     userId: string;
 }
 

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -39,13 +39,10 @@ import { ITree } from '@fluidframework/protocol-definitions';
 import { IVersion } from '@fluidframework/protocol-definitions';
 import { MessageType } from '@fluidframework/protocol-definitions';
 
-// @public (undocumented)
+// @public
 export enum AttachState {
-    // (undocumented)
     Attached = "Attached",
-    // (undocumented)
     Attaching = "Attaching",
-    // (undocumented)
     Detached = "Detached"
 }
 

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -28,10 +28,26 @@ import { IDeltaManager } from "./deltas";
 import { ICriticalContainerError, ContainerWarning } from "./error";
 import { ILoader, ILoaderOptions } from "./loader";
 
-// Represents the attachment state of the entity.
+/**
+ * The attachment state of some Fluid data (e.g. a container or data store), denoting whether it is uploaded to the
+ * service.  The transition from detached to attached state is a one-way transition.
+ */
 export enum AttachState {
+    /**
+     * In detached state, the data is only present on the local client's machine.  It has not yet been uploaded
+     * to the service.
+     */
     Detached = "Detached",
+
+    /**
+     * In attaching state, the data has started the upload to the service, but has not yet completed.
+     */
     Attaching = "Attaching",
+
+    /**
+     * In attached state, the data has completed upload to the service.  It can be accessed by other clients after
+     * reaching attached state.
+     */
     Attached = "Attached",
 }
 

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -103,11 +103,10 @@ export class RootDataObject extends DataObject<{}, RootDataObjectProps> {
 }
 
 const rootDataStoreId = "rootDOId";
+
 /**
- * The DOProviderContainerRuntimeFactory is the container code for our scenario.
- *
- * By including the createRequestHandler, we can create any droplet types we include in the registry on-demand.
- * These can then be retrieved via container.request("/dataObjectId").
+ * The DOProviderContainerRuntimeFactory is container code that provides a single RootDataObject.  This data object is
+ * dynamically customized (registry and initial objects) based on the schema provided to the container runtime factory.
  */
 export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
     private readonly rootDataObjectFactory; // type is DataObjectFactory

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -8,8 +8,15 @@ import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 
+/**
+ * A mapping of string identifiers to instantiated DataObjects or SharedObjects.
+ */
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
+/**
+ * A mapping of string identifiers to classes that will later be used to instantiate a corresponding DataObject
+ * or SharedObject in a LoadableObjectRecord.
+ */
 export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>;
 
 /**
@@ -36,6 +43,11 @@ export type SharedObjectClass<T extends IFluidLoadable>
  */
 export type LoadableObjectCtor<T extends IFluidLoadable> = new(...args: any[]) => T;
 
+/**
+ * The ContainerSchema declares the Fluid objects that will be available in the container.  It includes both the
+ * instances of objects that are initially available upon container creation, as well as the types of objects that may
+ * be dynamically created throughout the lifetime of the container.
+ */
 export interface ContainerSchema {
     /**
      * initialObjects defines loadable objects that will be created when the Container

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -144,22 +144,33 @@ export interface IServiceAudience<M extends IMember> extends IEventProvider<ISer
 }
 
 /**
- * Base interface for information for each connection made to the Fluid session, which will be
- * different even if it is by the same user, i.e. the connection's id will be uniquely generated for each time the user
- * connects This interface can be extended to provide additional information specific to each service.
+ * Base interface for information for each connection made to the Fluid session.  This interface can be extended
+ * to provide additional information specific to each service.
  */
 export interface IConnection {
+    /**
+     * A unique ID for the connection.  A single user may have multiple connections, each with a different ID.
+     */
     id: string;
+
+    /**
+     * Whether the connection is in read or read/write mode.
+     */
     mode: "write" | "read";
 }
 
 /**
- * Base interface to be implemented to fetch each service's member. The user ID is unique for each individual
- * user that is connecting to the session. However, one user may have multiple connections from different tabs,
- * devices, etc. and the information for each is provided within the connections array. This interface can be
- * extended by each service to provide additional service-specific user metadata.
+ * Base interface to be implemented to fetch each service's member.  This interface can be extended by each service
+ * to provide additional service-specific user metadata.
  */
 export interface IMember {
+    /**
+     * An ID for the user, unique among each individual user connecting to the session.
+     */
     userId: string;
+
+    /**
+     * The set of connections the user has made, e.g. from multiple tabs or devices.
+     */
     connections: IConnection[];
 }

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -21,25 +21,29 @@ export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>
 
 /**
  * A LoadableObjectClass is an class object of DataObject or SharedObject
+ * @typeParam T - The class of the DataObject or SharedObject
  */
 export type LoadableObjectClass<T extends IFluidLoadable> = DataObjectClass<T> | SharedObjectClass<T>;
 
 /**
  * A DataObjectClass is a class that has a factory that can create a DataObject and a
  * constructor that will return the type of the DataObject.
+ * @typeParam T - The class of the DataObject
  */
 export type DataObjectClass<T extends IFluidLoadable>
-    = { readonly factory: IFluidDataStoreFactory }  & LoadableObjectCtor<T>;
+    = { readonly factory: IFluidDataStoreFactory } & LoadableObjectCtor<T>;
 
 /**
  * A SharedObjectClass is a class that has a factory that can create a DDS (SharedObject) and a
  * constructor that will return the type of the DataObject.
+ * @typeParam T - The class of the SharedObject
  */
 export type SharedObjectClass<T extends IFluidLoadable>
     = { readonly getFactory: () => IChannelFactory } & LoadableObjectCtor<T>;
 
 /**
  * An object with a constructor that will return an `IFluidLoadable`.
+ * @typeParam T - The class of the loadable object
  */
 export type LoadableObjectCtor<T extends IFluidLoadable> = new(...args: any[]) => T;
 
@@ -128,6 +132,7 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
  * Base interface to be implemented to fetch each service's audience. The generic M allows consumers to further
  * extend the client object with service-specific details about the connecting client, such as device information,
  * environment, or a username.
+ * @typeParam M - A service-specific member type.
  */
 export interface IServiceAudience<M extends IMember> extends IEventProvider<IServiceAudienceEvents<M>> {
     /**


### PR DESCRIPTION
More/improved documentation for items exported by the `fluid-framework` package, particularly for container-definitions and fluid-static.