### PR TITLE
Bump LTS branch

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -33,8 +33,8 @@ interface CompatConfig {
 
 // N, N - 1, and N - 2
 const defaultVersions = [0, -1, -2];
-// we are currently supporting 0.39 long-term
-const LTSVersions = ["^0.39.0"];
+// we are currently supporting 0.45 long-term
+const LTSVersions = ["^0.45.0"];
 
 function genConfig(compatVersion: number | string): CompatConfig[] {
     if (compatVersion === 0) {


### PR DESCRIPTION
Resolves https://github.com/microsoft/FluidFramework/issues/7349
Please note that I did not add sample test that Navin provided.
It passes, but I see other failures (in other tests, when running with ODSP), so not sure what's the process there to actually get these things enabled in CI loop.

The actual bug was fixed https://github.com/microsoft/FluidFramework/pull/6898/files in 0.45, and the changed made in 0.46 (allowing PUSH to enable new policy) indirectly dependent on that fix. The fix itself was very broad and was needed in general as we saw containers getting stuck with or without that new policy, so there is really no other way for customers to get improvements in this space other than being on 0.45 version of loader.

Luckily, the very last host (Office.com) finally moved from 0.40 to 0.48 last week, so we could start deprecation of 0.39 (it will take another two weeks for these changes and any potential future regressions to 0.39 loader config to hit hosts, so there is enough time for existing changes in all hosts to saturate to reasonable levels).

If we want to, we can wait a bit with this change to keep 0.39 mostly working (and not regressing)