### PR TITLE
Add Whole Summary Upload/Download support to GitRest

### DIFF
--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -24,6 +24,8 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1033.0",
+    "@fluidframework/protocol-base": "^0.1033.0",
+    "@fluidframework/protocol-definitions": "^0.1025.1",
     "@fluidframework/server-services-client": "^0.1033.0",
     "@fluidframework/server-services-core": "^0.1033.0",
     "@fluidframework/server-services-shared": "^0.1033.0",

--- a/server/gitrest/src/app.ts
+++ b/server/gitrest/src/app.ts
@@ -69,6 +69,7 @@ export function create(
     app.use(apiRoutes.git.commits);
     app.use(apiRoutes.repository.commits);
     app.use(apiRoutes.repository.contents);
+    app.use(apiRoutes.summaries);
 
     // catch 404 and forward to error handler
     app.use((req, res, next) => {

--- a/server/gitrest/src/routes/git/trees.ts
+++ b/server/gitrest/src/routes/git/trees.ts
@@ -64,7 +64,7 @@ async function getTree(repoManager: utils.RepositoryManager, owner: string, repo
     return getTreeInternal(repository, sha);
 }
 
-async function getTreeRecursive(
+export async function getTreeRecursive(
     repoManager: utils.RepositoryManager,
     owner: string,
     repo: string,

--- a/server/gitrest/src/routes/index.ts
+++ b/server/gitrest/src/routes/index.ts
@@ -53,6 +53,6 @@ export function create(
             commits: repositoryCommits.create(store, repoManager, externalStorageManager),
             contents: contents.create(store, repoManager),
         },
-        summaries: summaries.create(store, repoManager),
+        summaries: summaries.create(store, repoManager, externalStorageManager),
     };
 }

--- a/server/gitrest/src/routes/index.ts
+++ b/server/gitrest/src/routes/index.ts
@@ -16,6 +16,7 @@ import * as tags from "./git/tags";
 import * as trees from "./git/trees";
 import * as repositoryCommits from "./repository/commits";
 import * as contents from "./repository/contents";
+import * as summaries from "./summaries";
 /* eslint-enable import/no-internal-modules */
 
 export interface IRoutes {
@@ -31,6 +32,7 @@ export interface IRoutes {
         commits: Router;
         contents: Router;
     };
+    summaries: Router;
 }
 
 export function create(
@@ -51,5 +53,6 @@ export function create(
             commits: repositoryCommits.create(store, repoManager, externalStorageManager),
             contents: contents.create(store, repoManager),
         },
+        summaries: summaries.create(store, repoManager),
     };
 }

--- a/server/gitrest/src/routes/summaries.ts
+++ b/server/gitrest/src/routes/summaries.ts
@@ -1,0 +1,185 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ICreateTreeEntry } from "@fluidframework/gitresources";
+import { getGitMode, getGitType } from "@fluidframework/protocol-base";
+import { SummaryObject, SummaryType } from "@fluidframework/protocol-definitions";
+import {
+    IWholeFlatSummary,
+    IWholeSummaryBlob,
+    IWholeSummaryPayload,
+    IWholeSummaryTree,
+    IWholeSummaryTreeHandleEntry,
+    IWholeSummaryTreeValueEntry,
+    IWriteSummaryResponse,
+    NetworkError,
+    WholeSummaryTreeEntry,
+} from "@fluidframework/server-services-client";
+import { Router } from "express";
+import { Provider } from "nconf";
+import { RepositoryManager } from "../utils";
+/* eslint-disable import/no-internal-modules */
+import { createBlob } from "./git/blobs";
+import { createTree } from "./git/trees";
+/* eslint-enable import/no-internal-modules */
+import { handleResponse } from "./utils";
+
+export async function getSummary(
+    repoManager: RepositoryManager,
+    owner: string,
+    repo: string,
+    sha: string): Promise<IWholeFlatSummary> {
+    throw new NetworkError(501, "Not Implemented");
+}
+
+function getSummaryObjectFromWholeSummaryTreeEntry(entry: WholeSummaryTreeEntry): SummaryObject {
+    if ((entry as IWholeSummaryTreeHandleEntry).id !== undefined) {
+        return {
+            type: SummaryType.Handle,
+            handleType: entry.type === "tree" ? SummaryType.Tree : SummaryType.Blob,
+            handle: (entry as IWholeSummaryTreeHandleEntry).id,
+        };
+    }
+    if (entry.type === "blob") {
+        return {
+            type: SummaryType.Blob,
+            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
+            content: "",
+        };
+    }
+    if (entry.type === "tree") {
+        return {
+            type: SummaryType.Tree,
+            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
+            tree: {},
+            unreferenced: (entry as IWholeSummaryTreeValueEntry).unreferenced,
+        };
+    }
+    throw new NetworkError(400, `Unknown entry type: ${entry.type}`);
+}
+
+interface IRepositoryInformation {
+    repoManager: RepositoryManager;
+    owner: string;
+    repo: string;
+}
+
+async function writeSummaryTreeCore(
+    repoInfo: IRepositoryInformation,
+    wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
+): Promise<string> {
+    const entries: ICreateTreeEntry[] = await Promise.all(wholeSummaryTreeEntries.map(async (entry) => {
+        const summaryObject = getSummaryObjectFromWholeSummaryTreeEntry(entry);
+        const pathHandle = await writeSummaryTreeObject(repoInfo, entry, summaryObject);
+        return {
+            mode: getGitMode(summaryObject),
+            path: entry.path,
+            sha: pathHandle,
+            type: getGitType(summaryObject),
+        };
+    }));
+
+    const treeHandle = await createTree(
+        repoInfo.repoManager,
+        repoInfo.owner,
+        repoInfo.repo,
+        { tree: entries },
+    );
+    return treeHandle.sha;
+}
+
+async function writeSummaryTreeObject(
+    repoInfo: IRepositoryInformation,
+    wholeSummaryTreeEntry: WholeSummaryTreeEntry,
+    summaryObject: SummaryObject,
+): Promise<string> {
+    switch(summaryObject.type) {
+        case SummaryType.Blob:
+            return writeSummaryBlob(
+                repoInfo,
+                ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryBlob),
+            );
+        case SummaryType.Tree:
+            return writeSummaryTreeCore(
+                repoInfo,
+                ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryTree).entries ?? [],
+            );
+        case SummaryType.Handle:
+            return (wholeSummaryTreeEntry as IWholeSummaryTreeHandleEntry).id;
+        default:
+            throw new NetworkError(501, "Not Implemented");
+    }
+}
+
+async function writeSummaryBlob(repoInfo: IRepositoryInformation, blob: IWholeSummaryBlob): Promise<string> {
+    const blobResponse = await createBlob(
+        repoInfo.repoManager,
+        repoInfo.owner,
+        repoInfo.repo,
+        {
+            content: blob.content,
+            encoding: blob.encoding,
+        },
+    );
+    return blobResponse.sha;
+}
+
+export async function createSummary(
+    repoManager: RepositoryManager,
+    owner: string,
+    repo: string,
+    payload: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
+    const summaryHandle = await writeSummaryTreeCore({ repoManager, owner, repo }, payload.entries);
+    return { id: summaryHandle };
+}
+
+export async function deleteSummary(
+    repoManager: RepositoryManager,
+    owner: string,
+    repo: string,
+    softDelete: boolean): Promise<boolean> {
+    throw new NetworkError(501, "Not Implemented");
+}
+
+export function create(store: Provider, repoManager: RepositoryManager): Router {
+    const router: Router = Router();
+
+    /**
+     * Retrieves a summary.
+     * If sha is "latest", returns latest summary for owner/repo.
+     */
+    router.get("/repos/:owner/:repo/git/summaries/:sha", (request, response) => {
+        handleResponse(
+            getSummary(repoManager, request.params.owner, request.params.repo, request.params.sha),
+            response,
+        );
+    });
+
+    /**
+     * Creates a new summary.
+     */
+    router.post("/repos/:owner/:repo/git/summaries", (request, response) => {
+        const wholeSummaryPayload: IWholeSummaryPayload = request.body;
+        handleResponse(
+            createSummary(repoManager, request.params.owner, request.params.repo, wholeSummaryPayload),
+            response,
+            201,
+        );
+    });
+
+    /**
+     * Deletes the latest summary for the owner/repo.
+     * If header Soft-Delete="true", only flags summary as deleted.
+     */
+    router.delete("/repos/:owner/:repo/git/summaries/:sha", (request, response) => {
+        const softDelete = request.get("Soft-Delete")?.toLowerCase() === "true";
+        handleResponse(
+            deleteSummary(repoManager, request.params.owner, request.params.repo, softDelete),
+            response,
+        );
+    });
+
+    return router;
+}

--- a/server/gitrest/src/routes/utils.ts
+++ b/server/gitrest/src/routes/utils.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { NetworkError } from "@fluidframework/server-services-client";
+import { Response } from "express";
+
+export function handleResponse<T>(
+    resultP: Promise<T>,
+    response: Response,
+    successStatus: number = 200,
+    failureStatus: number = 400,
+) {
+    resultP
+        .then((result) => {
+            response.status(successStatus).json(result);
+        })
+        .catch((error) => {
+            if (error && error.code && error.code < 600 && error.code >= 400 && error.message !== undefined) {
+                response.status((error as NetworkError).code).json((error as NetworkError).message);
+            } else {
+                response.status(failureStatus).json(error);
+            }
+        });
+}


### PR DESCRIPTION
We've been adding a lot of features to the R11s Driver around "Whole Summary Upload/Download", however, the R11s Git storage scenario has been all but left behind. This PR adds whole summary support to GitRest such that `enableWholeSummaryUpload` flag in the R11s Driver works with the Git storage scenario.