### PR TITLE
Test/wes stress

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,9 @@
             "type": "node",
             "request": "attach",
             "name": "Attach by Process ID",
+            "skipFiles": [
+                "<node_internals>/**/*.js"
+            ],
             "processId": "${command:PickProcess}"
         },
         {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -28,7 +28,7 @@
     "full": "node ./dist/nodeStressTest.js --profile full",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
-    "start": "node ./dist/nodeStressTest.js",
+    "start": "node ./dist/nodeStressTest.js -v",
     "start:mini": "node ./dist/nodeStressTest.js  --profile mini",
     "start:reauth": "node ./dist/nodeStressTest.js --profile mini --browserAuth",
     "start:tinylicious:test": "tinylicious > tinylicious.log 2>&1",

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -161,6 +161,7 @@ extends EventForwarder<IDocumentDeltaConnectionEvents> implements IDocumentDelta
             "error",
             new FaultInjectionError("FaultInjectionError", canRetry));
     }
+
     public injectDisconnect() {
         assert(!this.disposed, "cannot inject disconnect into closed delta connection");
         this.emit("disconnect","FaultInjectionDisconnect");

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -93,7 +93,7 @@ class LoadTestDataStoreModel {
         const gcDataStoreIdKey = `gc_dataStore_${config.runId % halfClients}`;
         let gcDataStore: LoadTestDataStore | undefined;
         if (!root.has(gcDataStoreIdKey)) {
-            processSend(config.runId, "requesting GC DS");
+            processSend(config.runId, "creating GC DS");
             // The data store for this pair doesn't exist, create it and store its url.
             gcDataStore = await LoadTestDataStoreInstantiationFactory.createInstance(containerRuntime);
             root.set(gcDataStoreIdKey, gcDataStore.id);
@@ -160,7 +160,6 @@ class LoadTestDataStoreModel {
             gcDataStore.handle,
         );
 
-        processSend(config.runId, "reset");
         if(reset) {
             await LoadTestDataStoreModel.waitForCatchup(runtime, config.runId);
             processSend(config.runId, "caught up again");
@@ -322,7 +321,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
     public async run(config: IRunConfig, reset: boolean) {
         processSend(config.runId, "init");
         const dataModel = await LoadTestDataStoreModel.createRunnerInstance(
-                config, reset, this.root, this.runtime, this.context.containerRuntime);
+            config, reset, this.root, this.runtime, this.context.containerRuntime);
 
          // At every moment, we want half the client to be concurrent writers, and start and stop
         // in a rotation fashion for every cycle.

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -25,12 +25,19 @@ function printStatus(runConfig: IRunConfig, message: string) {
 }
 
 async function main() {
+    const parseIntArg = (value: any): number => {
+        if (isNaN(parseInt(value, 10))) {
+            throw new commander.InvalidArgumentError("Not a number.");
+        }
+        return parseInt(value, 10);
+    };
     commander
         .version("0.0.1")
         .requiredOption("-d, --driver <driver>", "Which test driver info to use", "odsp")
         .requiredOption("-p, --profile <profile>", "Which test profile to use from testConfig.json", "ci")
         .requiredOption("-u --url <url>", "Load an existing data store from the url")
-        .requiredOption("-r, --runId <runId>", "run a child process with the given id. Requires --url option.")
+        .requiredOption("-r, --runId <runId>",
+            "run a child process with the given id. Requires --url option.", parseIntArg)
         .requiredOption("-s, --seed <number>", "Seed for this runners random number generator")
         .option("-l, --log <filter>", "Filter debug logging. If not provided, uses DEBUG env variable.")
         .option("-v, --verbose", "Enables verbose logging")
@@ -43,6 +50,7 @@ async function main() {
     const log: string | undefined = commander.log;
     const verbose: boolean = commander.verbose ?? false;
     const seed: number = commander.seed;
+    console.log(typeof runId);
 
     const profile = getProfile(profileArg);
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -247,7 +247,7 @@ async function runnerProcess(
     }
 }
 
-function scheduleFaultInjection(
+export function scheduleFaultInjection(
     ds: FaultInjectionDocumentServiceFactory,
     container: Container,
     runConfig: IRunConfig,
@@ -304,7 +304,7 @@ function scheduleFaultInjection(
     schedule();
 }
 
-function scheduleContainerClose(
+export function scheduleContainerClose(
     container: Container,
     runConfig: IRunConfig,
     faultInjectionMinMs: number,

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -38,7 +38,7 @@ async function main() {
         .requiredOption("-u --url <url>", "Load an existing data store from the url")
         .requiredOption("-r, --runId <runId>",
             "run a child process with the given id. Requires --url option.", parseIntArg)
-        .requiredOption("-s, --seed <number>", "Seed for this runners random number generator")
+        .requiredOption("-s, --seed <number>", "Seed for this runners random number generator", parseIntArg)
         .option("-l, --log <filter>", "Filter debug logging. If not provided, uses DEBUG env variable.")
         .option("-v, --verbose", "Enables verbose logging")
         .parse(process.argv);
@@ -50,7 +50,7 @@ async function main() {
     const log: string | undefined = commander.log;
     const verbose: boolean = commander.verbose ?? false;
     const seed: number = commander.seed;
-    console.log(typeof runId);
+    console.log(typeof runId, typeof seed);
 
     const profile = getProfile(profileArg);
 

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -153,11 +153,15 @@ export function getProfile(profileArg: string) {
 
 export async function safeExit(code: number, url: string, runId?: number) {
     // There seems to be at least one dangling promise in ODSP Driver, give it a second to resolve
-    await Promise.race([
-        new Promise((res) => { setTimeout(res, 5000); }),
-        // Flush the logs
-        loggerP.then(async (l) => l.flush({ url, runId })),
-    ]);
+    await new Promise((res) => { setTimeout(res, 1000); });
+    // Flush the logs
+    await loggerP.then(async (l) => l.flush({ url, runId }));
 
     process.exit(code);
+}
+
+export function processSend(runId: number, task: string) {
+    if (process.send) {
+        return process.send({ runId, task });
+    }
 }

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -153,9 +153,11 @@ export function getProfile(profileArg: string) {
 
 export async function safeExit(code: number, url: string, runId?: number) {
     // There seems to be at least one dangling promise in ODSP Driver, give it a second to resolve
-    await (new Promise((res) => { setTimeout(res, 1000); }));
-    // Flush the logs
-    await loggerP.then(async (l) => l.flush({ url, runId }));
+    await Promise.race([
+        new Promise((res) => { setTimeout(res, 5000); }),
+        // Flush the logs
+        loggerP.then(async (l) => l.flush({ url, runId })),
+    ]);
 
     process.exit(code);
 }

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -21,8 +21,8 @@
         "mini": {
             "opRatePerMin": 60,
             "progressIntervalMs": 5000,
-            "numClients": 2,
-            "totalSendCount": 30,
+            "numClients": 10,
+            "totalSendCount": 300,
             "readWriteCycleMs": 10000,
             "faultInjectionMinMs": 0,
             "faultInjectionMaxMs": 50000

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -20,7 +20,7 @@ export const defaultTimeoutDurationMs = 250;
     executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void,
     timeoutOptions: TimeoutWithError | TimeoutWithValue<T> = {},
 ): Promise<T | void> {
-    // create the timeout error outside the async task, so it's callstack includes
+    // create the timeout error outside the async task, so its callstack includes
     // the original call site, this makes it easier to debug
     const err = timeoutOptions.reject === false
         ? undefined

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -46,3 +46,4 @@ stages:
             command: 'custom'
             workingDir: ${{ variables.testWorkspace }}/node_modules/@fluid-internal/test-service-load
             customCommand: 'run start'
+            verbose: true


### PR DESCRIPTION
Some changes I made to the stress tests while investigating why they were timing out. The main change is the addition of an IPC channel used by child processes to send updates to the orchestrator process. Orchestrator then can tell which processes have not sent ops recently and report them as stalled, along with the most recent updates they sent.

Using this I was able to narrow down where clients are hanging to the call to `ContainerRuntime.request()` made in `LoadTestDataStoreModel.getGCDataStore()`. Then, using `Attach by Process ID` in the vscode debugger, I was able to debug one of the stalled clients. Ultimately, when the call to `request()` is made, a new deferred promise is made for the data store, and this promise is awaited but never resolves. My guess is that a deferred promise should already exist for this data store.