### PR TITLE
Update inactiveObjectChanged error to log only once per data store per session.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -874,7 +874,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;
         this.summarizerNode = createRootSummarizerNodeWithGC(
-            this.logger,
+            ChildLogger.create(this.logger, "SummarizerNode"),
             // Summarize function to call when summarize is called. Summarizer node always tracks summary state.
             async (fullTree: boolean, trackState: boolean) => this.summarizeInternal(fullTree, trackState),
             // Latest change sequence number, no changes since summary applied yet

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -14,14 +14,14 @@ import { Container } from "@fluidframework/container-loader";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { TestDataObject } from "./mockSummarizerClient";
 
 /**
  * Validates this scenario: When a data store becomes inactive (has been unreferenced for a given amount of time),
  * using that data store results in an error telemetry.
  */
-describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
+describeFullCompat("GC inactive data store tests", (getTestObjectProvider) => {
     const dataObjectFactory = new DataObjectFactory(
         "TestDataObject",
         TestDataObject,
@@ -42,8 +42,8 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
         runtimeOptions,
     );
     const summaryLogger = new TelemetryNullLogger();
-    const inactiveObjectRevivedEvent = "fluid:telemetry:inactiveObjectRevived";
-    const inactiveObjectChangedEvent = "fluid:telemetry:inactiveObjectChanged";
+    const inactiveObjectRevivedEvent = "fluid:telemetry:SummarizerNode:inactiveObjectRevived";
+    const inactiveObjectChangedEvent = "fluid:telemetry:SummarizerNode:inactiveObjectChanged";
 
     let provider: ITestObjectProvider;
     let containerRuntime: ContainerRuntime;


### PR DESCRIPTION
See #7803.

Updating the `inactiveObjectChanged` error to be logged only once per data store per session. This should reduce its traffic in telemetry while we work on fixing the underlying issues.