### PR TITLE
[main -> 0.48] Move test_runtime_utils to dependencies

### DIFF
--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -30,10 +30,12 @@
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"
   },
+  "dependencies": {
+    "@fluidframework/test-runtime-utils": "^0.48.1"
+  },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@fluidframework/test-runtime-utils": "^0.48.1",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",


### PR DESCRIPTION
Port of https://github.com/microsoft/FluidFramework/pull/7566