### PR TITLE
Remove deprecated dirty document API surface from ContainerRuntime

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -10,6 +10,12 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
+## 0.49 Breaking changes
+- [Deprecated dirty document events and property removed from ContainerRuntime](#deprecated-dirty-document-events-and-property-removed-from-containerruntime)
+
+### Deprecated dirty document events and property removed from ContainerRuntime
+The `isDocumentDirty()` method, `"dirtyDocument"` and `"savedDocument"` events that were deprecated in 0.35 have now been removed.  For more information on replacements, see [DirtyDocument events and property](#DirtyDocument-events-and-property).
+
 ## 0.48 Breaking changes
 - [client-api package removed](#client-api-package-removed)
 - [SignalManager removed from fluid-framework export](#signalmanager-removed-from-fluid-framework-export)

--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -50,8 +50,6 @@ export interface IContainerRuntime extends IProvideContainerRuntime, IProvideFlu
     // (undocumented)
     readonly id: string;
     readonly isDirty: boolean;
-    // @deprecated (undocumented)
-    isDocumentDirty(): boolean;
     // (undocumented)
     readonly options: ILoaderOptions;
     raiseContainerWarning(warning: ContainerWarning): void;
@@ -70,7 +68,7 @@ export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     // (undocumented)
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void): any;
     // (undocumented)
-    (event: "dirtyDocument" | "dirty" | "disconnected" | "dispose" | "savedDocument" | "saved" | "attached", listener: () => void): any;
+    (event: "dirty" | "disconnected" | "dispose" | "saved" | "attached", listener: () => void): any;
     // (undocumented)
     (event: "connected", listener: (clientId: string) => void): any;
     // (undocumented)

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -137,8 +137,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     get IFluidTokenProvider(): IFluidTokenProvider | undefined;
     get isDirty(): boolean;
-    // @deprecated (undocumented)
-    isDocumentDirty(): boolean;
     static load(context: IContainerContext, registryEntries: NamedFluidDataStoreRegistryEntries, requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>, runtimeOptions?: IContainerRuntimeOptions, containerScope?: IFluidObject, existing?: boolean): Promise<ContainerRuntime>;
     // (undocumented)
     readonly logger: ITelemetryLogger;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -47,7 +47,7 @@ export interface IProvideContainerRuntime {
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
     (
-        event: "dirtyDocument" | "dirty" | "disconnected" | "dispose" | "savedDocument" | "saved" | "attached",
+        event: "dirty" | "disconnected" | "dispose" | "saved" | "attached",
         listener: () => void);
     (event: "connected", listener: (clientId: string) => void);
     (event: "localHelp", listener: (message: IHelpMessage) => void);
@@ -108,11 +108,6 @@ export interface IContainerRuntime extends
      * Used to raise an unrecoverable error on the runtime.
      */
     raiseContainerWarning(warning: ContainerWarning): void;
-
-    /**
-     * @deprecated - Please use isDirty()
-     */
-    isDocumentDirty(): boolean;
 
     /**
      * Returns true of document is dirty, i.e. there are some pending local changes that

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1573,15 +1573,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     };
 
     /**
-     * @deprecated - // back-compat: marked deprecated in 0.35
-     * Returns true of document is dirty, i.e. there are some pending local changes that
-     * either were not sent out to delta stream or were not yet acknowledged.
-     */
-    public isDocumentDirty(): boolean {
-        return this.dirtyContainer;
-    }
-
-    /**
      * Returns true of container is dirty, i.e. there are some pending local changes that
      * either were not sent out to delta stream or were not yet acknowledged.
      */
@@ -1999,9 +1990,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         this.dirtyContainer = dirty;
         if (this.emitDirtyDocumentEvent) {
-            // back-compat: dirtyDocument & savedDocument deprecated in 0.35.
-            this.emit(dirty ? "dirtyDocument" : "savedDocument");
-
             this.emit(dirty ? "dirty" : "saved");
             // back-compat: Loader API added in 0.35 only
             if (this.context.updateDirtyContainerState !== undefined) {

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -329,11 +329,7 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
     describe("Document Dirty State", () => {
         // Verifies that the document dirty state for the given document is as expected.
         function verifyDocumentDirtyState(dataStore: ITestFluidObject, expectedState: boolean) {
-            let dirty = (dataStore.context.containerRuntime as IContainerRuntime).isDirty;
-            // back-compat: 0.35: remove in future versions
-            if (dirty === undefined) {
-                dirty = (dataStore.context.containerRuntime as IContainerRuntime).isDocumentDirty();
-            }
+            const dirty = (dataStore.context.containerRuntime as IContainerRuntime).isDirty;
             assert.equal(dirty, expectedState, "The document dirty state is not as expected");
         }
 


### PR DESCRIPTION
These have been deprecated for ~7 months, seems reasonable to remove now.