### PR TITLE
Preventing Lumberjack from throwing errors

### DIFF
--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -51,6 +51,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "json-stringify-safe": "^5.0.1",
     "path-browserify": "^1.0.1",
+    "serialize-error": "^8.1.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",
     "@types/supertest": "^2.0.5",
     "@types/uuid": "^8.3.0",
@@ -70,6 +71,7 @@
     "eslint-plugin-prefer-arrow": "~1.2.2",
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
+    "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { serializeError } from "serialize-error";
 import { Lumber } from "./lumber";
 import { LumberEventName } from "./lumberEventNames";
 
@@ -93,25 +94,18 @@ export interface ILumberjackSchemaValidationResult {
 
 // Helper method to assist with handling Lumberjack/Lumber errors depending on the context.
 export function handleError(eventName: LumberEventName, errMsg: string, engineList: ILumberjackEngine[]) {
-    // If we are running in production, we want to avoid throwing errors that could cause
-    // the process to crash - especially since those would be telemetry errors. Instead,
-    // we log the error so it can be tracked
-    if (process.env.NODE_ENV === "production")
-    {
-        // If there is no LumberjackEngine specified, making the list empty,
-        // we log the error to the console as a last resort, so the information can
-        // be found in raw logs.
-        if (engineList.length === 0) {
-            console.error(errMsg);
-        } else {
-            // Otherwise, we log the error through the current LumberjackEngines.
-            const errLumber = new Lumber<LumberEventName>(
-                eventName,
-                LumberType.Metric,
-                engineList);
-            errLumber.error(errMsg);
-        }
+    const err = new Error(errMsg);
+    // If there is no LumberjackEngine specified, making the list empty,
+    // we log the error to the console as a last resort, so the information can
+    // be found in raw logs.
+    if (engineList.length === 0) {
+        console.error(serializeError(err));
     } else {
-        throw new Error(errMsg);
+        // Otherwise, we log the error through the current LumberjackEngines.
+        const errLumber = new Lumber<LumberEventName>(
+            eventName,
+            LumberType.Metric,
+            engineList);
+        errLumber.error(errMsg, err);
     }
 }

--- a/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
@@ -145,7 +145,7 @@ describe("Lumber", () => {
         assert.strictEqual(lumber.properties.get(key3), value3);
     });
 
-    it("Makes sure errorHandler is called when we try to complete an already completed Lumber.", () => {
+    it("Makes sure handleError is called when we try to complete an already completed Lumber.", () => {
         const handleErrorStub = Sinon.stub(resources, "handleError");
         const successMessage = "SuccessMessage";
         const alternativeSuccessMessage = "AlternativeSuccessMessage";
@@ -192,7 +192,7 @@ describe("Lumber", () => {
         assert.strictEqual(engineEmitStub.calledOnce, true);
     });
 
-    it("Makes sure errorHandler is called if schema validation fails.", () => {
+    it("Makes sure handleError is called if schema validation fails.", () => {
         const handleErrorStub = Sinon.stub(resources, "handleError");
         const successMessage = "SuccessMessage";
         const engine = new TestEngine1();

--- a/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
@@ -170,7 +170,6 @@ describe("Lumber", () => {
         assert.strictEqual(lumber.message, successMessage);
         assert.strictEqual(handleErrorStub.calledOnce, true);
         assert.strictEqual(engineEmitStub.calledOnce, true);
-
     });
 
     it("Makes sure we can complete Lumber if schema validation succeeds.", () => {
@@ -212,6 +211,5 @@ describe("Lumber", () => {
         assert.strictEqual(lumber.successful, true);
         assert.strictEqual(handleErrorStub.calledOnce, true);
         assert.strictEqual(engineEmitStub.calledOnce, true);
-
     });
 });

--- a/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
@@ -3,76 +3,62 @@
  * Licensed under the MIT License.
  */
 
+import assert from "assert";
+import Sinon from "sinon";
 import { TestEngine1, TestEngine2, TestLumberjack } from "../lumberjackCommonTestUtils";
 import { LumberEventName } from "../lumberEventNames";
-import assert from "assert";
+import * as resources from "../resources";
 
 describe("Lumberjack", () => {
     afterEach(() => {
         TestLumberjack.reset();
+        Sinon.restore();
     });
 
     it("Sets up Lumberjack's global instance and creates a Lumber metric.", () => {
+        const handleErrorStub = Sinon.stub(resources, "handleError");
         const engine = new TestEngine1();
         TestLumberjack.setup([engine]);
-        try {
-            TestLumberjack.newLumberMetric(LumberEventName.UnitTestEvent);
-        } catch (err) {
-            assert.fail("Lumberjack should not have failed to create Lumber as it has been set up already.");
-        }
+        TestLumberjack.newLumberMetric(LumberEventName.UnitTestEvent);
+        assert.strictEqual(handleErrorStub.notCalled, true);
     });
 
     it("Sets up a custom Lumberjack instance and creates a Lumber metric.", () => {
+        const handleErrorStub = Sinon.stub(resources, "handleError");
         const engine = new TestEngine1();
         const customInstance = TestLumberjack.createInstance([engine]);
-        try {
-            customInstance.newLumberMetric(LumberEventName.UnitTestEvent);
-        } catch (err) {
-            assert.fail("Custom Lumberjack instance should not have failed to create Lumber as it has been set up already.");
-        }
+        customInstance.newLumberMetric(LumberEventName.UnitTestEvent);
+        assert.strictEqual(handleErrorStub.notCalled, true);
     });
 
     it("Setting up custom instance of Lumberjack should not interfere with the global instance.", () => {
+        const handleErrorStub = Sinon.stub(resources, "handleError");
         const engine1 = new TestEngine1();
         const engine2 = new TestEngine2();
         TestLumberjack.setup([engine1]);
-        try {
-            TestLumberjack.createInstance([engine2]);
-        } catch (err) {
-            assert.fail("Creating a custom Lumberjack instance should not have failed since global and custom instances should be independent.");
-        }
+        TestLumberjack.createInstance([engine2]);
+        assert.strictEqual(handleErrorStub.notCalled, true);
     });
 
-    it("Lumberjack should fail when trying to set it up more than once.", () => {
+    it("An error should be logged when trying to setup Lumberjack more than once.", () => {
+        const handleErrorStub = Sinon.stub(resources, "handleError");
         const engine1 = new TestEngine1();
         const engine2 = new TestEngine2();
         TestLumberjack.setup([engine1]);
-        try {
-            TestLumberjack.setup([engine2]);
-        } catch (err) {
-            return;
-        }
-
-        assert.fail("Lumberjack should not allow setup more than once to avoid overriding engine list and schema validator.");
+        assert.strictEqual(handleErrorStub.notCalled, true);
+        TestLumberjack.setup([engine2]);
+        assert.strictEqual(handleErrorStub.calledOnce, true);
     });
 
     it("Lumberjack should fail when trying to use it with an empty engine list.", () => {
-        try {
-            TestLumberjack.setup([]);
-        } catch (err) {
-            return;
-        }
-
-        assert.fail("Lumberjack should not allow normal operation if the engine list used during setup was empty.");
+        const handleErrorStub = Sinon.stub(resources, "handleError");
+        TestLumberjack.setup([]);
+        assert.strictEqual(handleErrorStub.calledOnce, true);
     });
 
     it("Lumberjack should fail when trying to create a metric before being properly set up.", () => {
-        try {
-            TestLumberjack.newLumberMetric(LumberEventName.UnitTestEvent);
-        } catch (err) {
-            return;
-        }
-
-        assert.fail("Lumberjack should warn and throw error when a Lumber is created before it is fully set up.");
+        const handleErrorStub = Sinon.stub(resources, "handleError");
+        TestLumberjack.newLumberMetric(LumberEventName.UnitTestEvent);
+        assert.strictEqual(handleErrorStub.calledOnce, true);
     });
 });


### PR DESCRIPTION
Lumberjack originally threw errors when the environment was local/development. The intention was to try to make sure the developer would be aware that the setup/usage of Lumberjack was not correct, before getting the code to production and realizing telemetry was not working. However, such strategy proved to cause more harm than good. For instance, we have had different issues caused Lumberjack - issues on Tinylicious, client tests, etc. Therefore, it seems to be better to just log the error caused by Lumberjack instead.