### PR TITLE
Progress reporting on network calls

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -200,6 +200,12 @@ export class InsecureUrlResolver implements IUrlResolver {
     resolve(request: IRequest): Promise<IResolvedUrl | undefined>;
     }
 
+// @public
+export interface IProgress {
+    cancel?: AbortSignal;
+    retry?(delayInMs: number, error: any): void;
+}
+
 // @public (undocumented)
 export const isFluidResolvedUrl: (resolved: IResolvedUrl | undefined) => resolved is IFluidResolvedUrl;
 
@@ -336,7 +342,7 @@ export class RetryableError<T extends string> extends NetworkErrorBasic<T> {
 }
 
 // @public (undocumented)
-export function runWithRetry<T>(api: () => Promise<T>, fetchCallName: string, refreshDelayInfo: (id: string) => void, emitDelayInfo: (id: string, retryInMs: number, err: any) => void, logger: ITelemetryLogger, checkRetry?: () => void): Promise<T>;
+export function runWithRetry<T>(api: (cancel?: AbortSignal) => Promise<T>, fetchCallName: string, logger: ITelemetryLogger, progress: IProgress): Promise<T>;
 
 // @public (undocumented)
 export abstract class SnapshotExtractor {

--- a/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
+++ b/packages/drivers/routerlicious-driver/src/retriableGitManager.ts
@@ -158,17 +158,8 @@ export class RetriableGitManager implements IGitManager {
         return runWithRetry(
             api,
             callName,
-            (id: string) => this.refreshDelayInfo(id),
-            (id: string, retryInMs: number, err: any) => this.emitDelayInfo(id, retryInMs, err),
             this.logger,
+            {}, // progress
         );
-    }
-
-    private refreshDelayInfo(id: string): void {
-        return;
-    }
-
-    private emitDelayInfo(id: string, retryInMs: number, err: any): void {
-        return;
     }
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -890,10 +890,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                         this.subLogger,
                     ),
                     "containerAttach",
-                    (id: string) => this._deltaManager.refreshDelayInfo(id),
-                    (id: string, delayMs: number, error: any) =>
-                        this._deltaManager.emitDelayInfo(id, delayMs, error),
                     this.logger,
+                    {}, // progress
                 );
             }
             const resolvedUrl = this.service.resolvedUrl;
@@ -1421,7 +1419,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         const storageService = await this.service.connectToStorage();
 
         this._storageService =
-            new RetriableDocumentStorageService(storageService, this._deltaManager, this.logger);
+            new RetriableDocumentStorageService(storageService, this.logger);
 
         if(this.options.summarizeProtocolTree === true) {
             this._storageService =

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -3,18 +3,43 @@
  * Licensed under the MIT License.
  */
 
-import { v4 as uuid } from "uuid";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { delay, performance } from "@fluidframework/common-utils";
 import { canRetryOnError, getRetryDelayFromError } from "./network";
 
+/**
+ * Interface describing an object passed to various network APIs.
+ * It allows caller to control cancellation, as well as learn about any delays.
+ */
+export interface IProgress {
+    /**
+     * Abort signal used to cancel operation
+     * Note that most of the layers do not use this signal yet. We need to change that over time.
+     * Please consult with API documentation / implementation.
+     * Note that  number of layers may not check this signal while holding this request in a queue,
+     * so it may take a while it takes effect. This can be improved in the future.
+     * Layers in question are:
+     *    - driver (RateLimiter)
+     *    - runWithRetry
+     */
+    cancel?: AbortSignal;
+
+    /**
+     * Called whenever api returns cancellable error and the call is going to be retried.
+     * Any exception thrown from this call back result in cancellation of operation
+     * and propagation of thrown exception.
+     * @param delayInMs - delay before next retry. This value will depend on internal back-off logic,
+     * as well as information provided by service (like 429 error asking to wait for some time before retry)
+     * @param error - error object returned from the call.
+     */
+    retry?(delayInMs: number, error: any): void;
+}
+
 export async function runWithRetry<T>(
-    api: () => Promise<T>,
+    api: (cancel?: AbortSignal) => Promise<T>,
     fetchCallName: string,
-    refreshDelayInfo: (id: string) => void,
-    emitDelayInfo: (id: string, retryInMs: number, err: any) => void,
     logger: ITelemetryLogger,
-    checkRetry?: () => void,
+    progress: IProgress,
 ): Promise<T> {
     let result: T | undefined;
     let success = false;
@@ -22,18 +47,11 @@ export async function runWithRetry<T>(
     let numRetries = 0;
     const startTime = performance.now();
     let lastError: any;
-    let id: string | undefined;
     do {
         try {
-            result = await api();
-            if (id !== undefined) {
-                refreshDelayInfo(id);
-            }
+            result = await api(progress.cancel);
             success = true;
         } catch (err) {
-            if (checkRetry !== undefined) {
-                checkRetry();
-            }
             // If it is not retriable, then just throw the error.
             if (!canRetryOnError(err)) {
                 logger.sendErrorEvent({
@@ -48,10 +66,9 @@ export async function runWithRetry<T>(
             // If the error is throttling error, then wait for the specified time before retrying.
             // If the waitTime is not specified, then we start with retrying immediately to max of 8s.
             retryAfterMs = getRetryDelayFromError(err) ?? Math.min(retryAfterMs * 2, 8000);
-            if (id === undefined) {
-                id = uuid();
+            if (progress.retry) {
+                progress.retry(retryAfterMs, err);
             }
-            emitDelayInfo(id, retryAfterMs, err);
             await delay(retryAfterMs);
         }
     } while (!success);


### PR DESCRIPTION
We leverage container warnings today to communicate to host whenever we have any problems with connectivity.
I believe this is wrong (my mistake!) and the right way to deal with issues is by communicating status directly to caller (i.e. each call site is in full control and is responsible to figure out if any messaging is required to user).

Warnings have a lot of issues:
- There is "on" signal (i.e. start of throttling), but no "off" event (or rather we do not communicate to host how to pair them, and in many cases there are no "off" events).
- In most cases error / progress UX should be local. I.e. insert image scenario should show in-place progress / error UX, not use global container banner to tell the user that there are some issues with image upload. This composes much more naturally - if user deletes such pending upload, there is no more UX (even if call is not cancelled right away), whereas today we will keep showing error banner.

This change is just starting point. It does not change any public API yet, but it does remove warnings from telemetry.
See a bit more on how it shows up in telemetry here: https://github.com/microsoft/FluidFramework/issues/7804

In the future we should
- ensure that every call has cancellation token.
- There is proper handling of delays in our stack. For example, summary upload logic may decided to abandon upload if it did not happen for the long time and regenerate summary using newer state (before trying to upload again).
