### PR TITLE
Remove Twitter link in sidebar

### DIFF
--- a/docs/themes/thxvscode/layouts/partials/connect.html
+++ b/docs/themes/thxvscode/layouts/partials/connect.html
@@ -22,12 +22,6 @@
                 Ask questions
             </a>
         </li>
-        <li id="connect-twitter">
-            <a href="https://twitter.com/{{.Site.Params.Twitterhandle}}" target="_blank">
-                <img aria-hidden="true" alt="Twitter" src="/codicons/twitter.svg" />
-                @{{.Site.Params.Twitterhandle}}
-            </a>
-        </li>
         <li id="connect-github">
             <a href="https://www.github.com/{{.Site.Params.Githubrepo}}/issues/new/choose" target="_blank">
                 <img aria-hidden="true" alt="Issues" src="/codicons/bug.svg" />


### PR DESCRIPTION
It's not page-specific, and it's not an "action." It doesn't belong in the per-page sidebar.