### PR TITLE
Add reference sequence number to OpRoundtripTime telemetry and standardize that telemetry field name

### DIFF
--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -153,6 +153,7 @@ class OpPerfTelemetry {
             this.logger.sendPerformanceEvent({
                 eventName: "OpRoundtripTime",
                 sequenceNumber,
+                referenceSequenceNumber: message.referenceSequenceNumber,
                 duration,
                 category,
             });

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -130,7 +130,7 @@ export class RunningSummarizer implements IDisposable {
                 this.logger.sendErrorEvent({
                     eventName: "SummaryAckWaitTimeout",
                     maxAckWaitTime,
-                    refSequenceNumber: this.heuristicData.lastAttempt.refSequenceNumber,
+                    referenceSequenceNumber: this.heuristicData.lastAttempt.refSequenceNumber,
                     summarySequenceNumber: this.heuristicData.lastAttempt.summarySequenceNumber,
                     timePending: Date.now() - this.heuristicData.lastAttempt.summaryTime,
                 });
@@ -140,7 +140,7 @@ export class RunningSummarizer implements IDisposable {
             if (this.pendingAckTimer.hasTimer) {
                 this.logger.sendTelemetryEvent({
                     eventName: "MissingSummaryAckFoundByOps",
-                    refSequenceNumber: this.heuristicData.lastAttempt.refSequenceNumber,
+                    referenceSequenceNumber: this.heuristicData.lastAttempt.refSequenceNumber,
                     summarySequenceNumber: this.heuristicData.lastAttempt.summarySequenceNumber,
                 });
                 this.pendingAckTimer.clear();

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -101,8 +101,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
 
     public async run(
         onBehalfOf: string,
-        options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>
-    {
+        options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason> {
         try {
             return await this.runCore(onBehalfOf, options);
         } catch (error) {
@@ -119,7 +118,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
      * the run promise, and also close the container.
      * @param reason - reason code for stopping
      */
-     public stop(reason: SummarizerStopReason) {
+    public stop(reason: SummarizerStopReason) {
         this.stopDeferred.resolve(reason);
     }
 
@@ -136,8 +135,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
 
     private async runCore(
         onBehalfOf: string,
-        options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>
-    {
+        options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason> {
         // Initialize values and first ack (time is not exact)
         this.logger.sendTelemetryEvent({
             eventName: "RunningSummarizer",
@@ -284,7 +282,10 @@ export class Summarizer extends EventEmitter implements ISummarizer {
                     summaryLogger,
                 );
             } catch (error) {
-                summaryLogger.sendErrorEvent({ eventName: "HandleSummaryAckError", refSequenceNumber }, error);
+                summaryLogger.sendErrorEvent({
+                    eventName: "HandleSummaryAckError",
+                    referenceSequenceNumber: refSequenceNumber,
+                }, error);
             }
             refSequenceNumber++;
         }

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -244,7 +244,7 @@ export class SummaryGenerator {
             // Cumulatively add telemetry properties based on how far generateSummary went.
             const { referenceSequenceNumber: refSequenceNumber } = summaryData;
             generateTelemetryProps = {
-                refSequenceNumber,
+                referenceSequenceNumber: refSequenceNumber,
                 opsSinceLastAttempt: refSequenceNumber - this.heuristicData.lastAttempt.refSequenceNumber,
                 opsSinceLastSummary: refSequenceNumber - this.heuristicData.lastSuccessfulSummary.refSequenceNumber,
             };
@@ -308,7 +308,7 @@ export class SummaryGenerator {
             logger.sendTelemetryEvent({
                 eventName: "SummaryOp",
                 duration: broadcastDuration,
-                refSequenceNumber: summarizeOp.referenceSequenceNumber,
+                referenceSequenceNumber: summarizeOp.referenceSequenceNumber,
                 summarySequenceNumber: summarizeOp.sequenceNumber,
                 handle: summarizeOp.contents.handle,
             });

--- a/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
@@ -86,7 +86,7 @@ describeNoCompat("Generate Summary Stats", (getTestObjectProvider) => {
     function getGenerateSummaryEvent(sequenceNumber: number): ITelemetryBaseEvent | undefined {
         for (const event of mockLogger.events) {
             if (event.eventName === "fluid:telemetry:Summarizer:Running:GenerateSummary" &&
-                event.refSequenceNumber ? event.refSequenceNumber >= sequenceNumber : false) {
+                event.referenceSequenceNumber ? event.referenceSequenceNumber >= sequenceNumber : false) {
                 return event;
             }
         }


### PR DESCRIPTION
Add reference sequence number to OpRoundtripTime telemetry, which gives some hint on how many additional time the client might need to spend on other ops before.  This is not exact, because the processing for the ops in between can happen in parallel with the round trip to the server, but at least if it is 1, then there aren't other ops interfering.

Also, there was a mix of `refSequenceNumber` and `referenceSequenceNumber`  telemetry before