### PR TITLE
Add lumberjack logs under services-core and services-client

### DIFF
--- a/server/routerlicious/packages/services-core/src/debug.ts
+++ b/server/routerlicious/packages/services-core/src/debug.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import registerDebug from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:core");
 debug(`Package: ${pkgName} - Version: ${pkgVersion}`);
+Lumberjack.info(`Package: ${pkgName} - Version: ${pkgVersion}`);


### PR DESCRIPTION
Most of the files under these 2 repositories are interfaces which do not need logs.