### PR TITLE
Operation deletion function

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -64,7 +64,7 @@ async function getDeltasFromStorage(
     toTerm: number,
     fromSeq?: number,
     toSeq?: number): Promise<ISequencedDocumentMessage[]> {
-    const query: any = { documentId, tenantId };
+    const query: any = { documentId, tenantId, scheduledDeletionTime: { $exists: false } };
     query["operation.term"] = {};
     query["operation.sequenceNumber"] = {};
     query["operation.term"].$gte = fromTerm;

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -81,6 +81,17 @@ export interface ICollection<T> {
     update(filter: any, set: any, addToSet: any): Promise<void>;
 
     /**
+     * Finds the query in the database. If it exists, update all the values to set.
+     * Throws if query cannot be found.
+     *
+     * @param filter - data we want to find
+     * @param set - new values to change to
+     * @param addToSet - an operator that adds a value to the database unless the value already exists;
+     * only used in mongodb.ts
+     */
+    updateMany(filter: any, set: any, addToSet: any): Promise<void>;
+
+    /**
      * Finds the value that satisfies query. If it exists, update the value to new set.
      * Otherwise inserts the set to the datbase.
      *
@@ -110,6 +121,8 @@ export interface ICollection<T> {
     deleteOne(filter: any): Promise<any>;
 
     deleteMany(filter: any): Promise<any>;
+
+    distinct(key: any, query: any): Promise<any>;
 
     createIndex(index: any, unique: boolean): Promise<void>;
 

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -39,6 +39,14 @@ export interface IDatabaseManager {
  */
 export interface ICollection<T> {
     /**
+     * Executes an aggregration framework pipeline against the collection
+     *
+     * @param pipeline - array containing the aggregation framework commands for the execution
+     * @param options - optional settings
+     * @returns - cursor you can use to iterate over aggregated results
+     */
+    aggregate(group: any, options?: any): any;
+    /**
      * Finds queries in the database
      *
      * @param query - data we want to find

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -4,62 +4,62 @@
  */
 
 import { ICollection, IDocument } from "@fluidframework/server-services-core";
-import { Lumberjack, BaseTelemetryProperties } from "@fluidframework/server-services-telemetry";
+import { Lumberjack, getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
 
 export async function deleteSummarizedOps(
     opCollection: ICollection<unknown>,
     documentsCollection: ICollection<IDocument>,
     softDeleteRetentionPeriodMs: number,
     offlineWindowMs: number,
-    opsDeletionEnabled: boolean): Promise<void> {
-    if (!opsDeletionEnabled) {
-        return Promise.reject(new Error(`Operation deletion is not enabled`));
-    }
-    // eslint-disable-next-line no-null/no-null
-    const documentsArray = await documentsCollection.distinct("documentId", { documentId : { $ne : null } });
-    const currentEpochTime = new Date().getTime();
-    const epochTimeBeforeOfflineWindow =  currentEpochTime - offlineWindowMs;
-    const scheduledDeletionEpochTime = currentEpochTime + softDeleteRetentionPeriodMs;
-    let lumberjackProperties;
-
-    for (const docId of documentsArray) {
-        try {
-            const document = await documentsCollection.findOne({ documentId: docId });
-            lumberjackProperties = {
-                [BaseTelemetryProperties.tenantId]: document.tenantId,
-                [BaseTelemetryProperties.documentId]: docId,
-            };
-            const lastSummarySequenceNumber = JSON.parse(document.scribe).lastSummarySequenceNumber;
-
-            // first "soft delete" operations older than the offline window, which have been summarised
-            // soft delete is done by setting a scheduled deletion time
-            await opCollection.updateMany({
-                $and: [
-                    {
-                        documentId: docId,
-                    },
-                    {
-                        "operation.timestamp": { $lte: epochTimeBeforeOfflineWindow },
-                    },
-                    {
-                        "operation.sequenceNumber": { $lte: lastSummarySequenceNumber },
-                    },
-                    {
-                        scheduledDeletionTime: { $exists: false },
-                    },
-                ]},
-                { scheduledDeletionTime: scheduledDeletionEpochTime },
-                undefined);
-
-            // then permanently delete ops that have passed their retention period
-            // delete if current epoch time is greater than the scheduled deletion time of the op
-            await opCollection.deleteMany({
-                    documentId: docId,
-                    scheduledDeletionTime: { $lte: currentEpochTime },
-                });
-        } catch (error) {
-            Lumberjack.error(`Error while trying to delete ops`, lumberjackProperties, error);
-            throw error;
+    softDeletionEnabled: boolean,
+    permanentOpsDeletionEnabled: boolean): Promise<void> {
+        if (!softDeletionEnabled) {
+            return Promise.reject(new Error(`Operation deletion is not enabled`));
         }
-    }
+        // eslint-disable-next-line no-null/no-null
+        const documentsArray = await documentsCollection.distinct("documentId", { documentId : { $ne : null } });
+        const currentEpochTime = new Date().getTime();
+        const epochTimeBeforeOfflineWindow =  currentEpochTime - offlineWindowMs;
+        const scheduledDeletionEpochTime = currentEpochTime + softDeleteRetentionPeriodMs;
+        let lumberjackProperties;
+
+        for (const docId of documentsArray) {
+            try {
+                const document = await documentsCollection.findOne({ documentId: docId });
+                lumberjackProperties = getLumberBaseProperties(docId, document.tenantId);
+                const lastSummarySequenceNumber = JSON.parse(document.scribe).lastSummarySequenceNumber;
+
+                // first "soft delete" operations older than the offline window, which have been summarised
+                // soft delete is done by setting a scheduled deletion time
+                await opCollection.updateMany({
+                    $and: [
+                        {
+                            documentId: docId,
+                        },
+                        {
+                            "operation.timestamp": { $lte: epochTimeBeforeOfflineWindow },
+                        },
+                        {
+                            "operation.sequenceNumber": { $lte: lastSummarySequenceNumber },
+                        },
+                        {
+                            scheduledDeletionTime: { $exists: false },
+                        },
+                    ]},
+                    { scheduledDeletionTime: scheduledDeletionEpochTime },
+                    undefined);
+
+                if (permanentOpsDeletionEnabled) {
+                    // then permanently delete ops that have passed their retention period
+                    // delete if current epoch time is greater than the scheduled deletion time of the op
+                    await opCollection.deleteMany({
+                        documentId: docId,
+                        scheduledDeletionTime: { $lte: currentEpochTime },
+                    });
+                }
+            } catch (error) {
+                Lumberjack.error(`Error while trying to delete ops`, lumberjackProperties, error);
+                throw error;
+            }
+        }
 }

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -55,6 +55,7 @@ export async function deleteSummarizedOps(
                 });
         } catch (error) {
             Lumberjack.error(`Error while trying to delete ops`, lumberjackProperties, error);
+            throw error;
         }
     }
 }

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -24,11 +24,10 @@ export async function deleteSummarizedOps(
         const currentEpochTime = new Date().getTime();
         const epochTimeBeforeOfflineWindow =  currentEpochTime - offlineWindowMs;
         const scheduledDeletionEpochTime = currentEpochTime + softDeleteRetentionPeriodMs;
-        let lumberjackProperties;
 
         for (const doc of uniqueDocuments) {
+            const lumberjackProperties = getLumberBaseProperties(doc.documentId, doc.tenantId);
             try {
-                lumberjackProperties = getLumberBaseProperties(doc.documentId, doc.tenantId);
                 const lastSummarySequenceNumber = JSON.parse(doc.scribe).lastSummarySequenceNumber;
 
                 // first "soft delete" operations older than the offline window, which have been summarised

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -20,11 +20,15 @@ export async function deleteSummarizedOps(
     const currentEpochTime = new Date().getTime();
     const epochTimeBeforeOfflineWindow =  currentEpochTime - offlineWindowMs;
     const scheduledDeletionEpochTime = currentEpochTime + softDeleteRetentionPeriodMs;
+    let lumberjackProperties;
 
     for (const docId of documentsArray) {
-        const lumberjackProperties = { [BaseTelemetryProperties.documentId]: docId };
         try {
             const document = await documentsCollection.findOne({ documentId: docId });
+            lumberjackProperties = {
+                [BaseTelemetryProperties.tenantId]: document.tenantId,
+                [BaseTelemetryProperties.documentId]: docId,
+            };
             const lastSummarySequenceNumber = JSON.parse(document.scribe).lastSummarySequenceNumber;
 
             // first "soft delete" operations older than the offline window, which have been summarised

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ICollection, IDocument } from "@fluidframework/server-services-core";
+import { Lumberjack, BaseTelemetryProperties } from "@fluidframework/server-services-telemetry";
+
+export async function deleteSummarizedOps(
+    opCollection: ICollection<unknown>,
+    documentsCollection: ICollection<IDocument>,
+    softDeleteRetentionPeriodMs: number,
+    offlineWindowMs: number,
+    opsDeletionEnabled: boolean): Promise<void> {
+    if (!opsDeletionEnabled) {
+        return Promise.reject(new Error(`Operation deletion is not enabled`));
+    }
+    // eslint-disable-next-line no-null/no-null
+    const documentsArray = await documentsCollection.distinct("documentId", { documentId : { $ne : null } });
+    const currentEpochTime = new Date().getTime();
+    const epochTimeBeforeOfflineWindow =  currentEpochTime - offlineWindowMs;
+    const scheduledDeletionEpochTime = currentEpochTime + softDeleteRetentionPeriodMs;
+
+    for (const docId of documentsArray) {
+        const lumberjackProperties = { [BaseTelemetryProperties.documentId]: docId };
+        try {
+            const document = await documentsCollection.findOne({ documentId: docId });
+            const lastSummarySequenceNumber = JSON.parse(document.scribe).lastSummarySequenceNumber;
+
+            // first "soft delete" operations older than the offline window, which have been summarised
+            // soft delete is done by setting a scheduled deletion time
+            await opCollection.updateMany({
+                $and: [
+                    {
+                        documentId: docId,
+                    },
+                    {
+                        "operation.timestamp": { $lte: epochTimeBeforeOfflineWindow },
+                    },
+                    {
+                        "operation.sequenceNumber": { $lte: lastSummarySequenceNumber },
+                    },
+                    {
+                        scheduledDeletionTime: { $exists: false },
+                    },
+                ]},
+                { scheduledDeletionTime: scheduledDeletionEpochTime },
+                undefined);
+
+            // then permanently delete ops that have passed their retention period
+            // delete if current epoch time is greater than the scheduled deletion time of the op
+            await opCollection.deleteMany({
+                    documentId: docId,
+                    scheduledDeletionTime: { $lte: currentEpochTime },
+                });
+        } catch (error) {
+            Lumberjack.error(`Error while trying to delete ops`, lumberjackProperties, error);
+        }
+    }
+}

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -6,6 +6,7 @@
 export * from "./asyncLocalStorage";
 export * from "./auth";
 export * from "./conversion";
+export * from "./deleteSummarizedOps";
 export * from "./dns";
 export * from "./generateNames";
 export * from "./logger";

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -4,12 +4,18 @@
  */
 
 import * as core from "@fluidframework/server-services-core";
-import { Collection, MongoClient, MongoClientOptions } from "mongodb";
+import { AggregationCursor, Collection, MongoClient, MongoClientOptions } from "mongodb";
 
 const MaxFetchSize = 2000;
 
 export class MongoCollection<T> implements core.ICollection<T> {
     constructor(private readonly collection: Collection<T>) {
+    }
+
+    public aggregate(group: any, options?: any): AggregationCursor<T> {
+        const pipeline: any = [];
+        pipeline.$group = group;
+        return this.collection.aggregate(pipeline, options);
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types,@typescript-eslint/promise-function-async

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -37,8 +37,17 @@ export class MongoCollection<T> implements core.ICollection<T> {
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
+    public async updateMany(filter: object, set: any, addToSet: any): Promise<void> {
+        return this.updateManyCore(filter, set, addToSet, false);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
     public async upsert(filter: object, set: any, addToSet: any): Promise<void> {
         return this.updateCore(filter, set, addToSet, true);
+    }
+
+    public async distinct(key: any, query: any): Promise<any> {
+        return this.collection.distinct(key, query);
     }
 
     public async deleteOne(filter: any): Promise<any> {
@@ -97,6 +106,21 @@ export class MongoCollection<T> implements core.ICollection<T> {
         const options = { upsert };
 
         await this.collection.updateOne(filter, update, options);
+    }
+
+    private async updateManyCore(filter: any, set: any, addToSet: any, upsert: boolean): Promise<void> {
+        const update: any = {};
+        if (set) {
+            update.$set = set;
+        }
+
+        if (addToSet) {
+            update.$addToSet = addToSet;
+        }
+
+        const options = { upsert };
+
+        await this.collection.updateMany(filter, update, options);
     }
 }
 

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -32,6 +32,20 @@ export class TestCollection implements ICollection<any> {
         _.extend(value, set);
     }
 
+    public async updateMany(filter: any, set: any, addToSet: any): Promise<void> {
+        const values = this.findInternal(filter);
+        try {
+            values.forEach((value) => {
+                if (!value) {
+                    throw new Error("Not found");
+                }
+                _.extend(value, set);
+            });
+        } catch (e) {
+            return Promise.reject(e);
+        }
+    }
+
     public async upsert(filter: any, set: any, addToSet: any): Promise<void> {
         const value = this.findOneInternal(filter);
         if (!value) {
@@ -76,6 +90,10 @@ export class TestCollection implements ICollection<any> {
             this.removeOneInternal(value);
         });
         return values;
+    }
+
+    public async distinct(key: any, filter: any): Promise<any> {
+        throw new Error("Method not implemented.");
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -11,6 +11,10 @@ export class TestCollection implements ICollection<any> {
     constructor(public collection: any[]) {
     }
 
+    public async aggregate(group: any, options?: any) {
+        throw new Error("Method not implemented.");
+    }
+
     public async find(query: any, sort: any): Promise<any[]> {
         return this.findInternal(query, sort);
     }


### PR DESCRIPTION
Deletion function for operations supporting an offline window. First, we "soft delete" summarised ops which are older than the offline window by adding a "scheduledDeletionTime" field. Then we check for ops which already have this field, and permanently delete them if the current time is more than the scheduled deletion time. 

This method will be passed to a scheduler, which will run every x interval, to achieve a periodic deletion. Scheduler PR in the works here: 

https://github.com/microsoft/FluidFramework/pull/7640