### PR TITLE
Fix table formatting

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -88,19 +88,22 @@ menu:
 
 markup:
   goldmark:
+    parser:
+      attribute:
+        # enables adding CSS classes to black elements in markdown
+        block: true
     renderer:
-      attribute: true
       autoHeadingIDType: "github"
       # mark unsafe html as true since api-documenter uses html snippets in markdown
       unsafe: true
-      extensions:
-        definitionList: true
-        footnote: true
-        linkify: true
-        strikethrough: true
-        table: true
-        taskList: true
-        typographer: true
+    extensions:
+      definitionList: true
+      footnote: true
+      linkify: true
+      strikethrough: true
+      table: true
+      taskList: true
+      typographer: true
 
   highlight:
     codeFences: true

--- a/docs/content/docs/recipes/angular.md
+++ b/docs/content/docs/recipes/angular.md
@@ -50,6 +50,7 @@ This tutorial assumes that you are familiar with the [Fluid Framework Overview](
     |---|---|
     |fluid&#x2011;framework |Contains the SharedMap [distributed data structure]({{< relref "dds.md" >}}) that synchronizes data across clients. *This object will hold the most recent timestamp update made by any client.*|
     |fluidframework/tinylicious&#x2011;client |Defines the connection to a Fluid service server and defines the starting schema for the [Fluid container][].|
+    {.table}
 
     Run the following command to install the libraries.
 

--- a/docs/content/docs/recipes/react.md
+++ b/docs/content/docs/recipes/react.md
@@ -37,9 +37,9 @@ This tutorial assumes that you are familiar with the [Fluid Framework Overview](
 
     |Library |Description |
     |---|---|
-    |fluid&#x2011;framework&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;    |Contains the SharedMap [distributed data structure]({{< relref "dds.md" >}}) that synchronizes data across clients. *This object will hold the most recent timestamp update made by any client.*|
-    |fluidframework/tinylicious&#x2011;client&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;   |Defines the connection to a Fluid service server and defines the starting schema for the [Fluid container][].|
-    &nbsp;
+    |fluid&#x2011;framework    |Contains the SharedMap [distributed data structure]({{< relref "dds.md" >}}) that synchronizes data across clients. *This object will hold the most recent timestamp update made by any client.*|
+    |fluidframework/tinylicious&#x2011;client   |Defines the connection to a Fluid service server and defines the starting schema for the [Fluid container][].|
+    {.table}
 
     Run the following command to install the libraries.
 


### PR DESCRIPTION
Enables an option in Hugo that allows decorating block elements in Markdown with CSS classes. This seemed easier than messing with the CSS styles to get them to apply to the element automatically.