### PR TITLE
Layer-check: add support for specifying an output path for the markdown

### DIFF
--- a/tools/build-tools/README.md
+++ b/tools/build-tools/README.md
@@ -92,6 +92,8 @@ To build Fluid within VSCode, use Ctrl-Shift-B to break up the build task list a
 Usage: fluid-layer-check <options>
 Options:
      --dot <path>     Generate *.dot for GraphViz
+     --info <path>    Path to the layer graph json file
+     --md [<path>]    Generate PACKAGES.md file for human consumption. (default: current working directory)
      --defroot <path> Default root directory of the Fluid repo if infer failed (default: env _FLUID_DEFAULT_ROOT_)
      --root <path>    Root directory of the Fluid repo (default: env _FLUID_ROOT_)
      --timer          Measure elapsed time of each step

--- a/tools/build-tools/src/layerCheck/layerCheck.ts
+++ b/tools/build-tools/src/layerCheck/layerCheck.ts
@@ -18,7 +18,7 @@ Usage: fluid-layer-check <options>
 Options:
      --dot <path>     Generate *.dot for GraphViz
      --info <path>    Path to the layer graph json file
-     --md             Generate PACKAGES.md file for human consumption
+     --md <path>      Generate PACKAGES.md file for human consumption
 ${commonOptionString}
 `);
 }
@@ -26,7 +26,7 @@ ${commonOptionString}
 const packagesMdFileName: string = "PACKAGES.md";
 
 let dotGraphFilePath: string | undefined;
-let writePackagesMd: boolean = false;
+let mdFilePath: string | undefined;
 let layerInfoPath: string | undefined;
 
 function parseOptions(argv: string[]) {
@@ -60,8 +60,12 @@ function parseOptions(argv: string[]) {
         }
 
         if (arg === "--md") {
-            writePackagesMd = true;
-            continue;
+            if (i !== process.argv.length - 1) {
+                mdFilePath = process.argv[++i];
+                continue;
+            }
+            mdFilePath = ".";
+            break;
         }
 
         if (arg === "--info") {
@@ -100,8 +104,8 @@ async function main() {
         const layerGraph = LayerGraph.load(resolvedRoot, packages, layerInfoPath);
 
         // Write human-readable package list organized by layer
-        if (writePackagesMd) {
-            const packagesMdFilePath: string = path.join(resolvedRoot, "docs", packagesMdFileName);
+        if (mdFilePath) {
+            const packagesMdFilePath: string = path.join(resolvedRoot, mdFilePath, packagesMdFileName);
             await writeFileAsync(packagesMdFilePath, layerGraph.generatePackageLayersMarkdown(resolvedRoot));
         }
 

--- a/tools/build-tools/src/layerCheck/layerCheck.ts
+++ b/tools/build-tools/src/layerCheck/layerCheck.ts
@@ -18,7 +18,7 @@ Usage: fluid-layer-check <options>
 Options:
      --dot <path>     Generate *.dot for GraphViz
      --info <path>    Path to the layer graph json file
-     --md <path>      Generate PACKAGES.md file for human consumption
+     --md [<path>]      Generate PACKAGES.md file for human consumption. (default: current working directory)
 ${commonOptionString}
 `);
 }


### PR DESCRIPTION
This is in preparation for moving the PACKAGES.md file to the root. See #7660.