### PR TITLE
Fix deli trying to checkpoint old offsets

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -958,9 +958,9 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
             // we need to explicitly set nextKafkaCheckpointMessage to undefined!
             // because once we checkpoint the current message, DocumentContext.hasPendingWork() will be false
-            // that means that the partition will keep occuring since this lambda is up to date
+            // that means that the partition will keep checkpointing since this lambda is up to date
             // if we don't clear nextKafkaCheckpointMessage,
-            // it will try to checkpoint an old offset once the next message arrives
+            // it will try to checkpoint that old message offset once the next message arrives
             this.nextKafkaCheckpointMessage = undefined;
 
             return rawMessage;

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -580,8 +580,13 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
         // Store the previous minimum sequence number we returned and then update it. If there are no clients
         // then set the MSN to the next SN.
         const msn = this.clientSeqManager.getMinimumSequenceNumber();
-        this.noActiveClients = msn === -1;
-        this.minimumSequenceNumber = this.noActiveClients ? sequenceNumber : msn;
+        if (msn === -1) {
+            this.minimumSequenceNumber = sequenceNumber;
+            this.noActiveClients = true;
+        } else {
+            this.minimumSequenceNumber = msn;
+            this.noActiveClients = false;
+        }
 
         let sendType = SendType.Immediate;
         let instruction = InstructionType.NoOp;


### PR DESCRIPTION
It was possible for deli to try to checkpoint old offsets (offsets behind the tail) in certain scenarios.