### PR TITLE
Close document contexts when removing idle lambdas

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -36,6 +36,10 @@ export class DocumentContextManager extends EventEmitter {
         super();
     }
 
+    /**
+     * Creates a context that should be used for a single document partition
+     * This class is responsible for the lifetime of the context
+     */
     public createContext(head: IQueuedMessage): DocumentContext {
         // Contexts should only be created within the processing range of the manager
         assert(head.offset > this.tail.offset && head.offset <= this.head.offset);
@@ -49,6 +53,7 @@ export class DocumentContextManager extends EventEmitter {
     }
 
     public removeContext(context: DocumentContext): void {
+        context.close();
         this.contexts.delete(context);
     }
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -60,15 +60,16 @@ export class DocumentContext extends EventEmitter implements IContext {
     }
 
     public checkpoint(message: IQueuedMessage) {
+        if (this.closed) {
+            return;
+        }
+
         // Assert offset is between the current tail and head
         const offset = message.offset;
 
         assert(offset > this.tail.offset && offset <= this.head.offset,
-            `${offset} > ${this.tail.offset} && ${offset} <= ${this.head.offset}`);
-
-        if (this.closed) {
-            return;
-        }
+            `${offset} > ${this.tail.offset} && ${offset} <= ${this.head.offset} ` +
+            `(${message.topic}, ${message.partition})`);
 
         // Update the tail and broadcast the checkpoint
         this.tailInternal = message;


### PR DESCRIPTION
- Close the context when `removeContext` is called - This is called when an idle document partition is being removed
- Move `this.closed` check before the assert and add extra info to the assert