### PR TITLE
Riddler Deletion flow: handle null scheduledDeletionTime

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -304,7 +304,7 @@ export class TenantManager {
             };
             await collection.update(query, {
                 disabled: true,
-                scheduledDeletionTime: scheduledDeletionTime.toJSON(),
+                scheduledDeletionTime: scheduledDeletionTime?.toJSON(),
             }, null);
         } else {
             await collection.deleteOne({ _id: tenantId });


### PR DESCRIPTION
I introduced soft/hard deletion with a scheduled deletion time flag in #7701 but it does not correctly handle null case. This minor change fixes deletion calls without this field.