### PR TITLE
Move join session out of getWithRetryForTokenRefresh

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -231,34 +231,35 @@ export class OdspDocumentService implements IDocumentService {
      * @returns returns the document delta stream service for onedrive/sharepoint driver.
      */
     public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
+        // Presence of getWebsocketToken callback dictates whether callback is used for fetching
+        // websocket token or whether it is returned with joinSession response payload
+        const requestWebsocketTokenFromJoinSession = this.getWebsocketToken === undefined;
+        const joinSessionPromise = this.joinSession(requestWebsocketTokenFromJoinSession).catch((e) => {
+            const likelyFacetCodes = e as IFacetCodes;
+            if (Array.isArray(likelyFacetCodes.facetCodes)) {
+                for (const code of likelyFacetCodes.facetCodes) {
+                    switch (code) {
+                        case "sessionForbiddenOnPreservedFiles":
+                        case "sessionForbiddenOnModerationEnabledLibrary":
+                        case "sessionForbiddenOnRequireCheckout":
+                            // This document can only be opened in storage-only mode.
+                            // DeltaManager will recognize this error
+                            // and load without a delta stream connection.
+                            this._policies = {...this._policies,storageOnly: true};
+                            throw new DeltaStreamConnectionForbiddenError(code);
+                        default:
+                            continue;
+                    }
+                }
+            }
+            throw e;
+        });
         // Attempt to connect twice, in case we used expired token.
         return getWithRetryForTokenRefresh<IDocumentDeltaConnection>(async (options) => {
-            // Presence of getWebsocketToken callback dictates whether callback is used for fetching
-            // websocket token or whether it is returned with joinSession response payload
-            const requestWebsocketTokenFromJoinSession = this.getWebsocketToken === undefined;
             const websocketTokenPromise = requestWebsocketTokenFromJoinSession
                 ? Promise.resolve(null)
                 : this.getWebsocketToken!(options);
-            const joinSessionPromise = this.joinSession(requestWebsocketTokenFromJoinSession).catch((e) => {
-                const likelyFacetCodes = e as IFacetCodes;
-                if (Array.isArray(likelyFacetCodes.facetCodes)) {
-                    for (const code of likelyFacetCodes.facetCodes) {
-                        switch (code) {
-                            case "sessionForbiddenOnPreservedFiles":
-                            case "sessionForbiddenOnModerationEnabledLibrary":
-                            case "sessionForbiddenOnRequireCheckout":
-                                // This document can only be opened in storage-only mode.
-                                // DeltaManager will recognize this error
-                                // and load without a delta stream connection.
-                                this._policies = {...this._policies,storageOnly: true};
-                                throw new DeltaStreamConnectionForbiddenError(code);
-                            default:
-                                continue;
-                        }
-                    }
-                }
-                throw e;
-            });
+
             const [websocketEndpoint, websocketToken, io] =
                 await Promise.all([
                     joinSessionPromise,


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/7330
OdspDocumentService.connectToDeltaStream() calls this.joinSession() under getWithRetryForTokenRefresh(), but fetchJoinSession() has its own loop with getWithRetryForTokenRefresh(). This is likely not good, as we can retry 2X2 before failing with 403/401.
So moving the join session call out of getWithRetryForTokenRefresh and keeping the socket connection call within that.