### PR TITLE
Log snapshot cache entry age in ObtainSnapshot telemetry

### DIFF
--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -227,7 +227,9 @@ export interface IFlushOpsResponse {
     lastPersistedSequenceNumber?: number;
 }
 
-export interface ISnapshotResponse {
-    snapshot: ISnapshotContents,
+/**
+ * Represents the cached snapshot value.
+ */
+export interface ISnapshotCachedEntry extends ISnapshotContents {
     cacheEntryTime?: number,
 }

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -5,6 +5,7 @@
 
 import * as api from "@fluidframework/protocol-definitions";
 import { HostStoragePolicy } from "@fluidframework/odsp-driver-definitions";
+import { ISnapshotContents } from "./odspUtils";
 
 /**
  * Socket storage discovery api response
@@ -205,10 +206,10 @@ export interface IVersionedValueWithEpoch {
     value: any;
     fluidEpoch: string,
     // This is same as "persistedCacheValueVersion" below. This represents the version of data stored in cache.
-    version: 3,
+    version: 4,
 }
 
-export const persistedCacheValueVersion = 3;
+export const persistedCacheValueVersion = 4;
 
 export interface IGetOpsResponse {
     nonce: string;
@@ -224,4 +225,9 @@ export interface IFlushOpsResponse {
     /** Time in seconds */
     retryAfter?: number;
     lastPersistedSequenceNumber?: number;
+}
+
+export interface ISnapshotResponse {
+    snapshot: ISnapshotContents,
+    cacheEntryTime?: number,
 }

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -206,10 +206,10 @@ export interface IVersionedValueWithEpoch {
     value: any;
     fluidEpoch: string,
     // This is same as "persistedCacheValueVersion" below. This represents the version of data stored in cache.
-    version: 4,
+    version: 3,
 }
 
-export const persistedCacheValueVersion = 4;
+export const persistedCacheValueVersion = 3;
 
 export interface IGetOpsResponse {
     nonce: string;

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -231,5 +231,5 @@ export interface IFlushOpsResponse {
  * Represents the cached snapshot value.
  */
 export interface ISnapshotCachedEntry extends ISnapshotContents {
-    cacheEntryTime?: number,
+    cacheEntryTime: number,
 }

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -16,7 +16,7 @@ import {
     InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { IOdspSnapshot, IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
+import { IOdspSnapshot, ISnapshotCachedEntry, IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import {
@@ -266,8 +266,12 @@ async function fetchLatestSnapshotCore(
                 } else if (canCache) {
                     const fluidEpoch = response.odspSnapshotResponse.headers.get("x-fluid-epoch");
                     assert(fluidEpoch !== undefined, 0x1e6 /* "Epoch  should be present in response" */);
+                    const value: ISnapshotCachedEntry = {
+                        ...snapshot,
+                        cacheEntryTime: Date.now(),
+                    };
                     const valueWithEpoch: IVersionedValueWithEpoch = {
-                        value: { snapshot, entryTime: Date.now() },
+                        value,
                         fluidEpoch,
                         version: persistedCacheValueVersion,
                     };

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -415,8 +415,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 { eventName: "ObtainSnapshot" },
                 async (event: PerformanceEvent) => {
                     const props = {};
-                    let cachedSnapshot: ISnapshotContents | ISnapshotCachedEntry | undefined;
-                    const cachedSnapshotP: Promise<ISnapshotCachedEntry | undefined> =
+                    let cachedSnapshot: ISnapshotContents | undefined;
+                    const cachedSnapshotP: Promise<ISnapshotContents | undefined> =
                         this.epochTracker.get(createCacheSnapshotKey(this.odspResolvedUrl))
                             .then((snapshotCachedEntry: ISnapshotCachedEntry) => {
                                 if (snapshotCachedEntry !== undefined) {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -458,8 +458,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         }
                     }
                    const props = { method };
-                   if (props.method === "cache") {
-                       assert(cachedSnapshot.cacheEntryTime !== undefined, "Cache entry time should be present");
+                   if (props.method === "cache" && cachedSnapshot.cacheEntryTime !== undefined) {
                        // eslint-disable-next-line @typescript-eslint/dot-notation
                        props["cacheEntryAge"] = Date.now() - cachedSnapshot.cacheEntryTime;
                    }

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -468,6 +468,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         }
                     }
                     if (method === "network") {
+                        // eslint-disable-next-line @typescript-eslint/dot-notation
                         props["cacheEntryAge"] = undefined;
                     }
                     event.end({ ...props, method });

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -32,7 +32,7 @@ import {
     IDocumentStorageGetVersionsResponse,
     HostStoragePolicyInternal,
     IVersionedValueWithEpoch,
-    ISnapshotResponse,
+    ISnapshotCachedEntry,
 } from "./contracts";
 import { downloadSnapshot, fetchSnapshot, fetchSnapshotWithRedeem } from "./fetchSnapshot";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
@@ -414,8 +414,8 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                 this.logger,
                 { eventName: "ObtainSnapshot" },
                 async (event: PerformanceEvent) => {
-                    let cachedSnapshot: ISnapshotResponse | undefined;
-                    const cachedSnapshotP: Promise<ISnapshotResponse | undefined> =
+                    let cachedSnapshot: ISnapshotCachedEntry | undefined;
+                    const cachedSnapshotP: Promise<ISnapshotCachedEntry | undefined> =
                         this.epochTracker.get(createCacheSnapshotKey(this.odspResolvedUrl));
 
                     let method: string;
@@ -464,7 +464,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                        props["cacheEntryAge"] = Date.now() - cachedSnapshot.cacheEntryTime;
                    }
                     event.end({ ...props });
-                    return cachedSnapshot.snapshot;
+                    return cachedSnapshot;
                 },
                 {end: true, cancel: "error"},
             );
@@ -710,7 +710,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         "snapshotTree",
                     );
                 };
-                const snapshot = (await fetchSnapshot(this.snapshotUrl!, storageToken, id, this.fetchFullSnapshot, this.logger, snapshotDownloader)).snapshot;
+                const snapshot = await fetchSnapshot(this.snapshotUrl!, storageToken, id, this.fetchFullSnapshot, this.logger, snapshotDownloader);
                 let treeId = "";
                 if (snapshot.snapshotTree) {
                     assert(snapshot.snapshotTree.id !== undefined, 0x222 /* "Root tree should contain the id!!" */);

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -79,8 +79,9 @@ describe("Tests for snapshot fetch", () => {
         sequenceNumber: 0,
     };
 
-    const value: IVersionedValueWithEpoch =
-    {value: content, fluidEpoch: "epoch1", version: persistedCacheValueVersion };
+    const value: IVersionedValueWithEpoch = { value: { snapshot: content, cacheEntryTime: Date.now() },
+        fluidEpoch: "epoch1",
+        version: persistedCacheValueVersion };
 
     const expectedVersion = [{ id: "id", treeId: undefined!}];
 

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -79,7 +79,7 @@ describe("Tests for snapshot fetch", () => {
         sequenceNumber: 0,
     };
 
-    const value: IVersionedValueWithEpoch = { value: { snapshot: content, cacheEntryTime: Date.now() },
+    const value: IVersionedValueWithEpoch = { value: { ...content, cacheEntryTime: Date.now() },
         fluidEpoch: "epoch1",
         version: persistedCacheValueVersion };
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/7967
This logs the age of the snapshot cached entry which is fetched from cache in fetch snapshot sequence.
This will help hosts to see effectiveness of caching, and also using other data (how many ops were on top of such snapshot) to figure out effective caching duration.