### PR TITLE
Bubblebench: Recalibrate for 29.98 Hz displays

### DIFF
--- a/experimental/examples/bubblebench/common/src/stats.ts
+++ b/experimental/examples/bubblebench/common/src/stats.ts
@@ -23,7 +23,7 @@ export class Stats {
 
         // Note: frameFps can be infinite if the delta from the previous frame is 0 ms.
         if (isFinite(frameFps)) {
-            if (frameFps < 24) {
+            if (frameFps < 18) {
                 this._glitchCount++;
             }
 

--- a/experimental/examples/bubblebench/common/src/view/app.tsx
+++ b/experimental/examples/bubblebench/common/src/view/app.tsx
@@ -106,7 +106,7 @@ export const AppView: React.FC<IAppProps> = ({ app }: IAppProps) => {
         // 23.98, the lowest display refresh rate typically encountered on modern displays.
         if (!(stats.smoothFps > 23)) {
             app.decreaseBubbles();
-        } else if (stats.smoothFps > 23) {
+        } else if (stats.smoothFps > 24) {
             app.increaseBubbles();
         }
 

--- a/experimental/examples/bubblebench/common/src/view/app.tsx
+++ b/experimental/examples/bubblebench/common/src/view/app.tsx
@@ -102,10 +102,11 @@ export const AppView: React.FC<IAppProps> = ({ app }: IAppProps) => {
             }
         }
 
-        // Scale the number of local bubbles to target 30 fps.
-        if (!(stats.smoothFps > 30)) {
+        // Scale the number of local bubbles to target 23 fps.  We choose 23 fps because it is below
+        // 23.98, the lowest display refresh rate typically encountered on modern displays.
+        if (!(stats.smoothFps > 23)) {
             app.decreaseBubbles();
-        } else if (stats.smoothFps > 31) {
+        } else if (stats.smoothFps > 23) {
             app.increaseBubbles();
         }
 

--- a/experimental/examples/bubblebench/common/src/view/app.tsx
+++ b/experimental/examples/bubblebench/common/src/view/app.tsx
@@ -102,11 +102,11 @@ export const AppView: React.FC<IAppProps> = ({ app }: IAppProps) => {
             }
         }
 
-        // Scale the number of local bubbles to target 23 fps.  We choose 23 fps because it is below
-        // 23.98, the lowest display refresh rate typically encountered on modern displays.
-        if (!(stats.smoothFps > 23)) {
+        // Scale the number of local bubbles to target 22-23 fps.  We choose 22-23 fps because it
+        // is below 23.98, the lowest display refresh rate typically encountered on modern displays.
+        if (!(stats.smoothFps > 22)) {
             app.decreaseBubbles();
-        } else if (stats.smoothFps > 24) {
+        } else if (stats.smoothFps > 23) {
             app.increaseBubbles();
         }
 


### PR DESCRIPTION
Bubblebench works by loading the system until the FPS falls into the target window.

Previously, the target window chosen (30 fps) was unachievable on a machine with a slower refresh rate, resulting in a false score of < 1 bubble.

This recalibrates the benchmark to target ~23 FPS, which should be low enough for any modern display.