### PR TITLE
Update packages in container-definitions

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -353,6 +353,15 @@
             "@fluidframework/core-interfaces": "^0.39.8",
             "@fluidframework/protocol-definitions": "^0.1024.0"
           }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1024.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
+          "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
         }
       }
     },
@@ -362,20 +371,13 @@
       "integrity": "sha512-n1neSteU0P/mQjthiNqqrdXl3+VeJ2QFZva6QJOcFRVmjHe+c827g9VqEbz0WB8jcSKpf98n3QzTXAGmEqBeVg=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.39.6",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.39.6.tgz",
-      "integrity": "sha512-R+Bfnv0CWruzKu43wMhT6voF61kmpoDE2bLY4MZNB01Mgevvj50uCY42m3rQ36nEcu1+iEvP5/jDCxgMwtDEuw==",
+      "version": "0.40.0-38602",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0-38602.tgz",
+      "integrity": "sha512-bgO9VWR1VIWPQwTctFmnCAfdrthKFxsbI7ZzUVeKpNtyGC7eOTWxUk32pHOyKJtrV/jr11IqzNeBUEk7t6l09g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.39.6",
-        "@fluidframework/protocol-definitions": "^0.1024.0"
-      },
-      "dependencies": {
-        "@fluidframework/core-interfaces": {
-          "version": "0.39.6",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.6.tgz",
-          "integrity": "sha512-0xjYiRrd71+vS/cXPO8ejPuEfju7TD1NQquA+nWUcB9J5vv5NzdgQAcFAiPSmm/gwpKj4qbuVcN3144GN+qNEg=="
-        }
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/protocol-definitions": "^0.1025.0-38244"
       }
     },
     "@fluidframework/eslint-config-fluid": {
@@ -397,9 +399,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1024.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.0.tgz",
-      "integrity": "sha512-ksbjiihicwMbbX3fPkVOxsl8QDDiuc20T7t4Y7vq7aMkzPh4FAwoomjjreDSf71N6zAoz30HEzPPl0OwvPi0xw==",
+      "version": "0.1025.0-38244",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38244.tgz",
+      "integrity": "sha512-YcPZfyZu09IGQ7V0GwAsxrnOTMQllxZ9zKj72rYpHHpnJMU1wqAlMr/4BaKDeNp7Mb+ncCLnqLaDd4h/0Oa69w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
       }

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.5",
-    "@fluidframework/driver-definitions": "^0.39.6",
-    "@fluidframework/protocol-definitions": "^0.1024.0"
+    "@fluidframework/driver-definitions": "^0.40.0-38602",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38244"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
@@ -69,6 +69,7 @@
         "backCompat": false
       },
       "InterfaceDeclaration_IContainer": {
+        "forwardCompat": false,
         "backCompat": false
       },
       "InterfaceDeclaration_IContainerContext": {
@@ -83,9 +84,11 @@
         "backCompat": false
       },
       "InterfaceDeclaration_IHostLoader": {
+        "forwardCompat": false,
         "backCompat": false
       },
       "InterfaceDeclaration_ILoader": {
+        "forwardCompat": false,
         "backCompat": false
       },
       "InterfaceDeclaration_ILoaderHeader": {
@@ -96,9 +99,11 @@
         "backCompat": false
       },
       "InterfaceDeclaration_IProxyLoaderFactory": {
+        "forwardCompat": false,
         "backCompat": false
       },
       "InterfaceDeclaration_IRuntime": {
+        "forwardCompat": false,
         "backCompat": false
       },
       "InterfaceDeclaration_IRuntimeFactory": {

--- a/common/lib/container-definitions/src/test/validate0.39.8.ts
+++ b/common/lib/container-definitions/src/test/validate0.39.8.ts
@@ -205,13 +205,13 @@ use_old_InterfaceDeclaration_IConnectionDetails(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IContainer": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IContainer():
     old.IContainer;
 declare function use_current_InterfaceDeclaration_IContainer(
     use: current.IContainer);
 use_current_InterfaceDeclaration_IContainer(
     get_old_InterfaceDeclaration_IContainer());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -685,13 +685,13 @@ use_old_InterfaceDeclaration_IGenericError(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IHostLoader": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IHostLoader():
     old.IHostLoader;
 declare function use_current_InterfaceDeclaration_IHostLoader(
     use: current.IHostLoader);
 use_current_InterfaceDeclaration_IHostLoader(
     get_old_InterfaceDeclaration_IHostLoader());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -709,13 +709,13 @@ use_old_InterfaceDeclaration_IHostLoader(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ILoader": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_ILoader():
     old.ILoader;
 declare function use_current_InterfaceDeclaration_ILoader(
     use: current.ILoader);
 use_current_InterfaceDeclaration_ILoader(
     get_old_InterfaceDeclaration_ILoader());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -877,13 +877,13 @@ use_old_InterfaceDeclaration_IProvideRuntimeFactory(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProxyLoaderFactory": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IProxyLoaderFactory():
     old.IProxyLoaderFactory;
 declare function use_current_InterfaceDeclaration_IProxyLoaderFactory(
     use: current.IProxyLoaderFactory);
 use_current_InterfaceDeclaration_IProxyLoaderFactory(
     get_old_InterfaceDeclaration_IProxyLoaderFactory());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -925,13 +925,13 @@ use_old_InterfaceDeclaration_IResolvedFluidCodeDetails(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IRuntime": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IRuntime():
     old.IRuntime;
 declare function use_current_InterfaceDeclaration_IRuntime(
     use: current.IRuntime);
 use_current_InterfaceDeclaration_IRuntime(
     get_old_InterfaceDeclaration_IRuntime());
+*/
 
 /*
 * validate back compat by using current type in place of old type


### PR DESCRIPTION
Another intermediate package version change in the overall change to use BufferEncoding. This updates driver-definitions and protocol-definitions dependency versions.

One compat test is broken by my prior change for string->BufferEncoding. I verified that the others are real breaking changes.