### PR TITLE
Fix odsp end-to-end tests

### DIFF
--- a/api-report/test-driver-definitions.api.md
+++ b/api-report/test-driver-definitions.api.md
@@ -6,6 +6,7 @@
 
 import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';
+import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 
@@ -16,7 +17,7 @@ export interface ITelemetryBufferedLogger extends ITelemetryBaseLogger {
 
 // @public (undocumented)
 export interface ITestDriver {
-    createContainerUrl(testId: string): Promise<string>;
+    createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string>;
     createCreateNewRequest(testId?: string): IRequest;
     createDocumentServiceFactory(): IDocumentServiceFactory;
     createUrlResolver(): IUrlResolver;

--- a/api-report/test-drivers.api.md
+++ b/api-report/test-drivers.api.md
@@ -13,6 +13,7 @@ import { ILocalDeltaConnectionServer } from '@fluidframework/server-local-server
 import { InsecureTinyliciousUrlResolver } from '@fluidframework/tinylicious-driver';
 import { InsecureUrlResolver } from '@fluidframework/driver-utils';
 import { IRequest } from '@fluidframework/core-interfaces';
+import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { ITestDriver } from '@fluidframework/test-driver-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { LocalDeltaConnectionServer } from '@fluidframework/server-local-server';
@@ -138,7 +139,7 @@ export type RouterliciousDriverApiType = typeof RouterliciousDriverApi;
 // @public (undocumented)
 export class RouterliciousTestDriver implements ITestDriver {
     // (undocumented)
-    createContainerUrl(testId: string): Promise<string>;
+    createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string>;
     // (undocumented)
     createCreateNewRequest(testId: string): IRequest;
     // (undocumented)
@@ -161,7 +162,7 @@ export class RouterliciousTestDriver implements ITestDriver {
 export class TinyliciousTestDriver implements ITestDriver {
     constructor(api?: RouterliciousDriverApiType);
     // (undocumented)
-    createContainerUrl(testId: string): Promise<string>;
+    createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string>;
     // (undocumented)
     createCreateNewRequest(testId: string): IRequest;
     // (undocumented)

--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -4,7 +4,7 @@
  */
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
-import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 
 export type TestDriverTypes = "tinylicious" | "t9s" | "routerlicious" | "r11s" | "odsp" | "local";
 
@@ -63,8 +63,11 @@ export interface ITestDriver{
      * If you need more control you should disambiguate the driver based on its
      * type, this should only be done it absolutely necessary for complex scenarios
      * as the test may not work against all supported servers if done.
+     * UPDATE/To help with disambiguating the container the caller can pass an optional
+     * resolved URL associated with a container created earlier. The specific driver
+     * will use it as an additional hint when resolving the container URL.
      */
-    createContainerUrl(testId: string): Promise<string>;
+    createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string>;
 }
 
 /**

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -8,7 +8,7 @@ import { IRequest } from "@fluidframework/core-interfaces";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 import { InsecureUrlResolver } from "@fluidframework/driver-utils";
 import { v4 as uuid } from "uuid";
-import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IRouterliciousDriverPolicies } from "@fluidframework/routerlicious-driver";
 import { ITestDriver } from "@fluidframework/test-driver-definitions";
 import { RouterliciousDriverApiType, RouterliciousDriverApi } from "./routerliciousDriverApi";
@@ -111,8 +111,10 @@ export class RouterliciousTestDriver implements ITestDriver {
     ) {
     }
 
-    async createContainerUrl(testId: string): Promise<string> {
-        return `${this.serviceEndpoints.hostUrl}/${encodeURIComponent(this.tenantId)}/${encodeURIComponent(testId)}`;
+    async createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string> {
+        const containerId = containerUrl && "id" in containerUrl ? containerUrl.id : testId;
+        // eslint-disable-next-line max-len
+        return `${this.serviceEndpoints.hostUrl}/${encodeURIComponent(this.tenantId)}/${encodeURIComponent(containerId)}`;
     }
 
     createDocumentServiceFactory(): IDocumentServiceFactory {

--- a/packages/test/test-drivers/src/tinyliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/tinyliciousTestDriver.ts
@@ -11,7 +11,7 @@ import {
     defaultTinyliciousPort,
 } from "@fluidframework/tinylicious-driver";
 import { ITestDriver } from "@fluidframework/test-driver-definitions";
-import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { RouterliciousDriverApiType, RouterliciousDriverApi } from "./routerliciousDriverApi";
 
 export class TinyliciousTestDriver implements ITestDriver {
@@ -29,7 +29,8 @@ export class TinyliciousTestDriver implements ITestDriver {
     createCreateNewRequest(testId: string): IRequest {
         return createTinyliciousCreateNewRequest(testId);
     }
-    async createContainerUrl(testId: string): Promise<string> {
-        return `http://localhost:${defaultTinyliciousPort}/${testId}`;
+    async createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string> {
+        const containerId = containerUrl && "id" in containerUrl ? containerUrl.id : testId;
+        return `http://localhost:${defaultTinyliciousPort}/${containerId}`;
     }
 }

--- a/packages/test/test-end-to-end-tests/src/test/noDetlaStream.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/noDetlaStream.spec.ts
@@ -48,6 +48,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
     for(const testConfig of testConfigs) {
         it(`Validate Load Modes: ${JSON.stringify(testConfig ?? "undefined")}`, async function() {
             const provider  = getTestObjectProvider();
+            let containerUrl: IResolvedUrl | undefined;
             // initialize the container and its data
             {
                 const initLoader = createLoader(
@@ -58,6 +59,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
 
                 const initContainer = await initLoader.createDetachedContainer(provider.defaultCodeDetails);
                 await initContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+                containerUrl = initContainer.resolvedUrl;
 
                 const initDataObject = await requestFluidObject<ITestFluidObject>(initContainer, "default");
                 for(let i = 0; i < maxOps; i++) {
@@ -89,7 +91,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
                     provider.urlResolver,
                 );
                 const summaryContainer = await summaryLoader.resolve({
-                    url: await provider.driver.createContainerUrl(provider.documentId),
+                    url: await provider.driver.createContainerUrl(provider.documentId, containerUrl),
                 });
 
                 const summaryCollection =
@@ -109,7 +111,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
                     provider.urlResolver,
                 );
                 const validationContainer = await validationLoader.resolve({
-                    url: await provider.driver.createContainerUrl(provider.documentId),
+                    url: await provider.driver.createContainerUrl(provider.documentId, containerUrl),
                 });
                 const validationDataObject = await requestFluidObject<ITestFluidObject>(validationContainer, "default");
 
@@ -141,7 +143,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
                 );
 
                 const storageOnlyContainer = await storageOnlyLoader.resolve({
-                    url: await provider.driver.createContainerUrl(provider.documentId),
+                    url: await provider.driver.createContainerUrl(provider.documentId, containerUrl),
                     headers: {[LoaderHeader.loadMode]: testConfig.loadOptions},
                 }) as Container;
 

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -19,6 +19,7 @@ import {
     IDocumentService,
     IDocumentServiceFactory,
     IDocumentStorageService,
+    IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import { NonRetryableError, readAndParse } from "@fluidframework/driver-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -34,7 +35,8 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
             IFluidDataStoreFactory: new TestFluidObjectFactory(registry),
         };
         const text = "hello world";
-        let documentId: string;
+        const documentId = createDocumentId();
+        let containerUrl: IResolvedUrl | undefined;
         const provider = getTestObjectProvider();
         const logger = provider.logger;
 
@@ -57,8 +59,8 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
             assert(sharedString);
             sharedString.insertText(0, text);
 
-            await container.attach(provider.driver.createCreateNewRequest(createDocumentId()));
-            documentId = container.id;
+            await container.attach(provider.driver.createCreateNewRequest(documentId));
+            containerUrl = container.resolvedUrl;
         }
         { // normal load client
             const codeDetails = { package: "no-dynamic-pkg" };
@@ -73,7 +75,9 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
                 logger,
             });
 
-            const container = await loader.resolve({ url: await provider.driver.createContainerUrl(documentId) });
+            const container = await loader.resolve({
+                url: await provider.driver.createContainerUrl(documentId, containerUrl),
+            });
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
             const sharedString = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
             assert(sharedString);
@@ -119,7 +123,9 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
                 logger,
             });
 
-            const container = await loader.resolve({ url: await provider.driver.createContainerUrl(documentId) });
+            const container = await loader.resolve({
+                url: await provider.driver.createContainerUrl(documentId, containerUrl),
+            });
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
 
             try {
@@ -136,7 +142,8 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
             IFluidDataStoreFactory: new TestFluidObjectFactory(registry),
         };
         const text = "hello world";
-        let documentId: string;
+        const documentId = createDocumentId();
+        let containerUrl: IResolvedUrl | undefined;
         const provider = getTestObjectProvider();
         const logger = provider.logger;
 
@@ -174,8 +181,8 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
             }
             initialText = sharedString.getText();
 
-            await container.attach(provider.driver.createCreateNewRequest(createDocumentId()));
-            documentId = container.id;
+            await container.attach(provider.driver.createCreateNewRequest(documentId));
+            containerUrl = container.resolvedUrl;
         }
         { // normal load client
             const codeDetails = { package: "no-dynamic-pkg" };
@@ -190,7 +197,9 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
                 logger,
             });
 
-            const container = await loader.resolve({ url: await provider.driver.createContainerUrl(documentId) });
+            const container = await loader.resolve({
+                url: await provider.driver.createContainerUrl(documentId, containerUrl),
+            });
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
             const sharedString = await dataObject.root.get<IFluidHandle<SharedString>>(stringId)?.get();
             assert(sharedString);


### PR DESCRIPTION
This PR addresses a few odsp end-to-end test failures introduced recently after the container ID refactoring.

Made some adjustments to the test infrastructure. Specifically, added an optional resolved url parameter to help a driver resolve the container url using the ID of a container instance created earlier. Only tinylicious and routerlicious drivers were updated to use the new parameter.