### PR TITLE
fix (r11s): Don't treat all errors with code properties as valid network error codes

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/test/utils/rest.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/utils/rest.spec.ts
@@ -1,0 +1,86 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { NetworkError } from "@fluidframework/server-services-client";
+import assert from "assert";
+import { Response } from "express";
+import { handleResponse } from "../../utils";
+
+class MockResponse {
+    public statusCode: number = 200;
+    public responseData: string = "";
+
+    public status(status: number): MockResponse {
+        this.statusCode = status;
+        return this;
+    }
+
+    public json(json: any): MockResponse {
+        this.responseData = JSON.stringify(json);
+        return this;
+    }
+
+    public text(text: string): MockResponse {
+        this.responseData = text;
+        return this;
+    }
+}
+
+class MockMongoError extends Error {
+    constructor(public readonly code: number, public readonly message: string) {
+        super(message);
+    }
+}
+
+const defaultErrorCode = 400;
+
+describe("Routerlicious Base", () => {
+    describe("Rest Utils", () => {
+        describe("handleResponse()", () => {
+            it("handles success", async () => {
+                const mockResponse = new MockResponse();
+                const responseData = "hello";
+                await handleResponse(Promise.resolve(responseData), (mockResponse as unknown) as Response);
+                assert.strictEqual(mockResponse.statusCode, 200);
+                assert.strictEqual(mockResponse.responseData, JSON.stringify(responseData));
+            });
+            it("handles NetworkError error", async () => {
+                const mockResponse = new MockResponse();
+                const responseError = new NetworkError(404, "Not Found");
+                await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
+                assert.strictEqual(mockResponse.statusCode, responseError.code);
+                assert.strictEqual(mockResponse.responseData, JSON.stringify(responseError.message));
+            });
+            it("handles MongoError error", async () => {
+                const mockResponse = new MockResponse();
+                const responseError = new MockMongoError(11000, "E11000: Duplicate Key");
+                await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
+                assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
+                assert.strictEqual(mockResponse.responseData, JSON.stringify(responseError.message));
+            });
+            it("handles undefined error", async () => {
+                const mockResponse = new MockResponse();
+                const responseError = undefined;
+                await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
+                assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
+                assert.strictEqual(mockResponse.responseData, JSON.stringify(undefined));
+            });
+            it("handles string error", async () => {
+                const mockResponse = new MockResponse();
+                const responseError = "Failure occurred";
+                await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
+                assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
+                assert.strictEqual(mockResponse.responseData, JSON.stringify(responseError));
+            });
+            it("handles Error error", async () => {
+                const mockResponse = new MockResponse();
+                const responseError = new Error("Internal Error");
+                await handleResponse(Promise.reject(responseError), (mockResponse as unknown) as Response);
+                assert.strictEqual(mockResponse.statusCode, defaultErrorCode);
+                assert.strictEqual(mockResponse.responseData, JSON.stringify(responseError.message));
+            });
+        });
+    });
+});

--- a/server/routerlicious/packages/routerlicious-base/src/utils/rest.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/rest.ts
@@ -21,6 +21,12 @@ import type { Response } from "express";
             response.status(successStatus).json(result);
         },
         (error) => {
-            response.status(errorStatus ?? error?.code ?? 400).json(error?.message ?? error);
+            if (error?.name === "NetworkError") {
+                response
+                    .status(errorStatus ?? error.code ?? 400)
+                    .json(error.message ?? error);
+            } else {
+                response.status(errorStatus ?? 400).json(error?.message ?? error);
+            }
         });
 }

--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -12,5 +12,6 @@ export class NetworkError extends Error {
         message: string,
     ) {
         super(message);
+        this.name = "NetworkError";
     }
 }


### PR DESCRIPTION
If an insertion into MongoDb fails, it throws an error like
```json
{
  "code": 11000,
  "message": "E11000: Duplicate key error"
}
```
Unfortunately, the `handleResponse` method we use expects to sometimes receive a similar `NetworkError` type error with a `code` property, and uses that code property to set the HTTP response code. When a MongoError like above happens and is caught by `handleResponse`, an error is thrown about the invalid HTTP response code (11000) being set in the response.

This PR makes the usage of the NetworkError type more intentional. Also adds unit tests to make sure this works and continues to work.