### PR TITLE
Stress tests: Add timeouts to getGCDataStore

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -269,7 +269,10 @@ export class TestObjectProvider {
     }
 
 // @public (undocumented)
-export function timeoutPromise<T = void>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void, timeoutOptions?: TimeoutWithError | TimeoutWithValue<T>): Promise<T | void>;
+export function timeoutAwait<T = void>(promise: PromiseLike<T>, timeoutOptions?: TimeoutWithError | TimeoutWithValue<T>): Promise<T>;
+
+// @public (undocumented)
+export function timeoutPromise<T = void>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void, timeoutOptions?: TimeoutWithError | TimeoutWithValue<T>): Promise<T>;
 
 // @public (undocumented)
 export interface TimeoutWithError {
@@ -288,7 +291,7 @@ export interface TimeoutWithValue<T = void> {
     // (undocumented)
     reject: false;
     // (undocumented)
-    value?: T;
+    value: T;
 }
 
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -200,7 +200,7 @@ async function runnerProcess(
                 reset = false;
                 printStatus(runConfig, done ? `finished` : "closed");
             } catch (error) {
-                logger.sendErrorEvent({ eventName: "RunnerFailed" }, error);
+                loader.services.subLogger.sendErrorEvent({ eventName: "RunnerFailed" }, error);
             } finally {
                 if (!container.closed) {
                     container.close();

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -13,19 +13,27 @@ export const defaultTimeoutDurationMs = 250;
  export interface TimeoutWithValue<T = void>{
     durationMs?: number;
     reject: false;
-    value?: T;
+    value: T;
  }
+
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+export async function timeoutAwait<T = void>(
+    promise: PromiseLike<T>,
+    timeoutOptions: TimeoutWithError | TimeoutWithValue<T> = {},
+) {
+    return Promise.race([promise, timeoutPromise<T>(()=>{}, timeoutOptions)]);
+}
 
  export async function timeoutPromise<T = void>(
     executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void,
     timeoutOptions: TimeoutWithError | TimeoutWithValue<T> = {},
-): Promise<T | void> {
+): Promise<T> {
     // create the timeout error outside the async task, so it's callstack includes
     // the original call site, this makes it easier to debug
     const err = timeoutOptions.reject === false
         ? undefined
         : new Error(timeoutOptions.errorMsg ?? "Timeout");
-    return new Promise<T | void>((res,rej)=>{
+    return new Promise<T>((res,rej)=>{
         const timeout = setTimeout(
             ()=>timeoutOptions.reject === false ? res(timeoutOptions.value) : rej(err),
             timeoutOptions.durationMs ?? defaultTimeoutDurationMs);


### PR DESCRIPTION
Add some timeouts to the awaits in getGCDataStore to help diagnose hangs.