### PR TITLE
return stashed ops in serialize()

### DIFF
--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -115,6 +115,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     attach(request: IRequest): Promise<void>;
     readonly attachState: AttachState;
     close(error?: ICriticalContainerError): void;
+    // @deprecated
     closeAndGetPendingLocalState(): string;
     readonly closed: boolean;
     readonly codeDetails: IFluidCodeDetails | undefined;

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -144,6 +144,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     /**
      * Closes the container and returns serialized local state intended to be
      * given to a newly loaded container
+     * @deprecated use serialize()
      */
     closeAndGetPendingLocalState(): string;
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -758,7 +758,18 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     public serialize(): string {
-        assert(this.attachState === AttachState.Detached, 0x0d3 /* "Should only be called in detached container" */);
+        assert(this.attachState !== AttachState.Attaching, "Can't serialize while attaching");
+
+        if (this.attachState === AttachState.Attached) {
+            assert(this.resolvedUrl !== undefined && this.resolvedUrl.type === "fluid",
+                "resolved url should be valid Fluid url");
+            const pendingState: IPendingLocalState = {
+                pendingRuntimeState: this.context.getPendingLocalState(),
+                url: this.resolvedUrl.url,
+            };
+
+            return JSON.stringify(pendingState);
+        }
 
         const appSummary: ISummaryTree = this.context.createSummary();
         const protocolSummary = this.captureProtocolSummary();

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -60,22 +60,15 @@ const getPendingOps = async (args: ITestObjectProvider, send: boolean, cb: MapCa
 
     await cb(container, dataStore, map);
 
-    let pendingState: string;
+    const pendingState = container.serialize();
     if (send) {
-        const pendingRuntimeState = (container as any).context.runtime.getPendingLocalState();
         await args.ensureSynchronized();
-        const p = container.closeAndGetPendingLocalState();
-        assert.strictEqual(JSON.parse(p).pendingRuntimeState, undefined);
+        assert.strictEqual(JSON.parse(container.serialize()).pendingRuntimeState, undefined);
         // if we sent the ops successfully the pending state should have a clientId. if not they will be resent anyway
-        assert(pendingRuntimeState.clientId !== undefined, "no clientId for successful ops");
+        assert(JSON.parse(pendingState).pendingRuntimeState.clientId !== undefined, "no clientId for successful ops");
         assert(container.resolvedUrl !== undefined && container.resolvedUrl.type === "fluid");
-        pendingState = JSON.stringify({
-            url: container.resolvedUrl.url,
-            pendingRuntimeState,
-        });
-    } else {
-        pendingState = container.closeAndGetPendingLocalState();
     }
+    container.close();
 
     args.opProcessingController.resumeProcessing();
 


### PR DESCRIPTION
close #7719
Return stashed pending ops from `Container.serialize()` when attached, allowing users to get stashed ops without closing the container (functionality added in #7811)