### PR TITLE
Add UpdatedDurableSequenceNumber op event

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -685,7 +685,9 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
                         if (this.serviceConfiguration.deli.opEvent.enable) {
                             // ops were reliably stored
-                            this.emitOpEvent(OpEventType.UpdatedDurableSequenceNumber);
+                            // ensure op event timers & last sequenced op counters are reset
+                            // that will make the MaxTime & MaxOps op events will be accurate
+                            this.emitOpEvent(OpEventType.UpdatedDurableSequenceNumber, true);
                         }
                     }
 
@@ -1084,7 +1086,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
     /**
      * Resets the op event MaxTime timer
-     * Called after an opEvent is emitted or when the dsn is updated
+     * Called after an opEvent is emitted
      */
     private updateOpMaxTimeTimer() {
         const maxTime = this.serviceConfiguration.deli.opEvent.maxTime;
@@ -1107,11 +1109,11 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
     }
 
     /**
-     * Emits an opEvent based for the provided type
+     * Emits an opEvent for the provided type
      * Also resets the MaxTime timer
      */
-    private emitOpEvent(type: OpEventType) {
-        if (this.sequencedMessagesSinceLastOpEvent === 0) {
+    private emitOpEvent(type: OpEventType, force?: boolean) {
+        if (!force && this.sequencedMessagesSinceLastOpEvent === 0) {
             // no need to emit since no messages were handled since last time
             return;
         }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -686,7 +686,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                         if (this.serviceConfiguration.deli.opEvent.enable) {
                             // ops were reliably stored
                             // ensure op event timers & last sequenced op counters are reset
-                            // that will make the MaxTime & MaxOps op events will be accurate
+                            // that will make the MaxTime & MaxOps op events accurate
                             this.emitOpEvent(OpEventType.UpdatedDurableSequenceNumber, true);
                         }
                     }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -99,6 +99,7 @@ export enum OpEventType {
     Idle,
     MaxOps,
     MaxTime,
+    UpdatedDurableSequenceNumber,
 }
 
 export interface IDeliLambdaEvents extends IEvent {
@@ -683,9 +684,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                         this.emit("updatedDurableSequenceNumber", dsn);
 
                         if (this.serviceConfiguration.deli.opEvent.enable) {
-                            // since the dsn updated, ops were reliably stored
-                            // we can safely restart the MaxTime timer
-                            this.updateOpMaxTimeTimer();
+                            // ops were reliably stored
+                            this.emitOpEvent(OpEventType.UpdatedDurableSequenceNumber);
                         }
                     }
 


### PR DESCRIPTION
Add an op event for `UpdatedDurableSequenceNumber`. This will fix issues where deli is emitting `MaxOps` events in the wrong cases. DSN updates means that summary/ops were persisted to storage. It should reset the op event `sequencedMessagesSinceLastOpEvent` property. If it doesn't, `MaxOps` might be called even though there's only a few ops that have not been persisted. I want `MaxOps` to only emit when X number of ops have not been persisted