### PR TITLE
Add url back in ICreateBlobResponse

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -153,6 +153,7 @@ export interface IConnected {
 export interface ICreateBlobResponse {
     // (undocumented)
     id: string;
+    url: string;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -153,6 +153,7 @@ export interface IConnected {
 export interface ICreateBlobResponse {
     // (undocumented)
     id: string;
+    // @deprecated (undocumented)
     url: string;
 }
 

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -51,7 +51,7 @@ export interface IAttachment {
 export interface ICreateBlobResponse {
     id: string;
     /**
-     * deprecated - This could be removed in future.
+     * @deprecated - This could be removed in future.
      */
     url: string;
 }

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -50,6 +50,10 @@ export interface IAttachment {
 
 export interface ICreateBlobResponse {
     id: string;
+    /**
+     * deprecated - This could be removed in future.
+     */
+    url: string;
 }
 
 /**


### PR DESCRIPTION
The problem here is that mfs-loader depends on 0.1024.0 protocol-defn package which has url in ICreateBlobResponse. In the newly released package (0.1025.0), this field was removed with this PR: #6437.
Now when OWH was integrating it, it created problem for them as they depend on mfs loader which has url in interface while ffx will not have after integrating. It created compile time issues,