### PR TITLE
Remove offline summarizer errors from error table

### DIFF
--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -356,15 +356,17 @@ export class RunningSummarizer implements IDisposable {
                 totalAttempts++;
                 attemptPerPhase++;
 
+                const { delaySeconds: regularDelaySeconds = 0, ...options } = attempts[attemptPhase];
+                const delaySeconds = overrideDelaySeconds ?? regularDelaySeconds;
+
                 const summarizeProps: ITelemetryProperties = {
                     summarizeReason,
                     summarizeTotalAttempts: totalAttempts,
                     summarizeAttemptsPerPhase: attemptPerPhase,
                     summarizeAttemptPhase: attemptPhase + 1, // make everything 1-based
+                    ...options,
                 };
 
-                const { delaySeconds: regularDelaySeconds = 0, ...options } = attempts[attemptPhase];
-                const delaySeconds = overrideDelaySeconds ?? regularDelaySeconds;
                 if (delaySeconds > 0) {
                     this.logger.sendPerformanceEvent({
                         eventName: "SummarizeAttemptDelay",

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -240,7 +240,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
                 // If failure happened on container load, we may not yet realized that socket disconnected, so check
                 // offlineError.
                 const category = error?.errorType === DriverErrorType.offlineError ? "generic" : "error";
-                this.logger.sendErrorEvent(
+                this.logger.sendTelemetryEvent(
                     {
                         eventName: "SummarizerException",
                         category,

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -8,7 +8,7 @@ import { TypedEventEmitter, assert } from "@fluidframework/common-utils";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { IFluidRouter, IRequest } from "@fluidframework/core-interfaces";
 import { LoaderHeader } from "@fluidframework/container-definitions";
-import { DriverHeader } from "@fluidframework/driver-definitions";
+import { DriverHeader, DriverErrorType } from "@fluidframework/driver-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { createSummarizingWarning } from "./summarizer";
 import { ISummarizerClientElection, summarizerClientType } from "./summarizerClientElection";
@@ -236,7 +236,16 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
             // We could add error.fluidErrorCode !== "containerClosedWithoutErrorDuringLoad" check to narrow it down,
             // but that does not seem to be necessary.
             if (this.getShouldSummarizeState().shouldSummarize || this.summarizer !== undefined) {
-                this.logger.sendErrorEvent({ eventName: "SummarizerException" }, error);
+                // Report any failure as an error unless it was due to cancellation (like "disconnected" error)
+                // If failure happened on container load, we may not yet realized that socket disconnected, so check
+                // offlineError.
+                const category = error?.errorType === DriverErrorType.offlineError ? "generic" : "error";
+                this.logger.sendErrorEvent(
+                    {
+                        eventName: "SummarizerException",
+                        category,
+                    },
+                    error);
                 this.emit("summarizerWarning", error);
 
                 // Note that summarizer may keep going (like doing last summary).


### PR DESCRIPTION
Client becoming offline at different times of summarizer lifetime are prevailing reason for errors in telemetry.
These are not really errors, i.e. these are expected states that we should not bring attention of OCEs / developers, unless it keeps happening for long time (which is covered by such events as "Behind").

So this is my attempt to downplay severity and stop reporting them as errors.
It's a bit ugly, and in general goes against the rule of doing proper transformation through queries (and keeping telemetry "raw"). At the same time, we really want our telemetry errors to represents real issues that developers and OCEs need to pay attention, and keep the messaging simple.