### PR TITLE
Adding Lumberjack to Moira lambda

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -210,7 +210,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
         this.isNewDocument = this.sequenceNumber === 0;
 
-        if (serviceConfiguration.enableLumberMetrics) {
+        if (serviceConfiguration.enableLumberjack) {
             this.logSessionStartMetrics();
         }
     }
@@ -351,7 +351,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
         this.removeAllListeners();
 
-        if (this.serviceConfiguration.enableLumberMetrics) {
+        if (this.serviceConfiguration.enableLumberjack) {
             this.logSessionEndMetrics(closeType);
         }
     }

--- a/server/routerlicious/packages/lambdas/src/moira/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/lambda.ts
@@ -12,7 +12,7 @@ import {
     IServiceConfiguration,
     SequencedOperationType,
 } from "@fluidframework/server-services-core";
-
+import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import shajs from "sha.js";
 import Axios from "axios";
 
@@ -23,7 +23,9 @@ export class MoiraLambda implements IPartitionLambda {
 
     constructor(
         protected context: IContext,
-        private readonly serviceConfiguration: IServiceConfiguration) {
+        private readonly serviceConfiguration: IServiceConfiguration,
+        private readonly tenantId: string,
+        private readonly documentId: string) {
     }
 
     public handler(message: IQueuedMessage) {
@@ -129,11 +131,14 @@ export class MoiraLambda implements IPartitionLambda {
     ): Promise<void> {
         const commitGuid = opData.guid;
 
-        this.context.log?.info(
-            `MH Commit: branch: ${branchGuid},
-             commit ${commitGuid},
-             changeSet:  ${JSON.stringify(opData.changeSet, undefined, 2)}`,
-        );
+        const logMessage = `MH Commit: branch: ${branchGuid},
+        commit ${commitGuid},
+        changeSet:  ${JSON.stringify(opData.changeSet, undefined, 2)}`;
+        this.context.log?.info(logMessage);
+
+        if (this.serviceConfiguration.enableLumberMetrics) {
+            Lumberjack.info(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+        }
 
         let parentCommitGuid = opData.referenceGuid;
         // Create a branch for the first commit that does not yet reference any other commit
@@ -154,9 +159,17 @@ export class MoiraLambda implements IPartitionLambda {
         });
 
         if (branchCreationResponse.status === 200) {
-            this.context.log?.info(`Branch with guid: ${branchGuid} created`);
+            const logMessage = `Branch with guid: ${branchGuid} created`;
+            this.context.log?.info(logMessage);
+            if (this.serviceConfiguration.enableLumberMetrics) {
+                Lumberjack.info(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+            }
         } else {
-            this.context.log?.error(`Branch with guid ${branchGuid} failed`);
+            const logMessage = `Branch with guid ${branchGuid} failed`;
+            this.context.log?.error(logMessage);
+            if (this.serviceConfiguration.enableLumberMetrics) {
+                Lumberjack.error(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+            }
         }
         return rootCommitGuid;
     }
@@ -187,12 +200,24 @@ export class MoiraLambda implements IPartitionLambda {
                     rebase: true,
                 });
             if (commitCreationResponse.status === 200) {
-                this.context.log?.info(`Commit created ${JSON.stringify(commitData)}`);
+                const logMessage = `Commit created ${JSON.stringify(commitData)}`;
+                this.context.log?.info(logMessage);
+                if (this.serviceConfiguration.enableLumberMetrics) {
+                    Lumberjack.info(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+                }
             } else {
-                this.context.log?.error(`Commit failed ${JSON.stringify(commitData)}`);
+                const logMessage = `Commit failed ${JSON.stringify(commitData)}`;
+                this.context.log?.error(logMessage);
+                if (this.serviceConfiguration.enableLumberMetrics) {
+                    Lumberjack.error(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+                }
             }
         } catch (e) {
-            this.context.log?.error(`Commit failed. ${e.message}`);
+            const logMessage = `Commit failed. ${e.message}`;
+            this.context.log?.error(logMessage);
+            if (this.serviceConfiguration.enableLumberMetrics) {
+                Lumberjack.error(logMessage, getLumberBaseProperties(this.documentId, this.tenantId), e);
+            }
         }
     }
 }

--- a/server/routerlicious/packages/lambdas/src/moira/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/lambda.ts
@@ -12,7 +12,7 @@ import {
     IServiceConfiguration,
     SequencedOperationType,
 } from "@fluidframework/server-services-core";
-import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
+import { CommonProperties, getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import shajs from "sha.js";
 import Axios from "axios";
 
@@ -158,17 +158,22 @@ export class MoiraLambda implements IPartitionLambda {
             created: 0,
         });
 
+        const lumberProperties = {
+            ...getLumberBaseProperties(this.documentId, this.tenantId),
+            [CommonProperties.statusCode]: branchCreationResponse.status,
+        };
+
         if (branchCreationResponse.status === 200) {
             const logMessage = `Branch with guid: ${branchGuid} created`;
             this.context.log?.info(logMessage);
             if (this.serviceConfiguration.enableLumberMetrics) {
-                Lumberjack.info(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+                Lumberjack.info(logMessage, lumberProperties);
             }
         } else {
             const logMessage = `Branch with guid ${branchGuid} failed`;
             this.context.log?.error(logMessage);
             if (this.serviceConfiguration.enableLumberMetrics) {
-                Lumberjack.error(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+                Lumberjack.error(logMessage, lumberProperties);
             }
         }
         return rootCommitGuid;
@@ -199,17 +204,23 @@ export class MoiraLambda implements IPartitionLambda {
                     changeSet: JSON.stringify(opData.changeSet),
                     rebase: true,
                 });
+
+            const lumberProperties = {
+                ...getLumberBaseProperties(this.documentId, this.tenantId),
+                [CommonProperties.statusCode]: commitCreationResponse.status,
+            };
+
             if (commitCreationResponse.status === 200) {
                 const logMessage = `Commit created ${JSON.stringify(commitData)}`;
                 this.context.log?.info(logMessage);
                 if (this.serviceConfiguration.enableLumberMetrics) {
-                    Lumberjack.info(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+                    Lumberjack.info(logMessage, lumberProperties);
                 }
             } else {
                 const logMessage = `Commit failed ${JSON.stringify(commitData)}`;
                 this.context.log?.error(logMessage);
                 if (this.serviceConfiguration.enableLumberMetrics) {
-                    Lumberjack.error(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
+                    Lumberjack.error(logMessage, lumberProperties);
                 }
             }
         } catch (e) {

--- a/server/routerlicious/packages/lambdas/src/moira/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/lambda.ts
@@ -136,7 +136,7 @@ export class MoiraLambda implements IPartitionLambda {
         changeSet:  ${JSON.stringify(opData.changeSet, undefined, 2)}`;
         this.context.log?.info(logMessage);
 
-        if (this.serviceConfiguration.enableLumberMetrics) {
+        if (this.serviceConfiguration.enableLumberjack) {
             Lumberjack.info(logMessage, getLumberBaseProperties(this.documentId, this.tenantId));
         }
 
@@ -166,13 +166,13 @@ export class MoiraLambda implements IPartitionLambda {
         if (branchCreationResponse.status === 200) {
             const logMessage = `Branch with guid: ${branchGuid} created`;
             this.context.log?.info(logMessage);
-            if (this.serviceConfiguration.enableLumberMetrics) {
+            if (this.serviceConfiguration.enableLumberjack) {
                 Lumberjack.info(logMessage, lumberProperties);
             }
         } else {
             const logMessage = `Branch with guid ${branchGuid} failed`;
             this.context.log?.error(logMessage);
-            if (this.serviceConfiguration.enableLumberMetrics) {
+            if (this.serviceConfiguration.enableLumberjack) {
                 Lumberjack.error(logMessage, lumberProperties);
             }
         }
@@ -213,20 +213,20 @@ export class MoiraLambda implements IPartitionLambda {
             if (commitCreationResponse.status === 200) {
                 const logMessage = `Commit created ${JSON.stringify(commitData)}`;
                 this.context.log?.info(logMessage);
-                if (this.serviceConfiguration.enableLumberMetrics) {
+                if (this.serviceConfiguration.enableLumberjack) {
                     Lumberjack.info(logMessage, lumberProperties);
                 }
             } else {
                 const logMessage = `Commit failed ${JSON.stringify(commitData)}`;
                 this.context.log?.error(logMessage);
-                if (this.serviceConfiguration.enableLumberMetrics) {
+                if (this.serviceConfiguration.enableLumberjack) {
                     Lumberjack.error(logMessage, lumberProperties);
                 }
             }
         } catch (e) {
             const logMessage = `Commit failed. ${e.message}`;
             this.context.log?.error(logMessage);
-            if (this.serviceConfiguration.enableLumberMetrics) {
+            if (this.serviceConfiguration.enableLumberjack) {
                 Lumberjack.error(logMessage, getLumberBaseProperties(this.documentId, this.tenantId), e);
             }
         }

--- a/server/routerlicious/packages/lambdas/src/moira/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/moira/lambdaFactory.ts
@@ -24,7 +24,7 @@ export class MoiraLambdaFactory extends EventEmitter implements IPartitionLambda
     public async create(config: IPartitionLambdaConfig, context: IContext): Promise<IPartitionLambda> {
         // Takes in the io as well as the collection. I can probably keep the same lambda but only ever give it stuff
         // from a single document
-        return new MoiraLambda(context, this.serviceConfiguration);
+        return new MoiraLambda(context, this.serviceConfiguration, config.tenantId, config.documentId);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/utils/telemetryHelper.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/telemetryHelper.ts
@@ -24,7 +24,7 @@ export const createSessionMetric = (
     lumberEventName: LumberEventName,
     serviceConfiguration: IServiceConfiguration,
 ): Lumber<any> | undefined => {
-    if (!serviceConfiguration.enableLumberMetrics) {
+    if (!serviceConfiguration.enableLumberjack) {
         return;
     }
 

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -297,7 +297,8 @@ export class LocalOrderer implements IOrderer {
                 this.deltasKafka,
                 this.setup,
                 this.moiraContext,
-                async (_, context) => new MoiraLambda(context, this.serviceConfiguration),
+                async (_, context) =>
+                    new MoiraLambda(context, this.serviceConfiguration, this.tenantId, this.documentId),
             );
         }
     }

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -113,15 +113,15 @@ export interface IServerConfiguration {
     // Enable adding a traces array to operation messages
     enableTraces: boolean;
 
-    // Enable metrics using the Lumber telemetry framework
-    enableLumberMetrics: boolean;
+    // Enable telemetry using the Lumberjack framework
+    enableLumberjack: boolean;
 }
 
 export const DefaultServiceConfiguration: IServiceConfiguration = {
     blockSize: 64436,
     maxMessageSize: 16 * 1024,
     enableTraces: true,
-    enableLumberMetrics: true,
+    enableLumberjack: true,
     summary: {
         idleTime: 5000,
         maxOps: 1000,


### PR DESCRIPTION
Adding `Lumberjack` logs to the Moira lambda. And since that it is a lambda, handling a high volume of messages, I put `Lumberjack` behind `serviceConfiguration.enableLumberMetrics` so that if there is any performance impact, it can be quickly turned off.

@evaliyev, I believe you originally added the Moira lambda - can you help check if this pull request looks good?
Some context:
1. We are working on adding a new telemetry framework to all lambdas and other r11s components. It is called `Lumberjack` and is available in the server-services-telemetry package. The idea is to use `Lumberjack` for telemetry going forward - I also plan to retire `context.log`, `logger`, `winston` and similar soon.
2. I did not run and test these changes because it seems the Moira lambda is not setup to run as a container in Docker when standing up r11s. Can you help verify if the changes here are ok? Thanks! 😄 