### PR TITLE
Remove nav param from sharelink set in resolved url

### DIFF
--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -62,6 +62,9 @@ export function isOdcUrl(url: string | URL): boolean;
 export function isSpoUrl(url: string): boolean;
 
 // @public (undocumented)
+export const locatorQueryParamName = "nav";
+
+// @public (undocumented)
 export const OdcApiSiteOrigin = "https://api.onedrive.com";
 
 // @public (undocumented)
@@ -86,7 +89,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
     protected persistedCache: IPersistedCache;
     // (undocumented)
     readonly protocolName = "fluid-odsp:";
-}
+    }
 
 // @public (undocumented)
 export class OdspDocumentServiceFactoryWithCodeSplit extends OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -16,7 +16,12 @@ import {
     OdspResourceTokenFetchOptions,
     TokenFetcher,
 } from "@fluidframework/odsp-driver-definitions";
-import { getLocatorFromOdspUrl, storeLocatorInOdspUrl, encodeOdspFluidDataStoreLocator } from "./odspFluidFileLink";
+import {
+    getLocatorFromOdspUrl,
+    storeLocatorInOdspUrl,
+    encodeOdspFluidDataStoreLocator,
+    locatorQueryParamName,
+} from "./odspFluidFileLink";
 import { OdspDocumentInfo, OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic";
 import { createOdspCreateContainerRequest } from "./createOdspCreateContainerRequest";
 import { createOdspUrl } from "./createOdspUrl";
@@ -137,7 +142,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         const odspResolvedUrl = await new OdspDriverUrlResolver().resolve(requestToBeResolved);
 
         if (isSharingLinkToRedeem) {
-            odspResolvedUrl.sharingLinkToRedeem = request.url;
+            odspResolvedUrl.sharingLinkToRedeem = this.removeNavParam(request.url);
         }
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't have it already as a performance optimization.
@@ -145,6 +150,14 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
             this.getShareLinkPromise(odspResolvedUrl).catch(() => {});
         }
         return odspResolvedUrl;
+    }
+
+    private removeNavParam(link: string): string {
+        const url = new URL(link);
+        const params = new URLSearchParams(url.search);
+        params.delete(locatorQueryParamName);
+        url.search = params.toString();
+        return url.href;
     }
 
     private toInstrumentedTokenFetcher(

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -142,6 +142,9 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         const odspResolvedUrl = await new OdspDriverUrlResolver().resolve(requestToBeResolved);
 
         if (isSharingLinkToRedeem) {
+            // We need to remove the nav param if set by host when setting the sharelink as otherwise the shareLinkId
+            // when redeeming the share link during the redeem fallback for trees latest call becomes greater than
+            // the eligible length.
             odspResolvedUrl.sharingLinkToRedeem = this.removeNavParam(request.url);
         }
         if (odspResolvedUrl.itemId) {

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -100,7 +100,7 @@ function decodeOdspFluidDataStoreLocator(
     };
 }
 
-const locatorQueryParamName = "nav";
+export const locatorQueryParamName = "nav";
 
 /**
  * Embeds Fluid data store locator data into given ODSP url

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -100,6 +100,8 @@ function decodeOdspFluidDataStoreLocator(
     };
 }
 
+// This parameter is provided by host in the resolve request and it contains information about the file
+// like driveId, itemId, siteUrl, datastorePath, packageName etc.
 export const locatorQueryParamName = "nav";
 
 /**

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -182,7 +182,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
             return urlResolverWithShareLinkFetcher.resolve(
                 { url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
-        assert.strictEqual(resolvedUrl.sharingLinkToRedeem, url.toString(), "Sharing link should be set in resolved url");
+        assert(resolvedUrl.sharingLinkToRedeem !== undefined, "Sharing link should be set in resolved url");
     });
 
     it("Encode and decode nav param", async () => {
@@ -194,5 +194,17 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
         assert.strictEqual(locator?.itemId, itemId, "Item id should be equal");
         assert.strictEqual(locator?.dataStorePath, dataStorePath, "DataStore path should be equal");
         assert.strictEqual(locator?.siteUrl, siteUrl, "SiteUrl should be equal");
+    });
+
+    it("Check nav param removal for share link", async () => {
+        const customShareLink = `${sharelink}?query1=q1`;
+        const url = new URL(customShareLink);
+        storeLocatorInOdspUrl(url, { siteUrl, driveId, itemId, dataStorePath });
+        const resolvedUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
+            return urlResolverWithShareLinkFetcher.resolve(
+                { url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
+        });
+        assert.strictEqual(
+            resolvedUrl.sharingLinkToRedeem, customShareLink, "Nav param should not exist on sharelink");
     });
 });


### PR DESCRIPTION
Remove nav param from sharelink set in resolved url as this causes issue when making the redeem share link call during fallback for trees latest.