### PR TITLE
Consume BufferEncoding type change (Part 2)

### DIFF
--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -377,11 +377,11 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1025.0-24612",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-24612.tgz",
-      "integrity": "sha512-FIcKBhJcNl6XMajKcumihexpEOwYAeYKLma5H3KWx3GHDKchlJK260dH4zqV3eMcNs7Agz/G/30UmcB2DB7Wxw==",
+      "version": "0.1025.0-38244",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38244.tgz",
+      "integrity": "sha512-YcPZfyZu09IGQ7V0GwAsxrnOTMQllxZ9zKj72rYpHHpnJMU1wqAlMr/4BaKDeNp7Mb+ncCLnqLaDd4h/0Oa69w==",
       "requires": {
-        "@fluidframework/common-definitions": "^0.20.0-0"
+        "@fluidframework/common-definitions": "^0.20.0"
       }
     },
     "@microsoft/api-extractor": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.5",
-    "@fluidframework/protocol-definitions": "^0.1025.0-0"
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",


### PR DESCRIPTION
Update protocol-definitions version used by driver-definitions so that packages that use both can be updated compatibly. Missed this in #7565.