### PR TITLE
[bump] package version for core-interfaces (patch)

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -504,9 +504,9 @@
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.40.0-40653",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0-40653.tgz",
-      "integrity": "sha512-6D661o/dExlMPQBC0g6SrFBX3KecfxLwMXGEayjEsBhAuWgCJvRUEhdLYF/wSzWEOp8Qsp/O1XTRJSS1vKBJtQ=="
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0.tgz",
+      "integrity": "sha512-/QC26qfNamlHox3+YkfWz7q14cp4SA5CEcdi7vxytuDXlhrWOpNTCLT+BLXI4AxTO3KDTSqrYJTUTMgNGOfYng=="
     },
     "@fluidframework/driver-definitions": {
       "version": "0.41.0-40682",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -18,7 +18,7 @@
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:gen": "npm run build:gen:typetests",
-    "build:gen:typetests": "fluid-type-validator -d .",
+    "build:gen:typetests": "echo skipped",
     "build:test": "tsc --project ./src/test/types/tsconfig.json",
     "ci:build": "npm run build:gen && npm run build:compile",
     "ci:build:docs": "api-extractor run --typescript-compiler-folder ./node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/core-interfaces",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/core-interfaces",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Fluid object interfaces",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -18,7 +18,7 @@
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:gen": "npm run build:gen:typetests",
-    "build:gen:typetests": "fluid-type-validator -d .",
+    "build:gen:typetests": "echo skipped",
     "ci:build": "npm run build:gen && npm run build:compile",
     "ci:build:docs": "api-extractor run --typescript-compiler-folder ./node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",
     "ci:test": "echo No test for this package",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -433,9 +433,9 @@
       "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.40.0-40653",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0-40653.tgz",
-      "integrity": "sha512-6D661o/dExlMPQBC0g6SrFBX3KecfxLwMXGEayjEsBhAuWgCJvRUEhdLYF/wSzWEOp8Qsp/O1XTRJSS1vKBJtQ=="
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0.tgz",
+      "integrity": "sha512-/QC26qfNamlHox3+YkfWz7q14cp4SA5CEcdi7vxytuDXlhrWOpNTCLT+BLXI4AxTO3KDTSqrYJTUTMgNGOfYng=="
     },
     "@fluidframework/driver-definitions-0.39.8": {
       "version": "npm:@fluidframework/driver-definitions@0.39.8",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0"
   },
   "devDependencies": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -18,7 +18,7 @@
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",
     "build:gen": "npm run build:gen:typetests",
-    "build:gen:typetests": "fluid-type-validator -d .",
+    "build:gen:typetests": "echo skipped",
     "ci:build": "npm run build:gen && npm run build:compile",
     "ci:build:docs": "api-extractor run --typescript-compiler-folder ./node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",
     "ci:test": "echo No test for this package",

--- a/examples/agents/intelligence-runner-agent/package.json
+++ b/examples/agents/intelligence-runner-agent/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/sequence": "^0.50.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -37,7 +37,7 @@
     "@fluid-experimental/react-inputs": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/sequence": "^0.50.0",
     "@fluidframework/view-interfaces": "^0.50.0",
     "css-loader": "^1.0.0",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/runtime-utils": "^0.50.0",
     "css-loader": "^1.0.0",
     "react": "^16.10.2",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -44,7 +44,7 @@
     "@fluid-experimental/get-container": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/runtime-definitions": "^0.50.0",
     "@fluidframework/runtime-utils": "^0.50.0",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/cell": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/sequence": "^0.50.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/example-utils": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/ink": "^0.50.0",
     "react": "^16.10.2"
   },

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/task-manager": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/runtime-definitions": "^0.50.0",
     "react": "^16.10.2"

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -52,7 +52,7 @@
     "@fluid-example/search-menu": "^0.50.0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/ink": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -37,7 +37,7 @@
     "@fluid-example/client-ui-lib": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/merge-tree": "^0.50.0",
     "@fluidframework/runtime-definitions": "^0.50.0",
     "@fluidframework/sequence": "^0.50.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/multiview-coordinate-model": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/map": "^0.50.0"
   },
   "devDependencies": {

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -37,7 +37,7 @@
     "@fluid-example/example-utils": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/map": "^0.50.0",
     "react": "^16.10.2"
   },

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/merge-tree": "^0.50.0",
     "@types/node": "^12.19.0"
   },

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/ink": "^0.50.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/merge-tree": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/runtime-utils": "^0.50.0",
     "@fluidframework/sequence": "^0.50.0",
     "@fluidframework/view-interfaces": "^0.50.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/request-handler": "^0.50.0",
     "@fluidframework/runtime-utils": "^0.50.0",
     "css-loader": "^1.0.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/cell": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/runtime-definitions": "^0.50.0",
     "@fluidframework/sequence": "^0.50.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -72,7 +72,7 @@
     "@fluid-example/flow-util-lib": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/data-object-base": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/merge-tree": "^0.50.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/view-adapters": "^0.50.0",
     "@fluidframework/view-interfaces": "^0.50.0",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0"
+    "@fluidframework/core-interfaces": "^0.40.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/routerlicious-driver": "^0.50.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/iframe-driver": "^0.50.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -26,7 +26,7 @@
     "@fluid-example/key-value-cache": "^0.50.0",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/routerlicious-driver": "^0.50.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/data-object-base": "^0.50.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/data-object-base": "^0.50.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -34,7 +34,7 @@
     "@fluid-experimental/property-changeset": "^0.50.0",
     "@fluid-experimental/property-properties": "^0.50.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/shared-object-base": "^0.50.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/shared-object-base": "^0.50.0"

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluid-experimental/ot": "^0.50.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/shared-object-base": "^0.50.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/shared-object-base": "^0.50.0",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-base": "^0.1033.0-41017",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/view-interfaces": "^0.50.0",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -52,7 +52,7 @@
     "@fluid-experimental/tree": "^0.50.0",
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/view-interfaces": "^0.50.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/view-interfaces": "^0.50.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",
     "@fluidframework/view-interfaces": "^0.50.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/local-driver": "^0.50.0",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/runtime-utils": "^0.50.0",
     "@fluidframework/shared-summary-block": "^0.50.0"

--- a/experimental/framework/react/package.json
+++ b/experimental/framework/react/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.50.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2014,9 +2014,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.40.0-40653",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0-40653.tgz",
-			"integrity": "sha512-6D661o/dExlMPQBC0g6SrFBX3KecfxLwMXGEayjEsBhAuWgCJvRUEhdLYF/wSzWEOp8Qsp/O1XTRJSS1vKBJtQ=="
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.40.0.tgz",
+			"integrity": "sha512-/QC26qfNamlHox3+YkfWz7q14cp4SA5CEcdi7vxytuDXlhrWOpNTCLT+BLXI4AxTO3KDTSqrYJTUTMgNGOfYng=="
 		},
 		"@fluidframework/driver-definitions": {
 			"version": "0.41.0-40682",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-base": "^0.1033.0-41017",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/merge-tree": "^0.50.0",
     "@fluidframework/protocol-base": "^0.1033.0-41017",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/telemetry-utils": "^0.50.0"

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/shared-object-base": "^0.50.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-base": "^0.1033.0-41017",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/merge-tree": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/odsp-driver": "^0.50.0",
     "@fluidframework/odsp-driver-definitions": "^0.50.0"

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-base": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-base": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/odsp-driver": "^0.50.0",
     "@fluidframework/odsp-driver-definitions": "^0.50.0"

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "axios": "^0.21.1"
   },

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "nconf": "^0.11.0"

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/fluid-static": "^0.50.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/request-handler": "^0.50.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/request-handler": "^0.50.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/runtime-definitions": "^0.50.0",
     "@fluidframework/runtime-utils": "^0.50.0"
   },

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -58,7 +58,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.40.0-0"
+    "@fluidframework/core-interfaces": "^0.40.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/view-interfaces": "^0.50.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.40.0-0"
+    "@fluidframework/core-interfaces": "^0.40.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/hosts/base-host/package.json
+++ b/packages/hosts/base-host/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/telemetry-utils": "^0.50.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-utils": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/protocol-base": "^0.1033.0-41017",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/gitresources": "^0.1033.0-41017",
     "@fluidframework/protocol-base": "^0.1033.0-41017",

--- a/packages/loader/execution-context-loader/package.json
+++ b/packages/loader/execution-context-loader/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "comlink": "^4.3.0"

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/map": "^0.50.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/runtime-definitions": "^0.50.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
     "@fluidframework/container-utils": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/runtime-definitions": "^0.50.0",
     "@types/node": "^12.19.0"

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-utils": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -29,7 +29,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@types/node": "^12.19.0"

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/garbage-collector": "^0.50.0",
     "@fluidframework/protocol-base": "^0.1033.0-41017",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/container-runtime": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
     "@fluidframework/container-utils": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/cell": "^0.50.0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "uuid": "^8.3.1"

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/local-driver": "^0.50.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/container-runtime": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
     "@fluidframework/container-utils": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime": "^0.50.0",
     "@fluidframework/container-runtime-definitions": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/counter": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
     "@fluidframework/container-runtime": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/datastore": "^0.50.0",
     "@fluidframework/datastore-definitions": "^0.50.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/container-loader": "^0.50.0",
-    "@fluidframework/core-interfaces": "^0.40.0-0",
+    "@fluidframework/core-interfaces": "^0.40.0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/driver-utils": "^0.50.0",
     "@fluidframework/local-driver": "^0.50.0",


### PR DESCRIPTION
            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.24.1 (unchanged)
      @fluidframework/common-definitions:     0.21.0 (unchanged)
            @fluidframework/common-utils:     0.33.0 (unchanged)
         @fluidframework/core-interfaces:     0.40.0 -> 0.40.1
    @fluidframework/protocol-definitions:   0.1026.0 (unchanged)
      @fluidframework/driver-definitions:     0.41.0 (unchanged)
    @fluidframework/container-definitions:     0.41.0 (unchanged)
                                  Server:   0.1033.0 (unchanged)
                                  Client:     0.50.0 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for core-interfaces
         @fluidframework/core-interfaces -> ^0.40.0