### PR TITLE
hotfix: localSessionStorageCollection is missing three new properties

### DIFF
--- a/packages/drivers/local-driver/src/localSessionStorageDb.ts
+++ b/packages/drivers/local-driver/src/localSessionStorageDb.ts
@@ -17,6 +17,17 @@ class LocalSessionStorageCollection<T> implements ICollection<T> {
         this.collectionName = `${namespace}-${name}`;
     }
 
+    public aggregate(group: any, options?: any): any {
+        throw new Error("Method Not Implemented");
+    }
+
+    public async updateMany(filter: any, set: any, addToSet: any): Promise<void> {
+        throw new Error("Method Not Implemented");
+    }
+    public async distinct(key: any, query: any): Promise<any> {
+        throw new Error("Method Not Implemented");
+    }
+
     /**
      * {@inheritDoc @fluidframework/server-services-core#ICollection.find}
      *

--- a/server/tinylicious/src/routes/ordering/documents.ts
+++ b/server/tinylicious/src/routes/ordering/documents.ts
@@ -4,6 +4,7 @@
  */
 
 import { IDocumentStorage } from "@fluidframework/server-services-core";
+import { defaultHash } from "@fluidframework/server-services-client";
 import { Router } from "express";
 import { v4 as uuid } from "uuid";
 import { getParam } from "../../utils";
@@ -45,6 +46,7 @@ export function create(storage: IDocumentStorage): Router {
             summary,
             sequenceNumber,
             1,
+            defaultHash,
             values);
 
         createP.then(

--- a/server/tinylicious/src/services/inMemorycollection.ts
+++ b/server/tinylicious/src/services/inMemorycollection.ts
@@ -14,6 +14,17 @@ export class Collection<T> implements ICollection<T> {
     constructor() {
     }
 
+    public aggregate(group: any, options?: any): any {
+        throw new Error("Method Not Implemented");
+    }
+
+    public async updateMany(filter: any, set: any, addToSet: any): Promise<void> {
+        throw new Error("Method Not Implemented");
+    }
+    public async distinct(key: any, query: any): Promise<any> {
+        throw new Error("Method Not Implemented");
+    }
+
     public async find(query: any, sort?: any): Promise<T[]> {
         return this.findInternal(query, sort);
     }

--- a/server/tinylicious/src/services/levelDbCollection.ts
+++ b/server/tinylicious/src/services/levelDbCollection.ts
@@ -40,6 +40,17 @@ export class Collection<T> implements ICollection<T> {
                 private readonly property: ICollectionProperty) {
     }
 
+    public aggregate(group: any, options?: any): any {
+        throw new Error("Method Not Implemented");
+    }
+
+    public async updateMany(filter: any, set: any, addToSet: any): Promise<void> {
+        throw new Error("Method Not Implemented");
+    }
+    public async distinct(key: any, query: any): Promise<any> {
+        throw new Error("Method Not Implemented");
+    }
+
     public async find(query: any, sort?: any): Promise<T[]> {
         return this.findInternal(query, sort);
     }


### PR DESCRIPTION
#7844 added 3 new properties to ICollection, but not in localSessionStorageCollection. Adding these temporary implementation to unblock release
also adding them to levelDbCollection and inMemoryCollection
fix 2: #7310 added a new param `InitialHash` to IDocumentStorage.createDocument(), so adding that to documents.ts in tinylicious where it's called.