### PR TITLE
Skip blob related tests for FRS

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -51,8 +51,12 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
 
 describeFullCompat("blobs", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    beforeEach(async () => {
+    beforeEach(async function() {
         provider = getTestObjectProvider();
+        // Currently FRS does not support blob API.
+        if (provider.driver.type === "r11s" && provider.driver.endpointName === "frs") {
+            this.skip();
+        }
     });
 
     it("attach sends an op", async function() {
@@ -215,8 +219,12 @@ const getUrlFromItemId = (itemId: string, provider: ITestObjectProvider): string
 // tests above when the LTS version is bumped > 0.47
 describeNoCompat("blobs", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    beforeEach(async () => {
+    beforeEach(async function() {
         provider = getTestObjectProvider();
+        // Currently FRS does not support blob API.
+        if (provider.driver.type === "r11s" && provider.driver.endpointName === "frs") {
+            this.skip();
+        }
     });
 
     it("works in detached container", async function() {


### PR DESCRIPTION
FRS currently does not support blob APIs. This PR skips blob related E2E tests for FRS