### PR TITLE
Add url field back in ICreateBlobResponse as it breaks mfs loader

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -153,6 +153,8 @@ export interface IConnected {
 export interface ICreateBlobResponse {
     // (undocumented)
     id: string;
+    // (undocumented)
+    url: string;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -153,7 +153,7 @@ export interface IConnected {
 export interface ICreateBlobResponse {
     // (undocumented)
     id: string;
-    // (undocumented)
+    // @deprecated (undocumented)
     url: string;
 }
 

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -50,6 +50,8 @@ export interface IAttachment {
 
 export interface ICreateBlobResponse {
     id: string;
+    // @deprecated - It is an unused field and could be removed in future versions.
+    url: string;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -50,7 +50,9 @@ export interface IAttachment {
 
 export interface ICreateBlobResponse {
     id: string;
-    // @deprecated - It is an unused field and could be removed in future versions.
+    /**
+     * @deprecated - It is an unused field and could be removed in future versions.
+    */
     url: string;
 }
 


### PR DESCRIPTION
The problem here is that mfs-loader depends on 0.1024.0 protocol-defn package which has url in ICreateBlobResponse. In the newly released package (0.1025.0), this field was removed with this PR: https://github.com/microsoft/FluidFramework/pull/6437.
Now when OWH was integrating it, it created problem for them as they depend on  mfs loader which has url in interface while ffx will not have after integrating. It created compile time issues,