### PR TITLE
optional includeDisabled query param in riddler GETs

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -47,7 +47,8 @@ export function create(
      */
     router.get("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const includeDisabled = getParam(request.params, "includeDisabled")?.toLowerCase() === "true";
+        const includeDisabledRaw = request.query.includeDisabled as string;
+        const includeDisabled = includeDisabledRaw?.toLowerCase() === "true";
         const tenantP = manager.getTenant(tenantId, includeDisabled);
         handleResponse(tenantP, response);
     });
@@ -56,7 +57,8 @@ export function create(
      * Retrieves list of all tenants
      */
     router.get("/tenants", (request, response) => {
-        const includeDisabled = getParam(request.params, "includeDisabled")?.toLowerCase() === "true";
+        const includeDisabledRaw = request.query.includeDisabled as string;
+        const includeDisabled = includeDisabledRaw?.toLowerCase() === "true";
         const tenantP = manager.getAllTenants(includeDisabled);
         handleResponse(tenantP, response);
     });
@@ -66,7 +68,8 @@ export function create(
      */
     router.get("/tenants/:id/key", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const includeDisabled = getParam(request.params, "includeDisabled")?.toLowerCase() === "true";
+        const includeDisabledRaw = request.query.includeDisabled as string;
+        const includeDisabled = includeDisabledRaw?.toLowerCase() === "true";
         const tenantP = manager.getTenantKey(tenantId, includeDisabled);
         handleResponse(tenantP, response);
     });

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -55,7 +55,8 @@ export function create(
      */
     router.get("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const tenantP = manager.getTenant(tenantId);
+        const includeDisabled = getParam(request.params, "includeDisabled")?.toLowerCase() === "true";
+        const tenantP = manager.getTenant(tenantId, includeDisabled);
         handleResponse(tenantP, response);
     });
 
@@ -63,7 +64,8 @@ export function create(
      * Retrieves list of all tenants
      */
     router.get("/tenants", (request, response) => {
-        const tenantP = manager.getAllTenants();
+        const includeDisabled = getParam(request.params, "includeDisabled")?.toLowerCase() === "true";
+        const tenantP = manager.getAllTenants(includeDisabled);
         handleResponse(tenantP, response);
     });
 
@@ -71,7 +73,9 @@ export function create(
      * Retrieves the api key for the tenant
      */
     router.get("/tenants/:id/key", (request, response) => {
-        const tenantP = manager.getTenantKey(getParam(request.params, "id"));
+        const tenantId = getParam(request.params, "id");
+        const includeDisabled = getParam(request.params, "includeDisabled")?.toLowerCase() === "true";
+        const tenantP = manager.getTenantKey(tenantId, includeDisabled);
         handleResponse(tenantP, response);
     });
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -43,14 +43,6 @@ export function create(
     });
 
     /**
-     * Retrieves list of all deleted tenants
-     */
-     router.get("/tenants/disabled", (request, response) => {
-        const disabledTenantsP = manager.getDisabledTenants();
-        handleResponse(disabledTenantsP, response);
-    });
-
-    /**
      * Retrieves details for the given tenant
      */
     router.get("/tenants/:id", (request, response) => {

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -47,8 +47,7 @@ export function create(
      */
     router.get("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const includeDisabledRaw = request.query.includeDisabled as string;
-        const includeDisabled = includeDisabledRaw?.toLowerCase() === "true";
+        const includeDisabled = getIncludeDisabledFlag(request);
         const tenantP = manager.getTenant(tenantId, includeDisabled);
         handleResponse(tenantP, response);
     });
@@ -57,8 +56,7 @@ export function create(
      * Retrieves list of all tenants
      */
     router.get("/tenants", (request, response) => {
-        const includeDisabledRaw = request.query.includeDisabled as string;
-        const includeDisabled = includeDisabledRaw?.toLowerCase() === "true";
+        const includeDisabled = getIncludeDisabledFlag(request);
         const tenantP = manager.getAllTenants(includeDisabled);
         handleResponse(tenantP, response);
     });
@@ -68,8 +66,7 @@ export function create(
      */
     router.get("/tenants/:id/key", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const includeDisabledRaw = request.query.includeDisabled as string;
-        const includeDisabled = includeDisabledRaw?.toLowerCase() === "true";
+        const includeDisabled = getIncludeDisabledFlag(request);
         const tenantP = manager.getTenantKey(tenantId, includeDisabled);
         handleResponse(tenantP, response);
     });
@@ -137,6 +134,11 @@ export function create(
         const tenantP = manager.deleteTenant(tenantId, scheduledDeletionTime);
         handleResponse(tenantP, response);
     });
+
+    function getIncludeDisabledFlag(request): boolean {
+        const includeDisabledRaw = request.query.includeDisabled as string;
+        return includeDisabledRaw?.toLowerCase() === "true";
+    }
 
     return router;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -115,19 +115,6 @@ export class TenantManager {
         }));
     }
 
-    public async getDisabledTenants(): Promise<ITenantConfig[]> {
-        const tenants = await this.getAllTenantDocuments(true);
-        return tenants
-        .filter((tenant) => tenant.disabled)
-        .map((tenant) => ({
-            id: tenant._id,
-            orderer: tenant.orderer,
-            storage: tenant.storage,
-            customData: tenant.customData,
-            scheduledDeletionTime: tenant.scheduledDeletionTime,
-        }));
-    }
-
     /**
      * Generates a random tenant key
      */

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -49,10 +49,10 @@ export class TenantManager implements core.ITenantManager {
         return result.data;
     }
 
-    public async getTenant(tenantId: string, documentId: string): Promise<core.ITenant> {
+    public async getTenant(tenantId: string, documentId: string, includeDisabled = false): Promise<core.ITenant> {
         const [details, key] = await Promise.all([
-            Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`),
-            this.getKey(tenantId)]);
+            Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`, { params: { includeDisabled }}),
+            this.getKey(tenantId, includeDisabled)]);
 
         const defaultQueryString = {
             token: fromUtf8ToBase64(`${tenantId}`),
@@ -95,8 +95,10 @@ export class TenantManager implements core.ITenantManager {
             { token });
     }
 
-    public async getKey(tenantId: string): Promise<string> {
-        const result = await Axios.get(`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/key`);
+    public async getKey(tenantId: string, includeDisabled = false): Promise<string> {
+        const result = await Axios.get(
+            `${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/key`,
+            { params: { includeDisabled }});
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return result.data;
     }


### PR DESCRIPTION
Introduce **includeDisabled** query parameter in Riddler's existing GETs. While we have a dedicated route to get all disabled tenants, the client querying for tenant data may not know the tenant is disabled to explicitly call that and will have to rely on the normal GET tenant route. 

We can also remove the route to get all disabled tenants as it can now be achieved with get all tenants with **includeDisabled** parameter. 

An example of such a client is a client who is deleting documents and want to fetch details of the tenant that owns it when the tenant was already marked for deletion. 