### PR TITLE
r11s-driver: share snapshot and blob cache with summarizer

### DIFF
--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -54,7 +54,8 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 
 // @public
 export class DocumentService implements api.IDocumentService {
-    constructor(resolvedUrl: api.IResolvedUrl, ordererUrl: string, deltaStorageUrl: string, gitUrl: string, logger: ITelemetryLogger, tokenProvider: ITokenProvider, tenantId: string, documentId: string, driverPolicies: IRouterliciousDriverPolicies);
+    // Warning: (ae-forgotten-export) The symbol "ICache" needs to be exported by the entry point index.d.ts
+    constructor(resolvedUrl: api.IResolvedUrl, ordererUrl: string, deltaStorageUrl: string, gitUrl: string, logger: ITelemetryLogger, tokenProvider: ITokenProvider, tenantId: string, documentId: string, driverPolicies: IRouterliciousDriverPolicies, blobCache: ICache<ArrayBufferLike>, snapshotTreeCache: ICache<ISnapshotTree>);
     connectToDeltaStorage(): Promise<api.IDocumentDeltaStorageService>;
     connectToDeltaStream(client: IClient): Promise<api.IDocumentDeltaConnection>;
     connectToStorage(): Promise<api.IDocumentStorageService>;
@@ -74,7 +75,7 @@ export class DocumentService implements api.IDocumentService {
 
 // @public (undocumented)
 export class DocumentStorageService extends DocumentStorageServiceProxy {
-    constructor(id: string, manager: GitManager, logger: ITelemetryLogger, policies?: IDocumentStorageServicePolicies, driverPolicies?: IRouterliciousDriverPolicies);
+    constructor(id: string, manager: GitManager, logger: ITelemetryLogger, policies?: IDocumentStorageServicePolicies, driverPolicies?: IRouterliciousDriverPolicies, blobCache?: ICache<ArrayBufferLike>, snapshotTreeCache?: ICache<ISnapshotTree>);
     // (undocumented)
     getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null>;
     // (undocumented)

--- a/packages/drivers/routerlicious-driver/src/cache.ts
+++ b/packages/drivers/routerlicious-driver/src/cache.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface ICache<T> {
+    get(key: string): Promise<T | undefined>;
+    put(key: string, value: T): Promise<void>;
+}
+
+export class InMemoryCache<T> implements ICache<T> {
+    private readonly cache: Map<string, T> = new Map();
+
+    public async get(key: string): Promise<T | undefined> {
+        return this.cache.get(key);
+    }
+
+    public async put(key: string, value: T): Promise<void> {
+        this.cache.set(key, value);
+    }
+}

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import * as api from "@fluidframework/driver-definitions";
 import { RateLimiter } from "@fluidframework/driver-utils";
-import { IClient} from "@fluidframework/protocol-definitions";
+import { IClient, ISnapshotTree} from "@fluidframework/protocol-definitions";
 import { GitManager, Historian } from "@fluidframework/server-services-client";
 import io from "socket.io-client";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -17,6 +17,7 @@ import { NullBlobStorageService } from "./nullBlobStorageService";
 import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper, RouterliciousStorageRestWrapper } from "./restWrapper";
 import { IRouterliciousDriverPolicies } from "./policies";
+import { ICache } from "./cache";
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
@@ -33,6 +34,8 @@ export class DocumentService implements api.IDocumentService {
         protected tenantId: string,
         protected documentId: string,
         private readonly driverPolicies: IRouterliciousDriverPolicies,
+        private readonly blobCache: ICache<ArrayBufferLike>,
+        private readonly snapshotTreeCache: ICache<ISnapshotTree>,
     ) {
     }
 
@@ -80,7 +83,9 @@ export class DocumentService implements api.IDocumentService {
             gitManager,
             this.logger,
             documentStorageServicePolicies,
-            this.driverPolicies);
+            this.driverPolicies,
+            this.blobCache,
+            this.snapshotTreeCache);
         return this.documentStorageService;
     }
 

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -10,7 +10,7 @@ import {
     IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import { ISnapshotTree, ISummaryTree } from "@fluidframework/protocol-definitions";
 import {
     ensureFluidResolvedUrl,
     getDocAttributesFromProtocolSummary,
@@ -24,6 +24,7 @@ import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper } from "./restWrapper";
 import { convertSummaryToCreateNewSummary } from "./createNewUtils";
 import { parseFluidUrl, replaceDocumentIdInPath } from "./urlUtils";
+import { InMemoryCache } from "./cache";
 
 const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     enablePrefetch: true,
@@ -41,6 +42,8 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
     public readonly protocolName = "fluid:";
     private readonly driverPolicies: IRouterliciousDriverPolicies;
+    private readonly blobCache = new InMemoryCache<ArrayBufferLike>();
+    private readonly snapshotTreeCache = new InMemoryCache<ISnapshotTree>();
 
     constructor(
         private readonly tokenProvider: ITokenProvider,
@@ -163,6 +166,8 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             this.tokenProvider,
             tenantId,
             documentId,
-            this.driverPolicies);
+            this.driverPolicies,
+            this.blobCache,
+            this.snapshotTreeCache);
     }
 }


### PR DESCRIPTION
Hoisting the snapshot and blob cache from the DocumentStorageService into the DocumentServiceFactory so that the cache is shared with the summarizer client.

Also introduced ICache with an initial implementation of InMemoryCache to make it easier to swap to some other cache implementation later.