### PR TITLE
Update version of core-interfaces used in driver-definitions

### DIFF
--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -326,9 +326,9 @@
       "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.5.tgz",
-      "integrity": "sha512-n1neSteU0P/mQjthiNqqrdXl3+VeJ2QFZva6QJOcFRVmjHe+c827g9VqEbz0WB8jcSKpf98n3QzTXAGmEqBeVg=="
+      "version": "0.40.0-39960",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0-39960.tgz",
+      "integrity": "sha512-1rdR3n7aoU9ilvk8bw1+WKW1mB1/xq1Ho2PdTwD0L5EmD5DYYZ2AzQBSv9BxDebBOGkw8IodOiFusrcnoZU63Q=="
     },
     "@fluidframework/driver-definitions-0.39.8": {
       "version": "npm:@fluidframework/driver-definitions@0.39.8",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.40.0-39960",
+    "@fluidframework/core-interfaces": "^0.40.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },
   "devDependencies": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.39.5",
+    "@fluidframework/core-interfaces": "^0.40.0-39960",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },
   "devDependencies": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0-39960",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To pick up the IFluidSerializer change. This is an intermediate step to pick up the core-interfaces change in other packages.