### PR TITLE
Use updated type of encoding (Part 2)

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -371,13 +371,13 @@
       "integrity": "sha512-n1neSteU0P/mQjthiNqqrdXl3+VeJ2QFZva6QJOcFRVmjHe+c827g9VqEbz0WB8jcSKpf98n3QzTXAGmEqBeVg=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.40.0-38602",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0-38602.tgz",
-      "integrity": "sha512-bgO9VWR1VIWPQwTctFmnCAfdrthKFxsbI7ZzUVeKpNtyGC7eOTWxUk32pHOyKJtrV/jr11IqzNeBUEk7t6l09g==",
+      "version": "0.40.0-39010",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0-39010.tgz",
+      "integrity": "sha512-cd3ocIxK3oKqCMzjEKjnA8dge8ropK3FxgmNUZGHUvRStVsmjDr6Mc/FRO4j7WqB1c9eR9JxacVttAzWdQUMkw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.39.5",
-        "@fluidframework/protocol-definitions": "^0.1025.0-38244"
+        "@fluidframework/protocol-definitions": "^0.1025.0-38844"
       }
     },
     "@fluidframework/eslint-config-fluid": {
@@ -399,9 +399,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1025.0-38244",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38244.tgz",
-      "integrity": "sha512-YcPZfyZu09IGQ7V0GwAsxrnOTMQllxZ9zKj72rYpHHpnJMU1wqAlMr/4BaKDeNp7Mb+ncCLnqLaDd4h/0Oa69w==",
+      "version": "0.1025.0-38844",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0-38844.tgz",
+      "integrity": "sha512-IBmHnAJquLrVLe8ENod6zwOwZ8h2P/UPdgj4I1viGBFxORhpNk28HRHnZH00EhR6EvYuUTaRyz3FJExtz8/k8w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
       }

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.5",
-    "@fluidframework/driver-definitions": "^0.40.0-38602",
-    "@fluidframework/protocol-definitions": "^0.1025.0-38244"
+    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/protocol-definitions": "^0.1025.0-38844"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",


### PR DESCRIPTION
Update driver-definitions and protocol-definitions versions in container-definitions to remove node dependency. A subsequent change will update client packages.