### PR TITLE
Make RestLess more specific by adding an indicator in the header

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -465,9 +465,7 @@ export enum RestLessFieldNames {
     // (undocumented)
     Header = "header",
     // (undocumented)
-    Method = "method",
-    // (undocumented)
-    RestLess = "restless"
+    Method = "method"
 }
 
 // @public (undocumented)

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -465,7 +465,9 @@ export enum RestLessFieldNames {
     // (undocumented)
     Header = "header",
     // (undocumented)
-    Method = "method"
+    Method = "method",
+    // (undocumented)
+    RestLess = "restless"
 }
 
 // @public (undocumented)

--- a/server/routerlicious/packages/services-client/src/restLessClient.ts
+++ b/server/routerlicious/packages/services-client/src/restLessClient.ts
@@ -6,7 +6,6 @@
 import { AxiosRequestConfig } from "axios";
 
 export enum RestLessFieldNames {
-    RestLess = "restless",
     Method = "method",
     Header = "header",
     Body = "body",
@@ -39,7 +38,6 @@ export class RestLessClient {
         const newRequest = { ...request };
         const body = new URLSearchParams();
 
-        body.append(RestLessFieldNames.RestLess, "true");
         body.append(RestLessFieldNames.Method, newRequest.method ?? "GET");
 
         if (newRequest.headers) {
@@ -60,7 +58,7 @@ export class RestLessClient {
         newRequest.method = "POST";
         newRequest.headers = {
             // TODO: when we support blob/file uploads, we should potentially add compatibility with multipart/form-data
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/x-www-form-urlencoded;restless",
         };
 
         return newRequest;

--- a/server/routerlicious/packages/services-client/src/restLessClient.ts
+++ b/server/routerlicious/packages/services-client/src/restLessClient.ts
@@ -6,6 +6,7 @@
 import { AxiosRequestConfig } from "axios";
 
 export enum RestLessFieldNames {
+    RestLess = "restless",
     Method = "method",
     Header = "header",
     Body = "body",
@@ -38,6 +39,7 @@ export class RestLessClient {
         const newRequest = { ...request };
         const body = new URLSearchParams();
 
+        body.append(RestLessFieldNames.RestLess, "true");
         body.append(RestLessFieldNames.Method, newRequest.method ?? "GET");
 
         if (newRequest.headers) {


### PR DESCRIPTION
In #7525, Tanvir suggested adding an extra param or way to identify that a request is _for sure_ RestLess so that we don't translate requests unnecessarily or incorrectly. It turns out, you can add more pieces to the Content-Type header while still being within the CORS Simple Request restrictions. This PR adds `;restless` to the Content-Type header, and the server uses that as an official means of deciding that a request is RestLess.

Bonus: Also cleaned up the RestLessServer implementation a bit so that each call to RestLessServer.translate does not have to define all of the internal functions.