### PR TITLE
Better fetching cancelation

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -958,8 +958,11 @@ export class DeltaManager
             this.deltaStorage = await docService.connectToDeltaStorage();
         }
 
-        let controller = this.closeAbortController;
-        let listenerToClear: ((op: ISequencedDocumentMessage) => void) | undefined;
+        assert(this.closeAbortController.signal.onabort === null, 0x1e8 /* "reentrancy" */);
+        const controller = new AbortController();
+        this.closeAbortController.signal.onabort = () => controller.abort();
+
+        let cancelFetch: (op: ISequencedDocumentMessage) => boolean;
 
         if (to !== undefined) {
             const lastExpectedOp = to - 1; // make it inclusive!
@@ -978,26 +981,34 @@ export class DeltaManager
                 return;
             }
 
-            controller = new AbortController();
-
-            assert(this.closeAbortController.signal.onabort === null, 0x1e8 /* "reentrancy" */);
-            this.closeAbortController.signal.onabort = () => controller.abort();
-
-            const listener = (op: ISequencedDocumentMessage) => {
-                // Be prepared for the case where webSocket would receive the ops that we are trying to fill through
-                // storage. Ideally it should never happen (i.e. ops on socket are always ordered, and thus once we
-                // detected gap, this gap can't be filled in later on through websocket).
-                // And in practice that does look like the case. The place where this code gets hit is if we lost
-                // connection and reconnected (likely to another box), and new socket's initial ops contains these ops.
-                assert(op.sequenceNumber === this.lastQueuedSequenceNumber, 0x23a /* "seq#'s" */);
-                if (this.lastQueuedSequenceNumber >= lastExpectedOp) {
-                    controller.abort();
-                    this._inbound.off("push", listener);
-                }
-            };
-            this._inbound.on("push", listener);
-            listenerToClear = listener;
+            // Be prepared for the case where webSocket would receive the ops that we are trying to fill through
+            // storage. Ideally it should never happen (i.e. ops on socket are always ordered, and thus once we
+            // detected gap, this gap can't be filled in later on through websocket).
+            // And in practice that does look like the case. The place where this code gets hit is if we lost
+            // connection and reconnected (likely to another box), and new socket's initial ops contains these ops.
+            cancelFetch = (op: ISequencedDocumentMessage) => op.sequenceNumber >= lastExpectedOp;
+        } else {
+            // Unbound requests are made to proactively fetch ops, but also get up to date in cases where socket
+            // is silent (and connection is "read", thus we might not have any data on how far client is behind).
+            // Once we have any op coming in from socket, we can cancel it as it's not needed any more.
+            // That said, if we have socket connection, make sure we got ops up to checkpointSequenceNumber!
+            cancelFetch = (op: ISequencedDocumentMessage) => op.sequenceNumber >= this.lastObservedSeqNumber;
         }
+
+        let opsFromFetch = false;
+
+        const listenerToClear = (op: ISequencedDocumentMessage) => {
+            assert(op.sequenceNumber === this.lastQueuedSequenceNumber, 0x23a /* "seq#'s" */);
+            // Ops that are coming from this request should not cancel itself.
+            // This is useless for known ranges (to is defined) as it means request is over either way.
+            // And it will cancel unbound request too early, not allowing us to learn where the end of the file is.
+            if (!opsFromFetch && cancelFetch(op)) {
+                controller.abort();
+                this._inbound.off("push", listenerToClear);
+            }
+        };
+
+        this._inbound.on("push", listenerToClear);
 
         try {
             const stream = this.deltaStorage.fetchMessages(
@@ -1012,13 +1023,17 @@ export class DeltaManager
                 if (result.done) {
                     break;
                 }
-                callback(result.value);
+                try {
+                    opsFromFetch = true;
+                    callback(result.value);
+                } finally {
+                    opsFromFetch = false;
+                }
             }
         } finally {
+            assert(!opsFromFetch, "logic error");
             this.closeAbortController.signal.onabort = null;
-            if (listenerToClear !== undefined) {
-                this._inbound.off("push", listenerToClear);
-            }
+            this._inbound.off("push", listenerToClear);
         }
     }
 


### PR DESCRIPTION
There are couple active investigations around op roundtrip latency and join op receiving latency:
https://github.com/microsoft/FluidFramework/issues/7312
https://github.com/microsoft/FluidFramework/issues/7406

While not all conditions are well understood, it's pretty clearly that many cases run into the issue of pending storage op fetch requests blocking op processing, where they are not needed. I.e. the reason (translating to range of ops) we are asking for is no longer valid / required, but active fetch request might block future ops requests, as system (as it stands today) allows only one request at a time.

This change changes the following behavior:
1. Cancelation for request with known end limit (_to_ argument) are cancelled only when all ops in the range came in not through that request. That will ensure that we do not cancel (and report cancelation) for storage requests that are about to complete either way.
2. Main change: Cancel unbound storage op requests when op is coming in from ordering service that is above last known op (which is usually equal to checkpointSequenceNumber ordering service provided on connection, indicating where the end of the file is).

Potential future change to remove further bottlenecks: We might revisit the design of one request at a time.
I think allowing one bound and one unbound request makes sense, or maybe 2 requests of any type, not sure.
We will monitor data based on these results to make further determination.
