### PR TITLE
use normalizeError() on failed attach()

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -34,7 +34,6 @@ import {
 } from "@fluidframework/container-definitions";
 import {
     DataCorruptionError,
-    DataProcessingError,
     extractSafePropertiesFromMessage,
     GenericError,
     UsageError,
@@ -869,8 +868,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             assert(!canRetryOnError(error), 0x24f /* "retriable error thrown from attach()" */);
 
             // add resolved URL on error object so that host has the ability to find this document and delete it
-            const newError = DataProcessingError.wrapIfUnrecognized(
-                error, "errorWhileUploadingBlobsWhileAttaching", undefined);
+            const newError = normalizeError(error);
             const resolvedUrl = this.resolvedUrl;
             if (resolvedUrl) {
                 ensureFluidResolvedUrl(resolvedUrl);

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -243,7 +243,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP, /(0x202)|(0x204)/ /* "create empty file not supported" */);
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
         }
         await attachP;
 
@@ -292,7 +293,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const attachP = detachedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP, /(0x202)|(0x204)/ /* "create empty file not supported" */);
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
         }
         await attachP;
         detachedBlobStorage.blobs.clear();
@@ -319,7 +321,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const attachP = rehydratedContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP, /(0x202)|(0x204)/ /* "create empty file not supported" */);
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
         }
         await attachP;
 
@@ -347,7 +350,8 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
         if (provider.driver.type !== "odsp") {
             // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP, /(0x202)|(0x204)/ /* "create empty file not supported" */);
+            return assert.rejects(attachP,
+                (err) => /(0x202)|(0x204)/.test(err.message) /* "create empty file not supported" */);
         }
         await attachP;
 


### PR DESCRIPTION
Use `normalizeError()` instead of `DataProcessingError` in the event of an error occurring during the process of attaching the data of a new document.