### PR TITLE
Stop exporting internal class CollabWindowTracker from the container-loader package

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -38,17 +38,8 @@ import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { IVersion } from '@fluidframework/protocol-definitions';
-import { MessageType } from '@fluidframework/protocol-definitions';
 import { ReadOnlyInfo } from '@fluidframework/container-definitions';
 import { TelemetryLogger } from '@fluidframework/telemetry-utils';
-
-// @public (undocumented)
-export class CollabWindowTracker {
-    constructor(submit: (type: MessageType, contents: any) => void, activeConnection: () => boolean, NoopTimeFrequency?: number, NoopCountFrequency?: number);
-    scheduleSequenceNumberUpdate(message: ISequencedDocumentMessage, immediateNoOp: boolean): void;
-    // (undocumented)
-    stopSequenceNumberUpdate(): void;
-    }
 
 // @public (undocumented)
 export enum ConnectionState {

--- a/packages/loader/container-loader/src/collabWindowTracker.ts
+++ b/packages/loader/container-loader/src/collabWindowTracker.ts
@@ -1,0 +1,102 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert, Timer } from "@fluidframework/common-utils";
+import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+import { isSystemMessage } from "@fluidframework/protocol-base";
+
+// Here are key considerations when deciding conditions for when to send non-immediate noops:
+// 1. Sending them too often results in increase in file size and bandwidth, as well as catch up performance
+// 2. Sending too infrequently ensures that collab window is large, and as result Sequence DDS would have
+//    large catchUp blobs - see Issue #6364
+// 3. Similarly, processes that rely on "core" snapshot (and can't parse trailing ops, including above), like search
+//    parser in SPO, will result in non-accurate results due to presence of catch up blobs.
+// 4. Ordering service used 250ms timeout to coalesce non-immediate noops. It was changed to 2000 ms to allow more
+//    aggressive noop sending from client side.
+// 5. Number of ops sent by all clients is proportional to number of "write" clients (every client sends noops),
+//    but number of sequenced noops is a function of time (one op per 2 seconds at most).
+//    We should consider impact to both outbound traffic (might be huge, depends on number of clients) and file size.
+// Please also see Issue #5629 for more discussions.
+//
+// With that, the current algorithm is as follows:
+// 1. Sent noop 2000 ms of receiving an op if no ops were sent by this client within this timeframe.
+//    This will ensure that MSN moves forward with reasonable speed. If that results in too many sequenced noops,
+//    server timeout of 2000ms should be reconsidered to be increased.
+// 2. If there are more than 50 ops received without sending any ops, send noop to keep collab window small.
+//    Note that system ops (including noops themselves) are excluded, so it's 1 noop per 50 real ops.
+export class CollabWindowTracker {
+    private opsCountSinceNoop = 0;
+    private readonly timer: Timer;
+
+    constructor(
+        private readonly submit: (type: MessageType, contents: any) => void,
+        private readonly activeConnection: () => boolean,
+        NoopTimeFrequency: number = 2000,
+        private readonly NoopCountFrequency: number = 50,
+    ) {
+        this.timer = new Timer(NoopTimeFrequency, () => {
+            // Can get here due to this.stopSequenceNumberUpdate() not resetting timer.
+            // Also timer callback can fire even after timer cancellation if it was queued before cancellation.
+            if (this.opsCountSinceNoop !== 0) {
+                assert(this.activeConnection(),
+                    0x241 /* "disconnect should result in stopSequenceNumberUpdate() call" */);
+                this.submitNoop(false /* immediate */);
+            }
+        });
+    }
+
+    /**
+     * Schedules as ack to the server to update the reference sequence number
+     */
+    public scheduleSequenceNumberUpdate(message: ISequencedDocumentMessage, immediateNoOp: boolean): void {
+        // Exit early for inactive (not in quorum or not writers) clients.
+        // They don't take part in the minimum sequence number calculation.
+        if (!this.activeConnection()) {
+            return;
+        }
+
+        // While processing a message, an immediate no-op can be requested.
+        // i.e. to expedite approve or commit phase of quorum.
+        if (immediateNoOp) {
+            this.submitNoop(true /* immediate */);
+            return;
+        }
+
+        // We don't acknowledge no-ops to avoid acknowledgement cycles (i.e. ack the MSN
+        // update, which updates the MSN, then ack the update, etc...). Also, don't
+        // count system messages in ops count.
+        if (isSystemMessage(message)) {
+            return;
+        }
+        assert(message.type !== MessageType.NoOp, 0x0ce /* "Don't acknowledge no-ops" */);
+
+        this.opsCountSinceNoop++;
+        if (this.opsCountSinceNoop >= this.NoopCountFrequency) {
+            this.submitNoop(false /* immediate */);
+            return;
+        }
+        if (this.opsCountSinceNoop === 1) {
+            this.timer.restart();
+        }
+        assert(this.timer.hasTimer, 0x242 /* "has timer" */);
+    }
+
+    private submitNoop(immediate: boolean) {
+        // Anything other than null is immediate noop
+        this.submit(MessageType.NoOp, immediate ? "" : null);
+        assert(this.opsCountSinceNoop === 0,
+            0x243 /* "stopSequenceNumberUpdate should be called as result of sending any op!" */);
+    }
+
+    public stopSequenceNumberUpdate(): void {
+        this.opsCountSinceNoop = 0;
+        // Ideally, we cancel timer here. But that will result in too often set/reset cycle if this client
+        // keeps sending ops. In most cases it's actually better to let it expire (at most - 4 times per second)
+        // for nothing, then have a ton of set/reset cycles.
+        // Note that Timer.restart() is smart and will not change timer expiration if we keep extending timer
+        // expiration - it will restart the timer instead when it fires with adjusted expiration.
+        // this.timer.clear();
+    }
+}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -10,7 +10,7 @@ import {
     IDisposable,
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
-import { assert, performance, unreachableCase, Timer } from "@fluidframework/common-utils";
+import { assert, performance, unreachableCase } from "@fluidframework/common-utils";
 import {
     IRequest,
     IResponse,
@@ -106,6 +106,7 @@ import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService
 import { BlobOnlyStorage, ContainerStorageAdapter } from "./containerStorageAdapter";
 import { getSnapshotTreeFromSerializedContainer } from "./utils";
 import { QuorumProxy } from "./quorum";
+import { CollabWindowTracker } from "./collabWindowTracker";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -217,100 +218,6 @@ export async function waitContainerToCatchUp(container: Container) {
 
         container.resume();
     });
-}
-
-// Here are key considerations when deciding conditions for when to send non-immediate noops:
-// 1. Sending them too often results in increase in file size and bandwidth, as well as catch up performance
-// 2. Sending too infrequently ensures that collab window is large, and as result Sequence DDS would have
-//    large catchUp blobs - see Issue #6364
-// 3. Similarly, processes that rely on "core" snapshot (and can't parse trailing ops, including above), like search
-//    parser in SPO, will result in non-accurate results due to presence of catch up blobs.
-// 4. Ordering service used 250ms timeout to coalesce non-immediate noops. It was changed to 2000 ms to allow more
-//    aggressive noop sending from client side.
-// 5. Number of ops sent by all clients is proportional to number of "write" clients (every client sends noops),
-//    but number of sequenced noops is a function of time (one op per 2 seconds at most).
-//    We should consider impact to both outbound traffic (might be huge, depends on number of clients) and file size.
-// Please also see Issue #5629 for more discussions.
-//
-// With that, the current algorithm is as follows:
-// 1. Sent noop 2000 ms of receiving an op if no ops were sent by this client within this timeframe.
-//    This will ensure that MSN moves forward with reasonable speed. If that results in too many sequenced noops,
-//    server timeout of 2000ms should be reconsidered to be increased.
-// 2. If there are more than 50 ops received without sending any ops, send noop to keep collab window small.
-//    Note that system ops (including noops themselves) are excluded, so it's 1 noop per 50 real ops.
-export class CollabWindowTracker {
-    private opsCountSinceNoop = 0;
-    private readonly timer: Timer;
-
-    constructor(
-        private readonly submit: (type: MessageType, contents: any) => void,
-        private readonly activeConnection: () => boolean,
-        NoopTimeFrequency: number = 2000,
-        private readonly NoopCountFrequency: number = 50,
-    ) {
-        this.timer = new Timer(NoopTimeFrequency, () => {
-            // Can get here due to this.stopSequenceNumberUpdate() not resetting timer.
-            // Also timer callback can fire even after timer cancellation if it was queued before cancellation.
-            if (this.opsCountSinceNoop !== 0) {
-                assert(this.activeConnection(),
-                    0x241 /* "disconnect should result in stopSequenceNumberUpdate() call" */);
-                this.submitNoop(false /* immediate */);
-            }
-        });
-    }
-
-    /**
-     * Schedules as ack to the server to update the reference sequence number
-     */
-    public scheduleSequenceNumberUpdate(message: ISequencedDocumentMessage, immediateNoOp: boolean): void {
-        // Exit early for inactive (not in quorum or not writers) clients.
-        // They don't take part in the minimum sequence number calculation.
-        if (!this.activeConnection()) {
-            return;
-        }
-
-        // While processing a message, an immediate no-op can be requested.
-        // i.e. to expedite approve or commit phase of quorum.
-        if (immediateNoOp) {
-            this.submitNoop(true /* immediate */);
-            return;
-        }
-
-        // We don't acknowledge no-ops to avoid acknowledgement cycles (i.e. ack the MSN
-        // update, which updates the MSN, then ack the update, etc...). Also, don't
-        // count system messages in ops count.
-        if (isSystemMessage(message)) {
-            return;
-        }
-        assert(message.type !== MessageType.NoOp, 0x0ce /* "Don't acknowledge no-ops" */);
-
-        this.opsCountSinceNoop++;
-        if (this.opsCountSinceNoop >= this.NoopCountFrequency) {
-            this.submitNoop(false /* immediate */);
-            return;
-        }
-        if (this.opsCountSinceNoop === 1) {
-            this.timer.restart();
-        }
-        assert(this.timer.hasTimer, 0x242 /* "has timer" */);
-    }
-
-    private submitNoop(immediate: boolean) {
-        // Anything other than null is immediate noop
-        this.submit(MessageType.NoOp, immediate ? "" : null);
-        assert(this.opsCountSinceNoop === 0,
-            0x243 /* "stopSequenceNumberUpdate should be called as result of sending any op!" */);
-    }
-
-    public stopSequenceNumberUpdate(): void {
-        this.opsCountSinceNoop = 0;
-        // Ideally, we cancel timer here. But that will result in too often set/reset cycle if this client
-        // keeps sending ops. In most cases it's actually better to let it expire (at most - 4 times per second)
-        // for nothing, then have a ton of set/reset cycles.
-        // Note that Timer.restart() is smart and will not change timer expiration if we keep extending timer
-        // expiration - it will restart the timer instead when it fires with adjusted expiration.
-        // this.timer.clear();
-    }
 }
 
 const getCodeProposal =

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -3,5 +3,20 @@
  * Licensed under the MIT License.
  */
 
-export * from "./container";
-export * from "./loader";
+export {
+    ConnectionState,
+    Container,
+    IContainerLoadOptions,
+    IContainerConfig,
+    waitContainerToCatchUp,
+} from "./container";
+export {
+    ICodeDetailsLoader,
+    IDetachedBlobStorage,
+    IFluidModuleWithDetails,
+    ILoaderOptions,
+    ILoaderProps,
+    ILoaderServices,
+    Loader,
+    RelativeLoader,
+} from "./loader";

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -11,7 +11,7 @@ import { IClient, IDocumentMessage, MessageType } from "@fluidframework/protocol
 import { MockDocumentDeltaConnection, MockDocumentService } from "@fluidframework/test-loader-utils";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import { DeltaManager } from "../deltaManager";
-import { CollabWindowTracker } from "../container";
+import { CollabWindowTracker } from "../collabWindowTracker";
 
 describe("Loader", () => {
     describe("Container Loader", () => {


### PR DESCRIPTION
`CollabWindowTracker` is internal implementation detail.  No one outside of the package should use it.