### PR TITLE
Added tracking for objects that are referenced between summaries.

### DIFF
--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -80,6 +80,8 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     getQuorum(): IQuorum;
     // (undocumented)
+    handleDecoded(handleUrl: string): void;
+    // (undocumented)
     readonly id: string;
     // (undocumented)
     get IFluidHandleContext(): this;
@@ -104,6 +106,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     raiseContainerWarning(warning: ContainerWarning): void;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
+    resetUnreferencedState(routesToReset: string[]): void;
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
     reSubmit(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;

--- a/api-report/garbage-collector.api.md
+++ b/api-report/garbage-collector.api.md
@@ -13,8 +13,12 @@ export function cloneGCData(gcData: IGarbageCollectionData): IGarbageCollectionD
 // @public (undocumented)
 export class GCDataBuilder implements IGarbageCollectionData {
     // (undocumented)
-    addNode(id: string, outboundRoutes: string[]): void;
+    addNodes(gcNodes: {
+        [id: string]: string[];
+    }): void;
     addRouteToAllNodes(outboundRoute: string): void;
+    // (undocumented)
+    addSingleNode(id: string, outboundRoutes: string[]): void;
     // (undocumented)
     readonly gcNodes: {
         [id: string]: string[];

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -125,6 +125,7 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     readonly id: string;
     process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processSignal(message: any, local: boolean): void;
+    resetUnreferencedState(routesToReset: string[]): void;
     reSubmit(type: string, content: any, localOpMetadata: unknown): any;
     setConnectionState(connected: boolean, clientId?: string): any;
     summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats>;
@@ -313,6 +314,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     getGCSummaryDetails(): IGarbageCollectionSummaryDetails;
     isReferenced(): boolean;
+    resetUnreferencedState(): void;
     // (undocumented)
     summarize(fullTree: boolean, trackState?: boolean): Promise<ISummarizeResult>;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -387,6 +387,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     requestDataStore(request: IRequest): Promise<IResponse>;
     // (undocumented)
+    resetUnreferencedState(referencedRoutes: string[]): void;
+    // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
     reSubmit(content: any, localOpMetadata: unknown): void;

--- a/common/lib/core-interfaces/src/handles.ts
+++ b/common/lib/core-interfaces/src/handles.ts
@@ -39,6 +39,12 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
     attachGraph(): void;
 
     resolveHandle(request: IRequest): Promise<IResponse>;
+
+    /**
+     * Called when a handle belonging to this context is decoded.
+     * @param url - The url of the decoded handle.
+     */
+    handleDecoded(url: string): void;
 }
 
 export const IFluidHandle: keyof IProvideFluidHandle = "IFluidHandle";

--- a/common/lib/core-interfaces/src/handles.ts
+++ b/common/lib/core-interfaces/src/handles.ts
@@ -44,7 +44,7 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
      * Called when a handle belonging to this context is decoded.
      * @param url - The url of the decoded handle.
      */
-    handleDecoded(url: string): void;
+    handleDecoded(handle: IFluidHandle): void;
 }
 
 export const IFluidHandle: keyof IProvideFluidHandle = "IFluidHandle";

--- a/packages/runtime/container-runtime/src/containerHandleContext.ts
+++ b/packages/runtime/container-runtime/src/containerHandleContext.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    IFluidHandle,
     IFluidHandleContext,
     IRequest,
     IResponse,
@@ -16,9 +17,9 @@ export class ContainerFluidHandleContext implements IFluidHandleContext {
     public get IFluidRouter() { return this; }
     public get IFluidHandleContext() { return this; }
     public readonly absolutePath: string;
-    // Stores handles in this context that are decoded. Basically, handles that are parsed to get the underlying
+    // Stores urls of handles in this context that are decoded. Basically, handles that are parsed to get the underlying
     // objects. It helps in keeping track of all remote objects that are received and loaded by this container.
-    public decodedHandles: string[] = [];
+    public decodedHandleUrls: string[] = [];
 
     /**
      * Creates a new ContainerFluidHandleContext.
@@ -46,7 +47,7 @@ export class ContainerFluidHandleContext implements IFluidHandleContext {
         return this.runtime.resolveHandle(request);
     }
 
-    public handleDecoded(url: string): void {
-        this.decodedHandles.push(url);
+    public handleDecoded(handle: IFluidHandle): void {
+        this.decodedHandleUrls.push(handle.absolutePath);
     }
 }

--- a/packages/runtime/container-runtime/src/containerHandleContext.ts
+++ b/packages/runtime/container-runtime/src/containerHandleContext.ts
@@ -16,6 +16,9 @@ export class ContainerFluidHandleContext implements IFluidHandleContext {
     public get IFluidRouter() { return this; }
     public get IFluidHandleContext() { return this; }
     public readonly absolutePath: string;
+    // Stores handles in this context that are decoded. Basically, handles that are parsed to get the underlying
+    // objects. It helps in keeping track of all remote objects that are received and loaded by this container.
+    public decodedHandles: string[] = [];
 
     /**
      * Creates a new ContainerFluidHandleContext.
@@ -41,5 +44,9 @@ export class ContainerFluidHandleContext implements IFluidHandleContext {
 
     public async resolveHandle(request: IRequest): Promise<IResponse> {
         return this.runtime.resolveHandle(request);
+    }
+
+    public handleDecoded(url: string): void {
+        this.decodedHandles.push(url);
     }
 }

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -45,6 +45,14 @@ export interface IChannelContext {
      * 4. To update the timestamp when this context is marked as unreferenced.
      */
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
+
+    /**
+     * After GC has run, called to notify this context of routes whose unreferenced state needs to be reset. These
+     * are routes to nodes in the context that have transitioned from `unreferenced -> referenced -> unreferenced`
+     * since the last GC run.
+     * @param routesToReset - The routes to reset in this context.
+     */
+    resetUnreferencedState(referencedRoutes: string[]): void;
 }
 
 export function createServiceEndpoints(

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -142,7 +142,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         return this.dataStoreContext.IFluidHandleContext;
     }
 
-    public handleDecoded(handleUrl: string): void {}
+    public handleDecoded(handle: IFluidHandle): void {}
 
     private readonly serializer = new FluidSerializer(this.IFluidHandleContext);
     public get IFluidSerializer() { return this.serializer; }

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -135,6 +135,14 @@ export abstract class LocalChannelContextBase implements IChannelContext {
          * value. See - https://github.com/microsoft/FluidFramework/issues/4611
          */
     }
+
+    public resetUnreferencedState(referencedRoutes: string[]) {
+        /**
+         * Currently, DDSs are always considered referenced and are not garbage collected.
+         * Once we have GC at DDS level, this channel context's state will need to be reset.
+         * See - https://github.com/microsoft/FluidFramework/issues/4611
+         */
+    }
 }
 
 export class RehydratedLocalChannelContext extends LocalChannelContextBase {

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -279,4 +279,12 @@ export class RemoteChannelContext implements IChannelContext {
          */
         this.summarizerNode.updateUsedRoutes([""]);
     }
+
+    public resetUnreferencedState(referencedRoutes: string[]) {
+        /**
+         * Currently, DDSs are always considered referenced and are not garbage collected.
+         * Once we have GC at DDS level, this channel context's state will need to be reset.
+         * See - https://github.com/microsoft/FluidFramework/issues/4611
+         */
+    }
 }

--- a/packages/runtime/garbage-collector/src/utils.ts
+++ b/packages/runtime/garbage-collector/src/utils.ts
@@ -90,8 +90,14 @@ export function removeRouteFromAllNodes(gcNodes: { [ id: string ]: string[] }, o
 export class GCDataBuilder implements IGarbageCollectionData {
     public readonly gcNodes: { [ id: string ]: string[] } = {};
 
-    public addNode(id: string, outboundRoutes: string[]) {
-        this.gcNodes[id] = outboundRoutes;
+    public addSingleNode(id: string, outboundRoutes: string[]) {
+        this.gcNodes[id] = Array.from(outboundRoutes);
+    }
+
+    public addNodes(gcNodes: { [ id: string ]: string[] }) {
+        for (const [id, outboundRoutes] of Object.entries(gcNodes)) {
+            this.gcNodes[id] = Array.from(outboundRoutes);
+        }
     }
 
     /**
@@ -117,7 +123,7 @@ export class GCDataBuilder implements IGarbageCollectionData {
             }
 
             // Add the outbound routes against the normalized and prefixed id.
-            this.gcNodes[normalizedId] = outboundRoutes;
+            this.gcNodes[normalizedId] = Array.from(outboundRoutes);
         }
     }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -202,6 +202,14 @@ export interface IFluidDataStoreChannel extends
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
 
     /**
+     * After GC has run, called to notify this channel of routes whose unreferenced state needs to be reset. These
+     * are routes to nodes in the channel that have transitioned from `unreferenced -> referenced -> unreferenced`
+     * since the last GC run.
+     * @param routesToReset - The routes to reset in this channel.
+     */
+    resetUnreferencedState(routesToReset: string[]): void;
+
+    /**
      * Notifies this object about changes in the connection state.
      * @param value - New connection state.
      * @param clientId - ID of the client. It's old ID when in disconnected state and

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -156,6 +156,8 @@ export interface ISummarizerNode {
  * - deleteChild - Deletes a child node.
  * - isReferenced - This tells whether this node is referenced in the document or not.
  * - updateUsedRoutes - Used to notify this node of routes that are currently in use in it.
+ * - resetUnreferencedState - Used to notify this node to reset its unreferenced state.
+ * - getGCSummaryDetails - Returns GC details that may be added to this node's summary.
  */
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
     summarize(fullTree: boolean, trackState?: boolean): Promise<ISummarizeResult>;
@@ -204,6 +206,12 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
      * as part of this GC run, this timestamp is used to update the time when it happens.
      */
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
+
+    /**
+     * After GC has run, called to notify this node that its  unreferenced state needs to be reset. Basically, this
+     * node has transitioned from `unreferenced -> referenced -> unreferenced` since the last GC run.
+     */
+    resetUnreferencedState(): void;
 
     /** Returns the GC details that may be added to this node's summary. */
     getGCSummaryDetails(): IGarbageCollectionSummaryDetails;

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -104,7 +104,7 @@ export class FluidSerializer implements IFluidSerializer {
             // Update the root context of all handles that are decoded.
             // TODO: The cast to any is done temporarily until the change to IFluidHandleContext in `core-interfaces` is
             // merged and client is updated to the new `core-interfaces` version.
-            (this.root as any).handleDecoded(absolutePath);
+            (this.root as any).handleDecoded?.(absolutePath);
             return new RemoteFluidObjectHandle(absolutePath, this.root);
         } else {
             return value;

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -101,6 +101,10 @@ export class FluidSerializer implements IFluidSerializer {
                 ? value.url
                 : generateHandleContextPath(value.url, this.context);
 
+            // Update the root context of all handles that are decoded.
+            // TODO: The cast to any is done temporarily until the change to IFluidHandleContext in `core-interfaces` is
+            // merged and client is updated to the new `core-interfaces` version.
+            (this.root as any).handleDecoded(absolutePath);
             return new RemoteFluidObjectHandle(absolutePath, this.root);
         } else {
             return value;

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -101,11 +101,14 @@ export class FluidSerializer implements IFluidSerializer {
                 ? value.url
                 : generateHandleContextPath(value.url, this.context);
 
+            const decodedHandle = new RemoteFluidObjectHandle(absolutePath, this.root);
+
             // Update the root context of all handles that are decoded.
             // TODO: The cast to any is done temporarily until the change to IFluidHandleContext in `core-interfaces` is
             // merged and client is updated to the new `core-interfaces` version.
-            (this.root as any).handleDecoded?.(absolutePath);
-            return new RemoteFluidObjectHandle(absolutePath, this.root);
+            (this.root as any).handleDecoded?.(decodedHandle);
+
+            return decodedHandle;
         } else {
             return value;
         }

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -372,10 +372,14 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     }
 
     public resetUnreferencedState(): void {
+        this.resetUnreferencedStateCore();
+        this.stateResetSinceLastRun = true;
+    }
+
+    private resetUnreferencedStateCore(): void {
         this.inactive = false;
         this.unreferencedTimestampMs = undefined;
         this.unreferencedTimer.clear();
-        this.stateResetSinceLastRun = true;
     }
 
     public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {
@@ -395,7 +399,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
             this.logErrorIfInactive("inactiveObjectRevived", gcTimestamp);
 
             // Clear unreferenced / inactive state, if any.
-            this.resetUnreferencedState();
+            this.resetUnreferencedStateCore();
             return;
         }
 

--- a/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
@@ -198,6 +198,44 @@ describe("SummarizerNodeWithGC Tests", () => {
                 "summarize should not have thrown an error since GC was run",
             );
         });
+
+        it("should not regenerate summary when nothing changed since last summary", async () => {
+            // Get the GC data so that initialGCSummaryDetails is read and saved.
+            await summarizerNode.getGCData();
+            // Update the used routes to the same as the one in initialGCSummaryDetails.
+            summarizerNode.updateUsedRoutes([]);
+            const summarizeResult = await summarizerNode.summarize(false /* fullTree */);
+            assert(
+                summarizeResult.summary.type === SummaryType.Handle,
+                "The summary should be a handle since nothing changed since last summary",
+            );
+        });
+
+        it("should regenerate summary when used state changed since last summary", async () => {
+            // Get the GC data so that initialGCSummaryDetails is read and saved.
+            await summarizerNode.getGCData();
+            // Update the used routes to a different value than the one in initialGCSummaryDetails.
+            summarizerNode.updateUsedRoutes([""]);
+            const summarizeResult = await summarizerNode.summarize(false /* fullTree */);
+            assert(
+                summarizeResult.summary.type === SummaryType.Tree,
+                "The summary should be a tree since used routes changed since last summary",
+            );
+        });
+
+        it("should regenerate summary when unreferenced state reset since last summary", async () => {
+            // Reset the unreferenced state of the node.
+            summarizerNode.resetUnreferencedState();
+            // Get the GC data so that initialGCSummaryDetails is read and saved.
+            await summarizerNode.getGCData();
+            // Update the used routes to the same as the one in initialGCSummaryDetails.
+            summarizerNode.updateUsedRoutes([]);
+            const summarizeResult = await summarizerNode.summarize(false /* fullTree */);
+            assert(
+                summarizeResult.summary.type === SummaryType.Tree,
+                "The summary should be a tree since unreferenced state was reset since last summary",
+            );
+        });
     });
 
     describe("Unreferenced timeout expiry", () => {

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -522,6 +522,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter
 
     public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {}
 
+    public resetUnreferencedState(referencedRoutes: string[]) {}
+
     public getAttachSnapshot(): ITreeEntry[] {
         return [];
     }

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -16,6 +16,7 @@ import {
 import { ISummaryContext } from "@fluidframework/driver-definitions";
 import {
     ISummaryTree,
+    SummaryObject,
     SummaryType,
 } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, IGarbageCollectionSummaryDetails } from "@fluidframework/runtime-definitions";
@@ -92,25 +93,34 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
     }
 
     /**
-     * Generates a summary and returns the unreferenced timestamp for the data store with the given id in the summary.
-     * If the data store is referenced, the ureferenced timestamp is undefined.
+     * Generate and submit a summary. Return the data store channels summary tree.
      */
-    async function getDataStoreUnreferencedTimestamp(
+    async function getChannelsSummary(
         summarizerClient: { containerRuntime: ContainerRuntime, summaryCollection: SummaryCollection },
-        dataStoreId: string,
-    ): Promise<number | undefined> {
+    ) {
         const summaryResult = await submitAndAckSummary(provider, summarizerClient, logger, true /* fullTree */);
         latestAckedSummary = summaryResult.ackedSummary;
-
         assert(
             latestSummaryContext && latestSummaryContext.referenceSequenceNumber >= summaryResult.summarySequenceNumber,
             `Did not get expected summary. Expected: ${summaryResult.summarySequenceNumber}. ` +
             `Actual: ${latestSummaryContext?.referenceSequenceNumber}.`,
         );
         assert(latestUploadedSummary !== undefined, "Did not get a summary");
+        return (latestUploadedSummary.tree[channelsTreeName] as ISummaryTree)?.tree ?? latestUploadedSummary.tree;
+    }
 
-        const channelsTree =
-            (latestUploadedSummary.tree[channelsTreeName] as ISummaryTree)?.tree ?? latestUploadedSummary.tree;
+    /**
+     * Returns the unreferenced timestamp for the data store with the given id. If the data store is referenced, the
+     * ureferenced timestamp is undefined.
+     * If channelsSummary parameter is passed, get the unreferenced timestamp off of it. If it is undefined, generate
+     * and submit a summary, and get the data store channels summary tree first.
+     */
+    async function getDataStoreUnreferencedTimestamp(
+        summarizerClient: { containerRuntime: ContainerRuntime, summaryCollection: SummaryCollection },
+        dataStoreId: string,
+        channelsSummary?: { [path: string]: SummaryObject },
+    ): Promise<number | undefined> {
+        const channelsTree = channelsSummary ?? await getChannelsSummary(summarizerClient);
         for (const [ id, summaryObject ] of Object.entries(channelsTree)) {
             if (id === dataStoreId) {
                 assert(
@@ -207,6 +217,96 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         assert(unrefTimestamp3 !== undefined, `new data store should still have unreferenced timestamp`);
         assert.strictEqual(unrefTimestamp2, unrefTimestamp3, "The unreferenced timestamp should not have changed");
 
+    // This test has increased timeout because it waits for multiple summaries to be uploaded to server. It then also
+    // waits for those summaries to be ack'd. This may take a while.
+    }).timeout(20000);
+
+    /**
+     * This scenario is currently broken. Re-enable test once the following item is completed -
+     * https://github.com/microsoft/FluidFramework/issues/7924
+     */
+    it(`updates unreferenced timestamp when data store transitions between` +
+       `unreferenced -> referenced -> unreferenced between summaries`, async () => {
+        const summarizerClient = await getNewSummarizer();
+
+        // Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
+        const newDataStore = await dataObjectFactory.createInstance(mainDataStore.containerRuntime);
+        mainDataStore._root.set("newDataStore", newDataStore.handle);
+        await provider.ensureSynchronized();
+
+        // Mark the data store as unreferenced by deleting its handle from the DDS and validate that it now has an
+        // unreferenced timestamp.
+        mainDataStore._root.delete("newDataStore");
+        const unrefTimestamp1 = await getDataStoreUnreferencedTimestamp(summarizerClient, newDataStore.id);
+        assert(unrefTimestamp1 !== undefined, `data store should have unreferenced timestamp after being unreferenced`);
+
+        // Store the data store's handle in the referenced DDS again and the delete it again. The data store will
+        // transition from unreferened -> referenced -> unreferenced before the next summary happens. The data store
+        // will still be unreferenced but the unreferenced timestamp should update.
+        mainDataStore._root.set("newDataStore", newDataStore.handle);
+        await provider.ensureSynchronized();
+        mainDataStore._root.delete("newDataStore");
+
+        const unrefTimestamp2 = await getDataStoreUnreferencedTimestamp(summarizerClient, newDataStore.id);
+        assert(unrefTimestamp2 !== undefined, `data store should still have unreferenced timestamp`);
+        assert(unrefTimestamp2 > unrefTimestamp1, `new timestamp should be greater that the previous one`);
+    // This test has increased timeout because it waits for multiple summaries to be uploaded to server. It then also
+    // waits for those summaries to be ack'd. This may take a while.
+    }).timeout(20000);
+
+    /**
+     * Tests the following scenario where A, B and C are data stores:
+     * 1. Summary 1 at t1. Reference graph: A -> B -> C.
+     * 2. Summary 2 at t2. Reference graph: A    B (t2) -> C (t2). B and C have unreferenced time t2.
+     * 3. Op adds reference from A -> B.
+     *    Op removes reference from B -> C.
+     *    Op removes reference from A -> B.
+     *    A client could have added in-memory references to both B and C.
+     * 4. Summary 3 at t3. Reference graph: A    B (t3)    C (t3).
+     * Validates that the unreferenced time for B and C are t3.
+     *
+     * This scenario is currently broken. Re-enable test once the following item is completed -
+     * https://github.com/microsoft/FluidFramework/issues/7924
+    */
+    it(`updates unreferenced timestamp when data store transitions between` +
+       `unreferenced -> referenced -> unreferenced between summaries, and has outbound references`, async () => {
+        const summarizerClient = await getNewSummarizer();
+        const dataStoreA = mainDataStore;
+
+        // Create data stores A and B and mark them referenced as follows by storing their handles accordingly:
+        // dataStoreA -> dataStoreB -> dataStoreC
+        const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+        const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+        dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+        dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+        await provider.ensureSynchronized();
+
+        // Remove the reference to dataStoreB which marks both B and C as unreferenced.
+        dataStoreA._root.delete("dataStoreB");
+
+        // Validate that both B and C are both marked unreferenced at the same time.
+        const channelsSummary1 = await getChannelsSummary(summarizerClient);
+        const dsBTime1 = await getDataStoreUnreferencedTimestamp(summarizerClient, dataStoreB.id, channelsSummary1);
+        assert(dsBTime1 !== undefined, `data store B should have unreferenced timestamp after being unreferenced`);
+        const dsCTime1 = await getDataStoreUnreferencedTimestamp(summarizerClient, dataStoreC.id, channelsSummary1);
+        assert(dsBTime1 === dsCTime1, `both data stores should have the same unreferenced time`);
+
+        // Now update the references via ops as follows:
+        // 1. Add reference from A -> B
+        // 2. Remove reference from B -> C
+        // 3. Remove reference from A -> B
+        dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+        await provider.ensureSynchronized();
+        dataStoreB._root.delete("dataStoreC");
+        dataStoreA._root.delete("dataStoreB");
+
+        // Validate that both B and C's unreferenced timestamps are updated and are the same.
+        const channelsSummary2 = await getChannelsSummary(summarizerClient);
+        const dsBTime2 = await getDataStoreUnreferencedTimestamp(summarizerClient, dataStoreB.id, channelsSummary2);
+        assert(dsBTime2 !== undefined, `data store B should still have unreferenced timestamp`);
+        assert(dsBTime2 > dsBTime1, `The unreferenced timestamp should have been updated`);
+        const dsCTime2 = await getDataStoreUnreferencedTimestamp(summarizerClient, dataStoreC.id, channelsSummary2);
+        assert(dsBTime2 === dsCTime2, `both data stores should have the same unreferenced time`);
     // This test has increased timeout because it waits for multiple summaries to be uploaded to server. It then also
     // waits for those summaries to be ack'd. This may take a while.
     }).timeout(20000);


### PR DESCRIPTION
This will help identify objects that transition from `unreferenced -> referenced -> unreferenced` between summaries. The unreferenced timestamp of these objects needs to be updated since a client could have added in-memory references to them. We will need to adjust the time to wait before delete accordingly.

This change does the following:
- Every time a handle is parsed, the serializer notifies the root context (container runtime) of its URL.
- During GC, get objects that have been referenced since the last GC run. Then find objects that transitioned from `unreferenced -> referenced -> unreferenced` between the last and the current GC run.
- Reset the unreferenced timestamp of these objects.
- The new timestamp will be added when the GC mark phase runs.