### PR TITLE
[bump] package version for driver-definitions (patch)

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -371,13 +371,13 @@
       "integrity": "sha512-n1neSteU0P/mQjthiNqqrdXl3+VeJ2QFZva6QJOcFRVmjHe+c827g9VqEbz0WB8jcSKpf98n3QzTXAGmEqBeVg=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.40.0-39010",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0-39010.tgz",
-      "integrity": "sha512-cd3ocIxK3oKqCMzjEKjnA8dge8ropK3FxgmNUZGHUvRStVsmjDr6Mc/FRO4j7WqB1c9eR9JxacVttAzWdQUMkw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0.tgz",
+      "integrity": "sha512-xbdVs3l/5OdbidvA1CgOO9z13q/O+M5nWsxhVwr5BuvAqX5BOT5rKN659LeIw/LQQbiGEW6ahR1NN9kWwPmAlg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.39.5",
-        "@fluidframework/protocol-definitions": "^0.1025.0-38844"
+        "@fluidframework/protocol-definitions": "^0.1025.0"
       }
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.39.5",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },
   "devDependencies": {

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/driver-definitions",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -377,12 +377,12 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-        "version": "0.1025.0",
-        "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0.tgz",
-        "integrity": "sha512-Bul3hA6gZte+8d+sT3vBG2e7JsJIbJKCNP7V9PhH1dVkUH8sWvihSmgNVFcp01egbyFzzDJfHNY28UcNAZ+jkw==",
-        "requires": {
-          "@fluidframework/common-definitions": "^0.20.0"
-        }
+      "version": "0.1025.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1025.0.tgz",
+      "integrity": "sha512-Bul3hA6gZte+8d+sT3vBG2e7JsJIbJKCNP7V9PhH1dVkUH8sWvihSmgNVFcp01egbyFzzDJfHNY28UcNAZ+jkw==",
+      "requires": {
+        "@fluidframework/common-definitions": "^0.20.0"
+      }
     },
     "@microsoft/api-extractor": {
       "version": "7.16.1",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/driver-definitions",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Fluid driver definitions",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/iframe-driver": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -27,7 +27,7 @@
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/routerlicious-driver": "^0.49.0",
     "@fluidframework/routerlicious-host": "^0.49.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -46,7 +46,7 @@
     "@fluid-experimental/property-common": "^0.49.0",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-definitions": "^0.40.0-39046",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/local-driver": "^0.49.0",
     "@fluidframework/mocha-test-setup": "^0.49.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -29,7 +29,7 @@
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/local-driver": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/routerlicious-driver": "^0.49.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2014,13 +2014,13 @@
 			"integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.40.0-39010",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0-39010.tgz",
-			"integrity": "sha512-cd3ocIxK3oKqCMzjEKjnA8dge8ropK3FxgmNUZGHUvRStVsmjDr6Mc/FRO4j7WqB1c9eR9JxacVttAzWdQUMkw==",
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0.tgz",
+			"integrity": "sha512-xbdVs3l/5OdbidvA1CgOO9z13q/O+M5nWsxhVwr5BuvAqX5BOT5rKN659LeIw/LQQbiGEW6ahR1NN9kWwPmAlg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.39.5",
-				"@fluidframework/protocol-definitions": "^0.1025.0-38844"
+				"@fluidframework/protocol-definitions": "^0.1025.0"
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/replay-driver": "^0.49.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/telemetry-utils": "^0.49.0"

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/replay-driver": "^0.49.0"

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/odsp-driver": "^0.49.0",
     "@fluidframework/odsp-driver-definitions": "^0.49.0"
   },

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/telemetry-utils": "^0.49.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-base": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/routerlicious-driver": "^0.49.0",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -30,7 +30,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/driver-definitions": "^0.40.0-39010"
+    "@fluidframework/driver-definitions": "^0.40.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-base": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/gitresources": "^0.1032.0-39277",
     "@fluidframework/odsp-doclib-utils": "^0.49.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/odsp-driver": "^0.49.0",
     "@fluidframework/odsp-driver-definitions": "^0.49.0"
   },

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/telemetry-utils": "^0.49.0"

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-base": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/gitresources": "^0.1032.0-39277",
     "@fluidframework/protocol-base": "^0.1032.0-39277",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "axios": "^0.21.1"
   },
   "devDependencies": {

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "nconf": "^0.11.0"
   },

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/routerlicious-driver": "^0.49.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/fluid-static": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/container-loader": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/fluid-static": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/telemetry-utils": "^0.49.0",
     "@fluidframework/web-code-loader": "^0.49.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/container-utils": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-base": "^0.1032.0-39277",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/gitresources": "^0.1032.0-39277",
     "@fluidframework/protocol-base": "^0.1032.0-39277",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "comlink": "^4.3.0"
   },

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -29,7 +29,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/runtime-definitions": "^0.49.0",
     "@types/node": "^12.19.0"

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/container-utils": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/garbage-collector": "^0.49.0",
     "@fluidframework/protocol-base": "^0.1032.0-39277",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/container-utils": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/garbage-collector": "^0.49.0",
     "@fluidframework/protocol-base": "^0.1032.0-39277",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@types/node": "^12.19.0"
   },

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/routerlicious-driver": "^0.49.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -65,7 +65,7 @@
     "@fluidframework/datastore": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/driver-base": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/ink": "^0.49.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/counter": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/file-driver": "^0.49.0",
     "@fluidframework/ink": "^0.49.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "uuid": "^8.3.1"
   },

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/local-driver": "^0.49.0",
     "@fluidframework/odsp-doclib-utils": "^0.49.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/counter": "^0.49.0",
     "@fluidframework/datastore": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/ink": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/counter": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/map": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/runtime-definitions": "^0.49.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/local-driver": "^0.49.0",
     "@fluidframework/map": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/counter": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/ink": "^0.49.0",
     "@fluidframework/map": "^0.49.0",
     "@fluidframework/matrix": "^0.49.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/datastore": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/odsp-doclib-utils": "^0.49.0",
     "@fluidframework/odsp-driver": "^0.49.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/file-driver": "^0.49.0",
     "@fluidframework/ink": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/container-definitions": "^0.40.0-39046",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/local-driver": "^0.49.0",
     "@fluidframework/odsp-doclib-utils": "^0.49.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.40.0-39010",
+    "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",
     "@fluidframework/odsp-driver-definitions": "^0.49.0",
     "@fluidframework/telemetry-utils": "^0.49.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.0 (unchanged)
      @fluidframework/common-definitions:     0.21.0 (unchanged)
            @fluidframework/common-utils:     0.33.0 (unchanged)
         @fluidframework/core-interfaces:     0.40.0 (unchanged)
    @fluidframework/protocol-definitions:   0.1025.1 (unchanged)
      @fluidframework/driver-definitions:     0.40.0 -> 0.40.1
   @fluidframework/container-definitions:     0.40.0 (unchanged)
                                  Server:   0.1032.0 (unchanged)
                                  Client:     0.49.0 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for driver-definitions
      @fluidframework/driver-definitions -> ^0.40.0