### PR TITLE
Use updated type of encoding (Part 1)

### DIFF
--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -377,9 +377,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1025.0-38244",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38244.tgz",
-      "integrity": "sha512-YcPZfyZu09IGQ7V0GwAsxrnOTMQllxZ9zKj72rYpHHpnJMU1wqAlMr/4BaKDeNp7Mb+ncCLnqLaDd4h/0Oa69w==",
+      "version": "0.1025.0-38844",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38844.tgz",
+      "integrity": "sha512-IBmHnAJquLrVLe8ENod6zwOwZ8h2P/UPdgj4I1viGBFxORhpNk28HRHnZH00EhR6EvYuUTaRyz3FJExtz8/k8w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
       }

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.5",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244"
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -602,9 +602,9 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1031.0-38246",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1031.0-38246.tgz",
-      "integrity": "sha512-DTSkWproPdJPZiRANAkPnkkO1FBQpLVytDvIJWEMl6Y0Ygqd6aX6C3Yy/TYPKurIeu15uCnwSyFtV+aHUh/TnQ=="
+      "version": "0.1032.0-38847",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1032.0-38847.tgz",
+      "integrity": "sha512-fR+tKuRrPegeQYKju8EO0Ep3kdNYIF6KJGjmFEw+vs7kPJvkWF50aZlQ2IQEMiIHXfihk69fuBoJkjK8zH1+8Q=="
     },
     "@fluidframework/protocol-base": {
       "version": "0.1025.0-23979",

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.31.0-0",
-    "@fluidframework/gitresources": "^0.1031.0-38246",
+    "@fluidframework/gitresources": "^0.1032.0-38847",
     "@fluidframework/server-services": "^0.1025.0-0",
     "@fluidframework/server-services-client": "^0.1025.0-0",
     "@fluidframework/server-services-core": "^0.1025.0-0",

--- a/server/gitrest/src/routes/git/blobs.ts
+++ b/server/gitrest/src/routes/git/blobs.ts
@@ -8,6 +8,13 @@ import { Router } from "express";
 import nconf from "nconf";
 import * as utils from "../../utils";
 
+/**
+ * Validates that the input encoding is valid
+ */
+function validateEncoding(encoding: BufferEncoding): boolean {
+    return encoding === "utf-8" || encoding === "base64";
+}
+
 function validateBlob(blob: string): boolean {
     // eslint-disable-next-line no-null/no-null
     return blob !== undefined && blob !== null;
@@ -29,7 +36,7 @@ export async function createBlob(
     owner: string,
     repo: string,
     blob: ICreateBlobParams): Promise<ICreateBlobResponse> {
-        if (!blob || !validateBlob(blob.content)) {
+        if (!blob || !validateBlob(blob.content) || !validateEncoding(blob.encoding)) {
             // eslint-disable-next-line prefer-promise-reject-errors
             return Promise.reject("Invalid blob");
     }

--- a/server/gitrest/src/routes/git/blobs.ts
+++ b/server/gitrest/src/routes/git/blobs.ts
@@ -8,13 +8,6 @@ import { Router } from "express";
 import nconf from "nconf";
 import * as utils from "../../utils";
 
-/**
- * Validates that the input encoding is valid
- */
-function validateEncoding(encoding: BufferEncoding): boolean {
-    return encoding === "utf-8" || encoding === "base64";
-}
-
 function validateBlob(blob: string): boolean {
     // eslint-disable-next-line no-null/no-null
     return blob !== undefined && blob !== null;
@@ -36,7 +29,7 @@ export async function createBlob(
     owner: string,
     repo: string,
     blob: ICreateBlobParams): Promise<ICreateBlobResponse> {
-        if (!blob || !validateBlob(blob.content) || !validateEncoding(blob.encoding)) {
+        if (!blob || !validateBlob(blob.content)) {
             // eslint-disable-next-line prefer-promise-reject-errors
             return Promise.reject("Invalid blob");
     }

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -42,7 +42,7 @@ export class AttachmentTreeEntry {
 
 // @public
 export class BlobTreeEntry {
-    constructor(path: string, contents: string, encoding?: BufferEncoding);
+    constructor(path: string, contents: string, encoding?: "utf-8" | "base64");
     // (undocumented)
     readonly mode = FileMode.File;
     // (undocumented)

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -13,14 +13,13 @@ import { ISummaryHandle } from '@fluidframework/protocol-definitions';
 import { ISummaryTree as ISummaryTree_2 } from '@fluidframework/protocol-definitions';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { IUser } from '@fluidframework/protocol-definitions';
-import * as querystring from 'querystring';
 import * as resources from '@fluidframework/gitresources';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 import { SummaryObject } from '@fluidframework/protocol-definitions';
 
 // @public (undocumented)
 export class BasicRestWrapper extends RestWrapper {
-    constructor(baseurl?: string, defaultQueryString?: querystring.ParsedUrlQueryInput, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: querystring.ParsedUrlQueryInput, axios?: AxiosInstance, refreshDefaultQueryString?: () => querystring.ParsedUrlQueryInput, refreshDefaultHeaders?: () => querystring.ParsedUrlQueryInput, getCorrelationId?: () => string | undefined);
+    constructor(baseurl?: string, defaultQueryString?: Record<string, unknown>, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: Record<string, unknown>, axios?: AxiosInstance, refreshDefaultQueryString?: () => Record<string, unknown>, refreshDefaultHeaders?: () => Record<string, unknown>, getCorrelationId?: () => string | undefined);
     // (undocumented)
     protected request<T>(requestConfig: AxiosRequestConfig, statusCode: number, canRetry?: boolean): Promise<T>;
 }
@@ -471,25 +470,25 @@ export enum RestLessFieldNames {
 
 // @public (undocumented)
 export abstract class RestWrapper {
-    constructor(baseurl?: string, defaultQueryString?: querystring.ParsedUrlQueryInput, maxBodyLength?: number, maxContentLength?: number);
+    constructor(baseurl?: string, defaultQueryString?: Record<string, unknown>, maxBodyLength?: number, maxContentLength?: number);
     // (undocumented)
     protected readonly baseurl?: string;
     // (undocumented)
-    protected defaultQueryString: querystring.ParsedUrlQueryInput;
+    protected defaultQueryString: Record<string, unknown>;
     // (undocumented)
-    delete<T>(url: string, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
+    delete<T>(url: string, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
     // (undocumented)
-    protected generateQueryString(queryStringValues: querystring.ParsedUrlQueryInput): string;
+    protected generateQueryString(queryStringValues: Record<string, unknown>): string;
     // (undocumented)
-    get<T>(url: string, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
+    get<T>(url: string, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
     // (undocumented)
     protected readonly maxBodyLength: number;
     // (undocumented)
     protected readonly maxContentLength: number;
     // (undocumented)
-    patch<T>(url: string, requestBody: any, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
+    patch<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
     // (undocumented)
-    post<T>(url: string, requestBody: any, queryString?: querystring.ParsedUrlQueryInput, headers?: querystring.ParsedUrlQueryInput): Promise<T>;
+    post<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: Record<string, unknown>): Promise<T>;
     // (undocumented)
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 }

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -467,9 +467,9 @@
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1025.0-38244",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38244.tgz",
-			"integrity": "sha512-YcPZfyZu09IGQ7V0GwAsxrnOTMQllxZ9zKj72rYpHHpnJMU1wqAlMr/4BaKDeNp7Mb+ncCLnqLaDd4h/0Oa69w==",
+			"version": "0.1025.0-38844",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38844.tgz",
+			"integrity": "sha512-IBmHnAJquLrVLe8ENod6zwOwZ8h2P/UPdgj4I1viGBFxORhpNk28HRHnZH00EhR6EvYuUTaRyz3FJExtz8/k8w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0"
 			}

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-services-core": "^0.1032.0",
     "@types/node": "^12.19.0"
   },

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
     "@fluidframework/protocol-base": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-lambdas-driver": "^0.1032.0",
     "@fluidframework/server-services-client": "^0.1032.0",
     "@fluidframework/server-services-core": "^0.1032.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-lambdas": "^0.1032.0",
     "@fluidframework/server-memory-orderer": "^0.1032.0",
     "@fluidframework/server-services-client": "^0.1032.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-base": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-lambdas": "^0.1032.0",
     "@fluidframework/server-services-client": "^0.1032.0",
     "@fluidframework/server-services-core": "^0.1032.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -109,7 +109,7 @@ export class BlobTreeEntry {
      * @param contents - blob contents
      * @param encoding - encoding of contents; defaults to utf-8
      */
-    constructor(public readonly path: string, contents: string, encoding: BufferEncoding = "utf-8") {
+    constructor(public readonly path: string, contents: string, encoding: "utf-8" | "base64" = "utf-8") {
         this.value = { contents, encoding };
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-kafka-orderer": "^0.1032.0",
     "@fluidframework/server-lambdas": "^0.1032.0",
     "@fluidframework/server-lambdas-driver": "^0.1032.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-kafka-orderer": "^0.1032.0",
     "@fluidframework/server-lambdas": "^0.1032.0",
     "@fluidframework/server-lambdas-driver": "^0.1032.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
     "@fluidframework/protocol-base": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "axios": "^0.21.1",
     "debug": "^4.1.1",
     "jsrsasign": "^10.2.0",

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -261,7 +261,7 @@ export class GitManager implements IGitManager {
                         entryAsBlob.contents = this.translateSymlink(entryAsBlob.contents, depth);
                     }
 
-                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding as "utf-8" |"base64");
+                    const blobP = this.createBlob(entryAsBlob.contents, entryAsBlob.encoding);
                     entriesP.push(blobP);
                     break;
 

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { ParsedUrlQueryInput } from "querystring";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import { RestWrapper, BasicRestWrapper } from "./restWrapper";
@@ -32,7 +31,7 @@ export const getAuthorizationTokenFromCredentials = (credentials: ICredentials):
  * Implementation of the IHistorian interface that calls out to a REST interface
  */
 export class Historian implements IHistorian {
-    private readonly defaultQueryString: ParsedUrlQueryInput = {};
+    private readonly defaultQueryString: Record<string, unknown> = {};
     private readonly cacheBust: boolean;
 
     constructor(
@@ -168,7 +167,7 @@ export class Historian implements IHistorian {
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
-    private getQueryString(queryString?: {}): ParsedUrlQueryInput {
+    private getQueryString(queryString?: {}): Record<string, unknown> {
         if (this.cacheBust) {
             return {
                 cacheBust: Date.now(),

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -11,7 +11,7 @@ import { debug } from "./debug";
 export abstract class RestWrapper {
     constructor(
         protected readonly baseurl?: string,
-        protected defaultQueryString: querystring.ParsedUrlQueryInput = {},
+        protected defaultQueryString: Record<string, unknown> = {},
         protected readonly maxBodyLength = 1000 * 1024 * 1024,
         protected readonly maxContentLength = 1000 * 1024 * 1024,
     ) {
@@ -19,8 +19,8 @@ export abstract class RestWrapper {
 
     public async get<T>(
         url: string,
-        queryString?: querystring.ParsedUrlQueryInput,
-        headers?: querystring.ParsedUrlQueryInput,
+        queryString?: Record<string, unknown>,
+        headers?: Record<string, unknown>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -36,8 +36,8 @@ export abstract class RestWrapper {
     public async post<T>(
         url: string,
         requestBody: any,
-        queryString?: querystring.ParsedUrlQueryInput,
-        headers?: querystring.ParsedUrlQueryInput,
+        queryString?: Record<string, unknown>,
+        headers?: Record<string, unknown>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -53,8 +53,8 @@ export abstract class RestWrapper {
 
     public async delete<T>(
         url: string,
-        queryString?: querystring.ParsedUrlQueryInput,
-        headers?: querystring.ParsedUrlQueryInput,
+        queryString?: Record<string, unknown>,
+        headers?: Record<string, unknown>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -70,8 +70,8 @@ export abstract class RestWrapper {
     public async patch<T>(
         url: string,
         requestBody: any,
-        queryString?: querystring.ParsedUrlQueryInput,
-        headers?: querystring.ParsedUrlQueryInput,
+        queryString?: Record<string, unknown>,
+        headers?: Record<string, unknown>,
     ): Promise<T> {
         const options: AxiosRequestConfig = {
             baseURL: this.baseurl,
@@ -87,7 +87,7 @@ export abstract class RestWrapper {
 
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 
-    protected generateQueryString(queryStringValues: querystring.ParsedUrlQueryInput) {
+    protected generateQueryString(queryStringValues: Record<string, unknown>) {
         if (this.defaultQueryString || queryStringValues) {
             const queryStringMap = { ...this.defaultQueryString, ...queryStringValues };
 
@@ -104,13 +104,13 @@ export abstract class RestWrapper {
 export class BasicRestWrapper extends RestWrapper {
     constructor(
         baseurl?: string,
-        defaultQueryString: querystring.ParsedUrlQueryInput = {},
+        defaultQueryString: Record<string, unknown> = {},
         maxBodyLength = 1000 * 1024 * 1024,
         maxContentLength = 1000 * 1024 * 1024,
-        private defaultHeaders: querystring.ParsedUrlQueryInput = {},
+        private defaultHeaders: Record<string, unknown> = {},
         private readonly axios: AxiosInstance = Axios,
-        private readonly refreshDefaultQueryString?: () => querystring.ParsedUrlQueryInput,
-        private readonly refreshDefaultHeaders?: () => querystring.ParsedUrlQueryInput,
+        private readonly refreshDefaultQueryString?: () => Record<string, unknown>,
+        private readonly refreshDefaultHeaders?: () => Record<string, unknown>,
         private readonly getCorrelationId?: () => string | undefined,
     ) {
         super(baseurl, defaultQueryString, maxBodyLength, maxContentLength);
@@ -157,9 +157,9 @@ export class BasicRestWrapper extends RestWrapper {
     }
 
     private generateHeaders(
-        headers?: querystring.ParsedUrlQueryInput,
+        headers?: Record<string, unknown>,
         fallbackCorrelationId?: string,
-    ): querystring.ParsedUrlQueryInput {
+    ): Record<string, unknown> {
         let result = headers ?? {};
         if (this.defaultHeaders) {
             result = { ...this.defaultHeaders, ...headers };

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-services-client": "^0.1032.0",
     "@fluidframework/server-services-telemetry": "^0.1032.0",
     "@types/nconf": "^0.10.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
     "@fluidframework/protocol-base": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-services-client": "^0.1032.0",
     "@fluidframework/server-services-core": "^0.1032.0",
     "@socket.io/redis-adapter": "^7.0.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-services-client": "^0.1032.0",
     "@fluidframework/server-services-core": "^0.1032.0",
     "@fluidframework/server-services-telemetry": "^0.1032.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-services-client": "^0.1032.0",
     "@fluidframework/server-services-core": "^0.1032.0",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1032.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1032.0",
     "@fluidframework/protocol-base": "^0.1032.0",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844",
     "@fluidframework/server-services-client": "^0.1032.0",
     "@fluidframework/server-services-core": "^0.1032.0",
     "@fluidframework/server-services-telemetry": "^0.1032.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -218,9 +218,9 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1031.0-38246",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1031.0-38246.tgz",
-      "integrity": "sha512-DTSkWproPdJPZiRANAkPnkkO1FBQpLVytDvIJWEMl6Y0Ygqd6aX6C3Yy/TYPKurIeu15uCnwSyFtV+aHUh/TnQ=="
+      "version": "0.1032.0-38847",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1032.0-38847.tgz",
+      "integrity": "sha512-fR+tKuRrPegeQYKju8EO0Ep3kdNYIF6KJGjmFEw+vs7kPJvkWF50aZlQ2IQEMiIHXfihk69fuBoJkjK8zH1+8Q=="
     },
     "@fluidframework/mocha-test-setup": {
       "version": "0.27.9",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/gitresources": "^0.1031.0-38246",
+    "@fluidframework/gitresources": "^0.1032.0-38847",
     "@fluidframework/protocol-base": "^0.1028.1",
     "@fluidframework/protocol-definitions": "^0.1024.0",
     "@fluidframework/server-lambdas": "^0.1028.1",


### PR DESCRIPTION
Use updated encoding types from gitresources and protocol-definitions in routerlicious, tinylicious, driver-definitions, and gitrest.

Further pull requests to update container-definitions and client packages depend on this change.