### PR TITLE
IFluidSerializer.decode

### DIFF
--- a/common/lib/core-interfaces/api-report/core-interfaces.api.md
+++ b/common/lib/core-interfaces/api-report/core-interfaces.api.md
@@ -115,6 +115,7 @@ export const IFluidSerializer: keyof IProvideFluidSerializer;
 
 // @public (undocumented)
 export interface IFluidSerializer extends IProvideFluidSerializer {
+    decode(input: any): any;
     parse(value: string): any;
     replaceHandles(value: any, bind: IFluidHandle): any;
     stringify(value: any, bind: IFluidHandle): string;

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -54,6 +54,28 @@
   },
   "typeValidation": {
     "version": "0.40.0",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_IFluidHandle": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IFluidLoadable": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IFluidObject": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IFluidSerializer": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IProvideFluidHandle": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IProvideFluidLoadable": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_IProvideFluidSerializer": {
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/common/lib/core-interfaces/src/serializer.ts
+++ b/common/lib/core-interfaces/src/serializer.ts
@@ -32,6 +32,17 @@ export interface IFluidSerializer extends IProvideFluidSerializer {
     replaceHandles(value: any, bind: IFluidHandle): any;
 
     /**
+     * Given a fully-jsonable object tree that may have encoded handle objects embedded within, will return an
+     * equivalent object tree where any encoded IFluidHandles have been replaced with thier decoded form.
+     *
+     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * the root to any replaced handles.  (If no handles are found, returns the original object.)
+     *
+     * The decoded handles are implicitly bound to the handle context of this serializer.
+     */
+    decode(input: any): any;
+
+    /**
      * Stringifies a given value. Converts any IFluidHandle to its stringified equivalent.
      */
     stringify(value: any, bind: IFluidHandle): string;

--- a/common/lib/core-interfaces/src/test/validate0.39.8.ts
+++ b/common/lib/core-interfaces/src/test/validate0.39.8.ts
@@ -181,13 +181,13 @@ use_old_VariableDeclaration_IFluidHandle(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IFluidHandle": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IFluidHandle():
     old.IFluidHandle<any>;
 declare function use_current_InterfaceDeclaration_IFluidHandle(
     use: current.IFluidHandle<any>);
 use_current_InterfaceDeclaration_IFluidHandle(
     get_old_InterfaceDeclaration_IFluidHandle());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -277,13 +277,13 @@ use_old_VariableDeclaration_IFluidLoadable(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IFluidLoadable": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IFluidLoadable():
     old.IFluidLoadable;
 declare function use_current_InterfaceDeclaration_IFluidLoadable(
     use: current.IFluidLoadable);
 use_current_InterfaceDeclaration_IFluidLoadable(
     get_old_InterfaceDeclaration_IFluidLoadable());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -301,13 +301,13 @@ use_old_InterfaceDeclaration_IFluidLoadable(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IFluidObject": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IFluidObject():
     old.IFluidObject;
 declare function use_current_InterfaceDeclaration_IFluidObject(
     use: current.IFluidObject);
 use_current_InterfaceDeclaration_IFluidObject(
     get_old_InterfaceDeclaration_IFluidObject());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -493,13 +493,13 @@ use_old_VariableDeclaration_IFluidSerializer(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IFluidSerializer": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IFluidSerializer():
     old.IFluidSerializer;
 declare function use_current_InterfaceDeclaration_IFluidSerializer(
     use: current.IFluidSerializer);
 use_current_InterfaceDeclaration_IFluidSerializer(
     get_old_InterfaceDeclaration_IFluidSerializer());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -565,13 +565,13 @@ use_old_InterfaceDeclaration_IProvideFluidConfiguration(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProvideFluidHandle": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IProvideFluidHandle():
     old.IProvideFluidHandle;
 declare function use_current_InterfaceDeclaration_IProvideFluidHandle(
     use: current.IProvideFluidHandle);
 use_current_InterfaceDeclaration_IProvideFluidHandle(
     get_old_InterfaceDeclaration_IProvideFluidHandle());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -613,13 +613,13 @@ use_old_InterfaceDeclaration_IProvideFluidHandleContext(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProvideFluidLoadable": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IProvideFluidLoadable():
     old.IProvideFluidLoadable;
 declare function use_current_InterfaceDeclaration_IProvideFluidLoadable(
     use: current.IProvideFluidLoadable);
 use_current_InterfaceDeclaration_IProvideFluidLoadable(
     get_old_InterfaceDeclaration_IProvideFluidLoadable());
+*/
 
 /*
 * validate back compat by using current type in place of old type
@@ -685,13 +685,13 @@ use_old_InterfaceDeclaration_IProvideFluidRunnable(
 * validate forward compat by using old type in place of current type
 * to disable, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProvideFluidSerializer": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IProvideFluidSerializer():
     old.IProvideFluidSerializer;
 declare function use_current_InterfaceDeclaration_IProvideFluidSerializer(
     use: current.IProvideFluidSerializer);
 use_current_InterfaceDeclaration_IProvideFluidSerializer(
     get_old_InterfaceDeclaration_IProvideFluidSerializer());
+*/
 
 /*
 * validate back compat by using current type in place of old type


### PR DESCRIPTION
Expose decode method on IFluidSerializer, to be used to fix up serialization in SharedCell and future DDSes.

See full change draft here: #7697