### PR TITLE
Type Validation: Detect Removed Types

### DIFF
--- a/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
@@ -684,6 +684,30 @@ use_old_InterfaceDeclaration_IQuorum(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
+* "RemovedInterfaceDeclaration_IQuorumEvents": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IQuorumEvents():
+    old.IQuorumEvents;
+declare function use_current_RemovedInterfaceDeclaration_IQuorumEvents(
+    use: current.IQuorumEvents);
+use_current_RemovedInterfaceDeclaration_IQuorumEvents(
+    get_old_InterfaceDeclaration_IQuorumEvents());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
+* "RemovedInterfaceDeclaration_IQuorumEvents": {"backCompat": false}
+*/
+declare function get_current_RemovedInterfaceDeclaration_IQuorumEvents():
+    current.IQuorumEvents;
+declare function use_old_InterfaceDeclaration_IQuorumEvents(
+    use: old.IQuorumEvents);
+use_old_InterfaceDeclaration_IQuorumEvents(
+    get_current_RemovedInterfaceDeclaration_IQuorumEvents());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISequencedClient": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISequencedClient():

--- a/tools/build-tools/src/typeValidator/testGeneration.ts
+++ b/tools/build-tools/src/typeValidator/testGeneration.ts
@@ -9,7 +9,7 @@ import { generateTypeDataForProject, toTypeString, TypeData } from "./typeData";
 
 export function generateTests(packageDetails: PackageDetails) {
 
-    const currentTypeData = generateTypeDataForProject(packageDetails.packageDir, undefined);
+    const currentProjectData = generateTypeDataForProject(packageDetails.packageDir, undefined);
 
     let indexPath = "../..";
 
@@ -27,51 +27,57 @@ import * as old from "${oldVersion}";
 import * as current from "${indexPath}/index";
 `
             ];
-        const oldDetails = generateTypeDataForProject(packageDetails.packageDir, oldVersion);
-        const currentTypeMap = new Map<string, TypeData>(currentTypeData.typeData.map((v)=>[getFullTypeName(v),v]));
-        for(const oldTypeData of oldDetails.typeData){
-            // no need to test new types
-            if(currentTypeMap.has(getFullTypeName(oldTypeData))){
-                const oldType: TestCaseTypeData = {
-                    prefix: "old",
-                    ... oldTypeData,
-                }
-                const currentType: TestCaseTypeData = {
-                    prefix: "current",
-                    ... currentTypeMap.get(getFullTypeName(oldTypeData))!,
-
-                }
-                const brokenData = currentTypeData.packageDetails.broken?.[oldDetails.packageDetails.version]?.[getFullTypeName(currentType)];
-
-                testString.push(`/*`)
-                testString.push(`* Validate forward compat by using old type in place of current type`);
-                testString.push(`* If breaking change required, add in package.json under typeValidation.broken.${oldDetails.packageDetails.version}:`);
-                testString.push(`* "${getFullTypeName(currentType)}": {"forwardCompat": false}`);
-                const forwarCompatCase = buildTestCase(oldType, currentType);
-                if(brokenData?.forwardCompat !== false){
-                    testString.push("*/");
-                    testString.push(... forwarCompatCase);
-                }else{
-                    testString.push(... forwarCompatCase);
-                    testString.push("*/");
-                }
-                testString.push("");
-
-                testString.push(`/*`)
-                testString.push(`* Validate back compat by using current type in place of old type`);
-                testString.push(`* If breaking change required, add in package.json under typeValidation.broken.${oldDetails.packageDetails.version}:`);
-                testString.push(`* "${getFullTypeName(currentType)}": {"backCompat": false}`);
-                const backCompatCase = buildTestCase(currentType, oldType);
-                if(brokenData?.backCompat !== false){
-                    testString.push("*/");
-                    testString.push(... backCompatCase)
-                }else{
-                    testString.push(... backCompatCase);
-                    testString.push("*/");
-                }
-                testString.push("");
-
+        const oldProjectData = generateTypeDataForProject(packageDetails.packageDir, oldVersion);
+        const currentTypeMap = new Map<string, TypeData>(currentProjectData.typeData.map((v)=>[getFullTypeName(v),v]));
+        for(const oldTypeData of oldProjectData.typeData){
+            const oldType: TestCaseTypeData = {
+                prefix: "old",
+                ... oldTypeData,
             }
+            const currentTypeData = currentTypeMap.get(getFullTypeName(oldTypeData));
+            // if the current package is missing a type, we will use the old type data.
+            // this can represent a breaking change which can be disable in the package.json.
+            // this can also happen for type changes, like type to interface, which can remain
+            // compatible.
+            const currentType: TestCaseTypeData = currentTypeData === undefined
+            ?{
+                prefix: "current",
+                ... oldTypeData,
+                kind:`Removed${oldTypeData.kind}`,
+            }
+            :{
+                prefix: "current",
+                ... currentTypeData,
+            };
+            const brokenData = currentProjectData.packageDetails.broken?.[oldProjectData.packageDetails.version]?.[getFullTypeName(currentType)];
+
+            testString.push(`/*`)
+            testString.push(`* Validate forward compat by using old type in place of current type`);
+            testString.push(`* If breaking change required, add in package.json under typeValidation.broken.${oldProjectData.packageDetails.version}:`);
+            testString.push(`* "${getFullTypeName(currentType)}": {"forwardCompat": false}`);
+            const forwarCompatCase = buildTestCase(oldType, currentType);
+            if(brokenData?.forwardCompat !== false){
+                testString.push("*/");
+                testString.push(... forwarCompatCase);
+            }else{
+                testString.push(... forwarCompatCase);
+                testString.push("*/");
+            }
+            testString.push("");
+
+            testString.push(`/*`)
+            testString.push(`* Validate back compat by using current type in place of old type`);
+            testString.push(`* If breaking change required, add in package.json under typeValidation.broken.${oldProjectData.packageDetails.version}:`);
+            testString.push(`* "${getFullTypeName(currentType)}": {"backCompat": false}`);
+            const backCompatCase = buildTestCase(currentType, oldType);
+            if(brokenData?.backCompat !== false){
+                testString.push("*/");
+                testString.push(... backCompatCase)
+            }else{
+                testString.push(... backCompatCase);
+                testString.push("*/");
+            }
+            testString.push("");
         }
         const testPath =`${packageDetails.packageDir}/src/test/types`;
         if(!fs.existsSync(testPath)){
@@ -79,7 +85,7 @@ import * as current from "${indexPath}/index";
         }
 
         fs.writeFileSync(
-            `${testPath}/validate${oldDetails.packageDetails.version}.ts`,
+            `${testPath}/validate${oldProjectData.packageDetails.version}.ts`,
             testString.join("\n"));
     }
 }


### PR DESCRIPTION
Previously we just skipped types that existed in the old package, but not the new package, which will miss breaks. Now we will try to use the type even though it doesn't exist in the new package. There are valid cases where a type can change, these tests will now validate those, and for things that are truly removed, those breaks can be captured in the package json like any other