### PR TITLE
Add encode method to IFluidSerializer

### DIFF
--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -84,10 +84,12 @@ export type Factory = IFluidDataStoreFactory & Partial<IProvideFluidDataStoreReg
 export class FluidSerializer implements IFluidSerializer {
     constructor(context: IFluidHandleContext);
     decode(input: any): any;
+    encode(input: any, bind: IFluidHandle): any;
     // (undocumented)
     get IFluidSerializer(): this;
     // (undocumented)
     parse(input: string): any;
+    // @deprecated
     replaceHandles(input: any, bind: IFluidHandle): any;
     // (undocumented)
     protected serializeHandle(handle: IFluidHandle, bind: IFluidHandle): {

--- a/common/lib/core-interfaces/api-report/core-interfaces.api.md
+++ b/common/lib/core-interfaces/api-report/core-interfaces.api.md
@@ -116,6 +116,7 @@ export const IFluidSerializer: keyof IProvideFluidSerializer;
 // @public (undocumented)
 export interface IFluidSerializer extends IProvideFluidSerializer {
     decode?(input: any): any;
+    encode?(value: any, bind: IFluidHandle): any;
     parse(value: string): any;
     replaceHandles(value: any, bind: IFluidHandle): any;
     stringify(value: any, bind: IFluidHandle): string;

--- a/common/lib/core-interfaces/src/serializer.ts
+++ b/common/lib/core-interfaces/src/serializer.ts
@@ -28,12 +28,23 @@ export interface IFluidSerializer extends IProvideFluidSerializer {
      *
      * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
+     *
+     * This will be deprecated and replaced in the future with encode.
      */
     replaceHandles(value: any, bind: IFluidHandle): any;
 
     /**
+     * Given a mostly-plain object that may have handle objects embedded within, will return a fully-plain object
+     * where any embedded IFluidHandles have been replaced with a serializable form.
+     *
+     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * the root to any replaced handles.  (If no handles are found, returns the original object.)
+     */
+    encode?(value: any, bind: IFluidHandle): any;
+
+    /**
      * Given a fully-jsonable object tree that may have encoded handle objects embedded within, will return an
-     * equivalent object tree where any encoded IFluidHandles have been replaced with thier decoded form.
+     * equivalent object tree where any encoded IFluidHandles have been replaced with their decoded form.
      *
      * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)

--- a/common/lib/core-interfaces/src/serializer.ts
+++ b/common/lib/core-interfaces/src/serializer.ts
@@ -26,7 +26,7 @@ export interface IFluidSerializer extends IProvideFluidSerializer {
      * Given a mostly-plain object that may have handle objects embedded within, will return a fully-plain object
      * where any embedded IFluidHandles have been replaced with a serializable form.
      *
-     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
      *
      * This will be deprecated and replaced in the future with encode.
@@ -37,7 +37,7 @@ export interface IFluidSerializer extends IProvideFluidSerializer {
      * Given a mostly-plain object that may have handle objects embedded within, will return a fully-plain object
      * where any embedded IFluidHandles have been replaced with a serializable form.
      *
-     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
      */
     encode?(value: any, bind: IFluidHandle): any;
@@ -46,7 +46,7 @@ export interface IFluidSerializer extends IProvideFluidSerializer {
      * Given a fully-jsonable object tree that may have encoded handle objects embedded within, will return an
      * equivalent object tree where any encoded IFluidHandles have been replaced with their decoded form.
      *
-     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
      *
      * The decoded handles are implicitly bound to the handle context of this serializer.

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -38,8 +38,26 @@ export class FluidSerializer implements IFluidSerializer {
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
      *
      * Any unbound handles encountered are bound to the provided IFluidHandle.
+     *
+     * @deprecated - use encode
      */
-     public replaceHandles(
+    public replaceHandles(
+        input: any,
+        bind: IFluidHandle,
+    ) {
+        return this.encode(input, bind);
+    }
+
+    /**
+     * Given a mostly-jsonable object tree that may have handle objects embedded within, will return a
+     * fully-jsonable object tree where any embedded IFluidHandles have been replaced with a serializable form.
+     *
+     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * the root to any replaced handles.  (If no handles are found, returns the original object.)
+     *
+     * Any unbound handles encountered are bound to the provided IFluidHandle.
+     */
+    public encode(
         input: any,
         bind: IFluidHandle,
     ) {
@@ -53,14 +71,14 @@ export class FluidSerializer implements IFluidSerializer {
 
     /**
      * Given a fully-jsonable object tree that may have encoded handle objects embedded within, will return an
-     * equivalent object tree where any encoded IFluidHandles have been replaced with thier decoded form.
+     * equivalent object tree where any encoded IFluidHandles have been replaced with their decoded form.
      *
-     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
      *
      * The decoded handles are implicitly bound to the handle context of this serializer.
      */
-     public decode(input: any) {
+    public decode(input: any) {
         // If the given 'input' cannot contain handles, return it immediately.  Otherwise,
         // return the result of 'recursivelyReplace()'.
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/runtime/runtime-utils/src/serializer.ts
+++ b/packages/runtime/runtime-utils/src/serializer.ts
@@ -34,7 +34,7 @@ export class FluidSerializer implements IFluidSerializer {
      * Given a mostly-jsonable object tree that may have handle objects embedded within, will return a
      * fully-jsonable object tree where any embedded IFluidHandles have been replaced with a serializable form.
      *
-     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
      *
      * Any unbound handles encountered are bound to the provided IFluidHandle.
@@ -52,7 +52,7 @@ export class FluidSerializer implements IFluidSerializer {
      * Given a mostly-jsonable object tree that may have handle objects embedded within, will return a
      * fully-jsonable object tree where any embedded IFluidHandles have been replaced with a serializable form.
      *
-     * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
+     * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
      * the root to any replaced handles.  (If no handles are found, returns the original object.)
      *
      * Any unbound handles encountered are bound to the provided IFluidHandle.
@@ -97,7 +97,7 @@ export class FluidSerializer implements IFluidSerializer {
     }
 
     // If the given 'value' is an IFluidHandle, returns the encoded IFluidHandle.
-    // Otherwise returns the original 'value'.  Used by 'replaceHandles()' and 'stringify()'.
+    // Otherwise returns the original 'value'.  Used by 'encode()' and 'stringify()'.
     private readonly encodeValue = (value: any, bind: IFluidHandle) => {
         // Detect if 'value' is an IFluidHandle.
         const handle = value?.IFluidHandle;


### PR DESCRIPTION
The `encode` method will replace the confusing `replaceHandles` since it matches the paired `decode` method and indicates the direction of conversion.

Subsequent PRs will implement and consume this new method and deprecate `replaceHandles` over multiple versions to give users time to handle the breaking change.

#8045