### PR TITLE
Include property about container close state on container logger

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -678,7 +678,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this._deltaManager.logConnectionIssue({
                         eventName,
                         duration: performance.now() - this.connectionTransitionTimes[ConnectionState.Connecting],
-                        loaded: this.loaded,
                     });
                 },
             },


### PR DESCRIPTION
Vlad and I were looking at errors and wishing for a quick way to tell if the log was firing before or after the container was closed.