### PR TITLE
Fix (real service test pipeline): adding default value to testFileTarName

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -42,6 +42,7 @@ parameters:
 
 - name: testFileTarName
   type: string
+  default: null
 
 - name: extraDependencies
   type: string

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -36,10 +36,6 @@ parameters:
   type: boolean
   default: false
 
-- name: downloadTestFiles
-  type: boolean
-  default: false
-
 - name: testFileTarName
   type: string
   default: null
@@ -100,7 +96,6 @@ jobs:
               testCommand=${{ parameters.testCommand }}
               continueOnError=${{ parameters.continueOnError }}
               variant.flag=${{ variant.flags }}
-              downloadTestFiles=${{ parameters.downloadTestFiles }}
               testFileTarName=${{ parameters.testFileTarName }}
               extraDependencies=${{ parameters.extraDependencies }}
             "
@@ -186,7 +181,7 @@ jobs:
       # Download Test Files & Install Extra Dependencies
       # These steps are intended to include extra dependencies that are not available as
       # part of the normal package .tgz installed previously in the pipeline.
-      - ${{ if eq(parameters.downloadTestFiles, true) }}:
+      - ${{ if ne(parameters.testFileTarName, 'null') }}:
         # Download Artifact - Test Files
         - task: DownloadPipelineArtifact@2
           displayName: Download test files

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -49,7 +49,6 @@ stages:
         testPackage: "@fluidframework/azure-client"
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:azure
-        downloadTestFiles: true
         testFileTarName: azure-client
         extraDependencies: "cross-env mocha @fluidframework/test-client-utils"
         env:


### PR DESCRIPTION
#7876 introduced a new pipeline variable, `testFileTarName`, that does not have a default value. That makes the pipeline fail because the variable cannot be resolved. Trying to fix that issue in this PR.