### PR TITLE
Add api-extractor dev dependency to package

### DIFF
--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
+    "@microsoft/api-extractor": "^7.16.1",
     "@types/debug": "^4.1.5",
     "@types/jsrsasign": "^8.0.8",
     "@types/jwt-decode": "^2.2.1",


### PR DESCRIPTION
I've been seeing this build task fail otherwise:

```
@fluidframework/server-services-client: api-extractor run --local - 5.073s
```

@tylerbutler - Maybe fallout from #7530?