### PR TITLE
Remove registers from SharedString and MergeTree

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -38,7 +38,7 @@ The `@fluidframework/base-host` package has been removed.  See the [quick-start 
 If you were using the `UpgradeManager` utility from this package, external access to Quorum proposals is planned to be deprecated and so this is no longer recommended.  To upgrade code, instead use the `Container` API `proposeCodeDetails`.
 
 ### Registers removed from sequence and merge-tree
-The `@fluidframework/sequence` and `@fluidframework/merge-tree` packages provided cut/copy/paste functionalities that built on a register concept.  These functionalities have been removed.
+The `@fluidframework/sequence` and `@fluidframework/merge-tree` packages provided cut/copy/paste functionalities that built on a register concept.  These functionalities were never fully implemented and have been removed.
 
 ## 0.50 Breaking changes
 - [OpProcessingController removed](#opprocessingcontroller-removed)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -16,6 +16,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Deprecated `Loader._create` is removed](#deprecated-loadercreate-is-removed)
 - [Stop exporting internal class `CollabWindowTracker` ](#stop-exporting-internal-class-collabwindowtracker)
 - [base-host package removed](#base-host-package-removed)
+- [Registers removed from sequence and merge-tree](#Registers-removed-from-sequence-and-merge-tree)
 
 ### `maxMessageSize` property has been deprecated from IConnectionDetails and IDocumentDeltaConnection
 `maxMessageSize` is redundant and will be removed soon. Please use the `serviceConfiguration.maxMessageSize` property instead.
@@ -35,6 +36,9 @@ Use the Loader constructor with the `ILoaderProps` instead.
 The `@fluidframework/base-host` package has been removed.  See the [quick-start guide](https://fluidframework.com/docs/start/quick-start/) for recommended hosting practices.
 
 If you were using the `UpgradeManager` utility from this package, external access to Quorum proposals is planned to be deprecated and so this is no longer recommended.  To upgrade code, instead use the `Container` API `proposeCodeDetails`.
+
+### Registers removed from sequence and merge-tree
+The `@fluidframework/sequence` and `@fluidframework/merge-tree` packages provided cut/copy/paste functionalities that built on a register concept.  These functionalities have been removed.
 
 ## 0.50 Breaking changes
 - [OpProcessingController removed](#opprocessingcontroller-removed)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -119,8 +119,6 @@ export class Client {
     // (undocumented)
     cloneFromSegments(): Client;
     // (undocumented)
-    copyLocal(start: number, end: number, register: string): IMergeTreeInsertMsg | undefined;
-    // (undocumented)
     createTextHelper(): MergeTreeTextHelper;
     findReconnectionPostition(segment: ISegment, localSeq: number): number;
     // (undocumented)
@@ -191,16 +189,12 @@ export class Client {
     set mergeTreeMaintenanceCallback(callback: MergeTreeMaintenanceCallback | undefined);
     // (undocumented)
     noVerboseRemoteAnnotate: boolean;
-    // (undocumented)
-    pasteLocal(pos: number, register: string): IMergeTreeInsertMsg | undefined;
     peekPendingSegmentGroups(count?: number): SegmentGroup | SegmentGroup[] | undefined;
     posFromRelativePos(relativePos: IRelativePosition): number;
     regeneratePendingOp(resetOp: IMergeTreeOp, segmentGroup: SegmentGroup | SegmentGroup[]): IMergeTreeOp;
     // (undocumented)
-    registerCollection: RegisterCollection;
-    // (undocumented)
     removeLocalReference(lref: LocalReference): void;
-    removeRangeLocal(start: number, end: number, register?: string): IMergeTreeRemoveMsg | undefined;
+    removeRangeLocal(start: number, end: number): IMergeTreeRemoveMsg | undefined;
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number | undefined;
     serializeGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void;
     // (undocumented)
@@ -286,22 +280,16 @@ export function createAnnotateRangeOp(start: number, end: number, props: Propert
 export function createGroupOp(...ops: IMergeTreeDeltaOp[]): IMergeTreeGroupMsg;
 
 // @public (undocumented)
-export function createInsertFromRegisterOp(pos: number, register: string): IMergeTreeInsertMsg;
-
-// @public (undocumented)
 export function createInsertOp(pos: number, segSpec: any): IMergeTreeInsertMsg;
 
 // @public (undocumented)
 export function createInsertSegmentOp(pos: number, segment: ISegment): IMergeTreeInsertMsg;
 
 // @public (undocumented)
-export function createInsertToRegisterOp(start: number, end: number, register: string): IMergeTreeInsertMsg;
-
-// @public (undocumented)
 export function createMap<T>(): MapLike<T>;
 
 // @public
-export function createRemoveRangeOp(start: number, end: number, register?: string): IMergeTreeRemoveMsg;
+export function createRemoveRangeOp(start: number, end: number): IMergeTreeRemoveMsg;
 
 // @public (undocumented)
 export interface Dictionary<TKey, TData> {
@@ -546,8 +534,6 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
     // (undocumented)
     pos2?: number;
     // (undocumented)
-    register?: string;
-    // (undocumented)
     relativePos1?: IRelativePosition;
     // (undocumented)
     relativePos2?: IRelativePosition;
@@ -570,8 +556,6 @@ export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
     pos1?: number;
     // (undocumented)
     pos2?: number;
-    // (undocumented)
-    register?: string;
     // (undocumented)
     relativePos1?: IRelativePosition;
     // (undocumented)
@@ -1601,20 +1585,6 @@ export function refHasRangeLabel(refPos: ReferencePosition, label: string): bool
 
 // @public (undocumented)
 export function refHasTileLabel(refPos: ReferencePosition, label: string): boolean;
-
-// @public (undocumented)
-export class RegisterCollection {
-    // (undocumented)
-    clientCollections: MapLike<MapLike<ISegment[]> | undefined>;
-    // (undocumented)
-    get(clientId: string, id: string): ISegment[] | undefined;
-    // (undocumented)
-    getLength(clientId: string, id: string): number;
-    // (undocumented)
-    removeClient(clientId: string): void;
-    // (undocumented)
-    set(clientId: string, id: string, segments: ISegment[]): void;
-}
 
 // @public (undocumented)
 export const reservedMarkerIdKey = "markerId";

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -515,10 +515,8 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     protected applyStashedOp(): void;
     // (undocumented)
     protected client: Client;
-    copy(start: number, end: number, register: string): void;
     // (undocumented)
     createPositionReference(segment: T, offset: number, refType: ReferenceType): LocalReference;
-    cut(start: number, end: number, register: string): void;
     // (undocumented)
     protected didAttach(): void;
     // (undocumented)
@@ -562,7 +560,6 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     protected onConnect(): void;
     // (undocumented)
     protected onDisconnect(): void;
-    paste(pos: number, register: string): number;
     posFromRelativePos(relativePos: IRelativePosition): number;
     // (undocumented)
     protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;

--- a/docs/content/docs/updates/v0.51.md
+++ b/docs/content/docs/updates/v0.51.md
@@ -9,7 +9,7 @@ draft: true
 
 ## Breaking changes
 
-*No breaking changes.*
+- {{< issue 7647 >}} -- Remove register functionality from merge-tree and sequence.
 
 ## Other notable changes
 

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -876,41 +876,6 @@ export function internedSpaces(n: number) {
     }
     return indentStrings[n];
 }
-export class RegisterCollection {
-    clientCollections: MapLike<MapLike<ISegment[]> | undefined> = createMap();
-    set(clientId: string, id: string, segments: ISegment[]) {
-        let clientCollection = this.clientCollections[clientId];
-        if (!clientCollection) {
-            clientCollection = createMap();
-            this.clientCollections[clientId] = clientCollection;
-        }
-        clientCollection[id] = segments;
-    }
-
-    get(clientId: string, id: string) {
-        const clientCollection = this.clientCollections[clientId];
-        if (clientCollection) {
-            return clientCollection[id];
-        }
-    }
-
-    getLength(clientId: string, id: string) {
-        const segs = this.get(clientId, id);
-        let len = 0;
-        if (segs) {
-            for (const seg of segs) {
-                len += seg.cachedLength;
-            }
-        }
-        return len;
-    }
-
-    removeClient(clientId: string) {
-        this.clientCollections[clientId] = undefined;
-    }
-
-    // TODO: snapshot
-}
 
 export interface IConsensusInfo {
     marker: Marker;

--- a/packages/dds/merge-tree/src/opBuilder.ts
+++ b/packages/dds/merge-tree/src/opBuilder.ts
@@ -58,18 +58,15 @@ export function createAnnotateRangeOp(
 }
 
 /**
- * Creates the op to remove a range and puts the content of the removed range in a register
- * if a register name is provided
+ * Creates the op to remove a range
  *
  * @param start - The inclusive start of the range to remove
  * @param end - The exclusive end of the range to remove
- * @param register - Optional. The name of the register to store the removed range in
  */
-export function createRemoveRangeOp(start: number, end: number, register?: string): IMergeTreeRemoveMsg {
+export function createRemoveRangeOp(start: number, end: number): IMergeTreeRemoveMsg {
     return {
         pos1: start,
         pos2: end,
-        register,
         type: MergeTreeDeltaType.REMOVE,
     };
 }
@@ -89,34 +86,6 @@ export function createInsertOp(pos: number, segSpec: any): IMergeTreeInsertMsg {
     return {
         pos1: pos,
         seg: segSpec,
-        type: MergeTreeDeltaType.INSERT,
-    };
-}
-
-/**
- *
- * @param pos - The position to insert the register contents at
- * @param register - The name of the register to insert the value of
- */
-export function createInsertFromRegisterOp(pos: number, register: string): IMergeTreeInsertMsg {
-    return {
-        pos1: pos,
-        register,
-        type: MergeTreeDeltaType.INSERT,
-    };
-}
-
-/**
- *
- * @param start - The inclusive start of the range to insert into the register
- * @param end - The exclusive end of the range to insert into the register
- * @param register - The name of the register to insert the range contents into
- */
-export function createInsertToRegisterOp(start: number, end: number, register: string): IMergeTreeInsertMsg {
-    return {
-        pos1: start,
-        pos2: end,
-        register,
         type: MergeTreeDeltaType.INSERT,
     };
 }

--- a/packages/dds/merge-tree/src/ops.ts
+++ b/packages/dds/merge-tree/src/ops.ts
@@ -67,7 +67,6 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
     pos2?: number;
     relativePos2?: IRelativePosition;
     seg?: any;
-    register?: string;
 }
 
 export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
@@ -76,7 +75,6 @@ export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
     relativePos1?: IRelativePosition;
     pos2?: number;
     relativePos2?: IRelativePosition;
-    register?: string;
 }
 
 export interface ICombiningOp {

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -242,48 +242,6 @@ export abstract class SharedSegmentSequence<T extends ISegment>
         return removeOp;
     }
 
-    /**
-     * Removes the range and puts the content of the removed range in a register
-     *
-     * @param start - The inclusive start of the range to remove
-     * @param end - The exclusive end of the range to remove
-     * @param register - The name of the register to store the removed range in
-     */
-    public cut(start: number, end: number, register: string) {
-        const removeOp = this.client.removeRangeLocal(start, end, register);
-        if (removeOp) {
-            this.submitSequenceMessage(removeOp);
-        }
-    }
-
-    /**
-     * Inserts the content of the register.
-     *
-     * @param pos - The position to insert the content at.
-     * @param register - The name of the register to get the content from
-     */
-    public paste(pos: number, register: string) {
-        const insertOp = this.client.pasteLocal(pos, register);
-        if (insertOp) {
-            this.submitSequenceMessage(insertOp);
-        }
-        return pos;
-    }
-
-    /**
-     * Puts the content of the range in a register
-     *
-     * @param start - The inclusive start of the range
-     * @param end - The exclusive end of the range
-     * @param register - The name of the register to store the range in
-     */
-    public copy(start: number, end: number, register: string) {
-        const insertOp = this.client.copyLocal(start, end, register);
-        if (insertOp) {
-            this.submitSequenceMessage(insertOp);
-        }
-    }
-
     public groupOperation(groupOp: IMergeTreeGroupMsg) {
         this.client.localTransaction(groupOp);
         this.submitSequenceMessage(groupOp);


### PR DESCRIPTION
Resolves #6321

This functionality is not a great scenario fit for cut/copy/paste, and the sole scenario using it (shared-text) is not working properly already.  This change removes the functionality and updates the demo to drop it as well.