### PR TITLE
Include session id in document context assert messages

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { EventEmitter } from "events";
-import { IContext, IContextErrorData, IQueuedMessage } from "@fluidframework/server-services-core";
+import { IContext, IContextErrorData, IQueuedMessage, IRoutingKey } from "@fluidframework/server-services-core";
 import { DocumentContext } from "./documentContext";
 
 const LastCheckpointedOffset: IQueuedMessage = {
@@ -40,12 +40,12 @@ export class DocumentContextManager extends EventEmitter {
      * Creates a context that should be used for a single document partition
      * This class is responsible for the lifetime of the context
      */
-    public createContext(head: IQueuedMessage): DocumentContext {
+    public createContext(routingKey: IRoutingKey, head: IQueuedMessage): DocumentContext {
         // Contexts should only be created within the processing range of the manager
         assert(head.offset > this.tail.offset && head.offset <= this.head.offset);
 
         // Create the new context and register for listeners on it
-        const context = new DocumentContext(head, this.partitionContext.log, () => this.tail);
+        const context = new DocumentContext(routingKey, head, this.partitionContext.log, () => this.tail);
         this.contexts.add(context);
         context.addListener("checkpoint", () => this.updateCheckpoint());
         context.addListener("error", (error, errorData: IContextErrorData) => this.emit("error", error, errorData));

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -81,7 +81,7 @@ export class DocumentLambda implements IPartitionLambda {
         let document = this.documents.get(routingKey);
         if (!document) {
             // Create a new context and begin tracking it
-            const documentContext = this.contextManager.createContext(message);
+            const documentContext = this.contextManager.createContext(boxcar, message);
 
             document = new DocumentPartition(
                 this.factory,

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { DocumentContext } from "../../document-router/documentContext";
 import { DebugLogger, TestKafka } from "@fluidframework/server-test-utils";
-import { IContextErrorData } from "@fluidframework/server-services-core";
+import { IContextErrorData, IRoutingKey } from "@fluidframework/server-services-core";
 
 function validateException(fn: () => void) {
     try {
@@ -20,11 +20,15 @@ function validateException(fn: () => void) {
 describe("document-router", () => {
     describe("DocumentContext", () => {
         let testContext: DocumentContext;
+        let routingKey: IRoutingKey = {
+            tenantId: "test-tenant-id",
+            documentId: "test-document-id",
+        }
         let offset0 = TestKafka.createdQueuedMessage(0);
         let contextTailOffset = TestKafka.createdQueuedMessage(-1);
 
         beforeEach(async () => {
-            testContext = new DocumentContext(offset0, DebugLogger.create("fluid-server:TestDocumentContext"), () => contextTailOffset);
+            testContext = new DocumentContext(routingKey, offset0, DebugLogger.create("fluid-server:TestDocumentContext"), () => contextTailOffset);
         });
 
         describe(".setHead", () => {

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -41,6 +41,14 @@ export enum SystemOperations {
     Leave,
 }
 
+export interface IRoutingKey {
+    // The tenant the message is intended for
+    tenantId: string;
+
+    // The object the message is intended for
+    documentId: string;
+}
+
 export interface ISystemMessage extends IMessage {
     // Id of the service sending the message
     id: string;
@@ -55,13 +63,7 @@ export interface ISystemMessage extends IMessage {
 /**
  * Message relating to an object
  */
-export interface IObjectMessage extends IMessage {
-    // The tenant the message is intended for
-    tenantId: string;
-
-    // The object the message is intended for
-    documentId: string;
-
+export interface IObjectMessage extends IMessage, IRoutingKey {
     // The client who submitted the message
     clientId: string | null;
 
@@ -92,26 +94,15 @@ export interface IRawOperationMessage extends IObjectMessage {
 /**
  * A group of IRawOperationMessage objects. Used in receiving batches of ops from Kafka.
  */
-export interface IRawOperationMessageBatch {
+export interface IRawOperationMessageBatch extends IRoutingKey {
     // Some ordered index to distinguish different batches. In the Kafka context, it is the Kafka offset.
     index: number;
-
-    // The tenant the message is intended for
-    tenantId: string;
-
-    // The object the message is intended for
-    documentId: string;
 
     contents: IRawOperationMessage[];
 }
 
 // Need to change this name - it isn't necessarily ticketed
-export interface ITicketedMessage extends IMessage {
-    // The tenant the message is intended for
-    tenantId: string;
-
-    // The object the message is intended for
-    documentId: string;
+export interface ITicketedMessage extends IMessage, IRoutingKey {
 }
 
 /**

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -41,11 +41,14 @@ export enum SystemOperations {
     Leave,
 }
 
+/**
+ * Object that indicates a specific session/document in the system
+ */
 export interface IRoutingKey {
-    // The tenant the message is intended for
+    // The tenant id
     tenantId: string;
 
-    // The object the message is intended for
+    // The document id
     documentId: string;
 }
 


### PR DESCRIPTION
There's not enough data/telemetry to determine why these asserts are sometimes firing. Including the session id should help.
- Include session id in document context assert messages
- Add  `IRoutingKey` interface for passing around tenant/document id