### PR TITLE
Fix general error test and move it to use detached container flow.

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -22,7 +22,7 @@ import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 // REVIEW: enable compat testing?
 describeNoCompat("Errors Types", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    const fileName = uuid();
+    let fileName: string;
     const loaderContainerTracker = new LoaderContainerTracker();
     before(() => {
         provider = getTestObjectProvider();
@@ -36,6 +36,7 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                 provider.documentServiceFactory,
             codeLoader: new LocalCodeLoader([[provider.defaultCodeDetails, new TestFluidObjectFactory([])]]),
         });
+        fileName = uuid();
         loaderContainerTracker.add(loader);
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
         await container.attach(provider.driver.createCreateNewRequest(fileName));

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -4,57 +4,74 @@
  */
 
 import { strict as assert } from "assert";
-import {
-    ContainerErrorType,
-    LoaderHeader,
-} from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
-import { IRequest } from "@fluidframework/core-interfaces";
-import {
-    IFluidResolvedUrl,
-    IDocumentServiceFactory,
-    DriverErrorType,
-    IUrlResolver,
-} from "@fluidframework/driver-definitions";
-import {
-    createOdspNetworkError,
-} from "@fluidframework/odsp-doclib-utils";
+import { ContainerErrorType } from "@fluidframework/container-definitions";
+import { Container, ILoaderProps, Loader } from "@fluidframework/container-loader";
+import { IDocumentServiceFactory, DriverErrorType } from "@fluidframework/driver-definitions";
+import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import { isILoggingError, normalizeError } from "@fluidframework/telemetry-utils";
 import {
-    createDocumentId,
     LocalCodeLoader,
     LoaderContainerTracker,
     ITestObjectProvider,
+    TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 
 // REVIEW: enable compat testing?
 describeNoCompat("Errors Types", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    let urlResolver: IUrlResolver;
-    let testRequest: IRequest;
-    let testResolved: IFluidResolvedUrl;
-    let documentServiceFactory: IDocumentServiceFactory;
-    let codeLoader: LocalCodeLoader;
-    let loader: Loader;
+    const fileName = "containerTest";
     const loaderContainerTracker = new LoaderContainerTracker();
     before(() => {
         provider = getTestObjectProvider();
     });
+
+    beforeEach(async () => {
+        const loader = new Loader({
+            logger: provider.logger,
+            urlResolver: provider.urlResolver,
+            documentServiceFactory:
+                provider.documentServiceFactory,
+            codeLoader: new LocalCodeLoader([[provider.defaultCodeDetails, new TestFluidObjectFactory([])]]),
+        });
+        loaderContainerTracker.add(loader);
+        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        await container.attach(provider.driver.createCreateNewRequest(fileName));
+    });
+
     afterEach(() => {
         loaderContainerTracker.reset();
     });
 
+    async function loadContainer(props?: Partial<ILoaderProps>) {
+        const loader = new Loader({
+            ...props,
+            logger: provider.logger,
+            urlResolver: props?.urlResolver ?? provider.urlResolver,
+            documentServiceFactory:
+                props?.documentServiceFactory ?? provider.documentServiceFactory,
+            codeLoader: props?.codeLoader ??
+                new LocalCodeLoader([[provider.defaultCodeDetails, new TestFluidObjectFactory([])]]),
+        });
+        loaderContainerTracker.add(loader);
+        const requestUrl = await provider.driver.createContainerUrl(fileName);
+        const testResolved = await loader.services.urlResolver.resolve({ url: requestUrl });
+        ensureFluidResolvedUrl(testResolved);
+        return Container.load(
+            loader,
+            {
+                canReconnect: undefined,
+                clientDetailsOverride: undefined,
+                resolvedUrl: testResolved,
+                version: undefined,
+                loadMode: undefined,
+            },
+        );
+    }
+
     it("GeneralError Test", async () => {
-        const id = createDocumentId();
-        // Setup
-
-        urlResolver = provider.urlResolver;
-        testRequest = { url: await provider.driver.createContainerUrl(id) };
-        testResolved =
-            await urlResolver.resolve(testRequest) as IFluidResolvedUrl;
-        documentServiceFactory = provider.documentServiceFactory;
-
+        const documentServiceFactory = provider.documentServiceFactory;
         const mockFactory = Object.create(documentServiceFactory) as IDocumentServiceFactory;
         mockFactory.createDocumentService = async (resolvedUrl) => {
             const service = await documentServiceFactory.createDocumentService(resolvedUrl);
@@ -63,28 +80,8 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
             return service;
         };
 
-        codeLoader = new LocalCodeLoader([]);
-
-        loader = new Loader({
-            urlResolver,
-            documentServiceFactory: mockFactory,
-            codeLoader,
-            logger: provider.logger,
-        });
-        loaderContainerTracker.add(loader);
-
         try {
-            await Container.load(
-                loader,
-                {
-                    canReconnect: testRequest.headers?.[LoaderHeader.reconnect],
-                    clientDetailsOverride: testRequest.headers?.[LoaderHeader.clientDetails],
-                    resolvedUrl: testResolved,
-                    version: testRequest.headers?.[LoaderHeader.version] ?? undefined,
-                    loadMode: testRequest.headers?.[LoaderHeader.loadMode],
-                },
-            );
-
+            await loadContainer({ documentServiceFactory: mockFactory });
             assert.fail("Error expected");
         } catch (error) {
             assert(

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { v4 as uuid } from "uuid";
 import { ContainerErrorType } from "@fluidframework/container-definitions";
 import { Container, ILoaderProps, Loader } from "@fluidframework/container-loader";
 import { IDocumentServiceFactory, DriverErrorType } from "@fluidframework/driver-definitions";
@@ -21,7 +22,7 @@ import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 // REVIEW: enable compat testing?
 describeNoCompat("Errors Types", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    const fileName = "containerTest";
+    const fileName = uuid();
     const loaderContainerTracker = new LoaderContainerTracker();
     before(() => {
         provider = getTestObjectProvider();
@@ -61,11 +62,8 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
         return Container.load(
             loader,
             {
-                canReconnect: undefined,
-                clientDetailsOverride: undefined,
                 resolvedUrl: testResolved,
                 version: undefined,
-                loadMode: undefined,
             },
         );
     }


### PR DESCRIPTION
This test was not using detached container flow and it broke when we stopped created the file in odspTestDriver.ts createContainerUrl api where we wrongly used to create a new file even if it was not there.