### PR TITLE
Hide op argument so it is not used in Prosemirror

### DIFF
--- a/examples/data-objects/prosemirror/src/fluidCollabManager.ts
+++ b/examples/data-objects/prosemirror/src/fluidCollabManager.ts
@@ -213,7 +213,7 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 
         this.text.on(
             "pre-op",
-            (op, local) => {
+            (_, local) => {
                 if (local) {
                     return;
                 }
@@ -237,7 +237,7 @@ export class FluidCollabManager extends EventEmitter implements IRichTextEditor 
 
         this.text.on(
             "op",
-            (op, local) => {
+            (_, local) => {
                 this.emit("valueChanged");
 
                 if (local) {


### PR DESCRIPTION
Opting to hide the op argument as updating Prosemirror to only key on the `SequenceDeltaEvent` would require a rewrite.

#7776 