### PR TITLE
Historian includeDisabled tenant support 

### DIFF
--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -30,7 +30,12 @@ export interface ITenantService {
      * Retrieves the storage provider details for the given tenant.
      * If the provided token is invalid will return a broken promise.
      */
-    getTenant(tenantId: string, token: string): Promise<ITenantConfig>;
+    getTenant(tenantId: string, token: string, includeDisabled: boolean): Promise<ITenantConfig>;
+
+    /**
+     * Removes any existing cache for the given tenant and token.
+     */
+     deleteFromCache(tenantId: string, token: string): Promise<boolean>;
 }
 
 /**

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -30,7 +30,7 @@ export interface ITenantService {
      * Retrieves the storage provider details for the given tenant.
      * If the provided token is invalid will return a broken promise.
      */
-    getTenant(tenantId: string, token: string, includeDisabled: boolean): Promise<ITenantConfig>;
+    getTenant(tenantId: string, token: string, includeDisabledTenant: boolean): Promise<ITenantConfig>;
 
     /**
      * Removes any existing cache for the given tenant and token.

--- a/server/historian/packages/historian-base/src/services/redisTenantCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisTenantCache.ts
@@ -47,6 +47,11 @@ export class RedisTenantCache {
         }
     }
 
+    public async delete(key: string): Promise<boolean> {
+        const result = await this.client.del(this.getKey(key));
+        return result === 1;
+    }
+
     public async get(key: string): Promise<string> {
         return this.client.get(this.getKey(key));
     }

--- a/server/historian/packages/historian-base/src/services/riddlerService.ts
+++ b/server/historian/packages/historian-base/src/services/riddlerService.ts
@@ -36,12 +36,22 @@ export class RiddlerService implements ITenantService {
         );
     }
 
-    public async getTenant(tenantId: string, token: string): Promise<ITenantConfig> {
-        const [tenant] = await Promise.all([this.getTenantDetails(tenantId), this.verifyToken(tenantId, token)]);
+    public async getTenant(tenantId: string, token: string, includeDisabled = false): Promise<ITenantConfig> {
+        const [tenant] = await Promise.all([
+            this.getTenantDetails(tenantId, includeDisabled),
+            this.verifyToken(tenantId, token, includeDisabled)]);
         return tenant;
     }
 
-    private async getTenantDetails(tenantId: string): Promise<ITenantConfig> {
+    public async deleteFromCache(tenantId: string, token: string): Promise<boolean> {
+        const results = await Promise.all([
+            this.cache.delete(tenantId),
+            this.cache.delete(token)]);
+
+        return results.every(Boolean);
+    }
+
+    private async getTenantDetails(tenantId: string, includeDisabled = false): Promise<ITenantConfig> {
         const lumberProperties = { [BaseTelemetryProperties.tenantId]: tenantId };
         const cachedDetail = await this.cache.get(tenantId).catch((error) => {
             winston.error(`Error fetching tenant details from cache`, error);
@@ -58,7 +68,7 @@ export class RiddlerService implements ITenantService {
             return JSON.parse(cachedDetail) as ITenantConfig;
         }
         const tenantUrl = `/api/tenants/${tenantId}`;
-        const details = await this.restWrapper.get<ITenantConfig>(tenantUrl)
+        const details = await this.restWrapper.get<ITenantConfig>(tenantUrl, { includeDisabled })
             .catch(getRequestErrorTranslator(tenantUrl, "GET"));
         this.cache.set(tenantId, JSON.stringify(details)).catch((error) => {
             winston.error(`Error caching tenant details to redis`, error);
@@ -71,7 +81,7 @@ export class RiddlerService implements ITenantService {
         return details;
     }
 
-    private async verifyToken(tenantId: string, token: string): Promise<void> {
+    private async verifyToken(tenantId: string, token: string, includeDisabled = false): Promise<void> {
         const lumberProperties = { [BaseTelemetryProperties.tenantId]: tenantId };
         const cachedToken = await this.cache.exists(token).catch((error) => {
             winston.error(`Error fetching token from cache`, error);
@@ -90,7 +100,7 @@ export class RiddlerService implements ITenantService {
         }
 
         const tokenValidationUrl = `/api/tenants/${tenantId}/validate`;
-        await this.restWrapper.post(tokenValidationUrl, { token })
+        await this.restWrapper.post(tokenValidationUrl, { token }, { includeDisabled })
             .catch(getRequestErrorTranslator(tokenValidationUrl, "POST"));
 
         // TODO: ensure token expiration validity as well using `validateTokenClaimsExpiration` from `services-client`

--- a/server/historian/packages/historian-base/src/test/utils/testTenantService.ts
+++ b/server/historian/packages/historian-base/src/test/utils/testTenantService.ts
@@ -11,7 +11,7 @@ import { ITenantService } from "../../services";
 export class TestTenantService implements ITenantService {
     private readonly tenant = new TestTenant("http://test", "http://historian", new TestDb({}));
 
-    async getTenant(tenantId: string, token: string, includeDisabled = false): Promise<ITenantConfig> {
+    async getTenant(tenantId: string, token: string, includeDisabledTenant = false): Promise<ITenantConfig> {
         return Promise.resolve({
             id: "testTenant",
             storage: this.tenant.storage,

--- a/server/historian/packages/historian-base/src/test/utils/testTenantService.ts
+++ b/server/historian/packages/historian-base/src/test/utils/testTenantService.ts
@@ -11,12 +11,16 @@ import { ITenantService } from "../../services";
 export class TestTenantService implements ITenantService {
     private readonly tenant = new TestTenant("http://test", "http://historian", new TestDb({}));
 
-    async getTenant(tenantId: string, token: string): Promise<ITenantConfig> {
+    async getTenant(tenantId: string, token: string, includeDisabled = false): Promise<ITenantConfig> {
         return Promise.resolve({
             id: "testTenant",
             storage: this.tenant.storage,
             orderer: this.tenant.orderer,
             customData: {},
         });
+    }
+
+    async deleteFromCache(tenantId: string, token: string): Promise<boolean> {
+        return Promise.reject(new Error("Method not implemented."));
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -39,8 +39,8 @@ export function create(
      */
     router.post("/tenants/:id/validate", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const includeDisabled = getIncludeDisabledFlag(request);
-        const validP = manager.validateToken(tenantId, request.body.token,  includeDisabled);
+        const includeDisabledTenant = getIncludeDisabledFlag(request);
+        const validP = manager.validateToken(tenantId, request.body.token,  includeDisabledTenant);
         handleResponse(validP, response);
     });
 
@@ -49,8 +49,8 @@ export function create(
      */
     router.get("/tenants/:id", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const includeDisabled = getIncludeDisabledFlag(request);
-        const tenantP = manager.getTenant(tenantId, includeDisabled);
+        const includeDisabledTenant = getIncludeDisabledFlag(request);
+        const tenantP = manager.getTenant(tenantId, includeDisabledTenant);
         handleResponse(tenantP, response);
     });
 
@@ -58,8 +58,8 @@ export function create(
      * Retrieves list of all tenants
      */
     router.get("/tenants", (request, response) => {
-        const includeDisabled = getIncludeDisabledFlag(request);
-        const tenantP = manager.getAllTenants(includeDisabled);
+        const includeDisabledTenant = getIncludeDisabledFlag(request);
+        const tenantP = manager.getAllTenants(includeDisabledTenant);
         handleResponse(tenantP, response);
     });
 
@@ -68,8 +68,8 @@ export function create(
      */
     router.get("/tenants/:id/key", (request, response) => {
         const tenantId = getParam(request.params, "id");
-        const includeDisabled = getIncludeDisabledFlag(request);
-        const tenantP = manager.getTenantKey(tenantId, includeDisabled);
+        const includeDisabledTenant = getIncludeDisabledFlag(request);
+        const tenantP = manager.getTenantKey(tenantId, includeDisabledTenant);
         handleResponse(tenantP, response);
     });
 
@@ -138,7 +138,7 @@ export function create(
     });
 
     function getIncludeDisabledFlag(request): boolean {
-        const includeDisabledRaw = request.query.includeDisabled as string;
+        const includeDisabledRaw = request.query.includeDisabledTenant as string;
         return includeDisabledRaw?.toLowerCase() === "true";
     }
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -38,7 +38,9 @@ export function create(
      * Clients still need to verify the claims.
      */
     router.post("/tenants/:id/validate", (request, response) => {
-        const validP = manager.validateToken(getParam(request.params, "id"), request.body.token);
+        const tenantId = getParam(request.params, "id");
+        const includeDisabled = getIncludeDisabledFlag(request);
+        const validP = manager.validateToken(tenantId, request.body.token,  includeDisabled);
         handleResponse(validP, response);
     });
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -59,8 +59,8 @@ export class TenantManager {
     /**
      * Validates a tenant's API token
      */
-    public async validateToken(tenantId: string, token: string): Promise<void> {
-        const tenantKey = await this.getTenantKey(tenantId);
+    public async validateToken(tenantId: string, token: string, includeDisabled = false): Promise<void> {
+        const tenantKey = await this.getTenantKey(tenantId, includeDisabled);
 
         return new Promise<void>((resolve, reject) => {
             jwt.verify(token, tenantKey, (error) => {

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -59,8 +59,8 @@ export class TenantManager {
     /**
      * Validates a tenant's API token
      */
-    public async validateToken(tenantId: string, token: string, includeDisabled = false): Promise<void> {
-        const tenantKey = await this.getTenantKey(tenantId, includeDisabled);
+    public async validateToken(tenantId: string, token: string, includeDisabledTenant = false): Promise<void> {
+        const tenantKey = await this.getTenantKey(tenantId, includeDisabledTenant);
 
         return new Promise<void>((resolve, reject) => {
             jwt.verify(token, tenantKey, (error) => {
@@ -79,8 +79,8 @@ export class TenantManager {
     /**
      * Retrieves the details for the given tenant
      */
-    public async getTenant(tenantId: string, includeDisabled = false): Promise<ITenantConfig> {
-        const tenant = await this.getTenantDocument(tenantId, includeDisabled);
+    public async getTenant(tenantId: string, includeDisabledTenant = false): Promise<ITenantConfig> {
+        const tenant = await this.getTenantDocument(tenantId, includeDisabledTenant);
         if (!tenant) {
             winston.error("Tenant is disabled or does not exist.");
             return Promise.reject(new Error("Tenant is disabled or does not exist."));
@@ -103,8 +103,8 @@ export class TenantManager {
     /**
      * Retrieves the details for all tenants
      */
-    public async getAllTenants(includeDisabled = false): Promise<ITenantConfig[]> {
-        const tenants = await this.getAllTenantDocuments(includeDisabled);
+    public async getAllTenants(includeDisabledTenant = false): Promise<ITenantConfig[]> {
+        const tenants = await this.getAllTenantDocuments(includeDisabledTenant);
 
         return tenants.map((tenant) => ({
             id: tenant._id,
@@ -196,8 +196,8 @@ export class TenantManager {
     /**
      * Retrieves the secret for the given tenant
      */
-    public async getTenantKey(tenantId: string, includeDisabled = false): Promise<string> {
-        const encryptedTenantKey = (await this.getTenantDocument(tenantId, includeDisabled)).key;
+    public async getTenantKey(tenantId: string, includeDisabledTenant = false): Promise<string> {
+        const encryptedTenantKey = (await this.getTenantDocument(tenantId, includeDisabledTenant)).key;
         const tenantKey = this.secretManager.decryptSecret(encryptedTenantKey);
         if (tenantKey == null) {
             winston.error("Tenant key decryption failed.");
@@ -257,12 +257,12 @@ export class TenantManager {
     /**
      * Retrieves the raw database tenant document
      */
-    private async getTenantDocument(tenantId: string, includeDisabled = false): Promise<ITenantDocument> {
+    private async getTenantDocument(tenantId: string, includeDisabledTenant = false): Promise<ITenantDocument> {
         const db = await this.mongoManager.getDatabase();
         const collection = db.collection<ITenantDocument>(this.collectionName);
 
         const found = await collection.findOne({ _id: tenantId });
-        if (found.disabled && !includeDisabled) {
+        if (found.disabled && !includeDisabledTenant) {
             return null;
         }
 
@@ -274,7 +274,7 @@ export class TenantManager {
     /**
      * Retrieves all the raw database tenant documents
      */
-    private async getAllTenantDocuments(includeDisabled = false): Promise<ITenantDocument[]> {
+    private async getAllTenantDocuments(includeDisabledTenant = false): Promise<ITenantDocument[]> {
         const db = await this.mongoManager.getDatabase();
         const collection = db.collection<ITenantDocument>(this.collectionName);
 
@@ -284,7 +284,7 @@ export class TenantManager {
             this.attachDefaultsToTenantDocument(found);
         });
 
-        return includeDisabled ? allFound : allFound.filter((found) => !found.disabled);
+        return includeDisabledTenant ? allFound : allFound.filter((found) => !found.disabled);
     }
 
     /**

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -49,10 +49,11 @@ export class TenantManager implements core.ITenantManager {
         return result.data;
     }
 
-    public async getTenant(tenantId: string, documentId: string, includeDisabled = false): Promise<core.ITenant> {
+    public async getTenant(tenantId: string, documentId: string, includeDisabledTenant = false): Promise<core.ITenant> {
         const [details, key] = await Promise.all([
-            Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`, { params: { includeDisabled }}),
-            this.getKey(tenantId, includeDisabled)]);
+            Axios.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`,
+            { params: { includeDisabledTenant }}),
+            this.getKey(tenantId, includeDisabledTenant)]);
 
         const defaultQueryString = {
             token: fromUtf8ToBase64(`${tenantId}`),
@@ -95,10 +96,10 @@ export class TenantManager implements core.ITenantManager {
             { token });
     }
 
-    public async getKey(tenantId: string, includeDisabled = false): Promise<string> {
+    public async getKey(tenantId: string, includeDisabledTenant = false): Promise<string> {
         const result = await Axios.get(
             `${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/key`,
-            { params: { includeDisabled }});
+            { params: { includeDisabledTenant }});
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return result.data;
     }


### PR DESCRIPTION
## Changes
1. enable Historian to call Riddler to get disabled tenant's information and validate their token.
2. remove tenant cache in historian when a summary is hard deleted.