### PR TITLE
Better typing for summary results

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -246,11 +246,11 @@ export interface IAckedSummary {
 }
 
 // @public (undocumented)
-export interface IAckNackSummaryResult {
+export interface IAckSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
-    readonly summaryAckNackOp: ISummaryAckMessage | ISummaryNackMessage;
+    readonly summaryAckNackOp: ISummaryAckMessage;
 }
 
 // @public
@@ -357,6 +357,14 @@ export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "
     readonly stage: "generate";
     readonly summaryStats: IGeneratedSummaryStats;
     readonly summaryTree: ISummaryTree;
+}
+
+// @public (undocumented)
+export interface INackSummaryResult {
+    // (undocumented)
+    readonly ackNackDuration: number;
+    // (undocumented)
+    readonly summaryAckNackOp: ISummaryNackMessage;
 }
 
 // @public (undocumented)
@@ -473,7 +481,7 @@ export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRo
 
 // @public (undocumented)
 export interface ISummarizeResults {
-    readonly receivedSummaryAckOrNack: Promise<SummarizeResultPart<IAckNackSummaryResult>>;
+    readonly receivedSummaryAckOrNack: Promise<SummarizeResultPart<IAckSummaryResult, INackSummaryResult>>;
     readonly summaryOpBroadcasted: Promise<SummarizeResultPart<IBroadcastSummaryResult>>;
     readonly summarySubmitted: Promise<SummarizeResultPart<SubmitSummaryResult>>;
 }
@@ -661,12 +669,12 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     }
 
 // @public (undocumented)
-export type SummarizeResultPart<T> = {
+export type SummarizeResultPart<T, Y = undefined> = {
     success: true;
     data: T;
 } | {
     success: false;
-    data: T | undefined;
+    data: Y | undefined;
     message: string;
     error: any;
     retryAfterSeconds?: number;

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -250,7 +250,7 @@ export interface IAckSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
-    readonly summaryAckNackOp: ISummaryAckMessage;
+    readonly summaryAckOp: ISummaryAckMessage;
 }
 
 // @public
@@ -364,7 +364,7 @@ export interface INackSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
-    readonly summaryAckNackOp: ISummaryNackMessage;
+    readonly summaryNackOp: ISummaryNackMessage;
 }
 
 // @public (undocumented)
@@ -669,12 +669,12 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     }
 
 // @public (undocumented)
-export type SummarizeResultPart<T, Y = undefined> = {
+export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     success: true;
-    data: T;
+    data: TSuccess;
 } | {
     success: false;
-    data: Y | undefined;
+    data: TFailure | undefined;
     message: string;
     error: any;
     retryAfterSeconds?: number;

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -378,7 +378,6 @@ export class RunningSummarizer implements IDisposable {
                 const result = await resultSummarize.receivedSummaryAckOrNack;
 
                 if (result.success) {
-                    assert(result.data.summaryAckNackOp.type === MessageType.SummaryAck, 0x25c /* "not nack" */);
                     return;
                 }
                 // Check for retryDelay that can come from summaryNack or upload summary flow.

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -198,21 +198,21 @@ export interface IBroadcastSummaryResult {
 }
 
 export interface IAckSummaryResult {
-    readonly summaryAckNackOp: ISummaryAckMessage;
+    readonly summaryAckOp: ISummaryAckMessage;
     readonly ackNackDuration: number;
 }
 
 export interface INackSummaryResult {
-    readonly summaryAckNackOp: ISummaryNackMessage;
+    readonly summaryNackOp: ISummaryNackMessage;
     readonly ackNackDuration: number;
 }
 
-export type SummarizeResultPart<T, Y = undefined> = {
+export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     success: true;
-    data: T;
+    data: TSuccess;
 } | {
     success: false;
-    data: Y | undefined;
+    data: TFailure | undefined;
     message: string;
     error: any;
     retryAfterSeconds?: number;

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -197,17 +197,22 @@ export interface IBroadcastSummaryResult {
     readonly broadcastDuration: number;
 }
 
-export interface IAckNackSummaryResult {
-    readonly summaryAckNackOp: ISummaryAckMessage | ISummaryNackMessage;
+export interface IAckSummaryResult {
+    readonly summaryAckNackOp: ISummaryAckMessage;
     readonly ackNackDuration: number;
 }
 
-export type SummarizeResultPart<T> = {
+export interface INackSummaryResult {
+    readonly summaryAckNackOp: ISummaryNackMessage;
+    readonly ackNackDuration: number;
+}
+
+export type SummarizeResultPart<T, Y = undefined> = {
     success: true;
     data: T;
 } | {
     success: false;
-    data: T | undefined;
+    data: Y | undefined;
     message: string;
     error: any;
     retryAfterSeconds?: number;
@@ -219,7 +224,7 @@ export interface ISummarizeResults {
     /** Resolves when we observe our summarize op broadcast. */
     readonly summaryOpBroadcasted: Promise<SummarizeResultPart<IBroadcastSummaryResult>>;
     /** Resolves when we receive a summaryAck or summaryNack. */
-    readonly receivedSummaryAckOrNack: Promise<SummarizeResultPart<IAckNackSummaryResult>>;
+    readonly receivedSummaryAckOrNack: Promise<SummarizeResultPart<IAckSummaryResult, INackSummaryResult>>;
 }
 
 export type OnDemandSummarizeResult = (ISummarizeResults & {

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -335,7 +335,7 @@ export class SummaryGenerator {
                 this.heuristicData.markLastAttemptAsSuccessful();
                 summarizeEvent.end({ ...telemetryProps, handle: ackNackOp.contents.handle, message: "summaryAck" });
                 resultsBuilder.receivedSummaryAckOrNack.resolve({ success: true, data: {
-                    summaryAckNackOp: ackNackOp,
+                    summaryAckOp: ackNackOp,
                     ackNackDuration,
                 }});
             } else {
@@ -355,7 +355,7 @@ export class SummaryGenerator {
                     "summaryNack",
                     error,
                     { ...telemetryProps, nackRetryAfter: retryAfterSeconds },
-                    { summaryAckNackOp: ackNackOp, ackNackDuration },
+                    { summaryNackOp: ackNackOp, ackNackDuration },
                 );
             }
         } finally {

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -621,9 +621,9 @@ describe("Runtime", () => {
                     await emitAck();
                     const ackNackResult = await result.receivedSummaryAckOrNack;
                     assert(ackNackResult.success, "on-demand summary should succeed");
-                    assert(ackNackResult.data.summaryAckNackOp.type === MessageType.SummaryAck,
+                    assert(ackNackResult.data.summaryAckOp.type === MessageType.SummaryAck,
                         "should be ack");
-                    assert(ackNackResult.data.summaryAckNackOp.contents.handle === "test-ack-handle",
+                    assert(ackNackResult.data.summaryAckOp.contents.handle === "test-ack-handle",
                         "summary ack handle should be test-ack-handle");
                 });
 
@@ -683,9 +683,9 @@ describe("Runtime", () => {
                     await emitNack();
                     const ackNackResult = await result.receivedSummaryAckOrNack;
                     assert(!ackNackResult.success, "on-demand summary should fail");
-                    assert(ackNackResult.data?.summaryAckNackOp.type === MessageType.SummaryNack,
+                    assert(ackNackResult.data?.summaryNackOp.type === MessageType.SummaryNack,
                         "should be nack");
-                    assert(ackNackResult.data.summaryAckNackOp.contents.errorMessage === "test-nack",
+                    assert(ackNackResult.data.summaryNackOp.contents.errorMessage === "test-nack",
                         "summary nack error should be test-nack");
                 });
 
@@ -804,9 +804,9 @@ describe("Runtime", () => {
                     await emitAck();
                     const ackNackResult = await result.receivedSummaryAckOrNack;
                     assert(ackNackResult.success, "enqueued summary should succeed");
-                    assert(ackNackResult.data.summaryAckNackOp.type === MessageType.SummaryAck,
+                    assert(ackNackResult.data.summaryAckOp.type === MessageType.SummaryAck,
                         "should be ack");
-                    assert(ackNackResult.data.summaryAckNackOp.contents.handle === "test-ack-handle",
+                    assert(ackNackResult.data.summaryAckOp.contents.handle === "test-ack-handle",
                         "summary ack handle should be test-ack-handle");
                 });
 
@@ -861,9 +861,9 @@ describe("Runtime", () => {
                     await emitAck();
                     const ackNackResult = await result.receivedSummaryAckOrNack;
                     assert(ackNackResult.success, "enqueued summary should succeed");
-                    assert(ackNackResult.data.summaryAckNackOp.type === MessageType.SummaryAck,
+                    assert(ackNackResult.data.summaryAckOp.type === MessageType.SummaryAck,
                         "should be ack");
-                    assert(ackNackResult.data.summaryAckNackOp.contents.handle === "test-ack-handle",
+                    assert(ackNackResult.data.summaryAckOp.contents.handle === "test-ack-handle",
                         "summary ack handle should be test-ack-handle");
                 });
 


### PR DESCRIPTION
Making receivedSummaryAckOrNack typing a bit more strict - success path contains ack, and failure path may contain nack.
Before change - both success & failure paths could contain either ack or nack