### PR TITLE
Consume BufferEncoding type change (Part 1)

### DIFF
--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -329,9 +329,9 @@
       }
     },
     "@fluidframework/build-common": {
-      "version": "0.23.0-36574",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-      "integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+      "integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w==",
       "dev": true
     },
     "@fluidframework/common-definitions": {
@@ -602,9 +602,9 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1025.0-23979",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
-      "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
+      "version": "0.1031.0-38246",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1031.0-38246.tgz",
+      "integrity": "sha512-DTSkWproPdJPZiRANAkPnkkO1FBQpLVytDvIJWEMl6Y0Ygqd6aX6C3Yy/TYPKurIeu15uCnwSyFtV+aHUh/TnQ=="
     },
     "@fluidframework/protocol-base": {
       "version": "0.1025.0-23979",
@@ -631,6 +631,11 @@
             "lodash": "^4.17.21",
             "sha.js": "^2.4.11"
           }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1025.0-23979",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
+          "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
         }
       }
     },
@@ -825,6 +830,11 @@
             "sha.js": "^2.4.11"
           }
         },
+        "@fluidframework/gitresources": {
+          "version": "0.1025.0-23979",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
+          "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -860,6 +870,11 @@
             "lodash": "^4.17.21",
             "sha.js": "^2.4.11"
           }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1025.0-23979",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1025.0-23979.tgz",
+          "integrity": "sha512-N3VuxD5L/r/7ggSj6+9Sa1Md7NofbqRBv8Th2LcAeqD2Hll4OmUgCgUDgZg/rnBYPLmssr5u0BqdXr1I4kZuVg=="
         }
       }
     },

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.31.0-0",
-    "@fluidframework/gitresources": "^0.1025.0-0",
+    "@fluidframework/gitresources": "^0.1031.0-38246",
     "@fluidframework/server-services": "^0.1025.0-0",
     "@fluidframework/server-services-client": "^0.1025.0-0",
     "@fluidframework/server-services-core": "^0.1025.0-0",

--- a/server/gitrest/src/routes/git/blobs.ts
+++ b/server/gitrest/src/routes/git/blobs.ts
@@ -11,7 +11,7 @@ import * as utils from "../../utils";
 /**
  * Validates that the input encoding is valid
  */
-function validateEncoding(encoding: string): encoding is BufferEncoding {
+function validateEncoding(encoding: BufferEncoding): boolean {
     return encoding === "utf-8" || encoding === "base64";
 }
 

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -42,7 +42,7 @@ export class AttachmentTreeEntry {
 
 // @public
 export class BlobTreeEntry {
-    constructor(path: string, contents: string, encoding?: string);
+    constructor(path: string, contents: string, encoding?: BufferEncoding);
     // (undocumented)
     readonly mode = FileMode.File;
     // (undocumented)

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -467,9 +467,9 @@
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1024.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0.tgz",
-			"integrity": "sha512-ksbjiihicwMbbX3fPkVOxsl8QDDiuc20T7t4Y7vq7aMkzPh4FAwoomjjreDSf71N6zAoz30HEzPPl0OwvPi0xw==",
+			"version": "0.1025.0-38244",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38244.tgz",
+			"integrity": "sha512-YcPZfyZu09IGQ7V0GwAsxrnOTMQllxZ9zKj72rYpHHpnJMU1wqAlMr/4BaKDeNp7Mb+ncCLnqLaDd4h/0Oa69w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0"
 			}

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-services-core": "^0.1031.0",
     "@types/node": "^12.19.0"
   },

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
     "@fluidframework/protocol-base": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-lambdas-driver": "^0.1031.0",
     "@fluidframework/server-services-client": "^0.1031.0",
     "@fluidframework/server-services-core": "^0.1031.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-lambdas": "^0.1031.0",
     "@fluidframework/server-memory-orderer": "^0.1031.0",
     "@fluidframework/server-services-client": "^0.1031.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-base": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-lambdas": "^0.1031.0",
     "@fluidframework/server-services-client": "^0.1031.0",
     "@fluidframework/server-services-core": "^0.1031.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -109,7 +109,7 @@ export class BlobTreeEntry {
      * @param contents - blob contents
      * @param encoding - encoding of contents; defaults to utf-8
      */
-    constructor(public readonly path: string, contents: string, encoding: string = "utf-8") {
+    constructor(public readonly path: string, contents: string, encoding: BufferEncoding = "utf-8") {
         this.value = { contents, encoding };
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-kafka-orderer": "^0.1031.0",
     "@fluidframework/server-lambdas": "^0.1031.0",
     "@fluidframework/server-lambdas-driver": "^0.1031.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-kafka-orderer": "^0.1031.0",
     "@fluidframework/server-lambdas": "^0.1031.0",
     "@fluidframework/server-lambdas-driver": "^0.1031.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
     "@fluidframework/protocol-base": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "axios": "^0.21.1",
     "debug": "^4.1.1",
     "jsrsasign": "^10.2.0",

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -257,7 +257,7 @@ export class GitManager implements IGitManager {
                         entryAsBlob.contents = this.translateSymlink(entryAsBlob.contents, depth);
                     }
 
-                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding as BufferEncoding);
+                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding);
                     entriesP.push(blobP);
                     break;
 

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-services-client": "^0.1031.0",
     "@types/nconf": "^0.10.0",
     "@types/node": "^12.19.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
     "@fluidframework/protocol-base": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-services-client": "^0.1031.0",
     "@fluidframework/server-services-core": "^0.1031.0",
     "@socket.io/redis-adapter": "^7.0.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-services-client": "^0.1031.0",
     "@fluidframework/server-services-core": "^0.1031.0",
     "@fluidframework/server-services-telemetry": "^0.1031.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-services-client": "^0.1031.0",
     "@fluidframework/server-services-core": "^0.1031.0",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1031.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1031.0",
     "@fluidframework/protocol-base": "^0.1031.0",
-    "@fluidframework/protocol-definitions": "^0.1024.0",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
     "@fluidframework/server-services-client": "^0.1031.0",
     "@fluidframework/server-services-core": "^0.1031.0",
     "@fluidframework/server-services-telemetry": "^0.1031.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -218,9 +218,9 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
-      "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+      "version": "0.1031.0-38246",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1031.0-38246.tgz",
+      "integrity": "sha512-DTSkWproPdJPZiRANAkPnkkO1FBQpLVytDvIJWEMl6Y0Ygqd6aX6C3Yy/TYPKurIeu15uCnwSyFtV+aHUh/TnQ=="
     },
     "@fluidframework/mocha-test-setup": {
       "version": "0.27.9",
@@ -237,6 +237,13 @@
         "@fluidframework/gitresources": "^0.1028.1",
         "@fluidframework/protocol-definitions": "^0.1024.0",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        }
       }
     },
     "@fluidframework/protocol-definitions": {
@@ -276,6 +283,13 @@
         "semver": "^6.3.0",
         "sha.js": "^2.4.11",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        }
       }
     },
     "@fluidframework/server-local-server": {
@@ -335,6 +349,13 @@
         "jwt-decode": "^3.0.0",
         "sillyname": "0.1.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        }
       }
     },
     "@fluidframework/server-services-core": {
@@ -350,6 +371,13 @@
         "@types/node": "^12.19.0",
         "debug": "^4.1.1",
         "nconf": "^0.11.0"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        }
       }
     },
     "@fluidframework/server-services-shared": {
@@ -377,6 +405,11 @@
         "winston": "^3.3.3"
       },
       "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        },
         "@types/cors": {
           "version": "2.8.12",
           "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -528,6 +561,13 @@
         "lodash": "^4.17.21",
         "string-hash": "^1.1.3",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/gitresources": {
+          "version": "0.1028.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+          "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+        }
       }
     },
     "@microsoft/api-extractor": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/gitresources": "^0.1028.1",
+    "@fluidframework/gitresources": "^0.1031.0-38246",
     "@fluidframework/protocol-base": "^0.1028.1",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1028.1",

--- a/server/tinylicious/src/routes/storage/git/blobs.ts
+++ b/server/tinylicious/src/routes/storage/git/blobs.ts
@@ -15,7 +15,7 @@ export async function createBlob(
     authorization: string,
     body: ICreateBlobParams,
 ): Promise<ICreateBlobResponse> {
-    const buffer = Buffer.from(body.content, body.encoding as BufferEncoding);
+    const buffer = Buffer.from(body.content, body.encoding);
 
     const sha = await git.writeObject({
         dir: utils.getGitDir(store, tenantId),


### PR DESCRIPTION
Use updated pre-release gitresources and protocol-definitions that use BufferEncoding type instead of string (#7522). This updates gitrest, routerlicious, and tinylicious. A further change to runtime-utils depends on this change and will be updated in a subsequent pull request.