### PR TITLE
Send metadata property as string and convert back during retrieval

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -896,7 +896,7 @@ export class DeltaManager
         const message: IDocumentMessage = {
             clientSequenceNumber: ++this.clientSequenceNumber,
             contents: JSON.stringify(contents),
-            metadata,
+            metadata: JSON.stringify(metadata),
             referenceSequenceNumber: this.lastProcessedSequenceNumber,
             traces,
             type,
@@ -1553,6 +1553,10 @@ export class DeltaManager
             && message.type !== MessageType.ClientLeave
         ) {
             message.contents = JSON.parse(message.contents);
+        }
+
+        if (message.metadata !== undefined && typeof message.metadata === "string") {
+            message.metadata = JSON.parse(message.metadata);
         }
 
         if (message.type === MessageType.ClientLeave) {


### PR DESCRIPTION
Standardizing what client sends to the server (https://github.com/microsoft/FluidFramework/blob/main/common/lib/protocol-definitions/src/protocol.ts#L92). Given that everything client sends is primitive, we should update metadata as well. This will simplify service storage model.

Once this is baked in, I will open a separate PR to convert 'any' types to 'string'.