### PR TITLE
Allow delay to equal maxThrottleDelay without warning

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -279,7 +279,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
     private async delayBeforeCreatingSummarizer(): Promise<boolean> {
         // throttle creation of new summarizer containers to prevent spamming the server with websocket connections
         let delayMs = this.startThrottler.getDelay();
-        if (delayMs > 0 && delayMs >= this.startThrottler.maxDelayMs) {
+        if (delayMs > 0 && delayMs > this.startThrottler.maxDelayMs) {
             this.emit(
                 "summarizerWarning",
                 createSummarizingWarning("summaryManagerCreateSummarizerMaxThrottleDelay", false),


### PR DESCRIPTION
We're getting summaryManagerCreateSummarizerMaxThrottleDelay warnings under normal circumstances. The warning fires when the computed delay equals the maxThrottleDelay, which is permitted by getDelay(). To reduce the noise I'm causing the warning to fire only when maxThrottleDelay is exceeded. (It could be argued that this condition should be an error rather than a warning.)