### PR TITLE
Use new version of core-interfaces in container-definitions

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -375,20 +375,39 @@
         "@fluidframework/core-interfaces": "^0.39.5",
         "@fluidframework/driver-definitions": "^0.40.0",
         "@fluidframework/protocol-definitions": "^0.1025.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.39.8",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+          "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw==",
+          "dev": true
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "0.40.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0.tgz",
+          "integrity": "sha512-xbdVs3l/5OdbidvA1CgOO9z13q/O+M5nWsxhVwr5BuvAqX5BOT5rKN659LeIw/LQQbiGEW6ahR1NN9kWwPmAlg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.39.5",
+            "@fluidframework/protocol-definitions": "^0.1025.0"
+          }
+        }
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.5.tgz",
-      "integrity": "sha512-n1neSteU0P/mQjthiNqqrdXl3+VeJ2QFZva6QJOcFRVmjHe+c827g9VqEbz0WB8jcSKpf98n3QzTXAGmEqBeVg=="
+      "version": "0.40.0-40653",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0-40653.tgz",
+      "integrity": "sha512-6D661o/dExlMPQBC0g6SrFBX3KecfxLwMXGEayjEsBhAuWgCJvRUEhdLYF/wSzWEOp8Qsp/O1XTRJSS1vKBJtQ=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.40.0.tgz",
-      "integrity": "sha512-xbdVs3l/5OdbidvA1CgOO9z13q/O+M5nWsxhVwr5BuvAqX5BOT5rKN659LeIw/LQQbiGEW6ahR1NN9kWwPmAlg==",
+      "version": "0.41.0-40682",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.41.0-40682.tgz",
+      "integrity": "sha512-UmISQRHHAEKpA22rahzJmwSv6IW4syTgb3mKnjXRVktjpPSChtmbEu3ItFe/MIZU847/N+Gg4zQfD9owWy/plQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/core-interfaces": "^0.40.0-0",
         "@fluidframework/protocol-definitions": "^0.1025.0"
       }
     },

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.39.5",
-    "@fluidframework/driver-definitions": "^0.40.0",
+    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },
   "devDependencies": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -117,6 +117,28 @@
         "InterfaceDeclaration_IThrottlingWarning": {
           "backCompat": false
         }
+      },
+      "0.40.0": {
+        "InterfaceDeclaration_ICodeLoader": {
+          "forwardCompat": false,
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IContainerContext": {
+          "forwardCompat": false,
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidModule": {
+          "forwardCompat": false,
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IProvideRuntimeFactory": {
+          "forwardCompat": false,
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IRuntimeFactory": {
+          "forwardCompat": false,
+          "backCompat": false
+        }
       }
     }
   }

--- a/common/lib/container-definitions/src/test/types/validate0.40.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.40.0.ts
@@ -157,25 +157,25 @@ use_old_InterfaceDeclaration_ICodeAllowList(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_ICodeLoader": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_ICodeLoader():
     old.ICodeLoader;
 declare function use_current_InterfaceDeclaration_ICodeLoader(
     use: current.ICodeLoader);
 use_current_InterfaceDeclaration_ICodeLoader(
     get_old_InterfaceDeclaration_ICodeLoader());
+*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_ICodeLoader": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_ICodeLoader():
     current.ICodeLoader;
 declare function use_old_InterfaceDeclaration_ICodeLoader(
     use: old.ICodeLoader);
 use_old_InterfaceDeclaration_ICodeLoader(
     get_current_InterfaceDeclaration_ICodeLoader());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -229,25 +229,25 @@ use_old_InterfaceDeclaration_IContainer(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IContainerContext": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IContainerContext():
     old.IContainerContext;
 declare function use_current_InterfaceDeclaration_IContainerContext(
     use: current.IContainerContext);
 use_current_InterfaceDeclaration_IContainerContext(
     get_old_InterfaceDeclaration_IContainerContext());
+*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IContainerContext": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IContainerContext():
     current.IContainerContext;
 declare function use_old_InterfaceDeclaration_IContainerContext(
     use: old.IContainerContext);
 use_old_InterfaceDeclaration_IContainerContext(
     get_current_InterfaceDeclaration_IContainerContext());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -589,25 +589,25 @@ use_old_InterfaceDeclaration_IFluidCodeResolver(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IFluidModule": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IFluidModule():
     old.IFluidModule;
 declare function use_current_InterfaceDeclaration_IFluidModule(
     use: current.IFluidModule);
 use_current_InterfaceDeclaration_IFluidModule(
     get_old_InterfaceDeclaration_IFluidModule());
+*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IFluidModule": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IFluidModule():
     current.IFluidModule;
 declare function use_old_InterfaceDeclaration_IFluidModule(
     use: old.IFluidModule);
 use_old_InterfaceDeclaration_IFluidModule(
     get_current_InterfaceDeclaration_IFluidModule());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -853,25 +853,25 @@ use_old_InterfaceDeclaration_IProvideFluidTokenProvider(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IProvideRuntimeFactory": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IProvideRuntimeFactory():
     old.IProvideRuntimeFactory;
 declare function use_current_InterfaceDeclaration_IProvideRuntimeFactory(
     use: current.IProvideRuntimeFactory);
 use_current_InterfaceDeclaration_IProvideRuntimeFactory(
     get_old_InterfaceDeclaration_IProvideRuntimeFactory());
+*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IProvideRuntimeFactory": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IProvideRuntimeFactory():
     current.IProvideRuntimeFactory;
 declare function use_old_InterfaceDeclaration_IProvideRuntimeFactory(
     use: old.IProvideRuntimeFactory);
 use_old_InterfaceDeclaration_IProvideRuntimeFactory(
     get_current_InterfaceDeclaration_IProvideRuntimeFactory());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -973,25 +973,25 @@ use_old_VariableDeclaration_IRuntimeFactory(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IRuntimeFactory": {"forwardCompat": false}
-*/
 declare function get_old_InterfaceDeclaration_IRuntimeFactory():
     old.IRuntimeFactory;
 declare function use_current_InterfaceDeclaration_IRuntimeFactory(
     use: current.IRuntimeFactory);
 use_current_InterfaceDeclaration_IRuntimeFactory(
     get_old_InterfaceDeclaration_IRuntimeFactory());
+*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IRuntimeFactory": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IRuntimeFactory():
     current.IRuntimeFactory;
 declare function use_old_InterfaceDeclaration_IRuntimeFactory(
     use: old.IRuntimeFactory);
 use_old_InterfaceDeclaration_IRuntimeFactory(
     get_current_InterfaceDeclaration_IRuntimeFactory());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
Update the version of core-interfaces (and consequently driver-definitions) used by container-definitions. A subsequent PR will pick these up in client.