### PR TITLE
Fix deli checkpoint errors not being caught

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -22,7 +22,7 @@ export class CheckpointContext {
 
     /**
      * Checkpoints to the database & kafka
-     * Note: This is an async method, but youshould not await this
+     * Note: This is an async method, but you should not await this
      */
     public async checkpoint(checkpoint: ICheckpointParams) {
         // Exit early if already closed

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -20,7 +20,11 @@ export class CheckpointContext {
         private readonly context: IContext) {
     }
 
-    public checkpoint(checkpoint: ICheckpointParams) {
+    /**
+     * Checkpoints to the database & kafka
+     * Note: This is an async method, but youshould not await this
+     */
+    public async checkpoint(checkpoint: ICheckpointParams) {
         // Exit early if already closed
         if (this.closed) {
             return;
@@ -33,43 +37,58 @@ export class CheckpointContext {
             return;
         }
 
-        // Write the checkpoint data to MongoDB
-        this.pendingUpdateP = this.checkpointCore(checkpoint);
-        this.pendingUpdateP?.then(
-            () => {
-                // kafka checkpoint
-                // depending on the sequence of events, it might try to checkpoint the same offset a second time
-                // detect and prevent that case here
-                const kafkaCheckpointMessage = checkpoint.kafkaCheckpointMessage;
-                if (kafkaCheckpointMessage &&
-                    (this.lastKafkaCheckpointOffset === undefined ||
-                        kafkaCheckpointMessage.offset > this.lastKafkaCheckpointOffset)) {
-                    this.lastKafkaCheckpointOffset = kafkaCheckpointMessage.offset;
-                    this.context.checkpoint(kafkaCheckpointMessage);
-                }
+        // Database checkpoint
+        try {
+            this.pendingUpdateP = this.checkpointCore(checkpoint);
+            await this.pendingUpdateP;
+        } catch (ex) {
+            // TODO flag context as error / use this.context.error() instead?
+            this.context.log?.error(
+                `Error writing checkpoint to the database: ${JSON.stringify(ex)}`,
+                {
+                    messageMetaData: {
+                        documentId: this.id,
+                        tenantId: this.tenantId,
+                    },
+                });
+            Lumberjack.error(`Error writing checkpoint to the database`,
+                getLumberBaseProperties(this.id, this.tenantId), ex);
+            return;
+        }
 
-                this.pendingUpdateP = undefined;
+        // Kafka checkpoint
+        try {
+            // depending on the sequence of events, it might try to checkpoint the same offset a second time
+            // detect and prevent that case here
+            const kafkaCheckpointMessage = checkpoint.kafkaCheckpointMessage;
+            if (kafkaCheckpointMessage &&
+                (this.lastKafkaCheckpointOffset === undefined ||
+                    kafkaCheckpointMessage.offset > this.lastKafkaCheckpointOffset)) {
+                this.lastKafkaCheckpointOffset = kafkaCheckpointMessage.offset;
+                this.context.checkpoint(kafkaCheckpointMessage);
+            }
+        } catch (ex) {
+            // TODO flag context as error / use this.context.error() instead?
+            this.context.log?.error(
+                `Error writing checkpoint to kafka: ${JSON.stringify(ex)}`,
+                {
+                    messageMetaData: {
+                        documentId: this.id,
+                        tenantId: this.tenantId,
+                    },
+                });
+            Lumberjack.error(`Error writing checkpoint to the kafka`,
+                getLumberBaseProperties(this.id, this.tenantId), ex);
+        }
 
-                // Trigger another round if there is a pending update
-                if (this.pendingCheckpoint) {
-                    const pendingCheckpoint = this.pendingCheckpoint;
-                    this.pendingCheckpoint = undefined;
-                    this.checkpoint(pendingCheckpoint);
-                }
-            },
-            (error) => {
-                // TODO flag context as error
-                this.context.log?.error(
-                    `Error writing checkpoint to MongoDB: ${JSON.stringify(error)}`,
-                    {
-                        messageMetaData: {
-                            documentId: this.id,
-                            tenantId: this.tenantId,
-                        },
-                    });
-                Lumberjack.error(`Error writing checkpoint to MongoDB`,
-                    getLumberBaseProperties(this.id, this.tenantId), error);
-            });
+        this.pendingUpdateP = undefined;
+
+        // Trigger another round if there is a pending update
+        if (this.pendingCheckpoint) {
+            const pendingCheckpoint = this.pendingCheckpoint;
+            this.pendingCheckpoint = undefined;
+            void this.checkpoint(pendingCheckpoint);
+        }
     }
 
     public close() {

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -316,7 +316,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                 if (this.lastInstruction === InstructionType.ClearCache) {
                     checkpoint.clear = true;
                 }
-                this.checkpointContext.checkpoint(checkpoint);
+                void this.checkpointContext.checkpoint(checkpoint);
             },
             (error) => {
                 const errorMsg = `Could not send message to scriptorium`;


### PR DESCRIPTION
Errors when calling `context.checkpoint()` were thrown as unhandled rejections. 

I converted the method to be async with try catches so errors will now be logged correctly.