### PR TITLE
bump the peerDeps for the *-client packages

### DIFF
--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -68,6 +68,6 @@
     "typescript": "~4.1.3"
   },
   "peerDependencies": {
-    "fluid-framework": "^0.48.0"
+    "fluid-framework": "^0.49.1"
   }
 }

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -63,6 +63,6 @@
     "typescript": "~4.1.3"
   },
   "peerDependencies": {
-    "fluid-framework": "^0.48.0"
+    "fluid-framework": "^0.49.1"
   }
 }


### PR DESCRIPTION
the peerDependencies were not bumped for our client packages. This is breaking clients who are trying to upgrade to 0.49