### PR TITLE
Properly log websocket errors (#7670)

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -272,11 +272,10 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
      */
     protected createErrorObject(handler: string, error?: any, canRetry = true): DriverError {
         // Note: we suspect the incoming error object is either:
-        // - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
-        // - a socketError: add it to the OdspError object for driver to be able to parse it and reason
-        //   over it.
-        if (canRetry && typeof error === "object" && error !== null) {
-            return errorObjectFromSocketError(error, handler) as DriverError;
+        // - a socketError: add it to the OdspError object for driver to be able to parse it and reason over it.
+        // - anything else: let base class handle it
+        if (canRetry && Number.isInteger(error?.code) && typeof error?.message === "string") {
+            return errorObjectFromSocketError(error as IOdspSocketError, handler) as DriverError;
         } else {
             return super.createErrorObject(handler, error, canRetry);
         }

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -11,7 +11,7 @@ import { IOdspSocketError } from "./contracts";
  * Returns network error based on error object from ODSP socket (IOdspSocketError)
  */
 export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string): OdspError {
-    const message = `socket.io: ${handler}: ${socketError.message}`;
+    const message = `OdspSocketError (${handler}): ${socketError.message}`;
     return createOdspNetworkError(
         message,
         socketError.code,

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -85,7 +85,7 @@ describe("Odsp Error", () => {
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
         } else {
-            assert.equal(networkError.message, "socket.io: disconnect: testMessage");
+            assert.equal(networkError.message, "OdspSocketError (disconnect): testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
         }
@@ -100,7 +100,7 @@ describe("Odsp Error", () => {
         if (networkError.errorType !== DriverErrorType.genericNetworkError) {
             assert.fail("networkError should be a genericNetworkError");
         } else {
-            assert.equal(networkError.message, "socket.io: error: testMessage");
+            assert.equal(networkError.message, "OdspSocketError (error): testMessage");
             assert.equal(networkError.canRetry, false);
             assert.equal(networkError.statusCode, 400);
         }
@@ -112,11 +112,11 @@ describe("Odsp Error", () => {
             code: 429,
             retryAfter: 10,
         };
-        const networkError = errorObjectFromSocketError(socketError, "429");
+        const networkError = errorObjectFromSocketError(socketError, "handler");
         if (networkError.errorType !== DriverErrorType.throttlingError) {
             assert.fail("networkError should be a throttlingError");
         } else {
-            assert.equal(networkError.message, "socket.io: 429: testMessage");
+            assert.equal(networkError.message, "OdspSocketError (handler): testMessage");
             assert.equal(networkError.retryAfterSeconds, 10);
         }
     });

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -92,7 +92,7 @@ export function throwR11sNetworkError(
  * Returns network error based on error object from R11s socket (IR11sSocketError)
  */
 export function errorObjectFromSocketError(socketError: IR11sSocketError, handler: string): R11sError {
-    const message = `socket.io: ${handler}: ${socketError.message}`;
+    const message = `R11sSocketError (${handler}): ${socketError.message}`;
     return createR11sNetworkError(
         message,
         socketError.code,

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -169,7 +169,7 @@ describe("ErrorUtils", () => {
         const handler = "test_handler";
         const message = "test error";
         const assertExpectedMessage = (actualMessage: string) => {
-            const expectedMessage = `socket.io: ${handler}: ${message}`;
+            const expectedMessage = `R11sSocketError (${handler}): ${message}`;
             assert.strictEqual(actualMessage, expectedMessage);
         };
         it("creates non-retriable authorization error on 401", () => {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1064,8 +1064,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             isDirty: this.isDirty,
             lastSequenceNumber: this.deltaManager.lastSequenceNumber,
             attachState: this.attachState,
-            message: error?.message,
-        });
+        }, error);
 
         if (this.summaryManager !== undefined) {
             this.summaryManager.off("summarizerWarning", this.raiseContainerWarning);


### PR DESCRIPTION
Porting PR #7670 to 0.48
We were not logging WebSocket error when socket.io failed to connect to websocket