### PR TITLE
Add type safety to serverEpoch property

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -66,6 +66,8 @@ export interface IOdspError {
     readonly message: string;
     // (undocumented)
     online?: string;
+    // (undocumented)
+    serverEpoch?: string;
 }
 
 // @public (undocumented)

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -50,12 +50,14 @@ export enum OdspErrorType {
 
 /**
  * Base interface for all errors and warnings
+ * Superset of IDriverErrorBase, but with Odsp-specific errorType
  */
 export interface IOdspError {
     readonly errorType: OdspErrorType;
     readonly message: string;
     canRetry: boolean;
     online?: string;
+    serverEpoch?: string;
 }
 
 export type OdspError =

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -14,6 +14,7 @@ import {
     IEntry,
     IFileEntry,
     IPersistedCache,
+    IOdspError,
 } from "@fluidframework/odsp-driver-definitions";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { PerformanceEvent, isValidLegacyError } from "@fluidframework/telemetry-utils";
@@ -153,7 +154,7 @@ export class EpochTracker implements IPersistedFileCache {
             // Get the server epoch from error in case we don't have it as if undefined we won't be able
             // to mark it as epoch error.
             if (epochFromResponse === undefined) {
-                epochFromResponse = error.serverEpoch;
+                epochFromResponse = (error as IOdspError).serverEpoch;
             }
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;
@@ -187,7 +188,7 @@ export class EpochTracker implements IPersistedFileCache {
             // Get the server epoch from error in case we don't have it as if undefined we won't be able
             // to mark it as epoch error.
             if (epochFromResponse === undefined) {
-                epochFromResponse = error.serverEpoch;
+                epochFromResponse = (error as IOdspError).serverEpoch;
             }
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -15,7 +15,7 @@ import {
     NonRetryableError,
     OnlineStatus,
 } from "@fluidframework/driver-utils";
-import { OdspErrorType, OdspError } from "@fluidframework/odsp-driver-definitions";
+import { OdspErrorType, OdspError, IOdspError } from "@fluidframework/odsp-driver-definitions";
 import { parseAuthErrorClaims } from "./parseAuthErrorClaims";
 import { parseAuthErrorTenant } from "./parseAuthErrorTenant";
 
@@ -237,7 +237,7 @@ export function enrichOdspError(
             for (const key of Object.keys(headers))  {
                 props[key] = headers[key];
             }
-            props.serverEpoch = response.headers.get("x-fluid-epoch") ?? undefined;
+            (error as IOdspError).serverEpoch = response.headers.get("x-fluid-epoch") ?? undefined;
         }
     }
     error.addTelemetryProperties(props);

--- a/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
@@ -8,7 +8,7 @@
 import { strict as assert } from "assert";
 import { DriverErrorType, IThrottlingWarning } from "@fluidframework/driver-definitions";
 import { createWriteError, GenericNetworkError } from "@fluidframework/driver-utils";
-import { OdspErrorType, OdspError } from "@fluidframework/odsp-driver-definitions";
+import { OdspErrorType, OdspError, IOdspError } from "@fluidframework/odsp-driver-definitions";
 import { isILoggingError } from "@fluidframework/telemetry-utils";
 import { createOdspNetworkError, invalidFileNameStatusCode, enrichOdspError } from "../odspErrorUtils";
 
@@ -173,6 +173,7 @@ describe("OdspErrorUtils", () => {
             assert.equal(error.getTelemetryProperties().sprequestduration, 5);
             assert.equal(error.getTelemetryProperties().contentsize, 5);
             assert.equal(error.getTelemetryProperties().serverEpoch, "mock header x-fluid-epoch");
+            assert.equal((error as IOdspError).serverEpoch, "mock header x-fluid-epoch");
         });
     });
 


### PR DESCRIPTION
We have real logic that's depending on the internals of our `LoggingError` class to plumb the `serverEpoch` value from a header to be used when handling certain ODSP errors.  This change adds `serverEpoch` to an existing type and (somewhat sloppily) uses that to set/get that value throughout the code.