### PR TITLE
Do not give SummaryWrite scope to clients that are not summarizers

### DIFF
--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -53,7 +53,6 @@ class SocketIoServer implements core.IWebSocketServer {
         private readonly pub: Redis.Redis,
         private readonly sub: Redis.Redis) {
         this.io.on("connection", (socket: Socket) => {
-            winston.info(`Socket.io connection received: protocol ${socket.conn.protocol}`);
             const webSocket = new SocketIoSocket(socket);
             this.events.emit("connection", webSocket);
         });


### PR DESCRIPTION
Currently all the write clients are given SummaryWrite scope. This is more permissive than required and this also results in ops not being nacked from the non summarizer clients when SummaryMaxOps limit is reached.

Also, removing a noisy log line.