### PR TITLE
Stress test: fix another hang by waiting for connected event on the runtime

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -58,11 +58,11 @@ export class LoadTestDataStoreModel {
                     resolve();
                 };
                 const disposeListener = () => {
-                    runtime.deltaManager.off("connect", connectListener);
+                    runtime.off("connected", connectListener);
                     reject(new Error("disposed"));
                 };
 
-                runtime.deltaManager.once("connect", connectListener);
+                runtime.once("connected", connectListener);
                 runtime.once("dispose", disposeListener);
             });
         }


### PR DESCRIPTION
Since we checked `runtime.connected`, we should listen the `connected` event from there instead of on in the `deltamanager`, which might have a different value.