### PR TITLE
Introduce Historian Delete API & Document DeletionTime property

### DIFF
--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -331,9 +331,9 @@
 			}
 		},
 		"@fluidframework/build-common": {
-			"version": "0.23.0-36574",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0-36574.tgz",
-			"integrity": "sha512-pKxO3aNUlzNvIvktsUez7xBvyw8H81bVD8nbmELGNlEURGGN6iVQ8JKQV6+8bZGO2sprrGi7gHcfb5116EFWzg=="
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-common/-/build-common-0.23.0.tgz",
+			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
 			"version": "0.2.34654",

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -43,6 +43,14 @@ export function create(
         return service.createSummary(params);
     }
 
+    async function deleteSummary(
+        tenantId: string,
+        authorization: string,
+        softDelete: boolean): Promise<boolean> {
+        const service = await utils.createGitService(tenantId, authorization, tenantService, cache, asyncLocalStorage);
+        return service.deleteSummary(softDelete);
+        }
+
     router.get("/repos/:ignored?/:tenantId/git/summaries/:sha",
         throttle(throttler, winston, commonThrottleOptions),
         (request, response, next) => {
@@ -66,6 +74,21 @@ export function create(
                 response,
                 false,
                 201);
+    });
+
+    router.delete("/repos/:ignored?/:tenantId/git/summaries",
+    throttle(throttler, winston, commonThrottleOptions),
+    (request, response, next) => {
+        const softDelete = request.get("Soft-Delete")?.toLowerCase() === "true";
+        const summaryP = deleteSummary(
+            request.params.tenantId,
+            request.get("Authorization"),
+            softDelete);
+
+        utils.handleResponse(
+            summaryP,
+            response,
+            false);
     });
 
     return router;

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -77,18 +77,18 @@ export function create(
     });
 
     router.delete("/repos/:ignored?/:tenantId/git/summaries",
-    throttle(throttler, winston, commonThrottleOptions),
-    (request, response, next) => {
-        const softDelete = request.get("Soft-Delete")?.toLowerCase() === "true";
-        const summaryP = deleteSummary(
-            request.params.tenantId,
-            request.get("Authorization"),
-            softDelete);
+        throttle(throttler, winston, commonThrottleOptions),
+        (request, response, next) => {
+            const softDelete = request.get("Soft-Delete")?.toLowerCase() === "true";
+            const summaryP = deleteSummary(
+                request.params.tenantId,
+                request.get("Authorization"),
+                softDelete);
 
-        utils.handleResponse(
-            summaryP,
-            response,
-            false);
+            utils.handleResponse(
+                summaryP,
+                response,
+                false);
     });
 
     return router;

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -199,6 +199,11 @@ export class RestGitService {
         return summaryResponse;
     }
 
+    public async deleteSummary(softDelete: boolean): Promise<boolean> {
+        const headers = { "Soft-Delete": softDelete };
+        return this.delete<boolean>(`/repos/${this.getRepoPath()}/git/summaries`, headers);
+    }
+
     public async getSummary(sha: string, useCache: boolean): Promise<IWholeFlatSummary> {
         return this.resolve(
             `${sha}:summary`,
@@ -362,8 +367,8 @@ export class RestGitService {
         }).catch(getRequestErrorTranslator(url, "POST"));
     }
 
-    private async delete<T>(url: string): Promise<T> {
-        return this.restWrapper.delete<T>(url)
+    private async delete<T>(url: string, headers?: any): Promise<T> {
+        return this.restWrapper.delete<T>(url, undefined, headers)
             .catch(getRequestErrorTranslator(url, "DELETE"));
     }
 

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -88,6 +88,8 @@ export class GitManager implements IGitManager {
     // (undocumented)
     createTree(files: api.ITree): Promise<resources.ITree>;
     // (undocumented)
+    deleteSummary(softDelete: boolean): Promise<void>;
+    // (undocumented)
     getBlob(sha: string): Promise<resources.IBlob>;
     // (undocumented)
     getCommit(sha: string): Promise<resources.ICommit>;
@@ -126,6 +128,8 @@ export class Historian implements IHistorian {
     createTree(tree: resources.ICreateTreeParams): Promise<resources.ITree>;
     // (undocumented)
     deleteRef(ref: string): Promise<void>;
+    // (undocumented)
+    deleteSummary(softDelete: boolean): Promise<void>;
     // (undocumented)
     endpoint: string;
     // (undocumented)
@@ -219,6 +223,8 @@ export interface IGitManager {
     // (undocumented)
     createTree(files: api.ITree): Promise<resources.ITree>;
     // (undocumented)
+    deleteSummary(softDelete: boolean): Promise<void>;
+    // (undocumented)
     getBlob(sha: string): Promise<resources.IBlob>;
     // (undocumented)
     getCommit(sha: string): Promise<resources.ICommit>;
@@ -260,6 +266,8 @@ export interface IGitService {
     createTree(tree: resources.ICreateTreeParams): Promise<resources.ITree>;
     // (undocumented)
     deleteRef(ref: string): Promise<void>;
+    // (undocumented)
+    deleteSummary(softDelete: boolean): Promise<void>;
     // (undocumented)
     getBlob(sha: string): Promise<resources.IBlob>;
     // (undocumented)

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -230,6 +230,16 @@ export function configureWebSocketServices(
                 });
             }
 
+            const document = await storage.getDocument(claims.tenantId, claims.documentId);
+            if (document && document.deletionTime) {
+                // Prevent connection to existing documents that have been marked for deletion.
+                // eslint-disable-next-line prefer-promise-reject-errors
+                return Promise.reject({
+                    code: 404,
+                    message: "Trying to connect to deleted document",
+                });
+            }
+
             const clientId = generateClientId();
             const room: IRoom = {
                 tenantId: claims.tenantId,

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -230,16 +230,6 @@ export function configureWebSocketServices(
                 });
             }
 
-            const document = await storage.getDocument(claims.tenantId, claims.documentId);
-            if (document && document.deletionTime) {
-                // Prevent connection to existing documents that have been marked for deletion.
-                // eslint-disable-next-line prefer-promise-reject-errors
-                return Promise.reject({
-                    code: 404,
-                    message: "Trying to connect to deleted document",
-                });
-            }
-
             const clientId = generateClientId();
             const room: IRoom = {
                 tenantId: claims.tenantId,

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -88,7 +88,7 @@ export class DeliLambdaFactory extends EventEmitter implements IPartitionLambdaF
             throw error;
         }
 
-        if (!dbObject) {
+        if (!dbObject || dbObject.deletionTime) {
             // Temporary guard against failure until we figure out what causing this to trigger.
             return new NoOpLambda(context);
         }

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -91,9 +91,9 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
                 this.documentCollection.findOne({ documentId, tenantId }),
             ]);
 
-            // If the document doesn't exist then we trivially accept every message
-            if (!document) {
-                context.log?.info(`Creating NoOpLambda due to missing`, { messageMetaData });
+            // If the document doesn't exist or is marked for deletion then we trivially accept every message
+            if (!document || document.deletionTime) {
+                context.log?.info(`Creating NoOpLambda due to missing document`, { messageMetaData });
                 return new NoOpLambda(context);
             }
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -187,7 +187,10 @@ async function checkDocumentExistence(request: Request, storage: core.IDocumentS
     if (!tenantId || !documentId) {
         return Promise.reject(new Error("Invalid tenant or document id"));
     }
-    return storage.getDocument(tenantId, documentId);
+    const document = await storage.getDocument(tenantId, documentId);
+    if (!document || document.deletionTime) {
+        return Promise.reject(new Error("Cannot access document marked for deletion"));
+    }
 }
 
 const uploadBlob = async (uri: string, blobData: git.ICreateBlobParams): Promise<git.ICreateBlobResponse> =>

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -44,6 +44,9 @@ export function create(
                 getParam(request.params, "id"));
             documentP.then(
                 (document) => {
+                    if (!document || document.deletionTime) {
+                        response.status(404);
+                    }
                     response.status(200).json(document);
                 },
                 (error) => {

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -145,6 +145,10 @@ export class GitManager implements IGitManager {
         return this.historian.createSummary(summary);
     }
 
+    public async deleteSummary(softDelete: boolean): Promise<void> {
+        return this.historian.deleteSummary(softDelete);
+    }
+
     public async getSummary(sha: string): Promise<IWholeFlatSummary> {
         return this.historian.getSummary(sha);
     }

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -138,6 +138,10 @@ export class Historian implements IHistorian {
     public async createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
         return this.restWrapper.post<IWriteSummaryResponse>(`/git/summaries`, summary, this.getQueryString());
     }
+    public async deleteSummary(softDelete: boolean): Promise<void> {
+        const headers = { "Soft-Delete": softDelete };
+        return this.restWrapper.delete(`/git/summaries`, this.getQueryString(), headers);
+    }
     public async getSummary(sha: string): Promise<IWholeFlatSummary> {
         return this.restWrapper.get<IWholeFlatSummary>(`/git/summaries/${sha}`, this.getQueryString());
     }

--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -74,6 +74,7 @@ export interface IGitService {
     createTree(tree: git.ICreateTreeParams): Promise<git.ITree>;
     getTree(sha: string, recursive: boolean): Promise<git.ITree>;
     createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    deleteSummary(softDelete: boolean): Promise<void>;
     getSummary(sha: string): Promise<IWholeFlatSummary>;
 }
 
@@ -109,6 +110,7 @@ export interface IGitManager {
     upsertRef(branch: string, commitSha: string): Promise<git.IRef>;
     write(branch: string, inputTree: api.ITree, parents: string[], message: string): Promise<git.ICommit>;
     createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    deleteSummary(softDelete: boolean): Promise<void>;
     getSummary(sha: string): Promise<IWholeFlatSummary>;
 }
 

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -115,4 +115,7 @@ export interface IDocument {
 
     // Deli state
     deli: string;
+
+    // Timestamp of when this document will be permanently deleted
+    deletionTime?: string;
 }

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -116,6 +116,7 @@ export interface IDocument {
     // Deli state
     deli: string;
 
-    // Timestamp of when this document will be permanently deleted
+    // Timestamp of when this document and related data will be hard deleted.
+    // The document is soft deleted if a deletion timestamp is present.
     deletionTime?: string;
 }

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -15,7 +15,7 @@ export interface IDocumentDetails {
 }
 
 export interface IDocumentStorage {
-    getDocument(tenantId: string, documentId: string): Promise<any>;
+    getDocument(tenantId: string, documentId: string): Promise<IDocument>;
 
     getOrCreateDocument(tenantId: string, documentId: string): Promise<IDocumentDetails>;
 

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -39,15 +39,9 @@ export class DocumentStorage implements IDocumentStorage {
     /**
      * Retrieves database details for the given document
      */
-    public async getDocument(tenantId: string, documentId: string): Promise<any> {
+    public async getDocument(tenantId: string, documentId: string): Promise<IDocument> {
         const collection = await this.databaseManager.getDocumentCollection();
-        const document = await collection.findOne({ documentId, tenantId });
-
-        if (document && document.deletionTime) {
-            return Promise.reject(new Error("Cannot retrieve deleted document."));
-        }
-
-        return document;
+        return collection.findOne({ documentId, tenantId });
     }
 
     public async getOrCreateDocument(tenantId: string, documentId: string): Promise<IDocumentDetails> {

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -41,7 +41,13 @@ export class DocumentStorage implements IDocumentStorage {
      */
     public async getDocument(tenantId: string, documentId: string): Promise<any> {
         const collection = await this.databaseManager.getDocumentCollection();
-        return collection.findOne({ documentId, tenantId });
+        const document = await collection.findOne({ documentId, tenantId });
+
+        if (document && document.deletionTime) {
+            return Promise.reject(new Error("Cannot retrieve deleted document."));
+        }
+
+        return document;
     }
 
     public async getOrCreateDocument(tenantId: string, documentId: string): Promise<IDocumentDetails> {

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -8,6 +8,7 @@ import { IGitCache, IGitManager } from "@fluidframework/server-services-client";
 import {
     IDatabaseManager,
     IDeliState,
+    IDocument,
     IDocumentDetails,
     IDocumentStorage,
     IScribe,
@@ -40,7 +41,7 @@ export class TestDocumentStorage implements IDocumentStorage {
     /**
      * Retrieves database details for the given document
      */
-    public async getDocument(tenantId: string, documentId: string): Promise<any> {
+    public async getDocument(tenantId: string, documentId: string): Promise<IDocument> {
         const collection = await this.databaseManager.getDocumentCollection();
         return collection.findOne({ documentId, tenantId });
     }

--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -151,6 +151,10 @@ export class TestHistorian implements IHistorian {
         throw new Error("Not Supported");
     }
 
+    public async deleteSummary(softDelete: boolean): Promise<void> {
+        throw new Error("Not Supported");
+    }
+
     public async getSummary(sha: string): Promise<IWholeFlatSummary> {
         throw new Error("Not Supported");
     }


### PR DESCRIPTION
## Changes
* Introduce a delete API for summaries in Historian.
* introduce an optional **DeletionTime** property for documents that indicates that the document has been marked for deletion and the time at which the document metadata will be removed.
* Update Alfred connect document logic to prevent connecting to documents marked for deletion.
* Update Deli and Scribe to no longer process ops for documents marked for deletion. 