### PR TITLE
Log To Error For Container Perf Event Errors

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -371,7 +371,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                         onClosed(err);
                     });
             }),
-            { start: true, end: true, cancel: "generic" },
+            { start: true, end: true, cancel: "error" },
         );
     }
 
@@ -963,7 +963,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     public async request(path: IRequest): Promise<IResponse> {
         return PerformanceEvent.timedExecAsync(this.logger, { eventName: "Request" }, async () => {
             return this.context.request(path);
-        });
+        },
+        {end: true, cancel: "error"});
     }
 
     public async snapshot(tagMessage: string, fullTree: boolean = false): Promise<void> {


### PR DESCRIPTION
By default perf event logs to the generic table. this is usually correct, as some layer above will catch and log the exception, but at these top level events in container we should log directly to error, to ensure they are not lost