### PR TITLE
Change SummaryType from Enum to Namepsace

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -685,16 +685,27 @@ export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISumm
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
 // @public (undocumented)
-export const enum SummaryType {
+export namespace SummaryType {
     // (undocumented)
-    Attachment = 4,
+    export type Attachment = 4;
     // (undocumented)
-    Blob = 2,
+    export type Blob = 2;
     // (undocumented)
-    Handle = 3,
+    export type Handle = 3;
     // (undocumented)
-    Tree = 1
+    export type Tree = 1;
+    const // (undocumented)
+    Tree: Tree;
+    const // (undocumented)
+    Blob: Blob;
+    const // (undocumented)
+    Handle: Handle;
+    const // (undocumented)
+    Attachment: Attachment;
 }
+
+// @public (undocumented)
+export type SummaryType = SummaryType.Attachment | SummaryType.Blob | SummaryType.Handle | SummaryType.Tree;
 
 // @public (undocumented)
 export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -59,45 +59,10 @@
     "version": "0.1026.0",
     "broken": {
       "0.1024.0": {
-        "InterfaceDeclaration_ICreateBlobResponse": {
-          "backCompat": false
-        },
-        "InterfaceDeclaration_IQuorum": {
+        "InterfaceDeclaration_IBlob": {
           "forwardCompat": false
         },
-        "InterfaceDeclaration_ISummaryAttachment": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_ISummaryBlob": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_ISummaryHandle": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_ISummaryTree": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "TypeAliasDeclaration_SummaryObject": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "TypeAliasDeclaration_SummaryTree": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "EnumDeclaration_SummaryType": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "TypeAliasDeclaration_SummaryTypeNoHandle": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_IBlob": {
+        "InterfaceDeclaration_IQuorum": {
           "forwardCompat": false
         },
         "InterfaceDeclaration_ITree": {
@@ -105,40 +70,6 @@
         },
         "TypeAliasDeclaration_ITreeEntry": {
           "forwardCompat": false
-        }
-      },
-      "0.1025.1": {
-        "InterfaceDeclaration_ISummaryAttachment": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_ISummaryBlob": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_ISummaryHandle": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_ISummaryTree": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "TypeAliasDeclaration_SummaryObject": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "TypeAliasDeclaration_SummaryTree": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "EnumDeclaration_SummaryType": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "TypeAliasDeclaration_SummaryTypeNoHandle": {
-          "forwardCompat": false,
-          "backCompat": false
         }
       }
     }

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -21,12 +21,18 @@ export interface ISummaryCommitter {
     date: string;
 }
 
-export const enum SummaryType {
-    Tree = 1,
-    Blob = 2,
-    Handle = 3,
-    Attachment = 4,
+export namespace SummaryType {
+    export type Tree = 1;
+    export type Blob = 2;
+    export type Handle = 3;
+    export type Attachment = 4;
+
+    export const Tree: Tree = 1 as const;
+    export const Blob: Blob = 2 as const;
+    export const Handle: Handle = 3 as const;
+    export const Attachment: Attachment = 4 as const;
 }
+export type SummaryType = SummaryType.Attachment | SummaryType.Blob | SummaryType.Handle | SummaryType.Tree;
 
 export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;
 

--- a/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
@@ -385,13 +385,13 @@ use_current_InterfaceDeclaration_ICreateBlobResponse(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ICreateBlobResponse": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ICreateBlobResponse():
     current.ICreateBlobResponse;
 declare function use_old_InterfaceDeclaration_ICreateBlobResponse(
     use: old.ICreateBlobResponse);
 use_old_InterfaceDeclaration_ICreateBlobResponse(
     get_current_InterfaceDeclaration_ICreateBlobResponse());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -973,25 +973,25 @@ use_old_InterfaceDeclaration_ISummaryAck(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryAttachment": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryAttachment():
     old.ISummaryAttachment;
 declare function use_current_InterfaceDeclaration_ISummaryAttachment(
     use: current.ISummaryAttachment);
 use_current_InterfaceDeclaration_ISummaryAttachment(
     get_old_InterfaceDeclaration_ISummaryAttachment());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryAttachment": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryAttachment():
     current.ISummaryAttachment;
 declare function use_old_InterfaceDeclaration_ISummaryAttachment(
     use: old.ISummaryAttachment);
 use_old_InterfaceDeclaration_ISummaryAttachment(
     get_current_InterfaceDeclaration_ISummaryAttachment());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1021,25 +1021,25 @@ use_old_InterfaceDeclaration_ISummaryAuthor(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryBlob": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryBlob():
     old.ISummaryBlob;
 declare function use_current_InterfaceDeclaration_ISummaryBlob(
     use: current.ISummaryBlob);
 use_current_InterfaceDeclaration_ISummaryBlob(
     get_old_InterfaceDeclaration_ISummaryBlob());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryBlob": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryBlob():
     current.ISummaryBlob;
 declare function use_old_InterfaceDeclaration_ISummaryBlob(
     use: old.ISummaryBlob);
 use_old_InterfaceDeclaration_ISummaryBlob(
     get_current_InterfaceDeclaration_ISummaryBlob());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1117,25 +1117,25 @@ use_old_InterfaceDeclaration_ISummaryContent(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryHandle": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryHandle():
     old.ISummaryHandle;
 declare function use_current_InterfaceDeclaration_ISummaryHandle(
     use: current.ISummaryHandle);
 use_current_InterfaceDeclaration_ISummaryHandle(
     get_old_InterfaceDeclaration_ISummaryHandle());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryHandle": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryHandle():
     current.ISummaryHandle;
 declare function use_old_InterfaceDeclaration_ISummaryHandle(
     use: old.ISummaryHandle);
 use_old_InterfaceDeclaration_ISummaryHandle(
     get_current_InterfaceDeclaration_ISummaryHandle());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1213,25 +1213,25 @@ use_old_InterfaceDeclaration_ISummaryTokenClaims(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryTree": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryTree():
     old.ISummaryTree;
 declare function use_current_InterfaceDeclaration_ISummaryTree(
     use: current.ISummaryTree);
 use_current_InterfaceDeclaration_ISummaryTree(
     get_old_InterfaceDeclaration_ISummaryTree());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "InterfaceDeclaration_ISummaryTree": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryTree():
     current.ISummaryTree;
 declare function use_old_InterfaceDeclaration_ISummaryTree(
     use: old.ISummaryTree);
 use_old_InterfaceDeclaration_ISummaryTree(
     get_current_InterfaceDeclaration_ISummaryTree());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1525,97 +1525,97 @@ use_old_EnumDeclaration_ScopeType(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "TypeAliasDeclaration_SummaryObject": {"forwardCompat": false}
+*/
 declare function get_old_TypeAliasDeclaration_SummaryObject():
     old.SummaryObject;
 declare function use_current_TypeAliasDeclaration_SummaryObject(
     use: current.SummaryObject);
 use_current_TypeAliasDeclaration_SummaryObject(
     get_old_TypeAliasDeclaration_SummaryObject());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "TypeAliasDeclaration_SummaryObject": {"backCompat": false}
+*/
 declare function get_current_TypeAliasDeclaration_SummaryObject():
     current.SummaryObject;
 declare function use_old_TypeAliasDeclaration_SummaryObject(
     use: old.SummaryObject);
 use_old_TypeAliasDeclaration_SummaryObject(
     get_current_TypeAliasDeclaration_SummaryObject());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "TypeAliasDeclaration_SummaryTree": {"forwardCompat": false}
+*/
 declare function get_old_TypeAliasDeclaration_SummaryTree():
     old.SummaryTree;
 declare function use_current_TypeAliasDeclaration_SummaryTree(
     use: current.SummaryTree);
 use_current_TypeAliasDeclaration_SummaryTree(
     get_old_TypeAliasDeclaration_SummaryTree());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "TypeAliasDeclaration_SummaryTree": {"backCompat": false}
+*/
 declare function get_current_TypeAliasDeclaration_SummaryTree():
     current.SummaryTree;
 declare function use_old_TypeAliasDeclaration_SummaryTree(
     use: old.SummaryTree);
 use_old_TypeAliasDeclaration_SummaryTree(
     get_current_TypeAliasDeclaration_SummaryTree());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
-* "EnumDeclaration_SummaryType": {"forwardCompat": false}
+* "RemovedEnumDeclaration_SummaryType": {"forwardCompat": false}
+*/
 declare function get_old_EnumDeclaration_SummaryType():
     old.SummaryType;
-declare function use_current_EnumDeclaration_SummaryType(
+declare function use_current_RemovedEnumDeclaration_SummaryType(
     use: current.SummaryType);
-use_current_EnumDeclaration_SummaryType(
+use_current_RemovedEnumDeclaration_SummaryType(
     get_old_EnumDeclaration_SummaryType());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
-* "EnumDeclaration_SummaryType": {"backCompat": false}
-declare function get_current_EnumDeclaration_SummaryType():
+* "RemovedEnumDeclaration_SummaryType": {"backCompat": false}
+*/
+declare function get_current_RemovedEnumDeclaration_SummaryType():
     current.SummaryType;
 declare function use_old_EnumDeclaration_SummaryType(
     use: old.SummaryType);
 use_old_EnumDeclaration_SummaryType(
-    get_current_EnumDeclaration_SummaryType());
-*/
+    get_current_RemovedEnumDeclaration_SummaryType());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "TypeAliasDeclaration_SummaryTypeNoHandle": {"forwardCompat": false}
+*/
 declare function get_old_TypeAliasDeclaration_SummaryTypeNoHandle():
     old.SummaryTypeNoHandle;
 declare function use_current_TypeAliasDeclaration_SummaryTypeNoHandle(
     use: current.SummaryTypeNoHandle);
 use_current_TypeAliasDeclaration_SummaryTypeNoHandle(
     get_old_TypeAliasDeclaration_SummaryTypeNoHandle());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
 * "TypeAliasDeclaration_SummaryTypeNoHandle": {"backCompat": false}
+*/
 declare function get_current_TypeAliasDeclaration_SummaryTypeNoHandle():
     current.SummaryTypeNoHandle;
 declare function use_old_TypeAliasDeclaration_SummaryTypeNoHandle(
     use: old.SummaryTypeNoHandle);
 use_old_TypeAliasDeclaration_SummaryTypeNoHandle(
     get_current_TypeAliasDeclaration_SummaryTypeNoHandle());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/common/lib/protocol-definitions/src/test/types/validate0.1025.1.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1025.1.ts
@@ -1069,25 +1069,25 @@ use_old_InterfaceDeclaration_ISummaryAck(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryAttachment": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryAttachment():
     old.ISummaryAttachment;
 declare function use_current_InterfaceDeclaration_ISummaryAttachment(
     use: current.ISummaryAttachment);
 use_current_InterfaceDeclaration_ISummaryAttachment(
     get_old_InterfaceDeclaration_ISummaryAttachment());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryAttachment": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryAttachment():
     current.ISummaryAttachment;
 declare function use_old_InterfaceDeclaration_ISummaryAttachment(
     use: old.ISummaryAttachment);
 use_old_InterfaceDeclaration_ISummaryAttachment(
     get_current_InterfaceDeclaration_ISummaryAttachment());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1117,25 +1117,25 @@ use_old_InterfaceDeclaration_ISummaryAuthor(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryBlob": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryBlob():
     old.ISummaryBlob;
 declare function use_current_InterfaceDeclaration_ISummaryBlob(
     use: current.ISummaryBlob);
 use_current_InterfaceDeclaration_ISummaryBlob(
     get_old_InterfaceDeclaration_ISummaryBlob());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryBlob": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryBlob():
     current.ISummaryBlob;
 declare function use_old_InterfaceDeclaration_ISummaryBlob(
     use: old.ISummaryBlob);
 use_old_InterfaceDeclaration_ISummaryBlob(
     get_current_InterfaceDeclaration_ISummaryBlob());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1213,25 +1213,25 @@ use_old_InterfaceDeclaration_ISummaryContent(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryHandle": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryHandle():
     old.ISummaryHandle;
 declare function use_current_InterfaceDeclaration_ISummaryHandle(
     use: current.ISummaryHandle);
 use_current_InterfaceDeclaration_ISummaryHandle(
     get_old_InterfaceDeclaration_ISummaryHandle());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryHandle": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryHandle():
     current.ISummaryHandle;
 declare function use_old_InterfaceDeclaration_ISummaryHandle(
     use: old.ISummaryHandle);
 use_old_InterfaceDeclaration_ISummaryHandle(
     get_current_InterfaceDeclaration_ISummaryHandle());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1309,25 +1309,25 @@ use_old_InterfaceDeclaration_ISummaryTokenClaims(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryTree": {"forwardCompat": false}
+*/
 declare function get_old_InterfaceDeclaration_ISummaryTree():
     old.ISummaryTree;
 declare function use_current_InterfaceDeclaration_ISummaryTree(
     use: current.ISummaryTree);
 use_current_InterfaceDeclaration_ISummaryTree(
     get_old_InterfaceDeclaration_ISummaryTree());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "InterfaceDeclaration_ISummaryTree": {"backCompat": false}
+*/
 declare function get_current_InterfaceDeclaration_ISummaryTree():
     current.ISummaryTree;
 declare function use_old_InterfaceDeclaration_ISummaryTree(
     use: old.ISummaryTree);
 use_old_InterfaceDeclaration_ISummaryTree(
     get_current_InterfaceDeclaration_ISummaryTree());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1621,97 +1621,97 @@ use_old_EnumDeclaration_ScopeType(
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "TypeAliasDeclaration_SummaryObject": {"forwardCompat": false}
+*/
 declare function get_old_TypeAliasDeclaration_SummaryObject():
     old.SummaryObject;
 declare function use_current_TypeAliasDeclaration_SummaryObject(
     use: current.SummaryObject);
 use_current_TypeAliasDeclaration_SummaryObject(
     get_old_TypeAliasDeclaration_SummaryObject());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "TypeAliasDeclaration_SummaryObject": {"backCompat": false}
+*/
 declare function get_current_TypeAliasDeclaration_SummaryObject():
     current.SummaryObject;
 declare function use_old_TypeAliasDeclaration_SummaryObject(
     use: old.SummaryObject);
 use_old_TypeAliasDeclaration_SummaryObject(
     get_current_TypeAliasDeclaration_SummaryObject());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "TypeAliasDeclaration_SummaryTree": {"forwardCompat": false}
+*/
 declare function get_old_TypeAliasDeclaration_SummaryTree():
     old.SummaryTree;
 declare function use_current_TypeAliasDeclaration_SummaryTree(
     use: current.SummaryTree);
 use_current_TypeAliasDeclaration_SummaryTree(
     get_old_TypeAliasDeclaration_SummaryTree());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "TypeAliasDeclaration_SummaryTree": {"backCompat": false}
+*/
 declare function get_current_TypeAliasDeclaration_SummaryTree():
     current.SummaryTree;
 declare function use_old_TypeAliasDeclaration_SummaryTree(
     use: old.SummaryTree);
 use_old_TypeAliasDeclaration_SummaryTree(
     get_current_TypeAliasDeclaration_SummaryTree());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
-* "EnumDeclaration_SummaryType": {"forwardCompat": false}
+* "RemovedEnumDeclaration_SummaryType": {"forwardCompat": false}
+*/
 declare function get_old_EnumDeclaration_SummaryType():
     old.SummaryType;
-declare function use_current_EnumDeclaration_SummaryType(
+declare function use_current_RemovedEnumDeclaration_SummaryType(
     use: current.SummaryType);
-use_current_EnumDeclaration_SummaryType(
+use_current_RemovedEnumDeclaration_SummaryType(
     get_old_EnumDeclaration_SummaryType());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
-* "EnumDeclaration_SummaryType": {"backCompat": false}
-declare function get_current_EnumDeclaration_SummaryType():
+* "RemovedEnumDeclaration_SummaryType": {"backCompat": false}
+*/
+declare function get_current_RemovedEnumDeclaration_SummaryType():
     current.SummaryType;
 declare function use_old_EnumDeclaration_SummaryType(
     use: old.SummaryType);
 use_old_EnumDeclaration_SummaryType(
-    get_current_EnumDeclaration_SummaryType());
-*/
+    get_current_RemovedEnumDeclaration_SummaryType());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "TypeAliasDeclaration_SummaryTypeNoHandle": {"forwardCompat": false}
+*/
 declare function get_old_TypeAliasDeclaration_SummaryTypeNoHandle():
     old.SummaryTypeNoHandle;
 declare function use_current_TypeAliasDeclaration_SummaryTypeNoHandle(
     use: current.SummaryTypeNoHandle);
 use_current_TypeAliasDeclaration_SummaryTypeNoHandle(
     get_old_TypeAliasDeclaration_SummaryTypeNoHandle());
-*/
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
 * "TypeAliasDeclaration_SummaryTypeNoHandle": {"backCompat": false}
+*/
 declare function get_current_TypeAliasDeclaration_SummaryTypeNoHandle():
     current.SummaryTypeNoHandle;
 declare function use_old_TypeAliasDeclaration_SummaryTypeNoHandle(
     use: old.SummaryTypeNoHandle);
 use_old_TypeAliasDeclaration_SummaryTypeNoHandle(
     get_current_TypeAliasDeclaration_SummaryTypeNoHandle());
-*/
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
SummaryType being a const enum resulted in the type never being compatible across versions. Changing to a namespace type fixes the compatibly issue, and keeps it syntax compatible across versions. This allow removing much of the breaking section from the package.json. This will also allow us to more easily deprecate the const values later, and keep our definition packages types only, which is related to #6540 