### PR TITLE
Allow driver policies in test r11s driver - Docker

### DIFF
--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -20,15 +20,15 @@ export interface IServiceEndpoint {
 }
 
 const dockerConfig = (driverPolicies?: IRouterliciousDriverPolicies) => ({
-        serviceEndpoint: {
-            hostUrl: "http://localhost:3000",
-            ordererUrl: "http://localhost:3003",
-            deltaStorageUrl: "http://localhost:3001",
-        },
-        tenantId: "fluid",
-        tenantSecret: "create-new-tenants-if-going-to-production",
-        driverPolicies,
-    });
+    serviceEndpoint: {
+        hostUrl: "http://localhost:3000",
+        ordererUrl: "http://localhost:3003",
+        deltaStorageUrl: "http://localhost:3001",
+    },
+    tenantId: "fluid",
+    tenantSecret: "create-new-tenants-if-going-to-production",
+    driverPolicies,
+});
 
 function getConfig(
     fluidHost?: string,

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -60,7 +60,7 @@ function getLegacyConfigFromEnv() {
 function getEndpointConfigFromEnv(r11sEndpointName: string) {
     const configStr = process.env[`fluid__test__driver__${r11sEndpointName}`];
     if (r11sEndpointName === "docker") {
-        const dockerDriverPolicies = configStr === undefined ? configStr : JSON.parse(configStr).driverpolicies;
+        const dockerDriverPolicies = configStr === undefined ? configStr : (JSON.parse(configStr)).driverPolicies;
         return dockerConfig(dockerDriverPolicies);
     }
     if (r11sEndpointName === "r11s" && configStr === undefined) {


### PR DESCRIPTION
Currently, when we run real service tests with the test r11s driver in Docker, there is no way to overwrite `driverPolicies`, which are always set to `undefined`. This PR changes that, making it possible to read the environment variable config when targeting Docker and using its `driverPolicies` section.

Test strategy: tested locally targeting r11s with different driver policies set, and also with no environment variable set to confirm it works with the "undefined" case as well.