### PR TITLE
Refactor creation of ICancellableSummarizerController

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -645,7 +645,7 @@ export type SubmitSummaryResult = IBaseSummarizeResult | IGenerateSummaryTreeRes
 export class Summarizer extends EventEmitter implements ISummarizer {
     constructor(url: string,
     runtime: ISummarizerRuntime, configurationGetter: () => ISummaryConfiguration,
-    internalsProvider: ISummarizerInternalsProvider, handleContext: IFluidHandleContext, summaryCollection: SummaryCollection);
+    internalsProvider: ISummarizerInternalsProvider, handleContext: IFluidHandleContext, summaryCollection: SummaryCollection, runCoordinatorCreateFn: any);
     dispose(): void;
     // (undocumented)
     readonly enqueueSummarize: ISummarizer["enqueueSummarize"];

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -269,6 +269,12 @@ export interface IBroadcastSummaryResult {
     readonly summarizeOp: ISummaryOpMessage;
 }
 
+// @public (undocumented)
+export interface ICancellableSummarizerController extends ISummaryCancellationToken {
+    // (undocumented)
+    stop(reason: SummarizerStopReason): void;
+}
+
 // @public
 export interface ICancellationToken<T> {
     readonly cancelled: boolean;
@@ -645,7 +651,7 @@ export type SubmitSummaryResult = IBaseSummarizeResult | IGenerateSummaryTreeRes
 export class Summarizer extends EventEmitter implements ISummarizer {
     constructor(url: string,
     runtime: ISummarizerRuntime, configurationGetter: () => ISummaryConfiguration,
-    internalsProvider: ISummarizerInternalsProvider, handleContext: IFluidHandleContext, summaryCollection: SummaryCollection, runCoordinatorCreateFn: any);
+    internalsProvider: ISummarizerInternalsProvider, handleContext: IFluidHandleContext, summaryCollection: SummaryCollection, runCoordinatorCreateFn: (runtime: IConnectableRuntime) => Promise<ICancellableSummarizerController>);
     dispose(): void;
     // (undocumented)
     readonly enqueueSummarize: ISummarizer["enqueueSummarize"];

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -127,6 +127,7 @@ import { ISerializedElection, OrderedClientCollection, OrderedClientElection } f
 import { SummarizerClientElection, summarizerClientType } from "./summarizerClientElection";
 import {
     SubmitSummaryResult,
+    IConnectableRuntime,
     IGeneratedSummaryStats,
     ISubmitSummaryOptions,
     ISummarizer,
@@ -135,6 +136,7 @@ import {
     ISummarizerRuntime,
 } from "./summarizerTypes";
 import { formExponentialFn, Throttler } from "./throttler";
+import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
 
 export enum ContainerMessageType {
     // An op to be delivered to store
@@ -999,7 +1001,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     () => this.summaryConfiguration,
                     this /* ISummarizerInternalsProvider */,
                     this.IFluidHandleContext,
-                    this.summaryCollection);
+                    this.summaryCollection,
+                    async (runtime: IConnectableRuntime) => {
+                        const coord = await RunWhileConnectedCoordinator.create(runtime);
+                        return coord;
+                    });
             } else if (SummarizerClientElection.clientDetailsPermitElection(this.context.clientDetails)) {
                 // Create the SummaryManager and mark the initial state
                 this.summaryManager = new SummaryManager(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1002,10 +1002,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     this /* ISummarizerInternalsProvider */,
                     this.IFluidHandleContext,
                     this.summaryCollection,
-                    async (runtime: IConnectableRuntime) => {
-                        const coord = await RunWhileConnectedCoordinator.create(runtime);
-                        return coord;
-                    });
+                    async (runtime: IConnectableRuntime) => RunWhileConnectedCoordinator.create(runtime),
+                );
             } else if (SummarizerClientElection.clientDetailsPermitElection(this.context.clientDetails)) {
                 // Create the SummaryManager and mark the initial state
                 this.summaryManager = new SummaryManager(

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -10,4 +10,4 @@ export * from "./pendingStateManager";
 export * from "./summarizer";
 export * from "./summarizerTypes";
 export * from "./summaryCollection";
-export { neverCancelledSummaryToken } from "./runWhileConnectedCoordinator";
+export { ICancellableSummarizerController, neverCancelledSummaryToken } from "./runWhileConnectedCoordinator";

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -19,7 +19,7 @@ import {
     ISummaryConfiguration,
 } from "@fluidframework/protocol-definitions";
 import { create404Response } from "@fluidframework/runtime-utils";
-import { RunWhileConnectedCoordinator } from "./runWhileConnectedCoordinator";
+import { ICancellableSummarizerController } from "./runWhileConnectedCoordinator";
 import { SummaryCollection } from "./summaryCollection";
 import { SummarizerHandle } from "./summarizerHandle";
 import { RunningSummarizer } from "./runningSummarizer";
@@ -90,6 +90,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         private readonly internalsProvider: ISummarizerInternalsProvider,
         handleContext: IFluidHandleContext,
         public readonly summaryCollection: SummaryCollection,
+        private readonly runCoordinatorCreateFn,
     ) {
         super();
         this.logger = ChildLogger.create(this.runtime.logger, "Summarizer");
@@ -142,7 +143,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             initSummarySeqNumber: this.runtime.deltaManager.initialSequenceNumber,
         });
 
-        const runCoordinator = await RunWhileConnectedCoordinator.create(this.runtime);
+        const runCoordinator: ICancellableSummarizerController = await this.runCoordinatorCreateFn(this.runtime);
 
         // Wait for either external signal to cancel, or loss of connectivity.
         const stopP = Promise.race([runCoordinator.waitCancelled, this.stopDeferred.promise]);

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -32,6 +32,7 @@ import {
     SummarizerStopReason,
 } from "./summarizerTypes";
 import { SummarizeHeuristicData } from "./summarizerHeuristics";
+import { IConnectableRuntime } from ".";
 
 const summarizingError = "summarizingError";
 
@@ -90,7 +91,8 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         private readonly internalsProvider: ISummarizerInternalsProvider,
         handleContext: IFluidHandleContext,
         public readonly summaryCollection: SummaryCollection,
-        private readonly runCoordinatorCreateFn,
+        private readonly runCoordinatorCreateFn:
+            (runtime: IConnectableRuntime) => Promise<ICancellableSummarizerController>,
     ) {
         super();
         this.logger = ChildLogger.create(this.runtime.logger, "Summarizer");


### PR DESCRIPTION
Allow the creator of the Summarizer to define the function that creates the ICancellableSummarizerController. This gives the creator the option of using a controller other than RunWhileConnectedCoordinator, for instance.