### PR TITLE
Adding RunService metric and instrumenting rest of services-shared with Lumberjack

### DIFF
--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -61,7 +61,6 @@ export function runService<T extends IResources>(
         : configOrPath;
 
     const runnerMetric = Lumberjack.newLumberMetric(LumberEventName.RunService);
-
     const runningP = run(config, resourceFactory, runnerFactory, logger);
 
     runningP.then(
@@ -99,5 +98,5 @@ async function executeAndWait(func: () => void, waitInMs: number) {
     func();
     return new Promise((resolve) => {
         setTimeout(resolve, waitInMs);
-      });
+    });
 }

--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -6,7 +6,7 @@
 import { inspect } from "util";
 import nconf from "nconf";
 import { ILogger, IResources, IResourcesFactory, IRunnerFactory } from "@fluidframework/server-services-core";
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { Lumberjack, LumberEventName } from "@fluidframework/server-services-telemetry";
 
 /**
  * Uses the provided factories to create and execute a runner.
@@ -60,18 +60,20 @@ export function runService<T extends IResources>(
         ? nconf.argv().env({ separator: "__", parseValues: true }).file(configOrPath).use("memory")
         : configOrPath;
 
+    const runnerMetric = Lumberjack.newLumberMetric(LumberEventName.RunService);
+
     const runningP = run(config, resourceFactory, runnerFactory, logger);
 
     runningP.then(
         () => {
             logger?.info("Exiting");
-            Lumberjack.info("Exiting");
+            runnerMetric.success(`${group} exiting.`);
             process.exit(0);
         },
         (error) => {
             logger?.error(`${group} service exiting due to error`);
-            Lumberjack.error(`${group} service exiting due to error`, undefined, error);
             logger?.error(inspect(error));
+            runnerMetric.error(`${group} service exiting due to error`, error);
             if (error.forceKill) {
                 process.kill(process.pid, "SIGKILL");
             } else {

--- a/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoRedisConnection.ts
@@ -5,6 +5,7 @@
 
 import { Redis } from "ioredis";
 import * as winston from "winston";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { ISocketIoRedisConnection, ISocketIoRedisSubscriptionConnection } from "./redisSocketIoAdapter";
 
 /**
@@ -15,6 +16,7 @@ export class SocketIORedisConnection implements ISocketIoRedisConnection {
     constructor(protected readonly client: Redis) {
         client.on("error", (err) => {
             winston.error("Error with Redis:", err);
+            Lumberjack.error("Error with Redis:", undefined, err);
         });
     }
 

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from "events";
 import * as http from "http";
 import * as util from "util";
 import * as core from "@fluidframework/server-services-core";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { clone } from "lodash";
 import Redis from "ioredis";
 import { Namespace, Server, Socket } from "socket.io";
@@ -91,9 +92,11 @@ export function create(
 
     pub.on("error", (err) => {
         winston.error("Error with Redis pub connection: ", err);
+        Lumberjack.error("Error with Redis pub connection", undefined, err);
     });
     sub.on("error", (err) => {
         winston.error("Error with Redis sub connection: ", err);
+        Lumberjack.error("Error with Redis sub connection", undefined, err);
     });
 
     let adapter: (nsp: Namespace) => Adapter | undefined;

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -6,9 +6,12 @@
 // List of event names that should identify Lumber events throughout the code.
 // Values in the enum must be strings.
 export enum LumberEventName {
-    // Infrastructure and helpers
+    // Lumberjack infrastructure and helpers
     LumberjackError = "LumberjackError",
     LumberjackSchemaValidationFailure = "LumberjackSchemaValidationFailure",
+
+    // Fluid server infrastructure
+    RunService = "RunService",
 
     // Unit Testing
     UnitTestEvent = "UnitTestEvent",


### PR DESCRIPTION
* Adding new metric for tracking `runService` result. This will help keep track/alert on services restarting due to errors
   * Introducing "wait" logic before emitting `runService` telemetry data to allow the data to be emitted appropriately. Not waiting can cause the Node.js process to crash/exit before the data is allowed to be sent to the `winston` transport/`Lumberjack` engine.
* Adding Lumberjack instrumentation to the remaining of services-shared