### PR TITLE
implement term change 'Fluid object' => 'shared object'

### DIFF
--- a/docs/content/docs/concepts/architecture/index.md
+++ b/docs/content/docs/concepts/architecture/index.md
@@ -22,7 +22,7 @@ If you want to load a Fluid container on your app or website, you'll load the co
 want to create a new collaborative experience using the Fluid Framework, you'll create a Fluid container.
 
 A Fluid container includes state and app logic. It's a serverless app model with data persistence. It has at least one
-*Fluid object*, which encapsulates app logic. Fluid objects can have state, which is managed by *distributed data
+*shared object*, which encapsulates app logic. Shared objects can have state, which is managed by *distributed data
 structures* (DDSes).
 
 DDSes are used to distribute state to clients. Instead of centralizing merge logic in the
@@ -64,8 +64,8 @@ serverless application model with persistent data, the container is the serverle
 
 The Fluid container is the result of the principle "Move Logic to the Client." The container includes the merge logic
 used to replicate state across connected clients, but the container also includes app logic. The merge logic is
-incapsulated in our lowest level objects, **distributed data structures (DDS)**. App logic operating over this data is
-stored in **Fluid objects**.
+encapsulated in our lowest level objects, **distributed data structures (DDS)**. App logic operating over this data is
+stored in **shared objects**.
 
 ### Fluid service
 
@@ -81,6 +81,6 @@ the service with the assigned order of the operation.">
 From the client perspective, this op flow is accessed through a **DeltaConnection** object.
 
 The service also stores old operations, accessible to clients through a **DeltaStorageService** object, and stores
-summaries of the Fluid objects. It's worth discussing summaries at length, but for now, consider that merging
+summaries of the shared objects. It's worth discussing summaries at length, but for now, consider that merging
 1,000,000 changes could take some time, so we summarize the state of the objects and store it on the service for faster
 loading.

--- a/docs/content/docs/concepts/tob.md
+++ b/docs/content/docs/concepts/tob.md
@@ -71,9 +71,9 @@ storage and broadcast an event to the connected clients acknowledging that the s
 the clients will ignore both the summary op itself and the acknowledgement, since connected clients already receive all
 ops and are thus already consistent.
 
-Summary ops summarize the state of distributed data structures, so Fluid objects (which are a collection of distributed
+Summary ops summarize the state of distributed data structures, so Data Objects (which are a collection of distributed
 data structures) don't need to do anything to participate in summarization; it happens automatically, and all
-Fluid objects' data structures will be summarized.
+Data Objects' data structures will be summarized.
 
 <!-- AUTO-GENERATED-CONTENT:START (INCLUDE:path=docs/_includes/links.md) -->
 <!-- Links -->

--- a/docs/content/docs/deep/containers-runtime.md
+++ b/docs/content/docs/deep/containers-runtime.md
@@ -24,19 +24,19 @@ runtime through the runtime methods that expose useful properties of the instant
 
 ## What is a Fluid container?
 
-A Fluid container is a code-plus-data package. A container includes at least one Fluid object for app logic, but
-often multiple Fluid objects are composed together to create the overall experience.
+A Fluid container is a code-plus-data package. A container includes at least one shared object for app logic, but
+often multiple shared objects are composed together to create the overall experience.
 
 From the Fluid service perspective, the container is the atomic unit of Fluid. The service does not know about anything
 inside of a Fluid container.
 
-That being said, app logic is handled by Fluid objects and state is handled by the distributed data structures within
-the Fluid objects.
+That being said, app logic is handled by Data Objects and state is handled by the distributed data structures within
+the Data Objects.
 
 ## What does the Fluid container do?
 
 The Fluid container interacts with the [processes and distributes operations](./hosts), manages the [lifecycle of Fluid
-objects](./dataobject-aqueduct), and provides a request API for accessing Fluid objects.
+objects](./dataobject-aqueduct), and provides a request API for accessing shared objects.
 
 ### Process and distribute operations
 
@@ -47,18 +47,18 @@ The Fluid container includes code to process the operations from the DeltaConnec
 using the DeltaStorageService, and create or fetch summaries from the DocumentStorageService. Each of these are
 important, but the most critical is the op processing.
 
-The Fluid container is responsible for passing operations to the relevant distributed data structures and Fluid objects.
+The Fluid container is responsible for passing operations to the relevant distributed data structures and Data Objects.
 
-### Manage Fluid object lifecycle
+### Manage shared object lifecycle
 
 The container provides a `createDataStore` method to create new data stores. The container is responsible for
-instantiating the Fluid objects and creating the operations that let other connected clients know about the new Fluid
+instantiating the shared objects and creating the operations that let other connected clients know about the new Fluid
 object.
 
 ### Using a Fluid container: the Request API
 
 The Fluid container is interacted with through the request paradigm. While aqueduct creates a default request handler
-that returns the default Fluid objects, the request paradigm is a powerful pattern that lets developers create custom
+that returns the default Data Objects, the request paradigm is a powerful pattern that lets developers create custom
 logic.
 
 To retrieve the default data store, you can perform a request on the container. Similar to the [loaders API](./hosts.md)

--- a/docs/content/docs/deep/feature-detection-iprovide.md
+++ b/docs/content/docs/deep/feature-detection-iprovide.md
@@ -6,7 +6,7 @@ aliases:
   - "/docs/advanced/feature-detection-iprovide/"
 ---
 
-In an earlier section we introduced the DataObject, a convenient way to combine distributed data structures and our own
+In an earlier section we introduced the Data Object, a convenient way to combine distributed data structures and our own
 code (business logic) into a modular, reusable piece. This in turn enables us to modularize pieces of our application --
 data included.
 
@@ -14,14 +14,14 @@ Fluid can be a very dynamic system. There are scenarios in which your code will 
 and only if*, the object has certain capabilities; that is, it implements certain interfaces. So, your code needs a way
 of detecting whether the object implements specific interfaces. To make this easier, Fluid has a feature detection
 mechanism, which centers around a special interface called `IFluidObject`. Feature detection is a technique by which one
-Fluid object can dynamically determine the capabilities of another Fluid object.
+Data Object can dynamically determine the capabilities of another Data Object.
 
 In order to detect features supported by an unknown object, you cast it to an `IFluidObject` and then query the object
 for a specific interface that it may support. The interfaces exposed via `IFluidObject` include many core Fluid
 interfaces, such as `IFluidHandle` or `IFluidLoadable`, and this list can be augmented using [TypeScript's interface
 merging capabilities](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces). This
-discovery system (see example below) enables any Fluid object to record what interfaces it implements and make it
-possible for other Fluid objects to discover them. The specifics of how these interfaces are declared is not relevant
+discovery system (see example below) enables any Data Object to record what interfaces it implements and make it
+possible for other Data Objects to discover them. The specifics of how these interfaces are declared is not relevant
 until you want to define your own interfaces, which we'll cover in a later section.
 
 The following is an example of feature detection using `IFluidObject`:

--- a/docs/content/docs/deep/hosts.md
+++ b/docs/content/docs/deep/hosts.md
@@ -50,7 +50,7 @@ Fluid container from the loader. Finally, the host *does something* with the Flu
 multiple containers from the loader.
 
 <img src="/images/load-flow.png" alt="The Fluid loader connects to a URL using a container resolver, a
-service driver, and a container code loader. It then returns a Fluid container or Fluid object.">
+service driver, and a container code loader. It then returns a Fluid container or shared object.">
 
 We'll talk about each of these parts, starting with the request and loader dependencies, over the next sections.
 

--- a/docs/content/docs/glossary.md
+++ b/docs/content/docs/glossary.md
@@ -7,7 +7,7 @@ aliases:
 
 ## Aqueduct
 
-The `@fluidframework/aqueduct` package is a library for building Fluid objects and Fluid containers within the Fluid
+The `@fluidframework/aqueduct` package is a library for building shared objects and Fluid containers within the Fluid
 Framework. Its goal is to provide a thin base layer over the existing Fluid Framework interfaces that allows developers
 to get started quickly. [Learn more.]({{< relref "aqueduct.md" >}})
 
@@ -24,15 +24,15 @@ and load the container code bundle dynamically.
 ## Container
 
 The container is your application's entry point to the Fluid Framework. It runs your container code and is
-the object through which you'll retrieve your Fluid objects.
+the object through which you'll retrieve your shared objects.
 
 ## Container code
 
-You'll write container code to define which Fluid objects your scenario uses and how you'll access them.
+You'll write container code to define which shared objects your scenario uses and how you'll access them.
 
-## DataObject
+## Data Object
 
-DataObjects are higher-level Fluid objects, compared to distributed data structures, which are low-level Fluid objects.
+Data Objects are higher-level shared objects, compared to distributed data structures, which are low-level shared objects.
 DataObjects are used to organize distributed data structures into semantically meaningful groupings for your scenario,
 as well as providing an API surface to your data.
 
@@ -65,7 +65,7 @@ Client code responsible for connecting to the Fluid service.
 
 ## Shared object
 
-A distributed data structure (DDS) or `DataObject`.
+A distributed data structure (DDS) or Data Object.
 
 ## URL resolver
 

--- a/docs/content/docs/glossary.md
+++ b/docs/content/docs/glossary.md
@@ -33,7 +33,7 @@ You'll write container code to define which shared objects your scenario uses an
 ## Data Object
 
 Data Objects are higher-level shared objects, compared to distributed data structures, which are low-level shared objects.
-DataObjects are used to organize distributed data structures into semantically meaningful groupings for your scenario,
+Data Objects are used to organize distributed data structures into semantically meaningful groupings for your scenario,
 as well as providing an API surface to your data.
 
 ## Detached


### PR DESCRIPTION
In some cases I replaced "Fluid object" with "Data Object" where that seemed more correct than "shared object".