### PR TITLE
fix links pointing to updated examples

### DIFF
--- a/docs/content/docs/recipes/react.md
+++ b/docs/content/docs/recipes/react.md
@@ -7,7 +7,7 @@ aliases:
 
 In this tutorial, you'll learn about using the Fluid Framework by building a simple application that enables every client of the application to change a dynamic time stamp on itself and all other clients almost instantly. You'll also learn how to connect the Fluid data layer with a view layer made in [React](https://reactjs.org/).
 
-To jump ahead into the finished demo, check out the [Create React App demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/cra-demo).
+To jump ahead into the finished demo, check out the [Create React App demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/react-demo).
 
 The following image shows the time stamp application open in four browsers. Each has a button labeled **click** and beside it a Unix epoch time. The same time is in all four. The cursor is on the button in one browser.
 
@@ -225,7 +225,7 @@ Paste the URL of the application into the address bar of another tab or even ano
 - Try extending the demo with more key/value pairs and a more complex UI.
 - Consider using the [Fluent UI React controls](https://aka.ms/fluentui/) to give the application the look and feel of Microsoft 365. To install them in your project run the following in the command prompt: `npm install @fluentui/react`.
 - Try changing the container schema to use a different shared data object type or specify multiple objects in `initialObjects`.
-- For an example that will scale to larger applications and larger teams, check out the [Fluid React Starter in the FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/fluid-react-starter).
+- For an example that will scale to larger applications and larger teams, check out the [React Starter Template in the FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/react-starter-template).
 
 {{< callout tip >}}
 

--- a/docs/content/docs/recipes/react.md
+++ b/docs/content/docs/recipes/react.md
@@ -7,7 +7,7 @@ aliases:
 
 In this tutorial, you'll learn about using the Fluid Framework by building a simple application that enables every client of the application to change a dynamic time stamp on itself and all other clients almost instantly. You'll also learn how to connect the Fluid data layer with a view layer made in [React](https://reactjs.org/).
 
-To jump ahead into the finished demo, check out the [Create React App demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/react-demo).
+To jump ahead into the finished demo, check out the [React demo in our FluidExamples repo](https://github.com/microsoft/FluidExamples/tree/main/react-demo).
 
 The following image shows the time stamp application open in four browsers. Each has a button labeled **click** and beside it a Unix epoch time. The same time is in all four. The cursor is on the button in one browser.
 


### PR DESCRIPTION
https://github.com/microsoft/FluidExamples/pull/318 updates the package names of two of the react examples. they are referenced in our website, so this PR fixes those references. 