### PR TITLE
Make runWithRetry wrapper not log errors

### DIFF
--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -54,7 +54,7 @@ export async function runWithRetry<T>(
         } catch (err) {
             // If it is not retriable, then just throw the error.
             if (!canRetryOnError(err)) {
-                logger.sendErrorEvent({
+                logger.sendTelemetryEvent({
                     eventName: `${fetchCallName}_cancel`,
                     retry: numRetries,
                     duration: performance.now() - startTime,


### PR DESCRIPTION
After looking at more telemetry and thinking about it, I believe intermediate layers should not log errors, but rely on scenario (higher level caller) to make determination when and how to log an error. Intermediate layers may log more data, but it should be mostly FYI, as otherwise it creates too much noise and it's hard to analyze in aggregate (for example - why retryable errors are actually non-retryable when doing getVersions? The answer is that snapshot flow makes them so, but only that flow, and we log errors properly for whole scenarios).

To some extent it's follow up to https://github.com/microsoft/FluidFramework/pull/7841/files