### PR TITLE
SharedString docs

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -227,11 +227,8 @@ export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
 
 // @public
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
-    // (undocumented)
     insertMarker(pos: number, refType: MergeTree.ReferenceType, props?: MergeTree.PropertySet): any;
-    // (undocumented)
     insertText(pos: number, text: string, props?: MergeTree.PropertySet): any;
-    // (undocumented)
     posFromRelativePos(relativePos: MergeTree.IRelativePosition): any;
 }
 
@@ -606,7 +603,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     static getFactory(): SharedStringFactory;
     // (undocumented)
     getMarkerFromId(id: string): MergeTree.ISegment;
-    // (undocumented)
     getText(start?: number, end?: number): string;
     // (undocumented)
     getTextAndMarkers(label: string): {

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -169,15 +169,13 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
     };
     }
 
-// @public (undocumented)
+// @public
 export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     // (undocumented)
     operation: TOperation;
-    // (undocumented)
     position: number;
     // (undocumented)
     propertyDeltas: PropertySet;
-    // (undocumented)
     segment: ISegment;
 }
 
@@ -325,7 +323,6 @@ export class RunSegment extends SubSequence<SparseMatrixItem> {
 // @public
 export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
     constructor(opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs, mergeTreeClient: Client);
-    // (undocumented)
     readonly isLocal: boolean;
     // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs;
@@ -339,11 +336,9 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
     readonly deltaArgs: IMergeTreeDeltaCallbackArgs<TOperation>;
     // (undocumented)
     readonly deltaOperation: TOperation;
-    // (undocumented)
     get first(): Readonly<ISequenceDeltaRange<TOperation>>;
     // (undocumented)
     readonly isEmpty: boolean;
-    // (undocumented)
     get last(): Readonly<ISequenceDeltaRange<TOperation>>;
     get ranges(): readonly Readonly<ISequenceDeltaRange<TOperation>>[];
     }
@@ -622,7 +617,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     insertTextRelative(relativePos1: MergeTree.IRelativePosition, text: string, props?: MergeTree.PropertySet): void;
     // (undocumented)
     get ISharedString(): ISharedString;
-    // (undocumented)
     removeText(start: number, end: number): MergeTree.IMergeTreeRemoveMsg;
     replaceText(start: number, end: number, text: string, props?: MergeTree.PropertySet): void;
 }

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -215,7 +215,7 @@ export interface ISharedIntervalCollection<TInterval extends ISerializableInterv
     waitIntervalCollection(label: string): Promise<IntervalCollection<TInterval>>;
 }
 
-// @public (undocumented)
+// @public
 export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: "sequenceDelta", listener: (event: SequenceDeltaEvent, target: IEventThisPlaceHolder) => void): any;

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -156,7 +156,7 @@ export class Client {
     }
     /**
      * Annotates the range with the provided properties
-     * @param start - The inclusive start postition of the range to annotate
+     * @param start - The inclusive start position of the range to annotate
      * @param end - The exclusive end position of the range to annotate
      * @param props - The properties to annotate the range with
      * @param combiningOp - Specifies how to combine values for the property, such as "incr" for increment.

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -51,6 +51,9 @@ export type RangeStackMap = Properties.MapLike<Collections.Stack<ReferencePositi
 
 export interface IMergeNodeCommon {
     parent?: IMergeBlock;
+    /**
+     * The length of the contents of the node.
+     */
     cachedLength: number;
     index: number;
     ordinal: string;
@@ -84,6 +87,9 @@ export interface IRemovalInfo {
     removedClientOverlap?: number[];
 }
 
+/**
+ * A segment representing a portion of the merge tree.
+ */
 export interface ISegment extends IMergeNodeCommon, IRemovalInfo {
     readonly type: string;
     readonly segmentGroups: SegmentGroupCollection;

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2546,7 +2546,7 @@ export class MergeTree {
 
     /**
      * Annotate a range with properties
-     * @param start - The inclusive start postition of the range to annotate
+     * @param start - The inclusive start position of the range to annotate
      * @param end - The exclusive end position of the range to annotate
      * @param props - The properties to annotate the range with
      * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.

--- a/packages/dds/merge-tree/src/opBuilder.ts
+++ b/packages/dds/merge-tree/src/opBuilder.ts
@@ -40,7 +40,7 @@ export function createAnnotateMarkerOp(
 
 /**
  * Creates the op for annotating the range with the provided properties
- * @param start - The inclusive start postition of the range to annotate
+ * @param start - The inclusive start position of the range to annotate
  * @param end - The exclusive end position of the range to annotate
  * @param props - The properties to annotate the range with
  * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -27,13 +27,13 @@ export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment 
     }
 
     public addOrUpdate(newItem: T, update?: (existingItem: T, newItem: T) => T) {
-        const postition = this.findOrdinalPosition(this.getOrdinal(newItem));
-        if (postition.exists) {
+        const position = this.findOrdinalPosition(this.getOrdinal(newItem));
+        if (position.exists) {
             if (update) {
-                update(this.oridinalSortedItems[postition.index], newItem);
+                update(this.oridinalSortedItems[position.index], newItem);
             }
         } else {
-            this.oridinalSortedItems.splice(postition.index, 0, newItem);
+            this.oridinalSortedItems.splice(position.index, 0, newItem);
         }
     }
 

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -235,7 +235,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     /**
      * Inserts the content of the register.
      *
-     * @param pos - The postition to insert the content at.
+     * @param pos - The position to insert the content at.
      * @param register - The name of the register to get the content from
      */
     public paste(pos: number, register: string) {
@@ -288,7 +288,7 @@ export abstract class SharedSegmentSequence<T extends MergeTree.ISegment>
     /**
      * Annotates the range with the provided properties
      *
-     * @param start - The inclusive start postition of the range to annotate
+     * @param start - The inclusive start position of the range to annotate
      * @param end - The exclusive end position of the range to annotate
      * @param props - The properties to annotate the range with
      * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -42,9 +42,36 @@ import { ISharedIntervalCollection } from "./sharedIntervalCollection";
 const snapshotFileName = "header";
 const contentPath = "content";
 
-export interface ISharedSegmentSequenceEvents
-    extends ISharedObjectEvents {
-
+/**
+ * Events emitted in response to changes to the sequence data.
+ *
+ * ### "sequenceDelta"
+ *
+ * The sequenceDelta event is emitted when segments are inserted, annotated, or removed.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * (event: SequenceDeltaEvent, target: IEventThisPlaceHolder) => void
+ * ```
+ * - `event` - Various information on the segments that were modified.
+ *
+ * - `target` - The sequence itself.
+ *
+ * ### "maintenance"
+ *
+ * The maintenance event is emitted when segments are modified during merge-tree maintenance.
+ *
+ * #### Listener signature
+ *
+ * ```typescript
+ * (event: SequenceMaintenanceEvent, target: IEventThisPlaceHolder) => void
+ * ```
+ * - `event` - Various information on the segments that were modified.
+ *
+ * - `target` - The sequence itself.
+ */
+export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     (event: "sequenceDelta", listener: (event: SequenceDeltaEvent, target: IEventThisPlaceHolder) => void);
     (event: "maintenance",
         listener: (event: SequenceMaintenanceEvent, target: IEventThisPlaceHolder) => void);

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -84,10 +84,16 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
         return this.mergeTreeClient.longClientId;
     }
 
+    /**
+     * The first of the modified ranges.
+     */
     public get first(): Readonly<ISequenceDeltaRange<TOperation>> {
         return this.pFirst.value;
     }
 
+    /**
+     * The last of the modified ranges.
+     */
     public get last(): Readonly<ISequenceDeltaRange<TOperation>> {
         return this.pLast.value;
     }
@@ -105,6 +111,9 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
  * Ops may get multiple events. For instance, an insert-replace will get a remove then an insert event.
  */
 export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
+    /**
+     * Whether the event was caused by a locally-made change.
+     */
     public readonly isLocal: boolean;
 
     constructor(
@@ -134,9 +143,18 @@ export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenance
     }
 }
 
+/**
+ * A range that has changed corresponding to a segment modification.
+ */
 export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     operation: TOperation;
+    /**
+     * The index of the start of the range.
+     */
     position: number;
+    /**
+     * The segment that corresponds to the range.
+     */
     segment: ISegment;
     propertyDeltas: PropertySet;
 }

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -14,10 +14,25 @@ import { SharedStringFactory } from "./sequenceFactory";
  * Fluid object interface describing access methods on a SharedString
  */
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
+    /**
+     * Inserts the text at the postition.
+     * @param pos - The  postition to insert the text at
+     * @param text - The text to insert
+     * @param props - The properties of text
+     */
     insertText(pos: number, text: string, props?: MergeTree.PropertySet);
 
+    /**
+     * Inserts a marker at the postition.
+     * @param pos - The postition to insert the marker at
+     * @param refType - The reference type of the marker
+     * @param props - The properties of the marker
+     */
     insertMarker(pos: number, refType: MergeTree.ReferenceType, props?: MergeTree.PropertySet);
 
+    /**
+     * {@inheritDoc SharedSegmentSequence.posFromRelativePos}
+     */
     posFromRelativePos(relativePos: MergeTree.IRelativePosition);
 }
 
@@ -25,7 +40,7 @@ export type SharedStringSegment = MergeTree.TextSegment | MergeTree.Marker;
 
 /**
  * The Shared String is a specialized data structure for handling collaborative
- *  text. It is based on a more general Sequence data structure but has
+ * text. It is based on a more general Sequence data structure but has
  * additional features that make working with text easier.
  *
  * In addition to text, a Shared String can also contain markers. Markers can be
@@ -35,8 +50,7 @@ export type SharedStringSegment = MergeTree.TextSegment | MergeTree.Marker;
  */
 export class SharedString extends SharedSegmentSequence<SharedStringSegment> implements ISharedString {
     /**
-     * Create a new shared string
-     *
+     * Create a new shared string.
      * @param runtime - data store runtime the new shared string belongs to
      * @param id - optional name of the shared string
      * @returns newly create shared string (but not attached yet)
@@ -47,7 +61,6 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
 
     /**
      * Get a factory for SharedString to register with the data store.
-     *
      * @returns a factory that creates and load SharedString
      */
     public static getFactory() {
@@ -66,8 +79,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Inserts a marker at a relative postition
-     *
+     * Inserts a marker at a relative postition.
      * @param relativePos1 - The relative postition to insert the marker at
      * @param refType - The reference type of the marker
      * @param props - The properties of the marker
@@ -89,11 +101,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Inserts a marker at the postition
-     *
-     * @param pos - The postition to insert the marker at
-     * @param refType - The reference type of the marker
-     * @param props - The properties of the marker
+     * {@inheritDoc ISharedString.insertMarker}
      */
     public insertMarker(
         pos: number,
@@ -112,8 +120,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Inserts the text at the postition
-     *
+     * Inserts the text at the postition.
      * @param relativePos1 - The relative postition to insert the text at
      * @param text - The text to insert
      * @param props - The properties of text
@@ -132,11 +139,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Inserts the text at the postition
-     *
-     * @param pos - The  postition to insert the text at
-     * @param text - The text to insert
-     * @param props - The properties of text
+     * {@inheritDoc ISharedString.insertText}
      */
     public insertText(pos: number, text: string, props?: MergeTree.PropertySet) {
         const segment = new MergeTree.TextSegment(text);
@@ -149,9 +152,9 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
             this.submitSequenceMessage(insertOp);
         }
     }
+
     /**
      * Replaces a range with the provided text.
-     *
      * @param start - The inclusive start of the range to replace
      * @param end - The exclusive end of the range to replace
      * @param text - The text to replace the range with
@@ -166,9 +169,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Annotates the marker with the provided properties
-     * and calls the callback on concensus.
-     *
+     * Annotates the marker with the provided properties and calls the callback on consensus.
      * @param marker - The marker to annotate
      * @param props - The properties to annotate the marker with
      * @param consensusCallback - The callback called when consensus is reached
@@ -184,8 +185,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Annotates the marker with the provided properties
-     *
+     * Annotates the marker with the provided properties.
      * @param marker - The marker to annotate
      * @param props - The properties to annotate the marker with
      * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.
@@ -208,21 +208,31 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
         const segmentWindow = this.client.getCollabWindow();
         return this.mergeTreeTextHelper.getTextAndMarkers(segmentWindow.currentSeq, segmentWindow.clientId, label);
     }
+
+    /**
+     * Retrieve text from the SharedString in string format.
+     * @param start - The starting index of the text to retrieve, or 0 if omitted.
+     * @param end - The ending index of the text to retrieve, or the end of the string if omitted
+     * @returns The requested text content as a string.
+     */
     public getText(start?: number, end?: number) {
         const segmentWindow = this.client.getCollabWindow();
         return this.mergeTreeTextHelper.getText(segmentWindow.currentSeq, segmentWindow.clientId, "", start, end);
     }
+
     /**
-     * Adds spaces for markers and handles, so that position calculations account for them
+     * Adds spaces for markers and handles, so that position calculations account for them.
      */
     public getTextWithPlaceholders() {
         const segmentWindow = this.client.getCollabWindow();
         return this.mergeTreeTextHelper.getText(segmentWindow.currentSeq, segmentWindow.clientId, " ");
     }
+
     public getTextRangeWithPlaceholders(start: number, end: number) {
         const segmentWindow = this.client.getCollabWindow();
         return this.mergeTreeTextHelper.getText(segmentWindow.currentSeq, segmentWindow.clientId, " ", start, end);
     }
+
     public getTextRangeWithMarkers(start: number, end: number) {
         const segmentWindow = this.client.getCollabWindow();
         return this.mergeTreeTextHelper.getText(segmentWindow.currentSeq, segmentWindow.clientId, "*", start, end);

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -16,7 +16,7 @@ import { SharedStringFactory } from "./sequenceFactory";
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
     /**
      * Inserts the text at the postition.
-     * @param pos - The  postition to insert the text at
+     * @param pos - The postition to insert the text at
      * @param text - The text to insert
      * @param props - The properties of text
      */
@@ -164,6 +164,12 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
         this.replaceRange(start, end, MergeTree.TextSegment.make(text, props));
     }
 
+    /**
+     * Removes the text in the given range.
+     * @param start - The inclusive start of the range to remove
+     * @param end - The exclusive end of the range to replace
+     * @returns the message sent.
+     */
     public removeText(start: number, end: number) {
         return this.removeRange(start, end);
     }

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -15,16 +15,16 @@ import { SharedStringFactory } from "./sequenceFactory";
  */
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
     /**
-     * Inserts the text at the postition.
-     * @param pos - The postition to insert the text at
+     * Inserts the text at the position.
+     * @param pos - The position to insert the text at
      * @param text - The text to insert
      * @param props - The properties of text
      */
     insertText(pos: number, text: string, props?: MergeTree.PropertySet);
 
     /**
-     * Inserts a marker at the postition.
-     * @param pos - The postition to insert the marker at
+     * Inserts a marker at the position.
+     * @param pos - The position to insert the marker at
      * @param refType - The reference type of the marker
      * @param props - The properties of the marker
      */
@@ -79,8 +79,8 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Inserts a marker at a relative postition.
-     * @param relativePos1 - The relative postition to insert the marker at
+     * Inserts a marker at a relative position.
+     * @param relativePos1 - The relative position to insert the marker at
      * @param refType - The reference type of the marker
      * @param props - The properties of the marker
      */
@@ -120,8 +120,8 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     }
 
     /**
-     * Inserts the text at the postition.
-     * @param relativePos1 - The relative postition to insert the text at
+     * Inserts the text at the position.
+     * @param relativePos1 - The relative position to insert the text at
      * @param text - The text to insert
      * @param props - The properties of text
      */

--- a/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
@@ -33,9 +33,9 @@ export function createSharedStringWithInterception(
     let executingCallback: boolean = false;
 
     /**
-     * Inserts a marker at a relative postition.
+     * Inserts a marker at a relative position.
      *
-     * @param relativePos1 - The relative postition to insert the marker at
+     * @param relativePos1 - The relative position to insert the marker at
      * @param refType - The reference type of the marker
      * @param props - The properties of the marker
      */
@@ -59,9 +59,9 @@ export function createSharedStringWithInterception(
     };
 
     /**
-     * Inserts a marker at the postition.
+     * Inserts a marker at the position.
      *
-     * @param pos - The postition to insert the marker at
+     * @param pos - The position to insert the marker at
      * @param refType - The reference type of the marker
      * @param props - The properties of the marker
      */
@@ -88,9 +88,9 @@ export function createSharedStringWithInterception(
     };
 
     /**
-     * Inserts the text at a relative postition.
+     * Inserts the text at a relative position.
      *
-     * @param relativePos1 - The relative postition to insert the text at
+     * @param relativePos1 - The relative position to insert the text at
      * @param text - The text to insert
      * @param props - The properties of text
      */
@@ -114,9 +114,9 @@ export function createSharedStringWithInterception(
     };
 
     /**
-     * Inserts the text at the postition.
+     * Inserts the text at the position.
      *
-     * @param pos - The postition to insert the text at
+     * @param pos - The position to insert the text at
      * @param text - The text to insert
      * @param props - The properties of text
      */
@@ -219,7 +219,7 @@ export function createSharedStringWithInterception(
     /**
      * Annotates the range with the provided properties.
      *
-     * @param start - The inclusive start postition of the range to annotate
+     * @param start - The inclusive start position of the range to annotate
      * @param end - The exclusive end position of the range to annotate
      * @param props - The properties to annotate the range with
      * @param combiningOp - Optional. Specifies how to combine values for the property, such as "incr" for increment.


### PR DESCRIPTION
This change adds TSDocs for a subset of `SharedString`, `Sequence`, etc.  As a scoping measure, I limited the effort to the set that is directly used in the `CollaborativeTextArea` demo.