### PR TITLE
Props to pass info from loader to driver for telemetry logging

### DIFF
--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -139,8 +139,8 @@ export interface IDocumentService {
 
 // @public (undocumented)
 export interface IDocumentServiceFactory {
-    createContainer(createNewSummary: ISummaryTree | undefined, createNewResolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
-    createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
+    createContainer(createNewSummary: ISummaryTree | undefined, createNewResolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, props?: ILoaderInfoProps): Promise<IDocumentService>;
+    createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, props?: ILoaderInfoProps): Promise<IDocumentService>;
     protocolName: string;
 }
 
@@ -222,6 +222,14 @@ export interface IGenericNetworkError extends IDriverErrorBase {
     readonly errorType: DriverErrorType.genericNetworkError;
     // (undocumented)
     readonly statusCode?: number;
+}
+
+// @public
+export interface ILoaderInfoProps {
+    // (undocumented)
+    containerId?: string;
+    // (undocumented)
+    loaderVersion?: string;
 }
 
 // @public (undocumented)

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -311,6 +311,9 @@ export interface IDocumentServiceFactory {
     ): Promise<IDocumentService>;
 }
 
+/**
+ * Information that loader can pass to driver.
+ */
 export interface ILoaderInfoProps {
     // Id of the loaded container
     containerId?: string,

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -292,7 +292,11 @@ export interface IDocumentServiceFactory {
     /**
      * Returns an instance of IDocumentService
      */
-    createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger): Promise<IDocumentService>;
+    createDocumentService(
+        resolvedUrl: IResolvedUrl,
+        logger?: ITelemetryBaseLogger,
+        props?: ILoaderInfoProps,
+    ): Promise<IDocumentService>;
 
     /**
      * Creates a new document with the provided options. Returns the document service.
@@ -303,7 +307,15 @@ export interface IDocumentServiceFactory {
         createNewSummary: ISummaryTree | undefined,
         createNewResolvedUrl: IResolvedUrl,
         logger?: ITelemetryBaseLogger,
+        props?: ILoaderInfoProps,
     ): Promise<IDocumentService>;
+}
+
+export interface ILoaderInfoProps {
+    // Id of the loaded container
+    containerId?: string,
+    // Version of the loader which is using the driver factory.
+    loaderVersion?: string,
 }
 
 /**


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/8035
Refer: https://github.com/microsoft/FluidFramework/issues/7598
This will be used in both of above issues where we want to use the containerID and the loader version to log in server, push telemetry.
1.) Loader version will be used to pass to push so that it can log it.
2.) ContainerId will be passed to spo network calls. 