### PR TITLE
Add support for running load test tool directly against PushChannel

### DIFF
--- a/api-report/test-drivers.api.md
+++ b/api-report/test-drivers.api.md
@@ -59,7 +59,7 @@ export interface IOdspTestLoginInfo {
     // (undocumented)
     password: string;
     // (undocumented)
-    server: string;
+    siteUrl: string;
     // (undocumented)
     supportsBrowserAuth?: boolean;
     // (undocumented)

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -33,7 +33,7 @@ const passwordTokenConfig = (username, password): OdspTokenConfig => ({
 });
 
 export interface IOdspTestLoginInfo {
-    server: string;
+    siteUrl: string;
     username: string;
     password: string;
     supportsBrowserAuth?: boolean
@@ -105,10 +105,10 @@ export class OdspTestDriver implements ITestDriver {
     private static readonly driveIdPCache = new Map<string, Promise<string>>();
     // Choose a single random user up front for legacy driver which doesn't support isolateSocketCache
     private static readonly legacyDriverUserRandomIndex = Math.random();
-    private static async getDriveIdFromConfig(server: string, tokenConfig: TokenConfig): Promise<string> {
-        const siteUrl = `https://${tokenConfig.server}`;
+    private static async getDriveIdFromConfig(tokenConfig: TokenConfig): Promise<string> {
+        const siteUrl = tokenConfig.siteUrl;
         try {
-            return await getDriveId(server, "", undefined,
+            return await getDriveId(siteUrl, "", undefined,
                 {
                     accessToken: await this.getStorageToken({ siteUrl, refresh: false }, tokenConfig),
                     refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: true }, tokenConfig),
@@ -119,7 +119,7 @@ export class OdspTestDriver implements ITestDriver {
             }
         }
         return getDriveId(
-            server, "", undefined,
+            siteUrl, "", undefined,
             {
                 accessToken: await this.getStorageToken({ siteUrl, refresh: false, useBrowserAuth: true }, tokenConfig),
                 refreshTokenFn:
@@ -147,8 +147,17 @@ export class OdspTestDriver implements ITestDriver {
         const username = users[userIndex];
 
         const emailServer = username.substr(username.indexOf("@") + 1);
-        const tenantName = emailServer.substr(0, emailServer.indexOf("."));
-        const server = `${tenantName}.sharepoint.com`;
+
+        let siteUrl: string;
+        let tenantName: string;
+        if (emailServer.startsWith("http://") || emailServer.startsWith("https://")) {
+            // it's already a site url
+            siteUrl = emailServer;
+            tenantName = new URL(emailServer).hostname;
+        } else {
+            siteUrl = `https://${emailServer}.sharepoint.com`;
+            tenantName = emailServer.substr(0, emailServer.indexOf("."));
+        }
 
         // force isolateSocketCache because we are using different users in a single context
         // and socket can't be shared between different users
@@ -159,7 +168,7 @@ export class OdspTestDriver implements ITestDriver {
             {
                 username,
                 password: creds[username],
-                server,
+                siteUrl,
                 supportsBrowserAuth: config?.supportsBrowserAuth,
             },
             config?.directory ?? "",
@@ -170,18 +179,18 @@ export class OdspTestDriver implements ITestDriver {
         );
     }
 
-    private static async getDriveId(server: string, tokenConfig: TokenConfig) {
-        let driveIdP = this.driveIdPCache.get(server);
+    private static async getDriveId(siteUrl: string, tokenConfig: TokenConfig) {
+        let driveIdP = this.driveIdPCache.get(siteUrl);
         if (driveIdP) {
             return driveIdP;
         }
 
-        driveIdP = this.getDriveIdFromConfig(server, tokenConfig);
-        this.driveIdPCache.set(server, driveIdP);
+        driveIdP = this.getDriveIdFromConfig(tokenConfig);
+        this.driveIdPCache.set(siteUrl, driveIdP);
         try {
             return await driveIdP;
         } catch (e) {
-            this.driveIdPCache.delete(server);
+            this.driveIdPCache.delete(siteUrl);
             throw e;
         }
     }
@@ -199,7 +208,7 @@ export class OdspTestDriver implements ITestDriver {
             ...getMicrosoftConfiguration(),
         };
 
-        const driveId = await this.getDriveId(loginConfig.server, tokenConfig);
+        const driveId = await this.getDriveId(loginConfig.siteUrl, tokenConfig);
         const directoryParts = [directory];
 
         // if we are in a azure dev ops build use the build id in the dir path
@@ -228,10 +237,11 @@ export class OdspTestDriver implements ITestDriver {
         options: OdspResourceTokenFetchOptions & { useBrowserAuth?: boolean },
         config: IOdspTestLoginInfo & IClientConfig,
     ) {
-        const hostname = new URL(options.siteUrl).hostname;
+        const host = new URL(options.siteUrl).host;
+
         if (options.useBrowserAuth === true) {
             const browserTokens = await this.odspTokenManager.getOdspTokens(
-                hostname,
+                host,
                 config,
                 {
                     type: "browserLogin",
@@ -250,7 +260,7 @@ export class OdspTestDriver implements ITestDriver {
         // This function can handle token request for any multiple sites.
         // Where the test driver is for a specific site.
         const tokens = await this.odspTokenManager.getOdspTokens(
-            new URL(options.siteUrl).hostname,
+            host,
             config,
             passwordTokenConfig(config.username, config.password),
             options.refresh,
@@ -277,9 +287,9 @@ export class OdspTestDriver implements ITestDriver {
      */
     async createContainerUrl(testId: string): Promise<string> {
         if (!this.testIdToUrl.has(testId)) {
-            const siteUrl = `https://${this.config.server}`;
+            const siteUrl = this.config.siteUrl;
             const driveItem = await getDriveItemByRootFileName(
-                this.config.server,
+                this.config.siteUrl,
                 undefined,
                 `/${this.config.directory}/${testId}.fluid`,
                 {
@@ -316,7 +326,7 @@ export class OdspTestDriver implements ITestDriver {
 
     createCreateNewRequest(testId: string): IRequest {
         return this.api.createOdspCreateContainerRequest(
-            `https://${this.config.server}`,
+            this.config.siteUrl,
             this.config.driveId,
             this.config.directory,
             `${testId}.fluid`,
@@ -329,7 +339,7 @@ export class OdspTestDriver implements ITestDriver {
 
     private async getPushToken(options: OdspResourceTokenFetchOptions) {
         const tokens = await OdspTestDriver.odspTokenManager.getPushTokens(
-            new URL(options.siteUrl).hostname,
+            new URL(options.siteUrl).host,
             this.config,
             passwordTokenConfig(this.config.username, this.config.password),
             options.refresh,
@@ -340,7 +350,7 @@ export class OdspTestDriver implements ITestDriver {
 
     public getUrlFromItemId(itemId: string) {
         return this.api.createOdspUrl({
-            siteUrl: `https://${this.config.server}`,
+            siteUrl: this.config.siteUrl,
             driveId: this.config.driveId,
             itemId,
             dataStorePath: "/",

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -152,11 +152,11 @@ export class OdspTestDriver implements ITestDriver {
         let tenantName: string;
         if (emailServer.startsWith("http://") || emailServer.startsWith("https://")) {
             // it's already a site url
-            siteUrl = emailServer;
             tenantName = new URL(emailServer).hostname;
+            siteUrl = emailServer;
         } else {
-            siteUrl = `https://${emailServer}.sharepoint.com`;
             tenantName = emailServer.substr(0, emailServer.indexOf("."));
+            siteUrl = `https://${tenantName}.sharepoint.com`;
         }
 
         // force isolateSocketCache because we are using different users in a single context

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { getAadTenant } from "./odspDocLibUtils";
+import { getAadTenant, getAadUrl, getSiteUrl } from "./odspDocLibUtils";
 import { throwOdspNetworkError } from "./odspErrorUtils";
 import { unauthPostAsync } from "./odspRequest";
 
@@ -43,11 +43,11 @@ type TokenRequestBody =
         scope: string,
     };
 
-export const getOdspScope = (server: string) => `offline_access https://${server}/AllSites.Write`;
+export const getOdspScope = (server: string) => `offline_access ${getSiteUrl(server)}/AllSites.Write`;
 export const pushScope = "offline_access https://pushchannel.1drv.ms/PushChannel.ReadWrite.All";
 
 export function getFetchTokenUrl(server: string): string {
-    return `https://login.microsoftonline.com/${getAadTenant(server)}/oauth2/v2.0/token`;
+    return `${getAadUrl(server)}/${getAadTenant(server)}/oauth2/v2.0/token`;
 }
 
 export function getLoginPageUrl(
@@ -56,7 +56,7 @@ export function getLoginPageUrl(
     scope: string,
     odspAuthRedirectUri: string,
 ) {
-    return `https://login.microsoftonline.com/${getAadTenant(server)}/oauth2/v2.0/authorize?`
+    return `${getAadUrl(server)}/${getAadTenant(server)}/oauth2/v2.0/authorize?`
         + `client_id=${clientConfig.clientId}`
         + `&scope=${scope}`
         + `&response_type=code`

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -8,11 +8,37 @@ const odspTenants = new Map<string, string>([
     ["spo-df", "microsoft-my.sharepoint-df.com"],
 ]);
 
-export function isOdspHostname(hostname: string) {
-    return hostname.endsWith("sharepoint.com") || hostname.endsWith("sharepoint-df.com");
+export function isOdspHostname(server: string) {
+    return server.endsWith("sharepoint.com") || server.endsWith("sharepoint-df.com");
 }
 
-export function getAadTenant(hostname: string) {
+export function isPushChannelHostname(server: string) {
+    return server === "localhost:3000" || (server.includes(".push") && server.endsWith(".svc.ms"));
+}
+
+export function getAadUrl(server: string) {
+    if (isPushChannelHostname(server)) {
+        // special case for local / pushchannel testing
+        // if the SPO url is pushchannel, use the pushchannel AAD mock
+        if (server === "localhost:3000") {
+            return `http://localhost:3000`;
+        }
+
+        return getSiteUrl(server);
+    }
+
+    return `https://login.microsoftonline.com`;
+}
+
+export function getAadTenant(server: string) {
+    let hostname = server;
+
+    if (hostname.startsWith("http://")) {
+        hostname = hostname.substring(7);
+    } else if (hostname.startsWith("https://")) {
+        hostname = hostname.substring(8);
+    }
+
     let tenantName = hostname.substr(0, hostname.indexOf(".")).toLowerCase();
     let restOfTenantHostname = hostname.substr(tenantName.length).toLowerCase();
 
@@ -37,4 +63,14 @@ export function getServer(tenantId: string): string {
         throw Error(`Invalid SPO tenantId ${tenantId}.`);
     }
     return server;
+}
+
+export function getSiteUrl(server: string) {
+    if (server.startsWith("http://") || server.startsWith("https://")) {
+        // server is already a site url
+        return server;
+    }
+
+    // server is likely {tenantId}.sharepoint.com. add https to make it the site url
+    return `https://${server}`;
 }

--- a/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDocLibUtils.ts
@@ -13,17 +13,18 @@ export function isOdspHostname(server: string) {
 }
 
 export function isPushChannelHostname(server: string) {
-    return server === "localhost:3000" || (server.includes(".push") && server.endsWith(".svc.ms"));
+    return server.includes(".push") && server.endsWith(".svc.ms");
 }
 
 export function getAadUrl(server: string) {
-    if (isPushChannelHostname(server)) {
-        // special case for local / pushchannel testing
-        // if the SPO url is pushchannel, use the pushchannel AAD mock
-        if (server === "localhost:3000") {
-            return `http://localhost:3000`;
-        }
+    // special case for local / pushchannel testing
+    if (server === "localhost" || server.startsWith("localhost:")) {
+        // localhost will not be https
+        return `http://${server}`;
+    }
 
+    if (isPushChannelHostname(server)) {
+        // if the SPO url is pushchannel, use the pushchannel AAD mock
         return getSiteUrl(server);
     }
 

--- a/packages/utils/odsp-doclib-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDrives.ts
@@ -4,6 +4,7 @@
  */
 
 import { IOdspAuthRequestInfo } from "./odspAuth";
+import { getSiteUrl } from "./odspDocLibUtils";
 import { throwOdspNetworkError } from "./odspErrorUtils";
 import { getAsync, putAsync } from "./odspRequest";
 
@@ -66,9 +67,9 @@ export async function getDriveItemByRootFileName(
     let getDriveItemUrl;
     if (driveId !== undefined && driveId !== "") {
         const encodedDrive = encodeURIComponent(driveId);
-        getDriveItemUrl = `https://${server}${accountPath}/_api/v2.1/drives/${encodedDrive}/root:${path}:`;
+        getDriveItemUrl = `${getSiteUrl(server)}${accountPath}/_api/v2.1/drives/${encodedDrive}/root:${path}:`;
     } else {
-        getDriveItemUrl = `https://${server}${accountPath}/_api/v2.1/drive/root:${path}:`;
+        getDriveItemUrl = `${getSiteUrl(server)}${accountPath}/_api/v2.1/drive/root:${path}:`;
     }
     return getDriveItem(getDriveItemUrl, authRequestInfo, create);
 }
@@ -99,7 +100,7 @@ export async function getDriveItemByServerRelativePath(
     }
     const path = `/${pathParts.join("/")}`;
     const driveId = await getDriveId(server, account, library, authRequestInfo);
-    const getDriveItemUrl = `https://${server}/_api/v2.1/drives/${driveId}/root:${path}:`;
+    const getDriveItemUrl = `${getSiteUrl(server)}/_api/v2.1/drives/${driveId}/root:${path}:`;
     return getDriveItem(getDriveItemUrl, authRequestInfo, create);
 }
 
@@ -109,7 +110,7 @@ export async function getDriveItemFromDriveAndItem(
     item: string,
     authRequestInfo: IOdspAuthRequestInfo,
 ): Promise<IOdspDriveItem> {
-    const url = `https://${server}/_api/v2.1/drives/${drive}/items/${item}`;
+    const url = `${getSiteUrl(server)}/_api/v2.1/drives/${drive}/items/${item}`;
     return getDriveItem(url, authRequestInfo, false);
 }
 
@@ -119,7 +120,7 @@ export async function getChildrenByDriveItem(
     authRequestInfo: IOdspAuthRequestInfo,
 ): Promise<IOdspDriveItem[]> {
     if (!driveItem.isFolder) { return []; }
-    let url = `https://${server}/_api/v2.1/drives/${driveItem.driveId}/items/${driveItem.itemId}/children`;
+    let url = `${getSiteUrl(server)}/_api/v2.1/drives/${driveItem.driveId}/items/${driveItem.itemId}/children`;
     let children: any[] = [];
     do {
         const response = await getAsync(url, authRequestInfo);
@@ -167,14 +168,13 @@ export async function getDriveId(
     library: string | undefined,
     authRequestInfo: IOdspAuthRequestInfo,
 ): Promise<string> {
-    if (library === undefined)
-    {
+    if (library === undefined) {
         const drive = await getDefaultDrive(server, account, authRequestInfo);
         return drive.id;
     }
     const drives = await getDrives(server, account, authRequestInfo);
     const accountPath = account ? `/${account}` : "";
-    const drivePath = encodeURI(`https://${server}${accountPath}/${library}`);
+    const drivePath = encodeURI(`${getSiteUrl(server)}${accountPath}/${library}`);
     const index = drives.findIndex((value) => value.webUrl === drivePath);
     if (index === -1) {
         throw Error(`Drive ${drivePath} not found.`);
@@ -209,7 +209,7 @@ async function getDriveResponse(
     authRequestInfo: IOdspAuthRequestInfo,
 ) {
     const accountPath = account ? `/${account}` : "";
-    const getDriveUrl = `https://${server}${accountPath}/_api/v2.1/${routeTail}`;
+    const getDriveUrl = `${getSiteUrl(server)}${accountPath}/_api/v2.1/${routeTail}`;
     const response = await getAsync(getDriveUrl, authRequestInfo);
     if (response.status !== 200) {
         throwOdspNetworkError("failedToGetDriveResponse", response.status, response, undefined, { route: routeTail });


### PR DESCRIPTION
This change adds support for pointing the service load test tool at a specific Push server / test cluster.

We can do this because PushChannel test clusters have a built in mock for ODSP & AAD.
- All the ODSP opStream apis are supported for calls from odsp-driver
- The AAD `/token` api is supported for fetching fake storage & socket tokens.
- The majority of Push's unit tests run against this mock server so it's known to work with the odsp-driver version we consume for the tests.

Adding support for this required some changes:
- The siteUrl for ODSP calls was defaulting to `https://${server}`. That makes sense for SPO but that doesn't work for a local Push dev install (`http://localhost:3000`). So it will now detect if `server` already has `https://` or `http://` in the string and not mess with it.

- The AAD url was hard coded to `https://login.microsoftonline.com`. AAD `/token` requests need to be redirected to the Push AAD mock to work correctly. So when the `server` (SPO url) points to a PushChannel server, it will use that url as AAD.
As an aside, this logic does need to stop being hard coded at some point in order to support Gov/AirGap clouds.

- There are a few cases of things like `new URL(siteUrl).hostname`, which is an issue since `hostname` stripping out the port. So those will now use `host`, which includes the port when it's not 80/443.

The end result is that I can set `$env:login__odsp__test__accounts ='{"user1@http://localhost:3000": "password"}'` and the tests successfully runs against my local Push instance. It should also work against a real cluster deployed in Azure (pending a Push deployment with some changes).
This should be useful for testing client/Push changes because we can run large scale tests against test Push clusters whenever we want.
