### PR TITLE
Remove node dependency BufferEncoding

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -9,9 +9,6 @@ import { IErrorEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 
 // @public (undocumented)
-export type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
-
-// @public (undocumented)
 export type ConnectionMode = "write" | "read";
 
 // @public (undocumented)
@@ -50,7 +47,7 @@ export interface IBlob {
     // (undocumented)
     contents: string;
     // (undocumented)
-    encoding: BufferEncoding;
+    encoding: "utf-8" | "base64";
 }
 
 // @public

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -9,6 +9,9 @@ import { IErrorEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 
 // @public (undocumented)
+export type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
+
+// @public (undocumented)
 export type ConnectionMode = "write" | "read";
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -553,12 +553,6 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
-    "@types/node": {
-      "version": "12.20.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
-      "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q==",
-      "dev": true
-    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -39,7 +39,6 @@
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/protocol-definitions-0.1024.0": "npm:@fluidframework/protocol-definitions@0.1024.0",
     "@microsoft/api-extractor": "^7.16.1",
-    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -33,6 +33,9 @@ export enum FileMode {
     Symlink = "120000",
 }
 
+export type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" |
+                             "ucs-2" | "base64" | "latin1" | "binary" | "hex";
+
 /**
  * Raw blob stored within the tree
  */

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -33,9 +33,6 @@ export enum FileMode {
     Symlink = "120000",
 }
 
-export type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" |
-                             "ucs-2" | "base64" | "latin1" | "binary" | "hex";
-
 /**
  * Raw blob stored within the tree
  */
@@ -43,8 +40,8 @@ export interface IBlob {
     // Contents of the blob
     contents: string;
 
-    // The encoding of the contents string (utf-8 or base64)
-    encoding: BufferEncoding;
+    // The encoding of the contents string
+    encoding: "utf-8" | "base64";
 }
 
 export interface IAttachment {

--- a/common/lib/protocol-definitions/tsconfig.json
+++ b/common/lib/protocol-definitions/tsconfig.json
@@ -6,8 +6,7 @@
     ],
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./dist",
-        "types": ["node"]
+        "outDir": "./dist"
     },
     "include": [
         "src/**/*"

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -76,7 +76,7 @@ export class GitManager implements IGitManager {
     // (undocumented)
     addTree(tree: resources.ITree): void;
     // (undocumented)
-    createBlob(content: string, encoding: BufferEncoding): Promise<resources.ICreateBlobResponse>;
+    createBlob(content: string, encoding: "utf-8" | "base64"): Promise<resources.ICreateBlobResponse>;
     // (undocumented)
     createCommit(commit: resources.ICreateCommitParams): Promise<resources.ICommit>;
     // (undocumented)

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
-    "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",
     "concurrently": "^5.2.0",

--- a/server/routerlicious/packages/gitresources/src/resources.ts
+++ b/server/routerlicious/packages/gitresources/src/resources.ts
@@ -96,8 +96,8 @@ export interface ICreateBlobParams {
     // The encoded content
     content: string;
 
-    // The encoding of the content. Either utf8 or base64.
-    encoding: BufferEncoding;
+    // The encoding of the content.
+    encoding: "utf-8" |"base64";
 }
 
 /**

--- a/server/routerlicious/packages/gitresources/tsconfig.json
+++ b/server/routerlicious/packages/gitresources/tsconfig.json
@@ -6,8 +6,7 @@
     ],
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./dist",
-        "types": ["node"]
+        "outDir": "./dist"
     },
     "include": [
         "src/**/*"

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -119,7 +119,7 @@ export class GitManager implements IGitManager {
         return this.historian.getContent(path, commit);
     }
 
-    public createBlob(content: string, encoding: BufferEncoding): Promise<resources.ICreateBlobResponse> {
+    public createBlob(content: string, encoding: "utf-8" |"base64"): Promise<resources.ICreateBlobResponse> {
         const blob: resources.ICreateBlobParams = {
             content,
             encoding,
@@ -257,7 +257,7 @@ export class GitManager implements IGitManager {
                         entryAsBlob.contents = this.translateSymlink(entryAsBlob.contents, depth);
                     }
 
-                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding);
+                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding as "utf-8" |"base64");
                     entriesP.push(blobP);
                     break;
 

--- a/server/routerlicious/packages/services-client/src/test/historian.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/historian.spec.ts
@@ -36,7 +36,7 @@ describe("Historian", () => {
     };
     const mockBlob: git.IBlob = {
         content: "Hello, World!",
-        encoding: "utf8",
+        encoding: "utf-8",
         url: `${endpoint}/blob/${sha}`,
         sha,
         size: 20,
@@ -211,7 +211,7 @@ describe("Historian", () => {
         const url = getUrlWithToken(`/git/blobs`, initialCredentials);
         const blobParams: git.ICreateBlobParams = {
             content: "Hello, World",
-            encoding: "utf8",
+            encoding: "utf-8",
         };
         const response: git.ICreateBlobResponse = {
             sha,

--- a/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForHistorian.spec.ts
@@ -40,7 +40,7 @@ describe("Test for Historian", () => {
         const gitManager = new GitManager(historian);
         const blob1: ICreateBlobParams = {
             content: "content",
-            encoding: "utf8",
+            encoding: "utf-8",
         };
         const blob2: ICreateBlobParams = {
             content: fromUtf8ToBase64(blob1.content),


### PR DESCRIPTION
Remove node dependency and define only supported encoding values in @fluidframework/protocol-definitions and @fluidframework/gitresources.

Subsequent pull requests will consume this change.