### PR TITLE
Splay test imports

### DIFF
--- a/packages/dds/merge-tree/src/test/client.apis.ts
+++ b/packages/dds/merge-tree/src/test/client.apis.ts
@@ -6,16 +6,20 @@
 /* eslint-disable guard-for-in, no-restricted-syntax */
 
 import { strict as assert } from "assert";
-import * as MergeTree from "../";
-import * as Properties from "../properties";
+import { Client } from "../client";
+import {
+    createMap,
+    matchProperties,
+    PropertySet,
+} from "../properties";
 import { TestClient } from "./testClient";
 
 function checkGetPropertiesAtPos(
-    client: MergeTree.Client,
+    client: Client,
     pos: number,
-    props?: Properties.PropertySet, verbose = false) {
+    props?: PropertySet, verbose = false) {
     const propsRetrieved = client.getPropertiesAtPosition(pos);
-    const result = Properties.matchProperties(props, propsRetrieved);
+    const result = matchProperties(props, propsRetrieved);
     if ((!result) && verbose) {
         console.log(`At pos: ${pos}`);
         console.log("Expected props");
@@ -34,7 +38,7 @@ function checkGetPropertiesAtPos(
 export function clientGetPropertiesAtPositionTest() {
     const client = new TestClient();
     client.insertTextLocal(0, "the cat is on the mat");
-    const props = MergeTree.createMap<any>();
+    const props = createMap<any>();
     props.prop1 = 10;
     client.insertTextLocal(4, "fuzzy, fuzzy ", props);
 
@@ -46,7 +50,7 @@ export function clientGetPropertiesAtPositionTest() {
     return (testResult1 === testResult2 === testResult3 === testResult4 === true);
 }
 
-function checkGetSegmentExtentsOfPos(client: MergeTree.Client, pos: number, posStart: number,
+function checkGetSegmentExtentsOfPos(client: Client, pos: number, posStart: number,
     posAfterEnd: number, verbose = false) {
     const segExtents = client.getRangeExtentsOfPosition(pos);
     const result = segExtents.posStart === posStart && segExtents.posAfterEnd === posAfterEnd;
@@ -61,7 +65,7 @@ function checkGetSegmentExtentsOfPos(client: MergeTree.Client, pos: number, posS
 export function clientGetSegmentExtentsOfPositionTest() {
     const client = new TestClient();
     client.insertTextLocal(0, "the cat is on the mat");
-    const props = MergeTree.createMap<any>();
+    const props = createMap<any>();
     props.prop1 = 10;
     client.insertTextLocal(4, "fuzzy, fuzzy ", props);
     client.insertTextLocal(8, "more fuzzy text", {});

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { SegmentGroup } from "../";
 import { UnassignedSequenceNumber } from "../constants";
+import { SegmentGroup } from "../mergeTree";
 import { TestClient } from "./testClient";
 import { TestClientLogger } from "./testClientLogger";
 

--- a/packages/dds/merge-tree/src/test/client.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.spec.ts
@@ -4,8 +4,13 @@
  */
 
 import { strict as assert } from "assert";
-import * as MergeTree from "../";
 import { UniversalSequenceNumber } from "../constants";
+import {
+    Marker,
+    reservedMarkerIdKey,
+    reservedTileLabelsKey,
+} from "../mergeTree";
+import { ReferenceType } from "../ops";
 import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
 
@@ -31,10 +36,10 @@ describe("TestClient", () => {
 
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
 
             client.insertTextLocal(0, "abc");
@@ -56,10 +61,10 @@ describe("TestClient", () => {
 
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
             console.log(client.getText());
 
@@ -76,29 +81,29 @@ describe("TestClient", () => {
             const tileLabel = "EOP";
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
 
             client.insertTextLocal(0, "abc d");
 
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
 
             client.insertTextLocal(7, "ef");
             client.insertMarkerLocal(
                 8,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
             console.log(client.getText());
 
@@ -115,29 +120,29 @@ describe("TestClient", () => {
             const tileLabel = "EOP";
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
 
             client.insertTextLocal(0, "abc d");
 
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
 
             client.insertTextLocal(7, "ef");
             client.insertMarkerLocal(
                 8,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
             console.log(client.getText());
 
@@ -154,10 +159,10 @@ describe("TestClient", () => {
             const tileLabel = "EOP";
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
 
             console.log(client.getText());
@@ -181,10 +186,10 @@ describe("TestClient", () => {
             const tileLabel = "EOP";
             client.insertMarkerLocal(
                 0,
-                MergeTree.ReferenceType.Tile,
+                ReferenceType.Tile,
                 {
-                    [MergeTree.reservedTileLabelsKey]: [tileLabel],
-                    [MergeTree.reservedMarkerIdKey]: "some-id",
+                    [reservedTileLabelsKey]: [tileLabel],
+                    [reservedMarkerIdKey]: "some-id",
                 });
 
             client.insertTextLocal(0, "abc");
@@ -234,12 +239,12 @@ describe("TestClient", () => {
 
     describe(".annotateMarker", () => {
         it("annotate valid marker", () => {
-            const insertOp = client.insertMarkerLocal(0, MergeTree.ReferenceType.Tile, {
-                [MergeTree.reservedMarkerIdKey]: "123",
+            const insertOp = client.insertMarkerLocal(0, ReferenceType.Tile, {
+                [reservedMarkerIdKey]: "123",
             });
             assert(insertOp);
             const markerInfo = client.getContainingSegment(0);
-            const marker = markerInfo.segment as MergeTree.Marker;
+            const marker = markerInfo.segment as Marker;
             const annotateOp = client.annotateMarker(marker, { foo: "bar" }, undefined);
             assert(annotateOp);
             assert(marker.properties);

--- a/packages/dds/merge-tree/src/test/collections.list.spec.ts
+++ b/packages/dds/merge-tree/src/test/collections.list.spec.ts
@@ -4,14 +4,17 @@
  */
 
 import { strict as assert } from "assert";
-import * as Collections from "../collections";
+import {
+    List,
+    ListMakeHead,
+} from "../collections";
 
 describe("Collections.List", () => {
     const listCount = 5;
-    let list: Collections.List<number>;
+    let list: List<number>;
 
     beforeEach(() => {
-        list = Collections.ListMakeHead<number>();
+        list = ListMakeHead<number>();
         for (let i = 0; i < listCount; i++) {
             list.push(i);
         }

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.deltaCallback.spec.ts
@@ -4,7 +4,9 @@
  */
 
 import { strict as assert } from "assert";
-import { MergeTree, MergeTreeDeltaType, MergeTreeMaintenanceType } from "../";
+import { MergeTree } from "../mergeTree";
+import { MergeTreeDeltaType } from "../ops";
+import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
 import { TextSegment } from "../textSegment";
 import { countOperations, insertText } from "./testUtils";

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -7,10 +7,10 @@
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { TextSegment } from "../";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
 import { BaseSegment, Marker, MergeTree } from "../mergeTree";
 import { ICombiningOp, MergeTreeDeltaType, ReferenceType } from "../ops";
+import { TextSegment } from "../textSegment";
 
 describe("MergeTree", () => {
     let mergeTree: MergeTree;

--- a/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
@@ -4,8 +4,14 @@
  */
 
 import { strict as assert } from "assert";
-import { MergeTree, MergeTreeDeltaType, MergeTreeMaintenanceType, ReferenceType, TextSegment } from "../";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
+import { MergeTree } from "../mergeTree";
+import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback";
+import {
+    MergeTreeDeltaType,
+    ReferenceType,
+} from "../ops";
+import { TextSegment } from "../textSegment";
 import { countOperations, insertMarker, insertText } from "./testUtils";
 
 describe("MergeTree", () => {

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -4,7 +4,15 @@
  */
 
 import { strict as assert } from "assert";
-import { IMergeBlock, MaxNodesInBlock, MergeTree, MergeTreeTextHelper, TextSegment } from "../";
+import {
+    IMergeBlock,
+    MaxNodesInBlock,
+    MergeTree,
+} from "../mergeTree";
+import {
+    MergeTreeTextHelper,
+    TextSegment,
+} from "../textSegment";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
 import { insertText, nodeOrdinalsHaveIntegrity } from "./testUtils";
 

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.deltaCallback.spec.ts
@@ -5,8 +5,11 @@
 
 import { strict as assert } from "assert";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { MergeTree, MergeTreeDeltaType, MergeTreeMaintenanceType, TextSegment } from "../";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
+import { MergeTree } from "../mergeTree";
+import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback";
+import { MergeTreeDeltaType } from "../ops";
+import { TextSegment } from "../textSegment";
 import { countOperations } from "./testUtils";
 
 describe("MergeTree", () => {

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
@@ -4,8 +4,8 @@
  */
 
 import { strict as assert } from "assert";
-import { TextSegment } from "../";
 import { createInsertSegmentOp, createRemoveRangeOp } from "../opBuilder";
+import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
 
 describe("MergeTree.markRangeRemoved", () => {

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -10,7 +10,10 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { MockStorage } from "@fluidframework/test-runtime-utils";
 import random from "random-js";
 import { Client } from "../client";
-import * as Collections from "../collections";
+import {
+    List,
+    ListMakeHead,
+} from "../collections";
 import { UnassignedSequenceNumber } from "../constants";
 import { ISegment, Marker, MergeTree } from "../mergeTree";
 import { createInsertSegmentOp, createRemoveRangeOp } from "../opBuilder";
@@ -76,9 +79,9 @@ export class TestClient extends Client {
 
     declare public mergeTree: MergeTree;
 
-    public readonly checkQ: Collections.List<string> = Collections.ListMakeHead<string>();
+    public readonly checkQ: List<string> = ListMakeHead<string>();
     // eslint-disable-next-line max-len
-    protected readonly q: Collections.List<ISequencedDocumentMessage> = Collections.ListMakeHead<ISequencedDocumentMessage>();
+    protected readonly q: List<ISequencedDocumentMessage> = ListMakeHead<ISequencedDocumentMessage>();
 
     private readonly textHelper: MergeTreeTextHelper;
     constructor(

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -5,9 +5,15 @@
 
 import { strict as assert } from "assert";
 import fs from "fs";
-import { IMergeBlock, IMergeTreeDeltaOpArgs, Marker, MergeTree, TextSegment } from "../";
-import * as ops from "../ops";
-import * as Properties from "../properties";
+import {
+    IMergeBlock,
+    Marker,
+    MergeTree,
+} from "../mergeTree";
+import { IMergeTreeDeltaOpArgs } from "../mergeTreeDeltaCallback";
+import { TextSegment } from "../textSegment";
+import { ReferenceType } from "../ops";
+import { PropertySet } from "../properties";
 import { loadText } from "../text";
 
 export function loadTextFromFile(filename: string, mergeTree: MergeTree, segLimit = 0) {
@@ -26,7 +32,7 @@ export function insertMarker(
     refSeq: number,
     clientId: number,
     seq: number,
-    behaviors: ops.ReferenceType, props: Properties.PropertySet, opArgs: IMergeTreeDeltaOpArgs,
+    behaviors: ReferenceType, props: PropertySet, opArgs: IMergeTreeDeltaOpArgs,
 ) {
     mergeTree.insertSegments(pos, [Marker.make(behaviors, props)], refSeq, clientId, seq, opArgs);
 }
@@ -38,7 +44,7 @@ export function insertText(
     clientId: number,
     seq: number,
     text: string,
-    props: Properties.PropertySet,
+    props: PropertySet,
     opArgs: IMergeTreeDeltaOpArgs,
 ) {
     mergeTree.insertSegments(pos, [TextSegment.make(text, props)], refSeq, clientId, seq, opArgs);

--- a/packages/dds/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.ts
@@ -9,8 +9,12 @@ import path from "path";
 import random from "random-js";
 import { Trace } from "@fluidframework/common-utils";
 import { LocalReference } from "../localReference";
-import * as ops from "../ops";
-import * as Properties from "../properties";
+import { ReferenceType } from "../ops";
+import {
+    createMap,
+    extend,
+    MapLike,
+} from "../properties";
 import { TestClient } from "./testClient";
 import { loadTextFromFileWithMarkers } from "./testUtils";
 
@@ -32,9 +36,9 @@ export function propertyCopy() {
         map.set(a[i], v[i]);
     }
     let clockStart = clock();
-    let obj: Properties.MapLike<number>;
+    let obj: MapLike<number>;
     for (let j = 0; j < iterCount; j++) {
-        obj = Properties.createMap<number>();
+        obj = createMap<number>();
         for (let i = 0; i < propCount; i++) {
             obj[a[i]] = v[i];
         }
@@ -45,7 +49,7 @@ export function propertyCopy() {
     console.log(`arr prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
     clockStart = clock();
     for (let j = 0; j < iterCount; j++) {
-        const bObj = Properties.createMap<number>();
+        const bObj = createMap<number>();
         // eslint-disable-next-line guard-for-in, no-restricted-syntax
         for (const key in obj) {
             bObj[key] = obj[key];
@@ -57,7 +61,7 @@ export function propertyCopy() {
     console.log(`obj prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
     clockStart = clock();
     for (let j = 0; j < iterCount; j++) {
-        const bObj = Properties.createMap<number>();
+        const bObj = createMap<number>();
         for (const [key, value] of map) {
             bObj[key] = value;
         }
@@ -68,7 +72,7 @@ export function propertyCopy() {
     console.log(`map prop init time ${perIter} us per ${propCount} properties; ${perProp} us per property`);
     clockStart = clock();
     for (let j = 0; j < iterCount; j++) {
-        const bObj = Properties.createMap<number>();
+        const bObj = createMap<number>();
         map.forEach((value, key) => { bObj[key] = value; });
     }
     et = elapsedMicroseconds(clockStart);
@@ -116,9 +120,9 @@ function makeBookmarks(client: TestClient, bookmarkCount: number) {
     for (let i = 0; i < bookmarkCount; i++) {
         const pos = random.integer(0, len - 1)(mt);
         const segoff = client.getContainingSegment(pos);
-        let refType = ops.ReferenceType.Simple;
+        let refType = ReferenceType.Simple;
         if (i & 1) {
-            refType = ops.ReferenceType.SlideOnRemove;
+            refType = ReferenceType.SlideOnRemove;
         }
         const lref = new LocalReference(client, segoff.segment, segoff.offset, refType);
         client.mergeTree.addLocalReference(lref);
@@ -153,7 +157,7 @@ function measureFetch(startFile: string, withBookmarks = false) {
             const curSegOff = client.getContainingSegment(pos);
             const curSeg = curSegOff.segment;
             // Combine paragraph and direct properties
-            Properties.extend(properties, curSeg.properties);
+            extend(properties, curSeg.properties);
             pos += (curSeg.cachedLength - curSegOff.offset);
             count++;
         }


### PR DESCRIPTION
Very similar to #8119 

In addition to splitting namespaced imports, this change clarifies all imports from `"../"`.  This sets up to avoid exporting internal/test-only things from the package (random example, `MaxNodesInBlock`).  No actual changes to exports or functionality in this PR.