### PR TITLE
Remove deprecated stop() from ContainerRuntime

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -166,11 +166,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     setFlushMode(mode: FlushMode): void;
     // @deprecated
     snapshot(): Promise<ITree>;
-    // @deprecated (undocumented)
-    stop(): Promise<{
-        snapshot?: never;
-        state?: never;
-    }>;
     // (undocumented)
     get storage(): IDocumentStorageService;
     // (undocumented)

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -81,13 +81,6 @@ class ProxyRuntime implements IRuntime {
     }
     async setConnectionState(connected: boolean, clientId?: string) {
     }
-    /**
-     * @deprecated in 0.14, use dispose() to stop the runtime.
-     * Remove after IRuntime definition no longer includes it.
-     */
-    async stop(): Promise<{snapshot?: never, state?: never}> {
-        throw new Error("Method not implemented.");
-    }
     async process(message: ISequencedDocumentMessage, local: boolean, context: any) {
     }
     async processSignal(message: any, local: boolean) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1280,15 +1280,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    /**
-     * @deprecated in 0.14, use dispose() to stop the runtime.
-     * Remove after IRuntime definition no longer includes it.
-     */
-    public async stop(): Promise<{snapshot?: never, state?: never}> {
-        this.dispose(new Error("ContainerRuntimeStopped"));
-        throw new Error("Stop is no longer supported, use dispose to stop the runtime");
-    }
-
     private replayPendingStates() {
         // We need to be able to send ops to replay states
         if (!this.canSendOps()) { return; }


### PR DESCRIPTION
Following up on #6998, where I removed `stop()` from the `IRuntime` and more-aggressively blew up in implementation.  Here it is removed entirely.