### PR TITLE
fluid:telemetry:OdspDriver:DeltaConnection:GetOpsTooMany events in prod telemetry

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -30,7 +30,14 @@ export class OdspDeltaStorageService {
     ) {
     }
 
-    public async get(
+    /**
+     * Retrieves ops from cache
+     * @param from - inclusive
+     * @param to - exclusive
+     * @param telemetryProps - properties to add when issuing telemetry events
+     * @returns ops retrieved & info if result was partial (i.e. more is available)
+     */
+     public async get(
         from: number,
         to: number,
         telemetryProps: ITelemetryProperties,

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -331,7 +331,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     ) {
         super(socket, documentId, logger);
         this.socketReference = socketReference;
-        this.requestOpsNoncePrefix = `${this.documentId}-`;
+        this.requestOpsNoncePrefix = `${uuid()}-`;
     }
 
     /**

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -342,7 +342,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
      */
      public requestOps(from: number, to: number) {
         // Given that to is exclusive, we should be asking for at least something!
-        assert(to > from + 1, "empty request");
+        assert(to > from, "empty request");
 
         // PUSH may disable this functionality
         // back-compat: remove cast to any once latest version of IConnected is consumed

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -334,7 +334,16 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
         this.requestOpsNoncePrefix = `${this.documentId}-`;
     }
 
-    public requestOps(from: number, to: number) {
+    /**
+     * Retrieves ops from PUSH
+     * @param from - inclusive
+     * @param to - exclusive
+     * @returns ops retrieved
+     */
+     public requestOps(from: number, to: number) {
+        // Given that to is exclusive, we should be asking for at least something!
+        assert(to > from + 1, "empty request");
+
         // PUSH may disable this functionality
         // back-compat: remove cast to any once latest version of IConnected is consumed
         if ((this.details as any).supportedFeatures?.[feature_get_ops] !== true) {
@@ -353,9 +362,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
         // So track some number of requests, but log if we get too many in flight - that likely
         // indicates an error somewhere.
         if (this.getOpsMap.size >= 5) {
-            this.logger.sendTelemetryEvent({
-                eventName: "GetOpsTooMany",
-            });
             let time = start;
             let key: string | undefined;
             for (const [keyCandidate, value] of this.getOpsMap.entries()) {
@@ -364,6 +370,14 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                     key = keyCandidate;
                 }
             }
+            const payloadToDelete = this.getOpsMap.get(key!)!;
+            this.logger.sendErrorEvent({
+                eventName: "GetOpsTooMany",
+                from: payloadToDelete.from,
+                to: payloadToDelete.to,
+                length: payloadToDelete.to - payloadToDelete.from,
+                duration: performance.now() - payloadToDelete.start,
+            });
             this.getOpsMap.delete(key!);
         }
         this.getOpsMap.set(
@@ -377,7 +391,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
         this.socket.emit("get_ops", this.clientId, {
             nonce,
             from,
-            to,
+            to: to - 1,
         });
     }
 

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -117,7 +117,13 @@ export class OpsCache {
         }
     }
 
-    private async getCore(from: number, to?: number): Promise<IMessage[]> {
+    /**
+     * Retrieves ops from cache
+     * @param from - inclusive
+     * @param to - exclusive
+     * @returns ops retrieved
+     */
+     private async getCore(from: number, to?: number): Promise<IMessage[]> {
         const messages: IMessage[] = [];
         let batchNumber = this.getBatchNumber(from);
         // eslint-disable-next-line no-constant-condition
@@ -150,6 +156,12 @@ export class OpsCache {
         }
     }
 
+    /**
+     * Retrieves ops from cache
+     * @param from - inclusive
+     * @param to - exclusive
+     * @returns ops retrieved
+     */
     public async get(from: number, to?: number): Promise<IMessage[]> {
         const start = performance.now();
 


### PR DESCRIPTION
Please see Issue #7602 for more details.

These events should be error events.
Also collect a bit more data on them.

Based on looking at telemetry, some of that might be caused by a bug that caused us to fetch ops from seq=1, and PUSH being slow to respond to these events. This bug has been fixed.

Also off-by-1 error fixed (to be confirmed by Gary).

