### PR TITLE
Updating Node.js version used in r11s, Historian, GitRest

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.22.1-stretch AS base
+FROM node:12.22.7-stretch AS base
 
 # Add Tini
 ENV TINI_VERSION v0.18.0

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.22.1-slim AS base
+FROM node:12.22.7-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.22.1-slim AS base
+FROM node:12.22.7-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Updating the Node.js image using in r11s, Historian and GitRest Dockerfiles according to the latest Node.js security releases: [October 12th 2021 Security Releases](https://nodejs.org/en/blog/vulnerability/oct-2021-security-releases/)

Test strategy I used: built images locally with Docker, and referenced local Historian and GitRest images in r11s docker-compose.yml. Used clicker to validate behavior.