### PR TITLE
Review of _cancel events

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -203,11 +203,12 @@ export async function createNewFluidFileFromSummary(
                 }
                 event.end({
                     headers: Object.keys(headers).length !== 0 ? true : undefined,
+                    attempts: options.refresh ? 2 : 1,
                     ...fetchResponse.commonSpoHeaders,
                 });
                 return content;
             },
-            { end: true, cancel: "error" });
+        );
     });
 }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -460,7 +460,9 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     }
                     event.end({ method });
                     return cachedSnapshot;
-                });
+                },
+                {end: true, cancel: "error"},
+            );
 
             // Successful call, redirect future calls to getVersion only!
             this.firstVersionCall = false;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -371,7 +371,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                         onClosed(err);
                     });
             }),
-            { start: true, end: true, cancel: "generic" },
+            { start: true, end: true, cancel: "error" },
         );
     }
 
@@ -961,9 +961,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     public async request(path: IRequest): Promise<IResponse> {
-        return PerformanceEvent.timedExecAsync(this.logger, { eventName: "Request" }, async () => {
-            return this.context.request(path);
-        });
+        return PerformanceEvent.timedExecAsync(
+            this.logger,
+            { eventName: "Request" },
+            async () => this.context.request(path),
+            { end: true, cancel: "error" },
+        );
     }
 
     public async snapshot(tagMessage: string, fullTree: boolean = false): Promise<void> {

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -37,7 +37,7 @@ export async function runWithRetry<T>(
             // If it is not retriable, then just throw the error.
             if (!canRetryOnError(err)) {
                 logger.sendErrorEvent({
-                    eventName: fetchCallName,
+                    eventName: `${fetchCallName}_cancel`,
                     retry: numRetries,
                     duration: performance.now() - startTime,
                 }, err);
@@ -57,7 +57,7 @@ export async function runWithRetry<T>(
     } while (!success);
     if (numRetries > 0) {
         logger.sendTelemetryEvent({
-            eventName: fetchCallName,
+            eventName: `${fetchCallName}_lastError`,
             retry: numRetries,
             duration: performance.now() - startTime,
         },

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1680,47 +1680,43 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 deletedDataStores?: number,
                 totalDataStores?: number,
             } = {};
-            try {
-                // Get the container's GC data and run GC on the reference graph in it.
-                const gcData = await this.dataStores.getGCData(fullGC);
-                const { referencedNodeIds, deletedNodeIds } = runGarbageCollection(
-                    gcData.gcNodes, [ "/" ],
-                    this.logger,
-                );
+            // Get the container's GC data and run GC on the reference graph in it.
+            const gcData = await this.dataStores.getGCData(fullGC);
+            const { referencedNodeIds, deletedNodeIds } = runGarbageCollection(
+                gcData.gcNodes, [ "/" ],
+                this.logger,
+            );
 
-                // Update our summarizer node's used routes. Updating used routes in summarizer node before
-                // summarizing is required and asserted by the the summarizer node. We are the root and are
-                // always referenced, so the used routes is only self-route (empty string).
-                this.summarizerNode.updateUsedRoutes([""]);
+            // Update our summarizer node's used routes. Updating used routes in summarizer node before
+            // summarizing is required and asserted by the the summarizer node. We are the root and are
+            // always referenced, so the used routes is only self-route (empty string).
+            this.summarizerNode.updateUsedRoutes([""]);
 
-                // Remove this node's route ("/") and notify data stores of routes that are used in it.
-                const usedRoutes = referencedNodeIds.filter((id: string) => { return id !== "/"; });
-                const { dataStoreCount, unusedDataStoreCount } = this.dataStores.updateUsedRoutes(
-                    usedRoutes,
-                    // For now, we use the timestamp of the last op for gcTimestamp. However, there can be cases where
-                    // we don't have an op (on demand summaries for instance). In those cases, we will use the timestamp
-                    // of this client's connection - https://github.com/microsoft/FluidFramework/issues/7152.
-                    this.deltaManager.lastMessage?.timestamp,
-                );
+            // Remove this node's route ("/") and notify data stores of routes that are used in it.
+            const usedRoutes = referencedNodeIds.filter((id: string) => { return id !== "/"; });
+            const { dataStoreCount, unusedDataStoreCount } = this.dataStores.updateUsedRoutes(
+                usedRoutes,
+                // For now, we use the timestamp of the last op for gcTimestamp. However, there can be cases where
+                // we don't have an op (on demand summaries for instance). In those cases, we will use the timestamp
+                // of this client's connection - https://github.com/microsoft/FluidFramework/issues/7152.
+                this.deltaManager.lastMessage?.timestamp,
+            );
 
-                // Update stats to be reported in the peformance event.
-                gcStats.deletedNodes = deletedNodeIds.length;
-                gcStats.totalNodes = referencedNodeIds.length + deletedNodeIds.length;
-                gcStats.deletedDataStores = unusedDataStoreCount;
-                gcStats.totalDataStores = dataStoreCount;
+            // Update stats to be reported in the peformance event.
+            gcStats.deletedNodes = deletedNodeIds.length;
+            gcStats.totalNodes = referencedNodeIds.length + deletedNodeIds.length;
+            gcStats.deletedDataStores = unusedDataStoreCount;
+            gcStats.totalDataStores = dataStoreCount;
 
-                // If we are running in GC test mode, delete objects for unused routes. This enables testing scenarios
-                // involving access to deleted data.
-                if (this.gcTestMode) {
-                    this.dataStores.deleteUnusedRoutes(deletedNodeIds);
-                }
-            } catch (error) {
-                event.cancel(gcStats, error);
-                throw error;
+            // If we are running in GC test mode, delete objects for unused routes. This enables testing scenarios
+            // involving access to deleted data.
+            if (this.gcTestMode) {
+                this.dataStores.deleteUnusedRoutes(deletedNodeIds);
             }
             event.end(gcStats);
             return gcStats as IGCStats;
-        });
+        },
+        { end: true, cancel: "error" });
     }
 
     private async summarizeInternal(fullTree: boolean, trackState: boolean): Promise<ISummarizeInternalResult> {
@@ -2272,10 +2268,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     private async fetchSnapshotFromStorage(versionId: string, logger: ITelemetryLogger, event: ITelemetryGenericEvent) {
-        const perfEvent = PerformanceEvent.start(logger, event);
-        const stats: { getVersionDuration?: number; getSnapshotDuration?: number } = {};
-        let snapshot: ISnapshotTree;
-        try {
+        return PerformanceEvent.timedExecAsync(logger, event, async (perfEvent) => {
+            const stats: { getVersionDuration?: number; getSnapshotDuration?: number } = {};
             const trace = Trace.start();
 
             const versions = await this.storage.getVersions(versionId, 1);
@@ -2286,14 +2280,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
             stats.getSnapshotDuration = trace.trace().duration;
 
-            snapshot = maybeSnapshot;
-        } catch (error) {
-            perfEvent.cancel(stats, error);
-            throw error;
-        }
-
-        perfEvent.end(stats);
-        return snapshot;
+            perfEvent.end(stats);
+            return maybeSnapshot;
+        });
     }
 
     public getPendingLocalState() {


### PR DESCRIPTION
Change some to be an error, vs. others not to be an error.
Simplify code in couple places.

Overall theme - most of the events should be FYI kind of events. The top level scenario event is the one that should report an error.
I.e. in case of container attachment, we report an error only through container close event, though most errors will also be reported through containerAttach_cancel (as that's where most errors are).
None of low-level events report issues as errors.

Similar, only ObtainSnapshot event reports errors, not any sub-steps.

Please see https://github.com/microsoft/FluidFramework/issues/7804 for more details