### PR TITLE
Enabling Redis caching in Historian for WholeSummaries

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -63,9 +63,7 @@ export class DocumentService implements api.IDocumentService {
         const historian = new Historian(
             this.gitUrl,
             true,
-            // Disable caching of storage requests until we implement non-URL-based caching
-            // when using WholeSummaries, because we cannot gurantee that a summary sha is unique to the document.
-            this.driverPolicies.enableWholeSummaryUpload,
+            false,
             storageRestWrapper);
         const gitManager = new GitManager(historian);
         const documentStorageServicePolicies: api.IDocumentStorageServicePolicies = {

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -61,7 +61,8 @@ export function create(
             utils.handleResponse(
                 summaryP,
                 response,
-                useCache);
+                // Browser caching for summary data should be disabled for now.
+                false);
     });
 
     router.post("/repos/:ignored?/:tenantId/git/summaries",

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -18,6 +18,11 @@ export interface ICache {
      * Sets a cache value
      */
     set<T>(key: string, value: T): Promise<void>;
+
+    /**
+     * Deletes a cache value if it exists
+     */
+    deleteIfExists(key: string): Promise<void>;
 }
 
 export interface ITenantService {

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -20,9 +20,9 @@ export interface ICache {
     set<T>(key: string, value: T): Promise<void>;
 
     /**
-     * Deletes a cache value if it exists
+     * Deletes a cache key/value pair. Returns true if the key was deleted, and false if it does not exist.
      */
-    deleteIfExists(key: string): Promise<void>;
+    delete(key: string): Promise<boolean>;
 }
 
 export interface ITenantService {

--- a/server/historian/packages/historian-base/src/services/redisCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisCache.ts
@@ -44,19 +44,12 @@ export class RedisCache implements ICache {
         }
     }
 
-    public async deleteIfExists(key: string): Promise<void> {
-        const exists = await this.client.exists(this.getKey(key));
-        if (!exists) {
-            return;
-        }
-
+    public async delete(key: string): Promise<boolean> {
         const result = await this.client.del(this.getKey(key));
         // The DEL API in Redis returns the number of keys that were removed.
-        // If the key exists and we try to delete it, we expect a result equal to 1
-        // to indicate success
-        if (result !== 1) {
-            return Promise.reject(new Error(`Unable to delete key ${this.getKey(key)} from Redis.`));
-        }
+        // We always call Redis DEL with one key only, so we expect a result equal to 1
+        // to indicate that the key was removed. 0 would indicate that the key does not exist.
+        return result === 1;
     }
 
     /**

--- a/server/historian/packages/historian-base/src/services/redisCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisCache.ts
@@ -44,6 +44,21 @@ export class RedisCache implements ICache {
         }
     }
 
+    public async deleteIfExists(key: string): Promise<void> {
+        const exists = await this.client.exists(this.getKey(key));
+        if (!exists) {
+            return;
+        }
+
+        const result = await this.client.del(this.getKey(key));
+        // The DEL API in Redis returns the number of keys that were removed.
+        // If the key exists and we try to delete it, we expect a result equal to 1
+        // to indicate success
+        if (result !== 1) {
+            return Promise.reject(new Error(`Unable to delete key ${this.getKey(key)} from Redis.`));
+        }
+    }
+
     /**
      * Translates the input key to the one we will actually store in redis
      */

--- a/server/historian/packages/historian-base/src/test/utils/testCache.ts
+++ b/server/historian/packages/historian-base/src/test/utils/testCache.ts
@@ -16,11 +16,7 @@ export class TestCache implements ICache {
         this.dictionary.set(key, value);
         return Promise.resolve();
     }
-    async deleteIfExists<T>(key: string): Promise<void> {
-        if (this.dictionary.has(key)) {
-            this.dictionary.delete(key);
-        }
-
-        return Promise.resolve();
+    async delete(key: string): Promise<boolean> {
+        return Promise.resolve(this.dictionary.delete(key));
     }
 }

--- a/server/historian/packages/historian-base/src/test/utils/testCache.ts
+++ b/server/historian/packages/historian-base/src/test/utils/testCache.ts
@@ -16,4 +16,11 @@ export class TestCache implements ICache {
         this.dictionary.set(key, value);
         return Promise.resolve();
     }
+    async deleteIfExists<T>(key: string): Promise<void> {
+        if (this.dictionary.has(key)) {
+            this.dictionary.delete(key);
+        }
+
+        return Promise.resolve();
+    }
 }


### PR DESCRIPTION
Adding support to cache WholeSummary data in Historian/Redis.
1. `disableCache` was originally `true` for Historian used in R11s driver. Making it `false` so that the Historian client does not use the `disableCache` query parameter. 
2. Adding new `deleteIfExists()` function for Redis client in Historian so that we can delete the cached WholeSummary in two situations: when the Delete Summary API is exercised, and when a new summary for that tenantID/documentID is created, to force a cache miss and therefore repopulate the cache on the next Get Summary call.
3. Calling `deleteFromCacheIfExists()` in `RestGitService` in those two APIs (Create and Delete Summary). For Create Summary, only delete the previous cached summary data if the type of summary being created is `container`. `channel`s are not requested by clients, so they are not cached.