### PR TITLE
Prevent Lumberjack error messages in unit tests and when using debug()

### DIFF
--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -66,6 +66,11 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
         testDbFactory: ITestDbFactory = new TestDbFactory({}),
         serviceConfiguration?: Partial<IServiceConfiguration>,
     ): ILocalDeltaConnectionServer {
+        if (!Lumberjack.isSetupCompleted())
+        {
+            Lumberjack.setup([new TestEngine1()]);
+        }
+
         const nodesCollectionName = "nodes";
         const documentsCollectionName = "documents";
         const deltasCollectionName = "deltas";
@@ -100,13 +105,6 @@ export class LocalDeltaConnectionServer implements ILocalDeltaConnectionServer {
             logger,
             serviceConfiguration,
             pubsub);
-
-            const lumberjackEngine = new TestEngine1();
-
-            if (!Lumberjack.isSetupCompleted())
-            {
-                Lumberjack.setup([lumberjackEngine]);
-            }
 
         configureWebSocketServices(
             webSocketServer,

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -7,6 +7,7 @@ import assert from "assert";
 import express from "express";
 import request from "supertest";
 import nconf from "nconf";
+import { Lumberjack, TestEngine1 } from "@fluidframework/server-services-telemetry";
 import { TestTenantManager, TestThrottler, TestDocumentStorage, TestDbFactory, TestProducer, TestKafka } from "@fluidframework/server-test-utils";
 import { MongoDatabaseManager, MongoManager } from "@fluidframework/server-services-core";
 import * as alfredApp from "../../alfred/app";
@@ -40,6 +41,11 @@ const defaultProvider = new nconf.Provider({}).defaults({
         blobStorageUrl: "http://localhost:3001"
     }
 });
+
+if (!Lumberjack.isSetupCompleted())
+{
+    Lumberjack.setup([new TestEngine1()]);
+}
 
 describe("Routerlicious", () => {
     describe("Alfred", () => {

--- a/server/routerlicious/packages/services-core/src/debug.ts
+++ b/server/routerlicious/packages/services-core/src/debug.ts
@@ -3,10 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import registerDebug from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:core");
 debug(`Package: ${pkgName} - Version: ${pkgVersion}`);
-Lumberjack.info(`Package: ${pkgName} - Version: ${pkgVersion}`);

--- a/server/routerlicious/packages/services-shared/src/debug.ts
+++ b/server/routerlicious/packages/services-shared/src/debug.ts
@@ -4,9 +4,7 @@
  */
 
 import registerDebug from "debug";
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:services");
 debug(`Package: ${pkgName} - Version: ${pkgVersion}`);
-Lumberjack.debug(`Package: ${pkgName} - Version: ${pkgVersion}`);


### PR DESCRIPTION
1. Calling `Lumberjack` in `debug.ts` is causing some error messages to be printed when microservices start, since we only setup `Lumberjack` in `configureLogging()` and `Lumberjack` invocations in `debug.ts` happen before that. https://github.com/microsoft/FluidFramework/blob/9b236e6cfb1d02f45c4b4d8f38c234eef418bfdb/server/routerlicious/packages/services-utils/src/logger.ts#L72-L83
2. Also adding updates to prevent unnecessary `Lumberjack` error messages in unit tests.