### PR TITLE
Use more-scoped Quorum interfaces where safe

### DIFF
--- a/api-report/task-manager.api.md
+++ b/api-report/task-manager.api.md
@@ -12,7 +12,7 @@ import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidSerializer } from '@fluidframework/core-interfaces';
-import { IQuorum } from '@fluidframework/protocol-definitions';
+import { IQuorumClients } from '@fluidframework/protocol-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
@@ -29,7 +29,7 @@ export interface IOldestClientObservable extends IEventProvider<IOldestClientObs
     // (undocumented)
     connected: boolean;
     // (undocumented)
-    getQuorum(): IQuorum;
+    getQuorum(): IQuorumClients;
 }
 
 // @public (undocumented)

--- a/examples/data-objects/pond/src/providers/userInfo.ts
+++ b/examples/data-objects/pond/src/providers/userInfo.ts
@@ -6,7 +6,7 @@
 import { EventEmitter } from "events";
 
 import { IFluidHandleContext } from "@fluidframework/core-interfaces";
-import { IQuorum } from "@fluidframework/protocol-definitions";
+import { IQuorumClients } from "@fluidframework/protocol-definitions";
 import { DependencyContainer } from "@fluidframework/synthesize";
 import { IFluidDataStoreRegistry } from "@fluidframework/runtime-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
@@ -14,7 +14,7 @@ import { IContainerRuntime } from "@fluidframework/container-runtime-definitions
 import { IFluidUserInformation } from "../interfaces";
 
 export class UserInfo extends EventEmitter implements IFluidUserInformation {
-    private readonly quorum: IQuorum;
+    private readonly quorum: IQuorumClients;
 
     public on(event: "membersChanged", listener: () => void): this;
     public on(event: string | symbol, listener: (...args: any[]) => void): this {

--- a/examples/data-objects/vltava/src/fluidObjects/vltava/dataModel.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/vltava/dataModel.ts
@@ -9,7 +9,7 @@ import { IFluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidLastEditedTracker } from "@fluid-experimental/last-edited";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { IQuorum, ISequencedClient } from "@fluidframework/protocol-definitions";
+import { IQuorumClients, ISequencedClient } from "@fluidframework/protocol-definitions";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { handleFromLegacyUri } from "@fluidframework/request-handler";
 
@@ -30,7 +30,7 @@ export interface IVltavaDataModel extends EventEmitter {
 }
 
 export class VltavaDataModel extends EventEmitter implements IVltavaDataModel {
-    private readonly quorum: IQuorum;
+    private readonly quorum: IQuorumClients;
     private users: IVltavaUserDetails[] = [];
     private lastEditedTracker: IFluidLastEditedTracker | undefined;
 

--- a/experimental/framework/last-edited/src/setup.ts
+++ b/experimental/framework/last-edited/src/setup.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ISequencedDocumentMessage, IQuorum } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, IQuorumClients } from "@fluidframework/protocol-definitions";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { ILastEditDetails, IFluidLastEditedTracker } from "./interfaces";
@@ -21,7 +21,7 @@ function shouldDiscardMessageDefault(message: ISequencedDocumentMessage) {
 // client who sent the message doesn't exist in the quorum.
 function getLastEditDetailsFromMessage(
     message: ISequencedDocumentMessage,
-    quorum: IQuorum,
+    quorum: IQuorumClients,
 ): ILastEditDetails | undefined {
     const sequencedClient = quorum.getMember(message.clientId);
     const user = sequencedClient?.client.user;

--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -5,7 +5,7 @@
 
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
 import { AttachState } from "@fluidframework/container-definitions";
-import { IQuorum } from "@fluidframework/protocol-definitions";
+import { IQuorumClients } from "@fluidframework/protocol-definitions";
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 
 export interface ITaskManagerEvents extends ISharedObjectEvents {
@@ -64,7 +64,7 @@ export interface IOldestClientObservableEvents extends IEvent {
  * It's information about the connection, so the real source of truth is lower (at the connection layer).
  */
 export interface IOldestClientObservable extends IEventProvider<IOldestClientObservableEvents> {
-    getQuorum(): IQuorum;
+    getQuorum(): IQuorumClients;
     // Generic usage of attachState is a little unusual here.  We will treat ourselves as "the oldest client that
     // has information about this [container | data store]", which in the case of detached data store may disagree
     // with whether we're the oldest client on the connected container.  So in the data store case, it's only

--- a/packages/dds/task-manager/src/oldestClientObserver.ts
+++ b/packages/dds/task-manager/src/oldestClientObserver.ts
@@ -5,7 +5,7 @@
 
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { IQuorum } from "@fluidframework/protocol-definitions";
+import { IQuorumClients } from "@fluidframework/protocol-definitions";
 import { IOldestClientObservable, IOldestClientObserverEvents, IOldestClientObserver } from "./interfaces";
 
 /**
@@ -65,7 +65,7 @@ import { IOldestClientObservable, IOldestClientObserverEvents, IOldestClientObse
  */
 export class OldestClientObserver extends TypedEventEmitter<IOldestClientObserverEvents>
     implements IOldestClientObserver {
-    private readonly quorum: IQuorum;
+    private readonly quorum: IQuorumClients;
     private currentIsOldest: boolean = false;
     constructor(private readonly observable: IOldestClientObservable) {
         super();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -83,6 +83,7 @@ import {
     IPendingProposal,
     SummaryType,
     ISummaryContent,
+    IQuorumProposals,
 } from "@fluidframework/protocol-definitions";
 import {
     ChildLogger,
@@ -222,7 +223,7 @@ export async function waitContainerToCatchUp(container: Container) {
 
 const getCodeProposal =
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    (quorum: IQuorum) => quorum.get("code") ?? quorum.get("code2");
+    (quorum: IQuorumProposals) => quorum.get("code") ?? quorum.get("code2");
 
 export class Container extends EventEmitterWithErrorHandling<IContainerEvents> implements IContainer {
     public static version = "^0.1.0";

--- a/packages/runtime/container-runtime/src/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/orderedClientElection.ts
@@ -6,7 +6,7 @@
 import { IEvent, IEventProvider, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
-import { IClient, IQuorum, ISequencedClient } from "@fluidframework/protocol-definitions";
+import { IClient, IQuorumClients, ISequencedClient } from "@fluidframework/protocol-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 
 // helper types for recursive readonly.
@@ -97,7 +97,7 @@ export class OrderedClientCollection
     constructor(
         logger: ITelemetryLogger,
         deltaManager: Pick<IDeltaManager<unknown, unknown>, "lastSequenceNumber">,
-        quorum: Pick<IQuorum, "getMembers" | "on">,
+        quorum: Pick<IQuorumClients, "getMembers" | "on">,
     ) {
         super();
         this.logger = ChildLogger.create(logger, "OrderedClientCollection");


### PR DESCRIPTION
In #6730 I introduced split interfaces for Quorum proposals vs. client info.  This change updates client packages to use the more-specific interfaces wherever safe (no breaking changes).