### PR TITLE
[bump] package version for container-definitions (patch)

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/container-definitions",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/container-definitions",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Fluid container definitions",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-example/search-menu": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/ink": "^0.49.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.49.0",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluid-example/client-ui-lib": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/merge-tree": "^0.49.0",
     "@fluidframework/runtime-definitions": "^0.49.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-example/host-service-interfaces": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/cell": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -41,7 +41,7 @@
     "@fluid-example/table-document": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/runtime-utils": "^0.49.0",
     "@fluidframework/view-interfaces": "^0.49.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/request-handler": "^0.49.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -35,7 +35,7 @@
     "@fluid-experimental/get-container": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/map": "^0.49.0",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7"
   },
   "devDependencies": {

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -36,7 +36,7 @@
     "@fluid-example/todo": "^0.49.0",
     "@fluid-experimental/get-container": "^0.49.0",
     "@fluidframework/base-host": "^0.49.0",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@fluid-example/key-value-cache": "^0.49.0",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluid-experimental/property-common": "^0.49.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/local-driver": "^0.49.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/bubblebench-common": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/sharejs-json1": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/tree": "^0.49.0",
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/map": "^0.49.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1998,14 +1998,14 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.40.0-39046",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.40.0-39046.tgz",
-			"integrity": "sha512-uJH7eoph4NyCVs0Lb6CAvOVaW1A6pvqGo4jsduNNDASF71ansDX0dpw1lRE1XGnls4FBFrEhL6JEs1kSmkhkfA==",
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.40.0.tgz",
+			"integrity": "sha512-RrZGHxYooeNlvTIyTIFcazpL90Fe0k1iR414+EbFIvBo2CvrVpws035FxG+xOnTkU+0VvvGX7l4h7IGpDG+Qrg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.39.5",
-				"@fluidframework/driver-definitions": "^0.40.0-39010",
-				"@fluidframework/protocol-definitions": "^0.1025.0-38844"
+				"@fluidframework/driver-definitions": "^0.40.0",
+				"@fluidframework/protocol-definitions": "^0.1025.0"
 			}
 		},
 		"@fluidframework/core-interfaces": {

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/fluid-static": "^0.49.0",
     "@fluidframework/map": "^0.49.0",
     "@fluidframework/sequence": "^0.49.0"

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/driver-utils": "^0.49.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-utils": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/telemetry-utils": "^0.49.0"
   },

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore": "^0.49.0",
     "@fluidframework/datastore-definitions": "^0.49.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",
     "@fluidframework/container-utils": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/runtime-definitions": "^0.49.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-utils": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/datastore-definitions": "^0.49.0",
     "@fluidframework/driver-definitions": "^0.40.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/cell": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/container-runtime-definitions": "^0.49.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/cell": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/cell": "^0.49.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/container-runtime": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.49.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.40.0-39046",
+    "@fluidframework/container-definitions": "^0.40.0",
     "@fluidframework/container-loader": "^0.49.0",
     "@fluidframework/core-interfaces": "^0.39.7",
     "@fluidframework/driver-definitions": "^0.40.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.0 (unchanged)
      @fluidframework/common-definitions:     0.21.0 (unchanged)
            @fluidframework/common-utils:     0.33.0 (unchanged)
         @fluidframework/core-interfaces:     0.40.0 (unchanged)
    @fluidframework/protocol-definitions:   0.1025.1 (unchanged)
      @fluidframework/driver-definitions:     0.40.1 (unchanged)
   @fluidframework/container-definitions:     0.40.0 -> 0.40.1
                                  Server:   0.1032.0 (unchanged)
                                  Client:     0.49.0 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for container-definitions
   @fluidframework/container-definitions -> ^0.40.0