### PR TITLE
Remove outdated cookie JS

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -11,6 +11,7 @@ permalinks:
 
 params:
   appInsightKey: ""  # This is provided by the build system as an env variable
+  cookies: false
   customCSS: ["css/fluid.css", "css/tango.css"]
   dateform: "Jan 2, 2006"
   dateformNum: "2006-01-02"

--- a/docs/themes/thxvscode/layouts/_default/baseof.html
+++ b/docs/themes/thxvscode/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
 
 <body>
     <!-- EU Cookie Compliance JS -->
-    <script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
+    <script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
     <div id="main">
         {{- partial "header.html" . -}}
         <div {{ if .IsHome}}class="home" {{ end}}>
@@ -16,6 +16,7 @@
 
 {{ $script := resources.Get "js/bundle.js" | resources.ExecuteAsTemplate "js/main.js" .  | minify |fingerprint -}}
 <script src="{{ $script.Permalink | relURL }}"
-    {{ printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr }}></script>
-
+    {{ printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr -}}>
+</script>
+{{- partial "cookies.html" . -}}
 </html>

--- a/docs/themes/thxvscode/layouts/_default/baseof.html
+++ b/docs/themes/thxvscode/layouts/_default/baseof.html
@@ -3,8 +3,11 @@
 {{- partial "head.html" . -}}
 
 <body>
+    {{- if .Site.Params.cookies -}}
     <!-- EU Cookie Compliance JS -->
     <script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
+    {{- end -}}
+
     <div id="main">
         {{- partial "header.html" . -}}
         <div {{ if .IsHome}}class="home" {{ end}}>

--- a/docs/themes/thxvscode/layouts/_default/single-baseof.html
+++ b/docs/themes/thxvscode/layouts/_default/single-baseof.html
@@ -4,7 +4,7 @@
 
 <body>
     <!-- EU Cookie Compliance JS -->
-    <script src="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.js"></script>
+    <script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
     <div id="main">
         {{- partial "header.html" . -}}
         <div {{ if .IsHome}}class="home" {{ end}}>
@@ -50,6 +50,8 @@
 </body>
 
 {{ $script := resources.Get "js/bundle.js" | resources.ExecuteAsTemplate "js/main.js" . | minify |fingerprint -}}
-<script src="{{ $script.Permalink | relURL }}" {{ printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr }}></script>
-
+<script src="{{ $script.Permalink | relURL }}"
+    {{ printf "integrity=%q" $script.Data.Integrity | safeHTMLAttr }}>
+</script>
+{{- partial "cookies.html" . -}}
 </html>

--- a/docs/themes/thxvscode/layouts/_default/single-baseof.html
+++ b/docs/themes/thxvscode/layouts/_default/single-baseof.html
@@ -3,8 +3,11 @@
 {{- partial "head.html" . -}}
 
 <body>
+    {{- if .Site.Params.cookies -}}
     <!-- EU Cookie Compliance JS -->
     <script src="https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js"></script>
+    {{- end -}}
+
     <div id="main">
         {{- partial "header.html" . -}}
         <div {{ if .IsHome}}class="home" {{ end}}>

--- a/docs/themes/thxvscode/layouts/partials/cookies.html
+++ b/docs/themes/thxvscode/layouts/partials/cookies.html
@@ -1,0 +1,24 @@
+<script>
+    function onConsentChanged(categoryPreferences) {
+        console.log("onConsentChanged", categoryPreferences);
+    }
+
+    function manageConsent() {
+        if (WcpConsent.siteConsent.isConsentRequired) {
+            WcpConsent.siteConsent.manageConsent();
+        }
+    }
+
+    if (window.WcpConsent) {
+        if (WcpConsent.init("en-US", "cookie-banner", function (err, _siteConsent) {
+            if (!err) {
+                siteConsent = _siteConsent;  //siteConsent is used to get the current consent
+                if (siteConsent.isConsentRequired) {
+                    console.log("Consent required");
+                }
+            } else {
+                console.log("Error initializing WcpConsent: " + err);
+            }
+        }, onConsentChanged, WcpConsent.themes.light));
+    }
+</script>

--- a/docs/themes/thxvscode/layouts/partials/footer.html
+++ b/docs/themes/thxvscode/layouts/partials/footer.html
@@ -24,6 +24,7 @@
                 <ul class="links">
                     <li><a id="footer-privacy-link" href="https://privacy.microsoft.com/privacystatement"
                             target="_blank">Privacy</a></li>
+                    <li><a id="footer-cookie-link" style="cursor: pointer;" onclick="manageConsent()" target="_blank">Manage Cookies</a></li>
                     <li><a id="footer-terms-link" href="https://www.microsoft.com/legal/terms-of-use"
                             target="_blank">Terms of Use</a></li>
                     <li><a id="footer-license-link"

--- a/docs/themes/thxvscode/layouts/partials/footer.html
+++ b/docs/themes/thxvscode/layouts/partials/footer.html
@@ -24,7 +24,10 @@
                 <ul class="links">
                     <li><a id="footer-privacy-link" href="https://privacy.microsoft.com/privacystatement"
                             target="_blank">Privacy</a></li>
-                    <li><a id="footer-cookie-link" style="cursor: pointer;" onclick="manageConsent()" target="_blank">Manage Cookies</a></li>
+                    {{- if .Site.Params.cookies -}}
+                    <li><a id="footer-cookie-link" style="cursor: pointer;" onclick="manageConsent()"
+                    target="_blank">Manage Cookies</a></li>
+                    {{- end -}}
                     <li><a id="footer-terms-link" href="https://www.microsoft.com/legal/terms-of-use"
                             target="_blank">Terms of Use</a></li>
                     <li><a id="footer-license-link"

--- a/docs/themes/thxvscode/layouts/partials/head.html
+++ b/docs/themes/thxvscode/layouts/partials/head.html
@@ -28,8 +28,6 @@
     {{/* end */}}
 
     <link rel="stylesheet" href="/vendor/bootstrap/css/bootstrap.min.css">
-    <!-- EU Cookie Compliance CSS -->
-    <link rel="stylesheet" href="//uhf.microsoft.com/mscc/statics/mscc-0.3.6.min.css">
 
     {{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "css/style.css" . | toCSS | minify | fingerprint -}}
     <link rel="stylesheet" href="{{ $style.Permalink | relURL }}"

--- a/docs/themes/thxvscode/layouts/partials/navbarSticky.html
+++ b/docs/themes/thxvscode/layouts/partials/navbarSticky.html
@@ -3,6 +3,7 @@
 <div class="navbar-fixed-container">
     <div class="navbar navbar-inverse navbar-fixed-top {{ if .IsHome}}home{{ end }}" data-spy="affix"
         data-offset-top="1">
+        <div id="cookie-banner"></div>
         <nav role="navigation" aria-label="Top Level">
             <div class="container">
                 <div class="nav navbar-header">


### PR DESCRIPTION
We are currently using an outdated Microsoft cookie library. ~Even though we currently don't use cookies, we'll introduce one soon to store the state of the "update available" banner (see #7631). This change will prepare us for the future as well as removing the outdated lib.~

We're just going to remove the library altogether and avoid cookies.