### PR TITLE
Stop checking parent summary in scribe

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -13,13 +13,14 @@ import { ISummaryHandle } from '@fluidframework/protocol-definitions';
 import { ISummaryTree as ISummaryTree_2 } from '@fluidframework/protocol-definitions';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { IUser } from '@fluidframework/protocol-definitions';
+import * as querystring from 'querystring';
 import * as resources from '@fluidframework/gitresources';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 import { SummaryObject } from '@fluidframework/protocol-definitions';
 
 // @public (undocumented)
 export class BasicRestWrapper extends RestWrapper {
-    constructor(baseurl?: string, defaultQueryString?: Record<string, unknown>, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: Record<string, unknown>, axios?: AxiosInstance, refreshDefaultQueryString?: () => Record<string, unknown>, refreshDefaultHeaders?: () => Record<string, unknown>, getCorrelationId?: () => string | undefined);
+    constructor(baseurl?: string, defaultQueryString?: querystring.ParsedUrlQueryInput, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: querystring.ParsedUrlQueryInput, axios?: AxiosInstance, refreshDefaultQueryString?: () => querystring.ParsedUrlQueryInput, refreshDefaultHeaders?: () => querystring.ParsedUrlQueryInput, getCorrelationId?: () => string | undefined);
     // (undocumented)
     protected request<T>(requestConfig: AxiosRequestConfig, statusCode: number, canRetry?: boolean): Promise<T>;
 }
@@ -75,7 +76,7 @@ export class GitManager implements IGitManager {
     // (undocumented)
     addTree(tree: resources.ITree): void;
     // (undocumented)
-    createBlob(content: string, encoding: string): Promise<resources.ICreateBlobResponse>;
+    createBlob(content: string, encoding: BufferEncoding): Promise<resources.ICreateBlobResponse>;
     // (undocumented)
     createCommit(commit: resources.ICreateCommitParams): Promise<resources.ICommit>;
     // (undocumented)
@@ -462,25 +463,25 @@ export enum RestLessFieldNames {
 
 // @public (undocumented)
 export abstract class RestWrapper {
-    constructor(baseurl?: string, defaultQueryString?: Record<string, unknown>, maxBodyLength?: number, maxContentLength?: number);
+    constructor(baseurl?: string, defaultQueryString?: querystring.ParsedUrlQueryInput, maxBodyLength?: number, maxContentLength?: number);
     // (undocumented)
     protected readonly baseurl?: string;
     // (undocumented)
-    protected defaultQueryString: Record<string, unknown>;
+    protected defaultQueryString: querystring.ParsedUrlQueryInput;
     // (undocumented)
-    delete<T>(url: string, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
+    delete<T>(url: string, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
     // (undocumented)
-    protected generateQueryString(queryStringValues: Record<string, unknown>): string;
+    protected generateQueryString(queryStringValues: querystring.ParsedUrlQueryInput): string;
     // (undocumented)
-    get<T>(url: string, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
+    get<T>(url: string, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
     // (undocumented)
     protected readonly maxBodyLength: number;
     // (undocumented)
     protected readonly maxContentLength: number;
     // (undocumented)
-    patch<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
+    patch<T>(url: string, requestBody: any, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
     // (undocumented)
-    post<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
+    post<T>(url: string, requestBody: any, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
     // (undocumented)
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 }
@@ -490,7 +491,7 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
     constructor(manager: IGitManager, blobsShaCache: Map<string, string>, getPreviousFullSnapshot: (parentHandle: string) => Promise<ISnapshotTreeEx | null | undefined>);
     // (undocumented)
     writeSummaryTree(summaryTree: ISummaryTree_2, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<string>;
-}
+    }
 
 // @public
 export function validateTokenClaims(token: string, documentId: string, tenantId: string): ITokenClaims;
@@ -509,7 +510,8 @@ export class WholeSummaryUploadManager implements ISummaryUploadManager {
     constructor(manager: IGitManager);
     // (undocumented)
     writeSummaryTree(summaryTree: ISummaryTree, parentHandle: string | undefined, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<string>;
-}
+    }
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -104,22 +104,6 @@ export class SummaryWriter implements ISummaryWriter {
             };
         }
 
-        // We also validate that the parent summary is valid
-        try {
-            // eslint-disable-next-line @typescript-eslint/promise-function-async
-            await Promise.all(content.parents.map((parentSummary) => this.summaryStorage.getCommit(parentSummary)));
-        } catch (e) {
-            return {
-                message: {
-                    errorMessage: "One or more parent summaries are invalid.",
-                    summaryProposal: {
-                        summarySequenceNumber: op.sequenceNumber,
-                    },
-                },
-                status: false,
-            };
-        }
-
         // We should not accept this summary if it is less than current protocol sequence number
         if (op.referenceSequenceNumber < checkpoint.protocolState.sequenceNumber) {
             return {

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -104,6 +104,24 @@ export class SummaryWriter implements ISummaryWriter {
             };
         }
 
+        // When using git, we also validate whether the parent summary is valid
+        if (!this.enableWholeSummaryUpload) {
+            try {
+                // eslint-disable-next-line @typescript-eslint/promise-function-async
+                await Promise.all(content.parents.map((parentSummary) => this.summaryStorage.getCommit(parentSummary)));
+            } catch (e) {
+                return {
+                    message: {
+                        errorMessage: "One or more parent summaries are invalid.",
+                        summaryProposal: {
+                            summarySequenceNumber: op.sequenceNumber,
+                        },
+                    },
+                    status: false,
+                };
+            }
+        }
+
         // We should not accept this summary if it is less than current protocol sequence number
         if (op.referenceSequenceNumber < checkpoint.protocolState.sequenceNumber) {
             return {


### PR DESCRIPTION
Scribe already checks the 'head' field and ensures the summary chain is valid. Given that 'parent' field also points to the same handle, checking is redundant and can be removed. 