### PR TITLE
Type Validator: Ignore Pre-Release

### DIFF
--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -51,13 +51,13 @@ export function getPackageDetails(packageDir: string): PackageDetails {
     const pkgJson: PackageJson = JSON.parse(fs.readFileSync(packagePath).toString());
 
     // normalize the version to remove any pre-release version info,
-    // as we shouldn't change the type validation version from pre-release version
-    const normalizeVersion =
+    // as we shouldn't change the type validation version for pre-release versions
+    const normalizedVersion =
         pkgJson.version.includes("-") ?
             pkgJson.version.substring(0, pkgJson.version.indexOf("-")) :
             pkgJson.version;
 
-    if(normalizeVersion !== pkgJson.typeValidation?.version){
+    if(normalizedVersion !== pkgJson.typeValidation?.version){
         if(pkgJson.typeValidation !== undefined){
             pkgJson.devDependencies[`${pkgJson.name}-${pkgJson.typeValidation.version}`] =
                 `npm:${pkgJson.name}@${pkgJson.typeValidation.version}`;
@@ -65,7 +65,7 @@ export function getPackageDetails(packageDir: string): PackageDetails {
             pkgJson.devDependencies = createSortedObject(pkgJson.devDependencies);
         }
         pkgJson.typeValidation = {
-            version: normalizeVersion,
+            version: normalizedVersion,
             broken: pkgJson.typeValidation?.broken ?? {}
         }
         fs.writeFileSync(packagePath, JSON.stringify(pkgJson, undefined, 2));
@@ -77,7 +77,7 @@ export function getPackageDetails(packageDir: string): PackageDetails {
     return {
         name: pkgJson.name,
         packageDir,
-        version: normalizeVersion,
+        version: normalizedVersion,
         oldVersions,
         broken: pkgJson.typeValidation.broken
     }

--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from "fs";
+import * as semver from "semver";
 
 export type PackageDetails ={
     readonly name: string;
@@ -49,7 +50,14 @@ export function getPackageDetails(packageDir: string): PackageDetails {
 
     const pkgJson: PackageJson = JSON.parse(fs.readFileSync(packagePath).toString());
 
-    if(pkgJson.version !== pkgJson.typeValidation?.version){
+    // normalize the version to remove any pre-release version info,
+    // as we shouldn't change the type validation version from pre-release version
+    const normalizeVersion =
+        pkgJson.version.includes("-") ?
+            pkgJson.version.substring(0, pkgJson.version.indexOf("-")) :
+            pkgJson.version;
+
+    if(normalizeVersion !== pkgJson.typeValidation?.version){
         if(pkgJson.typeValidation !== undefined){
             pkgJson.devDependencies[`${pkgJson.name}-${pkgJson.typeValidation.version}`] =
                 `npm:${pkgJson.name}@${pkgJson.typeValidation.version}`;
@@ -57,7 +65,7 @@ export function getPackageDetails(packageDir: string): PackageDetails {
             pkgJson.devDependencies = createSortedObject(pkgJson.devDependencies);
         }
         pkgJson.typeValidation = {
-            version: pkgJson.version,
+            version: normalizeVersion,
             broken: pkgJson.typeValidation?.broken ?? {}
         }
         fs.writeFileSync(packagePath, JSON.stringify(pkgJson, undefined, 2));
@@ -69,7 +77,7 @@ export function getPackageDetails(packageDir: string): PackageDetails {
     return {
         name: pkgJson.name,
         packageDir,
-        version: pkgJson.version,
+        version: normalizeVersion,
         oldVersions,
         broken: pkgJson.typeValidation.broken
     }

--- a/tools/build-tools/src/typeValidator/packageJson.ts
+++ b/tools/build-tools/src/typeValidator/packageJson.ts
@@ -4,7 +4,6 @@
  */
 
 import * as fs from "fs";
-import * as semver from "semver";
 
 export type PackageDetails ={
     readonly name: string;


### PR DESCRIPTION
In the ci build we always bump the version in the package.json to a pre-release version. This creates an issue where we try to bump the type validation version when the version has not been released. This change normalizes the version to remove the pre-release, and will only bump the validation version if there is a change in that.

fixes #7875 

related to #7614 