### PR TITLE
Add a function to easily enable Test IUser object generation

### DIFF
--- a/api-report/test-client-utils.api.md
+++ b/api-report/test-client-utils.api.md
@@ -7,7 +7,7 @@
 import { InsecureTokenProvider } from '@fluidframework/test-runtime-utils';
 import { IUser } from '@fluidframework/protocol-definitions';
 
-// @public (undocumented)
+// @public
 export const generateTestUser: () => IUser & {
     name: string;
 };

--- a/api-report/test-client-utils.api.md
+++ b/api-report/test-client-utils.api.md
@@ -5,6 +5,12 @@
 ```ts
 
 import { InsecureTokenProvider } from '@fluidframework/test-runtime-utils';
+import { IUser } from '@fluidframework/protocol-definitions';
+
+// @public (undocumented)
+export const generateTestUser: () => IUser & {
+    name: string;
+};
 
 export { InsecureTokenProvider }
 

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -37,8 +37,7 @@
     "@fluidframework/azure-client": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/test-client-utils": "^0.50.0",
-    "fluid-framework": "^0.50.0",
-    "uuid": "^8.3.1"
+    "fluid-framework": "^0.50.0"
   },
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.50.0",

--- a/examples/hosts/app-integration/external-controller/src/app.ts
+++ b/examples/hosts/app-integration/external-controller/src/app.ts
@@ -9,12 +9,14 @@ import {
     AzureContainerServices,
     LOCAL_MODE_TENANT_ID,
 } from "@fluidframework/azure-client";
-import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
+import {
+    generateTestUser,
+    InsecureTokenProvider,
+} from "@fluidframework/test-client-utils";
 import {
     IFluidContainer,
     SharedMap,
 } from "fluid-framework";
-import { v4 as uuid } from "uuid";
 import { DiceRollerController } from "./controller";
 import { makeAppView } from "./view";
 
@@ -31,10 +33,7 @@ const userDetails: ICustomUserDetails = {
 // Define the server we will be using and initialize Fluid
 const useAzure = process.env.FLUID_CLIENT === "azure";
 
-const user = {
-    id: uuid(),
-    name: uuid(),
-};
+const user = generateTestUser();
 
 const azureUser = {
     userId: user.id,

--- a/packages/framework/test-client-utils/README.md
+++ b/packages/framework/test-client-utils/README.md
@@ -29,3 +29,13 @@ const tokenProvider = new InsecureTokenProvider("YOUR-TENANT-KEY-HERE", { id: "1
 ```
 
 Again, this should ONLY be used for local development as including the tenant key in the client code risks allowing malicious users to sniff it from the client bundle. Please consider using the [AzureFunctionTokenProvider](https://github.com/microsoft/FluidFramework/blob/main/packages/framework/azure-client/src/AzureFunctionTokenProvider.ts) or your own implementation that fulfills the `ITokenProvider` interface as an alternative for production scenarios.
+
+## generateTestUser
+
+A simple function that will generate a test user. This is to be used in conjuntion with `InsecureTokenProvider`. The response object will be `{ id: string, name: string}`. `id` will be a uuid and `name` will be a randomly generated friendly first and last name  seperated by a space.
+
+### Usage
+
+```javascript
+const tokenProvider = new InsecureTokenProvider("YOUR-TENANT-KEY-HERE", generateTestUser());
+```

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -31,7 +31,9 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/test-runtime-utils": "^0.50.0"
+    "@fluidframework/protocol-definitions": "^0.1025.0",
+    "@fluidframework/test-runtime-utils": "^0.50.0",
+    "sillyname": "0.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/framework/test-client-utils/src/generateTestUser.ts
+++ b/packages/framework/test-client-utils/src/generateTestUser.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
 import { IUser } from "@fluidframework/protocol-definitions";
 import generateName from "sillyname";
 import { v4 as uuid } from "uuid";
@@ -11,6 +10,6 @@ export const generateTestUser = (): IUser & { name: string } => {
     const user = {
         id: uuid(),
         name: generateName(),
-    }
-    return user; 
-} 
+    };
+    return user;
+};

--- a/packages/framework/test-client-utils/src/generateTestUser.ts
+++ b/packages/framework/test-client-utils/src/generateTestUser.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IUser } from "@fluidframework/protocol-definitions";
+import generateName from "sillyname";
+import { v4 as uuid } from "uuid";
+
+export const generateTestUser = (): IUser & { name: string } => {
+    const user = {
+        id: uuid(),
+        name: generateName(),
+    }
+    return user; 
+} 

--- a/packages/framework/test-client-utils/src/generateTestUser.ts
+++ b/packages/framework/test-client-utils/src/generateTestUser.ts
@@ -6,6 +6,10 @@ import { IUser } from "@fluidframework/protocol-definitions";
 import generateName from "sillyname";
 import { v4 as uuid } from "uuid";
 
+/**
+ * Create a new user object with a unique id (uuid) and random name (FIRST LAST)
+ * @returns a user object with a name and id property
+ */
 export const generateTestUser = (): IUser & { name: string } => {
     const user = {
         id: uuid(),

--- a/packages/framework/test-client-utils/src/index.ts
+++ b/packages/framework/test-client-utils/src/index.ts
@@ -11,3 +11,4 @@
  */
 
 export { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
+export { generateTestUser } from "./generateTestUser";


### PR DESCRIPTION
This is a simple function exported along side the InsecureTokenProvider that enables developers to generate a simple user object without writing additional boilerplate code. This works well for testing and prototyping.