### PR TITLE
Deli summary nack messages logic fixes

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -194,7 +194,9 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
         this.noActiveClients = msn === -1;
         this.minimumSequenceNumber = this.noActiveClients ? this.sequenceNumber : msn;
 
-        this.checkNackMessagesState();
+        if (this.serviceConfiguration.deli.summaryNackMessages.checkOnStartup) {
+            this.checkNackMessagesState();
+        }
 
         this.checkpointContext = new CheckpointContext(this.tenantId, this.documentId, checkpointManager, context);
 

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -60,6 +60,10 @@ export interface IDeliSummaryNackMessagesServerConfiguration {
     // the op count since the last summary exceeds this limit
     enable: boolean;
 
+    // Check the summary nack messages state when starting up
+    // It will potentionally reset the nackMessages flag
+    checkOnStartup: boolean;
+
     // Amount of ops since the last summary before starting to nack
     maxOps: number;
 
@@ -141,6 +145,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
         },
         summaryNackMessages: {
             enable: false,
+            checkOnStartup: false,
             maxOps: 5000,
             nackContent: {
                 code: 429,


### PR DESCRIPTION
- Reset nack messages when starting up if the initial state indicates that clients should not be getting nacked
- Fix `isServiceMessageType` check to be `message.operation.type` (Thanks @pradeepvairamani !)