### PR TITLE
Adding new event taskAssigned whenever there will be atomicChanged 

### DIFF
--- a/packages/runtime/agent-scheduler/src/agent.ts
+++ b/packages/runtime/agent-scheduler/src/agent.ts
@@ -23,9 +23,12 @@ export interface IAgentSchedulerEvents extends IEvent {
      * "lost" - task is lost due to disconnect or data store / container being attached.
      *      Task will be picked up again by some connected client (this client will try as well,
      *      unless release() is called)
+     * "taskAssigned" - when task is assigned to any client all connected clients will be notified
+     *      with key and currentClient in case we don't have any client for task then currentClient
+     *      will be sent as undefined.
      * @param listener - callback notified when change happened for particular key
      */
-    (event: "picked" | "released" | "lost", listener: (taskId: string) => void)
+    (event: "picked" | "released" | "lost" | "taskAssigned", listener: (taskId: string) => void)
 }
 
 /**

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -217,6 +217,9 @@ class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements
         // May be we want a randomized timer (Something like raft) to reduce chattiness?
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.consensusRegisterCollection.on("atomicChanged", async (key: string, currentClient: string | null) => {
+            // emit on current client change
+            this.emit("taskAssigned", key, currentClient);
+
             // Check if this client was chosen.
             if (this.isActive() && currentClient === this.clientId) {
                 this.onNewTaskAssigned(key);

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -177,7 +177,7 @@ class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements
         await Promise.all(clearP);
     }
 
-    private getTaskClientId(url: string): string | null | undefined {
+    public getTaskClientId(url: string): string | null | undefined {
         return this.consensusRegisterCollection.read(url);
     }
 


### PR DESCRIPTION
This is required to support AIM specific Agent Scheduler, because we are already maintaining current client in DDS after this SB will won't use another DDS to do the same.

