### PR TITLE
Allow AgentScheduler to be accessible through a DataObject

### DIFF
--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -34,6 +34,7 @@
     "webpack:dev": "webpack --env.development"
   },
   "dependencies": {
+    "@fluidframework/agent-scheduler": "^0.49.0",
     "@fluidframework/azure-client": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/test-client-utils": "^0.49.0",

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -2,6 +2,8 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
+import { AgentSchedulerWrapper } from "@fluidframework/agent-scheduler";
 import {
     AzureFunctionTokenProvider,
     AzureClient,
@@ -62,6 +64,7 @@ const containerSchema = {
         /* [id]: DataObject */
         map1: SharedMap,
         map2: SharedMap,
+        schedulerWrapper: AgentSchedulerWrapper,
     },
 };
 
@@ -114,6 +117,8 @@ async function start(): Promise<void> {
     const sharedMap2 = container.initialObjects.map2 as SharedMap;
     const diceRollerController1 = new DiceRollerController(sharedMap1);
     const diceRollerController2 = new DiceRollerController(sharedMap2);
+
+    console.log((container.initialObjects.schedulerWrapper as AgentSchedulerWrapper).scheduler);
 
     const contentDiv = document.getElementById("content") as HTMLDivElement;
     contentDiv.append(makeAppView([diceRollerController1, diceRollerController2], services.audience));

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -46,6 +46,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
+    "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.39.8",

--- a/packages/runtime/agent-scheduler/src/index.ts
+++ b/packages/runtime/agent-scheduler/src/index.ts
@@ -4,5 +4,5 @@
  */
 
 export * from "./agent";
-export { AgentSchedulerFactory } from "./scheduler";
+export { AgentSchedulerFactory, AgentSchedulerWrapper } from "./scheduler";
 export * from "./taskSubscription";


### PR DESCRIPTION
This draft PR is for example purposes and meant to show how we can create a wrapper around `AgentScheduler` to create a `DataObject` for it so that it can be included into the `containerSchema` of a `FluidContainer`.

Without this change, `AgentScheduler` always needed to be included in the data store registry, which is inaccessible (and intentionally so to prevent over-complicating the dev surface) when creating a new `FluidContainer`. This approach allows us to preserve the `FluidContainer` API while supporting usage of `AgentScheduler`, as required by the SyncBridge team.