### PR TITLE
Increase the Real Service Stress test to 2 hours

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -33,7 +33,7 @@ stages:
         poolBuild: Main
         testPackage: "@fluid-internal/test-service-load"
         testWorkspace: ${{ variables.testWorkspace }}
-        timeoutInMinutes: 60
+        timeoutInMinutes: 120
         testCommand: start
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)


### PR DESCRIPTION
The Real Service Stress Test is timing out at 60 minutes. Occasionally these tests pass because they finish before the timeout. This is an interim solution until we determine a better course of action.