### PR TITLE
[bump] package version for eslint-config-fluid (patch)

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -302,9 +302,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.24.0-40592",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0-40592.tgz",
-      "integrity": "sha512-CppHlFSk3SYZil//u1JOAU0OUU2384vf4lajwgGRax6obySHLPLSg8ZWivZKW8XV4YQ9NmnIgfxtQXvP6RBMNQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0.tgz",
+      "integrity": "sha512-AkAf3hQXVOcPuyeYCqcgpu/YSjVNdY2n1XspL3u763is4TDQSavdWiBu6KmTSmhdTPObFJh9U3NVIOxV2TBLSg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.4.0",

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.40870",
     "@fluidframework/common-definitions-0.20.0": "npm:@fluidframework/common-definitions@0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.24.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.24.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -548,9 +548,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.24.0-40592",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0-40592.tgz",
-      "integrity": "sha512-CppHlFSk3SYZil//u1JOAU0OUU2384vf4lajwgGRax6obySHLPLSg8ZWivZKW8XV4YQ9NmnIgfxtQXvP6RBMNQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0.tgz",
+      "integrity": "sha512-AkAf3hQXVOcPuyeYCqcgpu/YSjVNdY2n1XspL3u763is4TDQSavdWiBu6KmTSmhdTPObFJh9U3NVIOxV2TBLSg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.4.0",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.40870",
     "@fluidframework/common-utils-0.32.1": "npm:@fluidframework/common-utils@0.32.1",
-    "@fluidframework/eslint-config-fluid": "^0.24.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.24.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/base64-js": "^1.3.0",
     "@types/benchmark": "^2.1.0",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -519,9 +519,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.24.0-40592",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0-40592.tgz",
-      "integrity": "sha512-CppHlFSk3SYZil//u1JOAU0OUU2384vf4lajwgGRax6obySHLPLSg8ZWivZKW8XV4YQ9NmnIgfxtQXvP6RBMNQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0.tgz",
+      "integrity": "sha512-AkAf3hQXVOcPuyeYCqcgpu/YSjVNdY2n1XspL3u763is4TDQSavdWiBu6KmTSmhdTPObFJh9U3NVIOxV2TBLSg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.4.0",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-tools": "^0.2.40870",
     "@fluidframework/container-definitions-0.39.8": "npm:@fluidframework/container-definitions@0.39.8",
     "@fluidframework/container-definitions-0.40.0": "npm:@fluidframework/container-definitions@0.40.0",
-    "@fluidframework/eslint-config-fluid": "^0.24.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.24.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.0",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -434,9 +434,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.24.0-40592",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0-40592.tgz",
-      "integrity": "sha512-CppHlFSk3SYZil//u1JOAU0OUU2384vf4lajwgGRax6obySHLPLSg8ZWivZKW8XV4YQ9NmnIgfxtQXvP6RBMNQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0.tgz",
+      "integrity": "sha512-AkAf3hQXVOcPuyeYCqcgpu/YSjVNdY2n1XspL3u763is4TDQSavdWiBu6KmTSmhdTPObFJh9U3NVIOxV2TBLSg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.4.0",

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.40870",
     "@fluidframework/core-interfaces-0.39.8": "npm:@fluidframework/core-interfaces@0.39.8",
-    "@fluidframework/eslint-config-fluid": "^0.24.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.24.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/node": "^12.19.0",
     "@typescript-eslint/eslint-plugin": "~4.14.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -485,9 +485,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.24.0-40592",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0-40592.tgz",
-      "integrity": "sha512-CppHlFSk3SYZil//u1JOAU0OUU2384vf4lajwgGRax6obySHLPLSg8ZWivZKW8XV4YQ9NmnIgfxtQXvP6RBMNQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0.tgz",
+      "integrity": "sha512-AkAf3hQXVOcPuyeYCqcgpu/YSjVNdY2n1XspL3u763is4TDQSavdWiBu6KmTSmhdTPObFJh9U3NVIOxV2TBLSg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.4.0",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-tools": "^0.2.40870",
     "@fluidframework/driver-definitions-0.39.8": "npm:@fluidframework/driver-definitions@0.39.8",
     "@fluidframework/driver-definitions-0.40.0": "npm:@fluidframework/driver-definitions@0.40.0",
-    "@fluidframework/eslint-config-fluid": "^0.24.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.24.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@typescript-eslint/eslint-plugin": "~4.14.0",
     "@typescript-eslint/parser": "~4.14.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -433,9 +433,9 @@
       "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.24.0-40592",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0-40592.tgz",
-      "integrity": "sha512-CppHlFSk3SYZil//u1JOAU0OUU2384vf4lajwgGRax6obySHLPLSg8ZWivZKW8XV4YQ9NmnIgfxtQXvP6RBMNQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.24.0.tgz",
+      "integrity": "sha512-AkAf3hQXVOcPuyeYCqcgpu/YSjVNdY2n1XspL3u763is4TDQSavdWiBu6KmTSmhdTPObFJh9U3NVIOxV2TBLSg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.4.0",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.40870",
-    "@fluidframework/eslint-config-fluid": "^0.24.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.24.0",
     "@fluidframework/protocol-definitions-0.1024.0": "npm:@fluidframework/protocol-definitions@0.1024.0",
     "@fluidframework/protocol-definitions-0.1025.1": "npm:@fluidframework/protocol-definitions@0.1025.1",
     "@microsoft/api-extractor": "^7.16.1",


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.0 -> 0.24.1
      @fluidframework/common-definitions:     0.21.0 (unchanged)
            @fluidframework/common-utils:     0.33.0 (unchanged)
          @fluidframework/core-interfaces:     0.40.0 (unchanged)
    @fluidframework/protocol-definitions:   0.1026.0 (unchanged)
      @fluidframework/driver-definitions:     0.41.0 (unchanged)
    @fluidframework/container-definitions:     0.41.0 (unchanged)
                                  Server:   0.1033.0 (unchanged)
                                  Client:     0.50.0 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for eslint-config-fluid
     @fluidframework/eslint-config-fluid -> ^0.24.0