### PR TITLE
Add deepLinkInfo and upToDateMarker parts to the nav parameter

### DIFF
--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -129,7 +129,11 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     // (undocumented)
     dataStorePath: string;
     // (undocumented)
+    deepLinkInfo?: string;
+    // (undocumented)
     fileVersion?: string;
+    // (undocumented)
+    upToDateMarker?: string;
 }
 
 // @public

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -15,6 +15,8 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     appName?: string;
     containerPackageName?: string;
     fileVersion?: string;
+    deepLinkInfo?: string;
+    upToDateMarker?: string;
 }
 
 export enum SharingLinkHeader {

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -25,6 +25,12 @@ export function createOdspUrl(
     if (l.fileVersion) {
         odspUrl += `&fileVersion=${encodeURIComponent(l.fileVersion)}`;
     }
+    if (l.deepLinkInfo) {
+        odspUrl += `&deepLinkInfo=${encodeURIComponent(l.deepLinkInfo)}`;
+    }
+    if (l.upToDateMarker) {
+        odspUrl += `&upToDateMarker=${encodeURIComponent(l.upToDateMarker)}`;
+    }
 
     return odspUrl;
 }

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -16,6 +16,8 @@ const fluidDataStorePathParamName = "c";
 const fluidAppNameParamName = "a";
 const fluidContainerPackageNameParamName = "p";
 const fluidFileVersionParamName = "v";
+const fluidDeepLinkInfoParamName = "l";
+const fluidUpToDateMarkerParamName = "u";
 
 /**
  * Transforms given Fluid data store locator into string that can be embedded into url
@@ -42,6 +44,14 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
     if (locator.fileVersion) {
         locatorSerialized += `&${fluidFileVersionParamName}=${
             encodeURIComponent(locator.fileVersion)}`;
+    }
+    if (locator.deepLinkInfo) {
+        locatorSerialized += `&${fluidDeepLinkInfoParamName}=${
+            encodeURIComponent(locator.deepLinkInfo)}`;
+    }
+    if (locator.upToDateMarker) {
+        locatorSerialized += `&${fluidUpToDateMarkerParamName}=${
+            encodeURIComponent(locator.upToDateMarker)}`;
     }
 
     return fromUtf8ToBase64(locatorSerialized);
@@ -72,6 +82,9 @@ function decodeOdspFluidDataStoreLocator(
     const appName = locatorInfo.get(fluidAppNameParamName) ?? undefined;
     const containerPackageName = locatorInfo.get(fluidContainerPackageNameParamName) ?? undefined;
     const fileVersion = locatorInfo.get(fluidFileVersionParamName) ?? undefined;
+    const deepLinkInfo = locatorInfo.get(fluidDeepLinkInfoParamName) ?? undefined;
+    const upToDateMarker = locatorInfo.get(fluidUpToDateMarkerParamName) ?? undefined;
+
     // "" is a valid value for dataStorePath so simply check for absence of the param;
     // the rest of params must be present and non-empty
     if (!sitePath || !driveId || !itemId || dataStorePath === null) {
@@ -97,6 +110,8 @@ function decodeOdspFluidDataStoreLocator(
         appName,
         containerPackageName,
         fileVersion,
+        deepLinkInfo,
+        upToDateMarker,
     };
 }
 

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -197,8 +197,8 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
         assert.strictEqual(locator?.itemId, itemId, "Item id should be equal");
         assert.strictEqual(locator?.dataStorePath, dataStorePath, "DataStore path should be equal");
         assert.strictEqual(locator?.siteUrl, siteUrl, "SiteUrl should be equal");
-        assert.strictEqual(locator?.deepLinkInfo, deepLinkInfo, "SiteUrl should be equal");
-        assert.strictEqual(locator?.upToDateMarker, upToDateMarker, "SiteUrl should be equal");
+        assert.strictEqual(locator?.deepLinkInfo, deepLinkInfo, "DeepLinkInfo should be equal");
+        assert.strictEqual(locator?.upToDateMarker, upToDateMarker, "UpToDateMarker should be equal");
     });
 
     it("Check nav param removal for share link", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -25,6 +25,8 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
     const dataStorePath = "dataStorePath";
     const fileName = "fileName";
     const fileVersion = "173.0";
+    const deepLinkInfo = "someDeepLinkInfo";
+    const upToDateMarker = "1234";
     const sharelink = "https://microsoft.sharepoint-df.com/site/SHARELINK";
     const urlsWithNavParams = [
         // Base64 encoded and then URI encoded string: d=driveId&f=fileId&c=dataStorePath&s=siteUrl&fluid=1&v=173.0
@@ -188,13 +190,15 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 
     it("Encode and decode nav param", async () => {
         const encodedUrl = new URL(sharelink);
-        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, itemId, dataStorePath });
+        storeLocatorInOdspUrl(encodedUrl, { siteUrl, driveId, itemId, dataStorePath, deepLinkInfo, upToDateMarker });
 
         const locator = getLocatorFromOdspUrl(encodedUrl);
         assert.strictEqual(locator?.driveId, driveId, "Drive id should be equal");
         assert.strictEqual(locator?.itemId, itemId, "Item id should be equal");
         assert.strictEqual(locator?.dataStorePath, dataStorePath, "DataStore path should be equal");
         assert.strictEqual(locator?.siteUrl, siteUrl, "SiteUrl should be equal");
+        assert.strictEqual(locator?.deepLinkInfo, deepLinkInfo, "SiteUrl should be equal");
+        assert.strictEqual(locator?.upToDateMarker, upToDateMarker, "SiteUrl should be equal");
     });
 
     it("Check nav param removal for share link", async () => {


### PR DESCRIPTION
This code change adds some scaffolding that is needed for the Deep Linking scenario. We will be passing information through the nav parameter in the URL that will give a loaded page 2 bits of information: the deepLinkInfo (a key for a location information that will be stored in the document's root DDS) and an upToDate marker that allows us to know when the contents have been updated enough for us to navigate (this will likely be a sequence number).

This has been discussed with @vladsud previously.