### PR TITLE
perf(historian): cache summary on creation

### DIFF
--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -193,11 +193,13 @@ export class RestGitService {
     }
 
     public async createSummary(summaryParams: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
-        const summaryResponse = await this.post<IWriteSummaryResponse>(
+        const summaryResponse = await this.post<IWholeFlatSummary>(
             `/repos/${this.getRepoPath()}/git/summaries`,
              summaryParams);
-        this.deleteFromCache(this.getSummaryCacheKey(summaryParams.type));
-        return summaryResponse;
+        // Cache the written summary for future retrieval. If this fails, next summary retrieval
+        // will receive an older version, but that is OK. Client will catch up with ops.
+        this.setCache(this.getSummaryCacheKey("container"), summaryResponse);
+        return { id: summaryResponse.id };
     }
 
     public async deleteSummary(softDelete: boolean): Promise<boolean> {


### PR DESCRIPTION
Soon, our summary API will be expected to return the accepted summary on creation, rather than just the ID. This will allow Historian to cache the summary on creation, which will hypothetically prevent the majority of read requests to the storage service behind the summary API.