### PR TITLE
Making sure that container errors are reported correctly on close

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -797,6 +797,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             {
                 eventName: "ContainerClose",
                 loaded: this.loaded,
+                category: error === undefined ? "generic" : "error",
             },
             error,
         );

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -124,7 +124,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
      * @param error - optional error object to log
      */
     public sendTelemetryEvent(event: ITelemetryGenericEvent, error?: any) {
-        this.sendTelemetryEventCore({ ...event, category: "generic"}, error);
+        this.sendTelemetryEventCore({ ...event, category: event.category ?? "generic" }, error);
     }
 
     /**
@@ -169,7 +169,7 @@ export abstract class TelemetryLogger implements ITelemetryLogger {
     public sendPerformanceEvent(event: ITelemetryPerformanceEvent, error?: any): void {
         const perfEvent = {
             ...event,
-            category: event.category ? event.category : "performance",
+            category: event.category ?? "performance",
         };
 
         this.sendTelemetryEventCore(perfEvent, error);


### PR DESCRIPTION
Noticed by looking at telemetry and not finding errors there :(
That's a regression from https://github.com/microsoft/FluidFramework/pull/7363
We could force callers to use right API instead of overwriting category, but we already allow that for "performance" events, and the code is a bit shorter than way, so I feel supporting this flow is better.