### PR TITLE
Create share link while creating a file with snapshot summary

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -89,14 +89,7 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     hashedDocumentId: string;
     // (undocumented)
     odspResolvedUrl: true;
-    shareLinkInfo: {
-        createLink?: {
-            type?: ShareLinkTypes;
-            link?: string;
-            error?: any;
-        };
-        sharingLinkToRedeem?: string;
-    };
+    shareLinkInfo?: ShareLinkInfoType;
     // @deprecated (undocumented)
     sharingLinkToRedeem?: string;
     // (undocumented)
@@ -175,6 +168,16 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
     driveId?: string;
     itemId?: string;
     siteUrl: string;
+}
+
+// @public (undocumented)
+export interface ShareLinkInfoType {
+    createLink?: {
+        type?: ShareLinkTypes;
+        link?: string;
+        error?: any;
+    };
+    sharingLinkToRedeem?: string;
 }
 
 // @public

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -89,7 +89,15 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     hashedDocumentId: string;
     // (undocumented)
     odspResolvedUrl: true;
-    // (undocumented)
+    shareLinkInfo: {
+        createLink?: {
+            type?: string;
+            link?: string;
+            error?: any;
+        };
+        sharingLinkToRedeem?: string;
+    };
+    // @deprecated (undocumented)
     sharingLinkToRedeem?: string;
     // (undocumented)
     summarizer: boolean;

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -91,7 +91,7 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     odspResolvedUrl: true;
     shareLinkInfo: {
         createLink?: {
-            type?: string;
+            type?: ShareLinkTypes;
             link?: string;
             error?: any;
         };
@@ -175,6 +175,12 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
     driveId?: string;
     itemId?: string;
     siteUrl: string;
+}
+
+// @public
+export enum ShareLinkTypes {
+    // (undocumented)
+    csl = "csl"
 }
 
 // @public

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -18,6 +18,7 @@ export interface HostStoragePolicy {
     concurrentSnapshotFetch?: boolean;
     // (undocumented)
     enableRedeemFallback?: boolean;
+    enableShareLinkWithCreate?: boolean;
     fetchBinarySnapshotFormat?: boolean;
     isolateSocketCache?: boolean;
     // (undocumented)

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -170,7 +170,7 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
     siteUrl: string;
 }
 
-// @public (undocumented)
+// @public
 export interface ShareLinkInfoType {
     createLink?: {
         type?: ShareLinkTypes;

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -25,8 +25,8 @@ import { TokenFetcher } from '@fluidframework/odsp-driver-definitions';
 // @public
 export function checkUrl(documentUrl: URL): DriverPreCheckInfo | undefined;
 
-// @public (undocumented)
-export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string): IRequest;
+// @public
+export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createLinkType?: string): IRequest;
 
 // @public
 export function createOdspUrl(l: OdspFluidDataStoreLocator): string;

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -20,13 +20,14 @@ import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { OdspResourceTokenFetchOptions } from '@fluidframework/odsp-driver-definitions';
+import { ShareLinkTypes } from '@fluidframework/odsp-driver-definitions';
 import { TokenFetcher } from '@fluidframework/odsp-driver-definitions';
 
 // @public
 export function checkUrl(documentUrl: URL): DriverPreCheckInfo | undefined;
 
 // @public
-export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createLinkType?: string): IRequest;
+export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createLinkType?: ShareLinkTypes): IRequest;
 
 // @public
 export function createOdspUrl(l: OdspFluidDataStoreLocator): string;

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -104,4 +104,12 @@ export interface HostStoragePolicy {
      * If set to true, socket cache are per OdspDocumentService instead of shared across all instances
      */
     isolateSocketCache?: boolean;
+
+    /**
+     * Enable creation of sharing link along with the creation of file by setting this value to true.
+     * If the host provides a 'createLinkType' parameter in the request URL to the container.attach()
+     * method, we will request for send the request to ODSP with the same (if the flag is enabled) so
+     * that a sharing can be created with the creation of file to save number for round trips made to ODSP.
+     */
+     enableShareLinkWithCreate?: boolean
 }

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -20,6 +20,45 @@ export interface IOdspUrlParts {
 export enum ShareLinkTypes {
     csl = "csl",
 }
+/**
+ * Sharing link data created for the ODSP item.
+ * Contains information about either sharing link created while creating a new file or
+ * a redeemable share link created when loading an existing file
+ */
+export interface ShareLinkInfoType {
+
+    /**
+     * We create a new file in ODSP with the /snapshot api call. Applications then call separate apis to
+     * create a sharing link for that file. To reduce the number of api calls, ODSP now provides a feature
+     * where we can create a share link along with creating a file by passing a query parameter called
+     * createShareLink. createLink object below saves the data corresponding to this feature.
+     */
+    createLink?: {
+        /**
+         * Type of shareLink requested/created when creating the file for the first time.
+         * At the time of adding this comment (Sept/2021) ODSP only supports creation of CSL links
+         * when provided as a request parameter with the /snapshot api call.
+        */
+        type?: ShareLinkTypes,
+
+        /**
+         * Share link created when the file is created for the first time with /snapshot api call.
+         * This link does not require redemption.
+         */
+        link?: string,
+
+        /**
+         * Error message if creation of sharing link fails with /snapshot api call
+         */
+        error?: any
+    }
+
+    /**
+     * This is used to save the network calls while doing trees/latest call as if the client does not have
+     * permission then this link can be redeemed for the permissions in the same network call.
+     */
+    sharingLinkToRedeem?: string,
+}
 export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     type: "fluid";
     odspResolvedUrl: true;
@@ -63,38 +102,5 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
      * Contains information about either sharing link created while creating a new file or
      * a redeemable share link created when loading an existing file
      */
-    shareLinkInfo: {
-
-        /**
-         * We create a new file in ODSP with the /snapshot api call. Applications then call separate apis to
-         * create a sharing link for that file. To reduce the number of api calls, ODSP now provides a feature
-         * where we can create a share link along with creating a file by passing a query parameter called
-         * createShareLink. createLink object below saves the data corresponding to this feature.
-         */
-        createLink?: {
-            /**
-             * Type of shareLink requested/created when creating the file for the first time.
-             * At the time of adding this comment (Sept/2021) ODSP only supports creation of CSL links
-             * when provided as a request parameter with the /snapshot api call.
-            */
-            type?: ShareLinkTypes,
-
-            /**
-             * Share link created when the file is created for the first time with /snapshot api call.
-             * This link does not require redemption.
-             */
-            link?: string,
-
-            /**
-             * Error message if creation of sharing link fails with /snapshot api call
-             */
-            error?: any
-        }
-
-        /**
-         * This is used to save the network calls while doing trees/latest call as if the client does not have
-         * permission then this link can be redeemed for the permissions in the same network call.
-         */
-        sharingLinkToRedeem?: string,
-    }
+    shareLinkInfo?: ShareLinkInfoType
 }

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -11,6 +11,15 @@ export interface IOdspUrlParts {
     itemId: string;
 }
 
+/**
+ * Type of shareLink requested/created when creating the file for the first time.
+ * At the time of adding this comment (Sept/2021) ODSP only supports creation of CSL links
+ * when provided as a request parameter with the /snapshot api call.
+ * In future, we can add more types here.
+*/
+export enum ShareLinkTypes {
+    csl = "csl",
+}
 export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     type: "fluid";
     odspResolvedUrl: true;
@@ -65,10 +74,10 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
         createLink?: {
             /**
              * Type of shareLink requested/created when creating the file for the first time.
-             * At the time of adding this comment (09/21/2021) ODSP only supports creation of CSL links
+             * At the time of adding this comment (Sept/2021) ODSP only supports creation of CSL links
              * when provided as a request parameter with the /snapshot api call.
             */
-            type?: string,
+            type?: ShareLinkTypes,
 
             /**
              * Share link created when the file is created for the first time with /snapshot api call.

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -36,8 +36,9 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
 
     summarizer: boolean;
 
-    // This is used to save the network calls while doing trees/latest call as if the client does not have permission
-    // then this link can be redeemed for the permissions in the same network call.
+    /**
+     * @deprecated Use shareLinkInfo.sharingLinkToRedeem instead
+     */
     sharingLinkToRedeem?: string;
 
     codeHint?: {
@@ -47,4 +48,44 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     }
 
     fileVersion: string | undefined;
+
+    /**
+     * Sharing link data created for the ODSP item.
+     * Contains information about either sharing link created while creating a new file or
+     * a redeemable share link created when loading an existing file
+     */
+    shareLinkInfo: {
+
+        /**
+         * We create a new file in ODSP with the /snapshot api call. Applications then call separate apis to
+         * create a sharing link for that file. To reduce the number of api calls, ODSP now provides a feature
+         * where we can create a share link along with creating a file by passing a query parameter called
+         * createShareLink. createLink object below saves the data corresponding to this feature.
+         */
+        createLink?: {
+            /**
+             * Type of shareLink requested/created when creating the file for the first time.
+             * At the time of adding this comment (09/21/2021) ODSP only supports creation of CSL links
+             * when provided as a request parameter with the /snapshot api call.
+            */
+            type?: string,
+
+            /**
+             * Share link created when the file is created for the first time with /snapshot api call.
+             * This link does not require redemption.
+             */
+            link?: string,
+
+            /**
+             * Error message if creation of sharing link fails with /snapshot api call
+             */
+            error?: any
+        }
+
+        /**
+         * This is used to save the network calls while doing trees/latest call as if the client does not have
+         * permission then this link can be redeemed for the permissions in the same network call.
+         */
+        sharingLinkToRedeem?: string,
+    }
 }

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -197,6 +197,8 @@ export interface ICreateFileResponse {
     itemId: string;
     itemUrl: string;
     sequenceNumber: number;
+    sharingLink?: string;
+    sharingLinkErrorReason?: string
 }
 
 export interface IVersionedValueWithEpoch {

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -66,8 +66,8 @@ export async function createNewFluidFile(
 
     let itemId: string;
     let summaryHandle: string = "";
-    let sharingLink: string = "";
-    let sharingLinkErrorReason: string = "";
+    let sharingLink: string | undefined;
+    let sharingLinkErrorReason: string | undefined;
     if (createNewSummary === undefined) {
         itemId = await createNewEmptyFluidFile(getStorageToken, newFileInfo, logger, epochTracker);
     } else {
@@ -75,13 +75,16 @@ export async function createNewFluidFile(
             getStorageToken, newFileInfo, logger, createNewSummary, epochTracker);
         itemId = content.itemId;
         summaryHandle = content.id;
-        sharingLink = content.sharingLink || "";
-        sharingLinkErrorReason = content.sharingLinkErrorReason || "";
+        sharingLink = content.sharingLink;
+        sharingLinkErrorReason = content.sharingLinkErrorReason;
     }
 
     const odspUrl = createOdspUrl({... newFileInfo, itemId, dataStorePath: "/"});
     const resolver = new OdspDriverUrlResolver();
     const odspResolvedUrl = await resolver.resolve({ url: odspUrl });
+    fileEntry.docId = odspResolvedUrl.hashedDocumentId;
+    fileEntry.resolvedUrl = odspResolvedUrl;
+
     if(sharingLink || sharingLinkErrorReason) {
         odspResolvedUrl.shareLinkInfo = {
             createLink: {

--- a/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
+++ b/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
@@ -5,16 +5,25 @@
 import { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions";
 
+/**
+ * Create the request request object with url and headers for creating a new file on OneDrive Sharepoint
+ * @param siteUrl - Base url for OneDrive
+ * @param driveId - drive identifier
+ * @param filePath - path where file needs to be created
+ * @param fileName - name of the new file to be created
+ * @param createLinkType - type of sharing link you would like to create for this file
+ */
 export function createOdspCreateContainerRequest(
     siteUrl: string,
     driveId: string,
     filePath: string,
     fileName: string,
+    createLinkType?: string,
 ): IRequest {
     const createNewRequest: IRequest = {
         url: `${siteUrl}?driveId=${encodeURIComponent(
             driveId,
-        )}&path=${encodeURIComponent(filePath)}`,
+        )}&path=${encodeURIComponent(filePath)}${createLinkType ? `&createLinkType=${createLinkType}` : ""}`,
         headers: {
             [DriverHeader.createNew]: {
                 fileName,

--- a/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
+++ b/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
@@ -4,9 +4,10 @@
  */
 import { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions";
+import { ShareLinkTypes } from "@fluidframework/odsp-driver-definitions";
 
 /**
- * Create the request request object with url and headers for creating a new file on OneDrive Sharepoint
+ * Create the request object with url and headers for creating a new file on OneDrive Sharepoint
  * @param siteUrl - Base url for OneDrive
  * @param driveId - drive identifier
  * @param filePath - path where file needs to be created
@@ -18,7 +19,7 @@ export function createOdspCreateContainerRequest(
     driveId: string,
     filePath: string,
     fileName: string,
-    createLinkType?: string,
+    createLinkType?: ShareLinkTypes,
 ): IRequest {
     const createNewRequest: IRequest = {
         url: `${siteUrl}?driveId=${encodeURIComponent(

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -139,9 +139,10 @@ async function redeemSharingLink(
             eventName: "RedeemShareLink",
         },
         async () => getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
-                assert(!!odspResolvedUrl.sharingLinkToRedeem, 0x1ed /* "Share link should be present" */);
+                assert(!!odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem,
+                    0x1ed /* "Share link should be present" */);
                 const storageToken = await storageTokenFetcher(tokenFetchOptions, "RedeemShareLink");
-                const encodedShareUrl = getEncodedShareUrl(odspResolvedUrl.sharingLinkToRedeem);
+                const encodedShareUrl = getEncodedShareUrl(odspResolvedUrl.shareLinkInfo.sharingLinkToRedeem);
                 const redeemUrl = `${odspResolvedUrl.siteUrl}/_api/v2.0/shares/${encodedShareUrl}`;
                 const { url, headers } = getUrlAndHeadersWithAuth(redeemUrl, storageToken);
                 headers.prefer = "redeemSharingLink";
@@ -356,8 +357,8 @@ async function fetchSnapshotContentsCoreV1(
             }
         });
     }
-    if (odspResolvedUrl.sharingLinkToRedeem) {
-        formParams.push(`sl: ${odspResolvedUrl.sharingLinkToRedeem}`);
+    if (odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem) {
+        formParams.push(`sl: ${odspResolvedUrl.shareLinkInfo.sharingLinkToRedeem}`);
     }
     formParams.push(`_post: 1`);
     formParams.push(`\r\n--${formBoundary}--`);
@@ -403,9 +404,9 @@ async function fetchSnapshotContentsCoreV2(
     const fullUrl = `${odspResolvedUrl.siteUrl}/_api/v2.1/drives/${odspResolvedUrl.driveId}/items/${
         odspResolvedUrl.itemId}/opStream/attachments/latest/content`;
     const queryParams = { ...snapshotOptions };
-    if (odspResolvedUrl.sharingLinkToRedeem) {
+    if (odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem) {
         // eslint-disable-next-line @typescript-eslint/dot-notation
-        queryParams["sl"] = odspResolvedUrl.sharingLinkToRedeem;
+        queryParams["sl"] = odspResolvedUrl.shareLinkInfo.sharingLinkToRedeem;
     }
     const queryString = getQueryString(queryParams);
     const { url, headers } = getUrlAndHeadersWithAuth(`${fullUrl}${queryString}`, storageToken);

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -105,6 +105,13 @@ export async function fetchSnapshotWithRedeem(
             await redeemSharingLink(odspResolvedUrl, storageTokenFetcher, logger);
             const odspResolvedUrlWithoutShareLink: IOdspResolvedUrl =
                 { ...odspResolvedUrl, sharingLinkToRedeem: undefined };
+            if(odspResolvedUrlWithoutShareLink.shareLinkInfo) {
+                odspResolvedUrlWithoutShareLink.shareLinkInfo = {
+                    ...odspResolvedUrlWithoutShareLink.shareLinkInfo,
+                    sharingLinkToRedeem: undefined,
+                };
+            }
+
             return fetchLatestSnapshotCore(
                 odspResolvedUrlWithoutShareLink,
                 storageTokenFetcher,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -69,11 +69,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             siteUrl: odspResolvedUrl.siteUrl,
             filePath,
             filename: odspResolvedUrl.fileName,
+            createLinkType: odspResolvedUrl.shareLinkInfo?.createLink?.type,
         };
-
-        if(odspResolvedUrl.shareLinkInfo?.createLink?.type) {
-            newFileInfo.createLinkType = odspResolvedUrl.shareLinkInfo.createLink.type;
-        }
 
         const odspLogger = createOdspLogger(logger);
 

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -64,12 +64,16 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
         if (filePath === undefined || filePath === null) {
             throw new Error("File path should be provided!!");
         }
-        const newFileParams: INewFileInfo = {
+        const newFileInfo: INewFileInfo = {
             driveId: odspResolvedUrl.driveId,
             siteUrl: odspResolvedUrl.siteUrl,
             filePath,
             filename: odspResolvedUrl.fileName,
         };
+
+        if(odspResolvedUrl.shareLinkInfo?.createLink?.type) {
+            newFileInfo.createLinkType = odspResolvedUrl.shareLinkInfo.createLink.type;
+        }
 
         const odspLogger = createOdspLogger(logger);
 
@@ -94,7 +98,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
                         this.getStorageToken,
                         true /* throwOnNullToken */,
                     ),
-                    newFileParams,
+                    newFileInfo,
                     odspLogger,
                     createNewSummary,
                     cacheAndTracker.epochTracker,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -69,7 +69,10 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             siteUrl: odspResolvedUrl.siteUrl,
             filePath,
             filename: odspResolvedUrl.fileName,
-            createLinkType: odspResolvedUrl.shareLinkInfo?.createLink?.type,
+            // set createLinkType to undefined if enableShareLinkWithCreate is set to false,
+            // so that share link creation with create file can be enabled
+            createLinkType: this.hostPolicy.enableShareLinkWithCreate ?
+            odspResolvedUrl.shareLinkInfo?.createLink?.type : undefined,
         };
 
         const odspLogger = createOdspLogger(logger);

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { IFluidCodeDetails, IRequest, isFluidPackage } from "@fluidframework/core-interfaces";
 import { DriverHeader, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
-import { IOdspResolvedUrl, ShareLinkTypes } from "@fluidframework/odsp-driver-definitions";
+import { IOdspResolvedUrl, ShareLinkTypes, ShareLinkInfoType } from "@fluidframework/odsp-driver-definitions";
 import { createOdspCreateContainerRequest } from "./createOdspCreateContainerRequest";
 import { createOdspUrl } from "./createOdspUrl";
 import { getApiRoot } from "./odspUrlHelper";
@@ -71,6 +71,14 @@ export class OdspDriverUrlResolver implements IUrlResolver {
             if (!(fileName && siteURL && driveID && filePath !== null && filePath !== undefined)) {
                 throw new Error("Proper new file params should be there!!");
             }
+            let shareLinkInfo: ShareLinkInfoType | undefined;
+            if(createLinkType && createLinkType in ShareLinkTypes) {
+                shareLinkInfo = {
+                    createLink: {
+                        type: ShareLinkTypes[createLinkType],
+                    },
+                };
+            }
             return {
                 endpoints: {
                     snapshotStorageUrl: "",
@@ -93,11 +101,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                     containerPackageName: packageName ? packageName : undefined,
                 },
                 fileVersion: undefined,
-                shareLinkInfo: {
-                    createLink: {
-                        type: createLinkType ? ShareLinkTypes[createLinkType] : undefined,
-                    },
-                },
+                shareLinkInfo,
             };
         }
         const { siteUrl, driveId, itemId, path, containerPackageName, fileVersion } = decodeOdspUrl(request.url);
@@ -139,7 +143,6 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 containerPackageName,
             },
             fileVersion,
-            shareLinkInfo: {},
         };
     }
 

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -67,6 +67,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
             const driveID = searchParams.get("driveId");
             const filePath = searchParams.get("path");
             const packageName = searchParams.get("containerPackageName");
+            const createLinkType = searchParams.get("createLinkType");
             if (!(fileName && siteURL && driveID && filePath !== null && filePath !== undefined)) {
                 throw new Error("Proper new file params should be there!!");
             }
@@ -92,6 +93,11 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                     containerPackageName: packageName ? packageName : undefined,
                 },
                 fileVersion: undefined,
+                shareLinkInfo: {
+                    createLink: {
+                        type: createLinkType || "",
+                    },
+                },
             };
         }
         const { siteUrl, driveId, itemId, path, containerPackageName, fileVersion } = decodeOdspUrl(request.url);
@@ -133,6 +139,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 containerPackageName,
             },
             fileVersion,
+            shareLinkInfo: {},
         };
     }
 

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { IFluidCodeDetails, IRequest, isFluidPackage } from "@fluidframework/core-interfaces";
 import { DriverHeader, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
-import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
+import { IOdspResolvedUrl, ShareLinkTypes } from "@fluidframework/odsp-driver-definitions";
 import { createOdspCreateContainerRequest } from "./createOdspCreateContainerRequest";
 import { createOdspUrl } from "./createOdspUrl";
 import { getApiRoot } from "./odspUrlHelper";
@@ -95,7 +95,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 fileVersion: undefined,
                 shareLinkInfo: {
                     createLink: {
-                        type: createLinkType || "",
+                        type: createLinkType ? ShareLinkTypes[createLinkType] : undefined,
                     },
                 },
             };

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -146,6 +146,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
             // when redeeming the share link during the redeem fallback for trees latest call becomes greater than
             // the eligible length.
             odspResolvedUrl.sharingLinkToRedeem = this.removeNavParam(request.url);
+            odspResolvedUrl.shareLinkInfo.sharingLinkToRedeem = request.url;
         }
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't have it already as a performance optimization.

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -146,7 +146,8 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
             // when redeeming the share link during the redeem fallback for trees latest call becomes greater than
             // the eligible length.
             odspResolvedUrl.sharingLinkToRedeem = this.removeNavParam(request.url);
-            odspResolvedUrl.shareLinkInfo.sharingLinkToRedeem = request.url;
+            odspResolvedUrl.shareLinkInfo = Object.assign(odspResolvedUrl.shareLinkInfo || {},
+                {sharingLinkToRedeem: odspResolvedUrl.sharingLinkToRedeem});
         }
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't have it already as a performance optimization.

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -25,6 +25,7 @@ import {
     tokenFromResponse,
     isTokenFromCache,
     OdspResourceTokenFetchOptions,
+    ShareLinkTypes,
     TokenFetcher,
     ICacheEntry,
     snapshotKey,
@@ -213,9 +214,9 @@ export interface INewFileInfo {
     /**
      * application can request creation of a share link along with the creation of a new file
      * by passing in an optional param to specify the kind of sharing link
-     * (at the time of adding this comment 9/21/2021), odsp only supports csl
+     * (at the time of adding this comment Sept/2021), odsp only supports csl
      */
-    createLinkType?: string;
+    createLinkType?: ShareLinkTypes;
 }
 
 export function getOdspResolvedUrl(resolvedUrl: IResolvedUrl): IOdspResolvedUrl {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -210,6 +210,12 @@ export interface INewFileInfo {
     driveId: string;
     filename: string;
     filePath: string;
+    /**
+     * application can request creation of a share link along with the creation of a new file
+     * by passing in an optional param to specify the kind of sharing link
+     * (at the time of adding this comment 9/21/2021), odsp only supports csl
+     */
+    createLinkType?: string;
 }
 
 export function getOdspResolvedUrl(resolvedUrl: IResolvedUrl): IOdspResolvedUrl {

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -70,6 +70,7 @@ describe("Odsp Driver Resolver", () => {
             fileVersion: undefined,
             summarizer: false,
             codeHint: { containerPackageName: undefined },
+            shareLinkInfo: {},
         };
         assert.deepStrictEqual(resolvedUrl, expected);
         const response = await resolver.getAbsoluteUrl(resolvedUrl, "/datastore");

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -97,13 +97,9 @@ describe("Odsp Driver Resolver", () => {
         const createLinkType = "csl";
         newRequest.url += `&createLinkType=${createLinkType}`;
         const resolvedUrl = await resolver.resolve(request);
-
-        assert.strictEqual(
-            resolvedUrl.shareLinkInfo, {
-                createLink: {
-                    type: createLinkType,
-                },
-            });
+        assert(resolvedUrl.shareLinkInfo !== undefined);
+        assert(resolvedUrl.shareLinkInfo.createLink !== undefined);
+        assert.strictEqual(resolvedUrl.shareLinkInfo.createLink.type, createLinkType);
     });
 
     it("Should resolve url with a string in the codeDetails package", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -70,7 +70,7 @@ describe("Odsp Driver Resolver", () => {
             fileVersion: undefined,
             summarizer: false,
             codeHint: { containerPackageName: undefined },
-            shareLinkInfo: {},
+            shareLinkInfo: undefined,
         };
         assert.deepStrictEqual(resolvedUrl, expected);
         const response = await resolver.getAbsoluteUrl(resolvedUrl, "/datastore");
@@ -90,6 +90,20 @@ describe("Odsp Driver Resolver", () => {
 
         assert.strictEqual(
             resolvedUrl.codeHint?.containerPackageName, packageName , "containerPackageName should match");
+    });
+
+    it("Should add shareLinkInfo with link type if request contains createLinkType", async () => {
+        const newRequest = request;
+        const createLinkType = "csl";
+        newRequest.url += `&createLinkType=${createLinkType}`;
+        const resolvedUrl = await resolver.resolve(request);
+
+        assert.strictEqual(
+            resolvedUrl.shareLinkInfo, {
+                createLink: {
+                    type: createLinkType,
+                },
+            });
     });
 
     it("Should resolve url with a string in the codeDetails package", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -183,6 +183,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
                 { url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
         assert(resolvedUrl.sharingLinkToRedeem !== undefined, "Sharing link should be set in resolved url");
+        assert.strictEqual(resolvedUrl.shareLinkInfo?.sharingLinkToRedeem, url.toString(), "Sharing link should be set in resolved url");
     });
 
     it("Encode and decode nav param", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -183,7 +183,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
                 { url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
         assert(resolvedUrl.sharingLinkToRedeem !== undefined, "Sharing link should be set in resolved url");
-        assert.strictEqual(resolvedUrl.shareLinkInfo?.sharingLinkToRedeem, url.toString(), "Sharing link should be set in resolved url");
+        assert(resolvedUrl.shareLinkInfo?.sharingLinkToRedeem !== undefined, "Sharing link should be set in resolved url");
     });
 
     it("Encode and decode nav param", async () => {

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -63,6 +63,7 @@ export const generateOdspHostStoragePolicy = (seed: number) => {
         cacheCreateNewSummary: booleanCases,
         fetchBinarySnapshotFormat: [false],
         isolateSocketCache: [true],
+        enableShareLinkWithCreate: [false],
     };
     return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };


### PR DESCRIPTION
ODSP /snapshot api now provides a new feature where we can create a file sharing link along with the creation of a new fluid file in the hope to improve performance by reducing the number of roundtrips to the server. Parameter can be provided to the api like so: `&createLinkType=csl`. When this parameter is provided, ODSP will return a sharing link or an error message in the response of the /snapshot api call. If the creation of sharing link fails, the API does not fail and just returns an error message. Note: at the moment, it only supports csl (oraganization) share links, but the code in this PR is written in a generic way to support other types as well in the future.

In order to let applications to request creation of a share link with file creation, this PR proposes following updates:

- `createOdspCreateContainerRequest` is updated to accept an additional optional parameter called `createLinkType`. Added supporting documentation in the comments. When `createLinkType` is not provided, attach flow proceeds as is. When this value is provided, we add a new request parameter to the /snapshot api call to let ODSP know that a sharing link needs to be created as well along with the creation of the file.
- Added a new property bag `shareLinkInfo` in `IOdspResolvedUrl` definition, which would save all the sharing link related information. 
- Moved the `sharingLinkToRedeem` within `shareLinkInfo` property bag in IOdspResolvedUrl and also updated corresponding usage. For now we are preserving `sharingLinkToRedeem` in IOdspResolvedUrl  as before as well, but it will be deprecated in future versions.
- `createNewFluidFile` method is updated to save the new share link or error message in `odspResolvedUrl.shareLinkInfo`.
- After container.attach() is complete, applications can request share link information by requesting container.resolvedUrl() and read the shareLinkInfo within this object.
- Added a new feature flag called `enableShareLinkWithCreate` so that this feature can be enables/disabled if needed. This flag is temporary until we are sure everything works smoothly.