### PR TITLE
Modify LazyLoadedDataObject.load signature to be consistent with other native dataobjects

### DIFF
--- a/api-report/data-object-base.api.md
+++ b/api-report/data-object-base.api.md
@@ -44,7 +44,7 @@ export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = IShared
     // (undocumented)
     get IProvideFluidHandle(): this;
     // (undocumented)
-    abstract load(): Promise<void>;
+    abstract load(context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, existing: boolean): Promise<void>;
     // (undocumented)
     request(r: IRequest): Promise<IResponse>;
     // (undocumented)

--- a/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
@@ -11,6 +11,7 @@ import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
 
 import { LazyLoadedDataObject, LazyLoadedDataObjectFactory } from "@fluidframework/data-object-base";
 import { BaseProperty, NodeProperty } from "@fluid-experimental/property-properties";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 
 export interface IPropertyTree extends EventEmitter {
     pset: NodeProperty;
@@ -32,6 +33,7 @@ const propertyKey = "propertyKey";
 export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> implements IPropertyTree {
     private _tree?: SharedPropertyTree;
     private _queryString: string | undefined;
+    private _existing: boolean = false;
 
     stopTransmission(stopped: boolean): void {
         this._tree?.stopTransmission(stopped);
@@ -90,7 +92,8 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
         /* this.initialize(false); */
         console.log("A");
     }
-    public async load() {
+    public async load(_context: IFluidDataStoreContext, _runtime: IFluidDataStoreRuntime, existing: boolean) {
+        this._existing = existing;
         /* this.initialize(true); */
         console.log("B");
     }
@@ -99,7 +102,7 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
         const url = request.url;
         console.log(url);
         this._queryString = url.split("?")[1];
-        await this.initialize(false);
+        await this.initialize(this._existing);
         return super.request(request);
     }
 }

--- a/experimental/PropertyDDS/examples/property-inspector/src/app.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/app.tsx
@@ -46,7 +46,7 @@ async function start(): Promise<void> {
         await getFRSContainer(documentId, ContainerFactory, createNew)
         : await getTinyliciousContainer(documentId, ContainerFactory, createNew);
 
-    const propertyTree: IPropertyTree = await getDefaultObjectFromContainer<IPropertyTree>(container);
+        const propertyTree: IPropertyTree = await getDefaultObjectFromContainer<IPropertyTree>(container);
 
     renderApp(propertyTree.tree, document.getElementById("root")!);
 

--- a/experimental/PropertyDDS/examples/property-inspector/src/dataObject.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/src/dataObject.ts
@@ -5,12 +5,13 @@
 
 import { EventEmitter } from "events";
 import { IFluidDataStoreContext, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { IFluidHandle , IRequest, IResponse} from "@fluidframework/core-interfaces";
+import { IFluidHandle, IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { SharedPropertyTree, PropertyTreeFactory } from "@fluid-experimental/property-dds";
 import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
 
 import { LazyLoadedDataObject, LazyLoadedDataObjectFactory } from "@fluidframework/data-object-base";
 import { BaseProperty } from "@fluid-experimental/property-properties";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 
 export interface IPropertyTree extends EventEmitter {
     pset: any;
@@ -32,6 +33,7 @@ const propertyKey = "propertyKey";
 export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> implements IPropertyTree {
     private _tree?: SharedPropertyTree;
     private _queryString: string | undefined;
+    private _existing: boolean = false;
 
     stopTransmission(stopped: boolean): void {
         this._tree?.stopTransmission(stopped);
@@ -91,7 +93,8 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
         /* this.initialize(false); */
         console.log("A");
     }
-    public async load() {
+    public async load(_context: IFluidDataStoreContext, _runtime: IFluidDataStoreRuntime, existing: boolean) {
+        this._existing = existing;
         /* this.initialize(true); */
         console.log("B");
     }
@@ -100,7 +103,7 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
         const url = request.url;
         console.log(url);
         this._queryString = url.split("?")[1];
-        await this.initialize(false);
+        await this.initialize(this._existing);
         return super.request(request);
     }
 }

--- a/experimental/PropertyDDS/examples/property-inspector/src/theme.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/src/theme.ts
@@ -4,7 +4,7 @@
  */
 import "@hig/fonts/build/ArtifaktElement.css";
 
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createTheme } from "@material-ui/core/styles";
 import { ToggleButtonClassKey } from "@material-ui/lab/ToggleButton";
 
 declare module "@material-ui/core/styles/overrides" {
@@ -13,7 +13,7 @@ declare module "@material-ui/core/styles/overrides" {
   }
 }
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
 
   overrides: {
     MuiButton: {

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/Theme.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/Theme.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@hig/fonts/build/ArtifaktElement.css';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import { ToggleButtonClassKey } from '@material-ui/lab/ToggleButton';
 
 declare module '@material-ui/core/styles/overrides' {
@@ -14,7 +14,7 @@ declare module '@material-ui/core/styles/overrides' {
   }
 }
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
 
   overrides: {
     MuiButton: {

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
@@ -1441,11 +1441,8 @@ PropertyFactory.prototype.inheritsFrom = function (in_templateTypeid, in_baseTyp
         return true;
     } else {
         var parents = {};
-        var scope = in_options.workspace ?
-            in_options.workspace.getRoot()._getCheckedOutRepositoryInfo().getScope() :
-            in_options.scope;
 
-        this._getAllParentsForTemplateInternal(in_templateTypeid, parents, true, scope);
+        this._getAllParentsForTemplateInternal(in_templateTypeid, parents, true, in_options.scope);
 
         // update the cache
         this._inheritanceCache[in_templateTypeid] = parents;

--- a/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
@@ -73,5 +73,6 @@ export abstract class LazyLoadedDataObject<
     // #endregion IFluidLoadable
 
     public abstract create(props?: any);
-    public abstract load(): Promise<void>;
+    public abstract load(context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime,
+         existing: boolean): Promise<void>;
 }

--- a/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
@@ -78,8 +78,8 @@ export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> impleme
         // New data store instances are synchronously created.  Loading a previously created
         // store is deferred (via a LazyPromise) until requested by invoking `.then()`.
         return existing
-            ? new LazyPromise(async () => this.load(context, runtime))
-            : this.createCore(context, runtime);
+            ? new LazyPromise(async () => this.load(context, runtime, existing))
+            : this.createCore(context, runtime, existing);
     }
 
     private createCore(context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, props?: any) {
@@ -90,13 +90,13 @@ export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> impleme
         return instance;
     }
 
-    private async load(context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime) {
+    private async load(context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, existing: boolean) {
         const instance = new this.ctor(
             context,
             runtime,
             await runtime.getChannel("root") as ISharedObject);
 
-        await instance.load();
+        await instance.load(context, runtime, existing);
         return instance;
     }
 }


### PR DESCRIPTION
Removing `existing` property from IFluidDataStoreRuntime in this [PR](https://github.com/microsoft/FluidFramework/pull/6869/files#diff-4a401bc44bcc17f58432c334e040fe9e666fd9624e35cba303eca3d0672c0592L45), broke PorpertyDDS samples logic which uses `LazyLoadedDataObject` for its DataObject. it always creates a new document when refreshing the app with the same document id. 

This PR changes **load** method signature in `LazyLoadedDataObject` to be consistent with other native data-objects classes, which makes the flag `existing` available through creation/loading of the document.

 

