### PR TITLE
Remove redundant `maxMessageSize` property

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -11,7 +11,10 @@ There are a few steps you can take to write a good change note and avoid needing
 - Consider providing code examples as part of guidance for non-trivial changes.
 
 ## 0.51 Breaking changes
-- [OpProcessingController removed](#OpProcessingController-removed)
+- [`maxMessageSize` property has been deprecated from IConnectionDetails and IDocumentDeltaConnection](#maxMessageSize-property-has-been-deprecated-from-IConnectionDetails-and-IDocumentDeltaConnection)
+
+## `maxMessageSize` property has been deprecated from IConnectionDetails and IDocumentDeltaConnection
+`maxMessageSize` is redundant and will be removed soon. Please use the `serviceConfiguration.maxMessageSize` property instead.
 
 ## 0.50 Breaking changes
 - [OpProcessingController removed](#OpProcessingController-removed)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -10,6 +10,9 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
+## 0.51 Breaking changes
+- [OpProcessingController removed](#OpProcessingController-removed)
+
 ## 0.50 Breaking changes
 - [OpProcessingController removed](#OpProcessingController-removed)
 - [Expose isDirty flag in the FluidContainer](#Expose-isDirty-flag-in-the-FluidContainer)

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -165,7 +165,7 @@ The dependencies between layers are enforced by the layer-check command._
 
 | Packages | Layer Dependencies |
 | --- | --- |
-| - [@fluid-experimental/get-container](/experimental/framework/get-container)</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp; | - [Base-Definitions](#Base-Definitions)</br>- [Protocol-Definitions](#Protocol-Definitions)</br>- [Driver-Definitions](#Driver-Definitions)</br>- [Container-Definitions](#Container-Definitions)</br>- [Loader](#Loader)</br>- [Server-Libs](#Server-Libs)</br>- [Routerlicious-Driver](#Routerlicious-Driver)</br>- [Test](#Test) |
+| - [@fluid-experimental/get-container](/experimental/framework/get-container)</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp;</br>&nbsp; | - [Base-Definitions](#Base-Definitions)</br>- [Protocol-Definitions](#Protocol-Definitions)</br>- [Driver-Definitions](#Driver-Definitions)</br>- [Container-Definitions](#Container-Definitions)</br>- [Driver-Utils](#Driver-Utils)</br>- [Loader](#Loader)</br>- [Server-Libs](#Server-Libs)</br>- [Routerlicious-Driver](#Routerlicious-Driver)</br>- [Test](#Test) |
 
 ### Examples
 

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -100,7 +100,7 @@ export interface IConnectionDetails {
     existing: boolean;
     // (undocumented)
     initialClients: ISignalClient[];
-    // (undocumented)
+    // @deprecated (undocumented)
     maxMessageSize: number;
     // (undocumented)
     mode: ConnectionMode;

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -25,7 +25,6 @@ export interface IConnectionDetails {
     mode: ConnectionMode;
     version: string;
     initialClients: ISignalClient[];
-    maxMessageSize: number;
     serviceConfiguration: IClientConfiguration;
     /**
      * Last known sequence number to ordering service at the time of connection

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -25,6 +25,10 @@ export interface IConnectionDetails {
     mode: ConnectionMode;
     version: string;
     initialClients: ISignalClient[];
+    /**
+     * @deprecated - please use `serviceConfiguration.maxMessageSize`
+     */
+    maxMessageSize: number;
     serviceConfiguration: IClientConfiguration;
     /**
      * Last known sequence number to ordering service at the time of connection

--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -96,6 +96,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     initialClients: ISignalClient[];
     initialMessages: ISequencedDocumentMessage[];
     initialSignals: ISignalMessage[];
+    // @deprecated
     maxMessageSize: number;
     mode: ConnectionMode;
     serviceConfiguration: IClientConfiguration;

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -170,6 +170,13 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     existing: boolean;
 
     /**
+     * Maximum size of a message that can be sent to the server. Messages larger than this size must be chunked.
+     *
+     * @deprecated - please use `serviceConfiguration.maxMessageSize`
+     */
+     maxMessageSize: number;
+
+    /**
      * Protocol version being used with the service
      */
     version: string;

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -170,11 +170,6 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     existing: boolean;
 
     /**
-     * Maximum size of a message that can be sent to the server. Messages larger than this size must be chunked.
-     */
-    maxMessageSize: number;
-
-    /**
      * Protocol version being used with the service
      */
     version: string;

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -174,7 +174,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
      *
      * @deprecated - please use `serviceConfiguration.maxMessageSize`
      */
-     maxMessageSize: number;
+    maxMessageSize: number;
 
     /**
      * Protocol version being used with the service

--- a/experimental/dds/tree/api/tree.api.md
+++ b/experimental/dds/tree/api/tree.api.md
@@ -98,7 +98,7 @@ export abstract class Checkout<TChange> extends EventEmitterWithErrorHandling<IC
     // @internal (undocumented)
     hasOpenEdit(): boolean;
     protected hintKnownEditingResult(edit: Edit<TChange>, result: ValidEditingResult<TChange>): void;
-    protected abstract readonly latestCommittedView: Snapshot;
+    protected abstract get latestCommittedView(): Snapshot;
     openEdit(): void;
     rebaseCurrentEdit(): EditValidationResult.Valid | EditValidationResult.Invalid;
     readonly tree: GenericSharedTree<TChange>;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -181,7 +181,7 @@ export class DocumentDeltaConnection
      * @returns the maximum size of a message before chunking is required
      */
     public get maxMessageSize(): number {
-        return this.details.maxMessageSize;
+        return this.details.serviceConfiguration.maxMessageSize;
     }
 
     /**

--- a/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
@@ -127,7 +127,7 @@ export class ReplayFileDeltaConnection
             mode,
             serviceConfiguration: {
                 blockSize: 64436,
-                maxMessageSize: 16 * 1024,
+                maxMessageSize: ReplayMaxMessageSize,
                 summary: {
                     idleTime: 5000,
                     maxOps: 1000,

--- a/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
@@ -100,7 +100,7 @@ export class InnerDocumentDeltaConnection
      * @returns the maximum size of a message before chunking is required
      */
     public get maxMessageSize(): number {
-        return this.details.maxMessageSize;
+        return this.details.serviceConfiguration.maxMessageSize;
     }
 
     /**

--- a/packages/drivers/iframe-driver/src/outerDocumentServiceFactory.ts
+++ b/packages/drivers/iframe-driver/src/outerDocumentServiceFactory.ts
@@ -223,7 +223,7 @@ export class DocumentServiceFactoryProxy implements IDocumentServiceFactoryProxy
             get initialClients() { return deltaStream.initialClients; },
             get initialMessages() { return deltaStream.initialMessages; },
             get initialSignals() { return deltaStream.initialSignals; },
-            maxMessageSize: deltaStream.maxMessageSize,
+            maxMessageSize: deltaStream.serviceConfiguration.maxMessageSize,
             mode: deltaStream.mode,
             serviceConfiguration: deltaStream.serviceConfiguration,
             version: deltaStream.version,

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -201,7 +201,7 @@ export class ReplayDocumentDeltaConnection
             mode: "read",
             serviceConfiguration: {
                 blockSize: 64436,
-                maxMessageSize: 16 * 1024,
+                maxMessageSize: ReplayDocumentDeltaConnection.ReplayMaxMessageSize,
                 summary: {
                     idleTime: 5000,
                     maxOps: 1000,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -128,7 +128,11 @@ class NoDeltaStream
     initialMessages: ISequencedDocumentMessage[] = [];
     initialSignals: ISignalMessage[] = [];
     initialClients: ISignalClient[] = [];
-    serviceConfiguration: IClientConfiguration = undefined as any;
+    serviceConfiguration: IClientConfiguration = {
+        maxMessageSize: 0,
+        blockSize: 0,
+        summary: undefined as any,
+    };
     checkpointSequenceNumber?: number | undefined = undefined;
     submit(messages: IDocumentMessage[]): void {
         this.emit("nack", this.clientId, messages.map((operation) => {
@@ -297,7 +301,6 @@ export class DeltaManager
 
     public get maxMessageSize(): number {
         return this.connection?.serviceConfiguration?.maxMessageSize
-            ?? this.connection?.maxMessageSize
             ?? DefaultChunkSize;
     }
 
@@ -634,7 +637,7 @@ export class DeltaManager
             existing: connection.existing,
             checkpointSequenceNumber: connection.checkpointSequenceNumber,
             get initialClients() { return connection.initialClients; },
-            maxMessageSize: connection.maxMessageSize,
+            maxMessageSize: connection.serviceConfiguration.maxMessageSize,
             mode: connection.mode,
             serviceConfiguration: connection.serviceConfiguration,
             version: connection.version,
@@ -1147,7 +1150,7 @@ export class DeltaManager
         assert(this.connection === undefined, 0x0e6 /* "old connection exists on new connection setup" */);
 
         assert(this.connectionP !== undefined || this.closed,
-            0x27f /* "reentrnacy may result in incorrect behavior" */);
+            0x27f /* "reentrancy may result in incorrect behavior" */);
 
         // back-compat: added in 0.45. Make it unconditional (i.e. use connection.disposable) in some future.
         const disposable = connection as Partial<IDisposable>;

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -100,7 +100,7 @@ extends EventForwarder<IDocumentDeltaConnectionEvents> implements IDocumentDelta
 
     public get mode() { return this.internal.mode; }
     public get existing() { return this.internal.existing; }
-    public get maxMessageSize() { return this.internal.maxMessageSize; }
+    public get maxMessageSize() { return this.internal.serviceConfiguration.maxMessageSize; }
     public get version() { return this.internal.version; }
     public get initialMessages() { return this.internal.initialMessages; }
 


### PR DESCRIPTION
Part of https://github.com/microsoft/FluidFramework/issues/7599