### PR TITLE
Properly handling server_disconnect events

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -34,7 +34,7 @@ export class DocumentDeltaConnection extends TypedEventEmitter<IDocumentDeltaCon
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): DriverError;
     // (undocumented)
     get details(): IConnected;
-    protected disconnect(socketProtocolError: boolean, reason: DriverError): void;
+    protected disconnect(socketProtocolError: boolean, reason: any): void;
     dispose(): void;
     // (undocumented)
     protected disposeCore(socketProtocolError: boolean, err: DriverError): void;

--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -37,7 +37,7 @@ export class DocumentDeltaConnection extends TypedEventEmitter<IDocumentDeltaCon
     protected disconnect(socketProtocolError: boolean, reason: any): void;
     dispose(): void;
     // (undocumented)
-    protected disposeCore(socketProtocolError: boolean, err: DriverError): void;
+    protected disposeCore(socketProtocolError: boolean, err: any): void;
     // (undocumented)
     get disposed(): boolean;
     protected _disposed: boolean;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -316,7 +316,7 @@ export class DocumentDeltaConnection
     // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
     public close() { this.dispose(); }
 
-    protected disposeCore(socketProtocolError: boolean, err: DriverError) {
+    protected disposeCore(socketProtocolError: boolean, err: any) {
         // Can't check this.disposed here, as we get here on socket closure,
         // so _disposed & socket.connected might be not in sync while processing
         // "dispose" event.

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -341,7 +341,7 @@ export class DocumentDeltaConnection
      *  (not on Fluid protocol level)
      * @param reason - reason for disconnect
      */
-    protected disconnect(socketProtocolError: boolean, reason: DriverError) {
+    protected disconnect(socketProtocolError: boolean, reason: any) {
         this.socket.disconnect();
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert, performance, Deferred } from "@fluidframework/common-utils";
+import { ITelemetryLogger, IEvent } from "@fluidframework/common-definitions";
+import { assert, performance, Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
 import { DriverError } from "@fluidframework/driver-definitions";
+import { OdspError } from "@fluidframework/odsp-driver-definitions";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 import {
     IClient,
     IConnect,
@@ -32,7 +34,11 @@ export interface FlushResult {
 // This allows reconnection after receiving a nack to be smooth
 const socketReferenceBufferTime = 2000;
 
-class SocketReference {
+export interface ISocketEvents extends IEvent {
+    (event: "server_disconnect", listener: (error: LoggingError & OdspError) => void);
+}
+
+class SocketReference extends TypedEventEmitter<ISocketEvents> {
     private references: number = 1;
     private delayDeleteTimeout: ReturnType<typeof setTimeout> | undefined;
     private _socket: SocketIOClient.Socket | undefined;
@@ -100,6 +106,8 @@ class SocketReference {
     }
 
     public constructor(public readonly key: string, socket: SocketIOClient.Socket) {
+        super();
+
         this._socket = socket;
         assert(!SocketReference.socketIoSockets.has(key), 0x220 /* "socket key collision" */);
         SocketReference.socketIoSockets.set(key, this);
@@ -117,7 +125,7 @@ class SocketReference {
             // comes in from "disconnect" listener below, before we close socket.
             this.isPendingInitialConnection = false;
 
-            socket.emit("disconnect", error);
+            this.emit("server_disconnect", error);
             this.closeSocket();
         });
     }
@@ -422,6 +430,10 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
         return this.flushDeferred.promise;
     }
 
+    protected serverDisconnectHandler = (error: LoggingError & OdspError) => {
+        this.disconnect(true, error);
+    };
+
     protected async initialize(connectMessage: IConnect, timeout: number) {
         if (this.enableMultiplexing) {
             // multiplex compatible early handlers
@@ -437,6 +449,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
                 }
             };
         }
+
+        this.socketReference!.once("server_disconnect", this.serverDisconnectHandler);
 
         this.socket.on("get_ops_response", (result: IGetOpsResponse) => {
             const messages = result.messages;
@@ -542,10 +556,12 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     /**
      * Disconnect from the websocket
      */
-    protected disconnect(socketProtocolError: boolean, reason: DriverError) {
+    protected disconnect(socketProtocolError: boolean, reason: any) {
         const socket = this.socketReference;
         assert(socket !== undefined, 0x0a2 /* "reentrancy not supported!" */);
         this.socketReference = undefined;
+
+        this.socket.off("server_disconnect", this.serverDisconnectHandler);
 
         if (!socketProtocolError && this.hasDetails) {
             // tell the server we are disconnecting this client from the document

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -431,7 +431,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     }
 
     protected serverDisconnectHandler = (error: LoggingError & OdspError) => {
-        this.disconnect(true, error);
+        this.disposeCore(true, error);
     };
 
     protected async initialize(connectMessage: IConnect, timeout: number) {

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -4,13 +4,12 @@
  */
 
 import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
-import { OdspError } from "@fluidframework/odsp-driver-definitions";
 import { IOdspSocketError } from "./contracts";
 
 /**
  * Returns network error based on error object from ODSP socket (IOdspSocketError)
  */
-export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string): OdspError {
+export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string) {
     const message = `OdspSocketError (${handler}): ${socketError.message}`;
     return createOdspNetworkError(
         message,


### PR DESCRIPTION
A version ago, server_disconnect errors were reported as "Disconnect: socket.io: disconnect: socket.io: server_disconnect: AccessExpired". This is not great as we go through createErrorObject() twice due to server_disconnect flow using disconnect flow.
It also has an issue with using socket.emit() which is not great (as it's easy to make mistake here - most of emits are actually messages sent over socket, like "op").

But after recent changes to capture more info for web socket errors, these same errors show up as "Disconnect: socket.io (disconnect): [object omitted]", which means we lose data.

Fixing it by refactoring server_disconnect flow.

