### PR TITLE
Expose some RdKafka specific functionality in IProducer & IConsumer interfaces

### DIFF
--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -54,6 +54,12 @@ export interface IConsumer {
     commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void>;
 
     /**
+     * Returns the offset of the latest consumsed message
+     * May return undefined if a consumer is not tracking this
+     */
+    getLatestMessageOffset(partitionId: number): number | undefined;
+
+    /**
      * Event handlers
      */
     on(event: "connected" | "disconnected" | "closed" | "paused" | "resumed", listener: () => void): this;
@@ -83,8 +89,9 @@ export interface IProducer<T = ITicketedMessage> {
 
     /**
      * Sends the message to a queue
+     * @param partitionId Specify this to send the messages to a specific partition. Only RdkafkaProducer supports this.
      */
-    send(messages: T[], tenantId: string, documentId: string): Promise<void>;
+    send(messages: T[], tenantId: string, documentId: string, partitionId?: number): Promise<void>;
 
     /**
      * Closes the underlying connection

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeConsumer.ts
@@ -49,6 +49,13 @@ export class KafkaNodeConsumer implements IConsumer {
         return this.client ? true : false;
     }
 
+    /**
+     * Returns the offset of the latest consumsed message
+     */
+    public getLatestMessageOffset(partitionId: number): number | undefined {
+        return undefined;
+    }
+
     public async commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void> {
         // Although tagged as optional, kafka-node requies a value in the metadata field.
         // Also logs are replayed from the last checkponited offset. To avoid reprocessing the last message

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -60,6 +60,13 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		return this.consumer?.isConnected() ? true : false;
 	}
 
+	/**
+	 * Returns the offset of the latest consumsed message
+	 */
+	public getLatestMessageOffset(partitionId: number): number | undefined {
+		return this.latestOffsets.get(partitionId);
+	}
+
 	protected connect() {
 		if (this.closed) {
 			return;

--- a/server/routerlicious/packages/test-utils/src/testKafka.ts
+++ b/server/routerlicious/packages/test-utils/src/testKafka.ts
@@ -27,6 +27,13 @@ export class TestConsumer implements core.IConsumer {
         return true;
     }
 
+    /**
+     * Returns the offset of the latest consumsed message
+     */
+    public getLatestMessageOffset(partitionId: number): number | undefined {
+        return undefined;
+    }
+
     public async commitCheckpoint(partitionId: number, queuedMessage: core.IQueuedMessage): Promise<void> {
         // For now we assume a single partition for the test consumer
         assert(partitionId === 0);


### PR DESCRIPTION
Add `getLatestMessageOffset` method to `IConsumer` and a `partitionId` arg to `IProducer.send`