### PR TITLE
Fix local mode for AzureClient

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -88,6 +88,9 @@ export { ITokenResponse }
 
 export { IUser }
 
+// @public
+export const LOCAL_MODE_TENANT_ID = "local";
+
 export { ScopeType }
 
 

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -7,6 +7,7 @@ import {
     AzureClient,
     AzureConnectionConfig,
     AzureContainerServices,
+    LOCAL_MODE_TENANT_ID,
 } from "@fluidframework/azure-client";
 import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
 import {
@@ -47,7 +48,7 @@ const connectionConfig: AzureConnectionConfig = useAzure ? {
     orderer: "",
     storage: "",
 } : {
-    tenantId: "local",
+    tenantId: LOCAL_MODE_TENANT_ID,
     tokenProvider: new InsecureTokenProvider("fooBar", user),
     orderer: "http://localhost:7070",
     storage: "http://localhost:7070",

--- a/packages/framework/azure-client/src/AzureClient.ts
+++ b/packages/framework/azure-client/src/AzureClient.ts
@@ -26,6 +26,11 @@ import { AzureAudience } from "./AzureAudience";
 import { AzureUrlResolver, createAzureCreateNewRequest } from "./AzureUrlResolver";
 
 /**
+ * Strongly typed id for connecting to a local Azure Fluid Relay service
+ */
+export const LOCAL_MODE_TENANT_ID = "local";
+
+/**
  * AzureClient provides the ability to have a Fluid object backed by the Azure Relay Service or,
  * when running with local tenantId, have it be backed by a Tinylicious local service instance
  */
@@ -43,9 +48,12 @@ export class AzureClient {
             this.props.connection.orderer,
             this.props.connection.storage,
         );
+        // The local service implementation differs from the Azure Fluid Relay service in blob
+        // storage format. Azure Fluid Relay supports whole summary upload. Local currently does not.
+        const enableWholeSummaryUpload = this.props.connection.tenantId !== LOCAL_MODE_TENANT_ID;
         this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
             this.props.connection.tokenProvider,
-            { enableWholeSummaryUpload: true },
+            { enableWholeSummaryUpload },
         );
     }
 


### PR DESCRIPTION
AzureClient is currently broken when talking to a local server because our tinylicious service does not support whole summary uploads.

This change ensures we create the correct driver depending on what service we are talking to.