### PR TITLE
Proper workflow to allow full offline support in presence of cached snapshot.

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -433,8 +433,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         ]);
                         cachedSnapshot = promiseRaceWinner.value;
 
-                        if (cachedSnapshot === undefined)
-                        {
+                        if (cachedSnapshot === undefined) {
                             // if network failed -> wait for cache ( then return network failure)
                             // If cache returned empty or failed -> wait for network (success of failure)
                             if (promiseRaceWinner.index === 1) {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -432,19 +432,20 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                             snapshotP.catch(() => undefined),
                         ]);
                         cachedSnapshot = promiseRaceWinner.value;
+                        method = promiseRaceWinner.index === 0 ? "cache" : "network";
 
                         if (cachedSnapshot === undefined) {
                             // if network failed -> wait for cache ( then return network failure)
                             // If cache returned empty or failed -> wait for network (success of failure)
                             if (promiseRaceWinner.index === 1) {
                                 cachedSnapshot = await cachedSnapshotP;
+                                method = "cache";
                             }
                             if (cachedSnapshot === undefined) {
                                 cachedSnapshot = await snapshotP;
+                                method = "network";
                             }
                         }
-
-                        method = promiseRaceWinner.index === 0 && promiseRaceWinner.value !== undefined ? "cache" : "network";
                     } else {
                         // Note: There's a race condition here - another caller may come past the undefined check
                         // while the first caller is awaiting later async code in this block.


### PR DESCRIPTION
Before this change, we fail in offline if network request happens to return with failure sooner than cache comes back with results.
Part of https://github.com/microsoft/FluidFramework/issues/7639
