### PR TITLE
Deprecate raiseContainerWarning

### DIFF
--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -52,6 +52,7 @@ export interface IContainerRuntime extends IProvideContainerRuntime, IProvideFlu
     readonly isDirty: boolean;
     // (undocumented)
     readonly options: ILoaderOptions;
+    // @deprecated
     raiseContainerWarning(warning: ContainerWarning): void;
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)

--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -115,6 +115,7 @@ export interface IFluidDataStoreRuntime extends IFluidRouter, IEventProvider<IFl
     readonly objectsRoutingContext: IFluidHandleContext;
     // (undocumented)
     readonly options: ILoaderOptions;
+    // @deprecated
     raiseContainerWarning(warning: ContainerWarning): void;
     // (undocumented)
     readonly rootRoutingContext: IFluidHandleContext;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -106,6 +106,7 @@ export interface IContainerRuntime extends
 
     /**
      * Used to raise an unrecoverable error on the runtime.
+     * @deprecated Warnings are being deprecated
      */
     raiseContainerWarning(warning: ContainerWarning): void;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1580,6 +1580,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this.context.audience!;
     }
 
+    // @deprecated Needs to become private
     public readonly raiseContainerWarning = (warning: ContainerWarning) => {
         this.context.raiseContainerWarning(warning);
     };

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -563,6 +563,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         return this._containerRuntime.submitDataStoreSignal(this.id, type, content);
     }
 
+    // @deprecated Warnings are being deprecated
     public raiseContainerWarning(warning: ContainerWarning): void {
         this.containerRuntime.raiseContainerWarning(warning);
     }

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -119,6 +119,7 @@ export interface IFluidDataStoreRuntime extends
 
     /**
      * Errors raised by distributed data structures
+     * @deprecated Warnings are being deprecated
      */
     raiseContainerWarning(warning: ContainerWarning): void;
 }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -759,6 +759,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         return this.deferredAttached.promise;
     }
 
+    // @deprecated Warnings are being deprecated
     public raiseContainerWarning(warning: ContainerWarning): void {
         this.dataStoreContext.raiseContainerWarning(warning);
     }


### PR DESCRIPTION
Inspired by https://github.com/microsoft/FluidFramework/issues/7800.
I no longer think this is the right building block to expose to container.
I'm leaving capability for now for summarizer warnings, but will remove usage from SharedObject in future PR.

