### PR TITLE
Exlcude test directories from extraneous-dependencies rule

### DIFF
--- a/common/build/eslint-config-fluid/eslint7.js
+++ b/common/build/eslint-config-fluid/eslint7.js
@@ -232,7 +232,7 @@ module.exports = {
         "import/no-extraneous-dependencies": [
             "error",
             {
-                "devDependencies": ["**/*.spec.ts", "src/test/**.ts"]
+                "devDependencies": ["**/*.spec.ts", "src/test/**"]
             }
         ],
         "import/no-internal-modules": "error",

--- a/common/build/eslint-config-fluid/no-tslint.js
+++ b/common/build/eslint-config-fluid/no-tslint.js
@@ -151,7 +151,7 @@ module.exports = {
         "import/no-extraneous-dependencies": [
             "error",
             {
-                "devDependencies": ["**/*.spec.ts"]
+                "devDependencies": ["**/*.spec.ts", "src/test/**"]
             }
         ],
         "import/no-internal-modules": "error",


### PR DESCRIPTION
This rule creates errors when tests use a devDependency. This rule allows test directories to use dev only dependencies. 