### PR TITLE
[0.47 > 0.48]: Add telemetry related to seq numbers in deltamanager

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -181,6 +181,10 @@ export class DeltaManager extends TypedEventEmitter<IDeltaManagerInternalEvents>
     // (undocumented)
     get lastMessage(): ISequencedDocumentMessage | undefined;
     // (undocumented)
+    get lastObservedSequenceNumber(): number;
+    // (undocumented)
+    get lastQueuedSeqNumber(): number;
+    // (undocumented)
     get lastSequenceNumber(): number;
     logConnectionIssue(event: ITelemetryErrorEvent): void;
     // (undocumented)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -639,6 +639,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     // load information to associate errors with the specific load point
                     dmInitialSeqNumber: () => this._deltaManager?.initialSequenceNumber,
                     dmLastKnownSeqNumber: () => this._deltaManager?.lastKnownSeqNumber,
+                    dmLastProcessedSeqNumber: () => this._deltaManager?.lastSequenceNumber,
+                    dmLastQueuedSeqNumber: () => this._deltaManager?.lastQueuedSeqNumber,
+                    dmLastObservedSeqNumber: () => this._deltaManager?.lastObservedSequenceNumber,
                     containerLoadedFromVersionId: () => this.loadedFromVersion?.id,
                     containerLoadedFromVersionDate: () => this.loadedFromVersion?.date,
                     // message information to associate errors with the specific execution state

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -267,6 +267,14 @@ export class DeltaManager
         return this.initSequenceNumber;
     }
 
+    public get lastQueuedSeqNumber(): number {
+        return this.lastQueuedSequenceNumber;
+    }
+
+    public get lastObservedSequenceNumber(): number {
+        return this.lastObservedSeqNumber;
+    }
+
     public get lastSequenceNumber(): number {
         return this.lastProcessedSequenceNumber;
     }
@@ -1580,6 +1588,12 @@ export class DeltaManager
             return;
         }
 
+        this.logger.sendTelemetryEvent({
+            eventName: "fetchingDeltas",
+            fetchReason: reason,
+            lastKnowOp,
+            to,
+        });
         try {
             assert(lastKnowOp === this.lastQueuedSequenceNumber, 0x0f1 /* "from arg" */);
             let from = lastKnowOp + 1;


### PR DESCRIPTION
Adding telemetry related to seq numbers in deltamanager. Like the last processed and queued seq numbers and event when we fetch the missing deltas.
We are facing issue where we are always fetching ops from 1 on container load even in case the summary seq number is greater.