### PR TITLE
PropertyDDS Performance improvements

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -60,6 +60,7 @@
     "ajv": "7.1.1",
     "ajv-keywords": "4.0.0",
     "async": "^3.2.0",
+    "fastest-json-copy": "^1.0.1",
     "lodash": "^4.17.21",
     "semver": "^7.3.4",
     "traverse": "0.6.6"

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
@@ -8,7 +8,7 @@
 
 import isObject from "lodash/isObject";
 import isString from "lodash/isString";
-import cloneDeep from "lodash/cloneDeep";
+import {copy as cloneDeep} from "fastest-json-copy";
 import isEmpty from "lodash/isEmpty";
 import extend from "lodash/extend";
 import each from "lodash/each";

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/array.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/array.ts
@@ -5,11 +5,10 @@
 /**
  * @fileoverview Helper functions and classes to work with array ChangeSets
  */
-
-import cloneDeep from "lodash/cloneDeep";
-import isNumber from "lodash/isNumber";
-import isString from "lodash/isString";
-import isEqual from "lodash/isEqual";
+ import {copy as cloneDeep} from "fastest-json-copy";
+ import isNumber from "lodash/isNumber";
+ import isString from "lodash/isString";
+ import isEqual from "lodash/isEqual";
 
 // @ts-ignore
 import { ConsoleUtils, constants } from "@fluid-experimental/property-common";

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/indexedCollection.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/indexedCollection.ts
@@ -6,7 +6,7 @@
  * @fileoverview Helper functions and classes to work with ChangeSets with indexed collections (sets and maps)
  */
 
- import cloneDeep from "lodash/cloneDeep";
+ import {copy as cloneDeep} from "fastest-json-copy";
  import isEmpty from "lodash/isEmpty";
  import isEqual from "lodash/isEqual";
  import isObject from "lodash/isObject";

--- a/experimental/PropertyDDS/packages/property-changeset/src/rebase.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/rebase.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import cloneDeep from "lodash/cloneDeep";
+import {copy as cloneDeep} from "fastest-json-copy";
 import isEqual from "lodash/isEqual";
 
 import { ChangeSet } from "./changeset";

--- a/experimental/PropertyDDS/packages/property-changeset/src/templateValidator.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/templateValidator.ts
@@ -25,7 +25,7 @@ import includes from "lodash/includes";
 import map from "lodash/map";
 import find from "lodash/find";
 import isEmpty from "lodash/isEmpty";
-import cloneDeep from "lodash/cloneDeep";
+import {copy as cloneDeep} from "fastest-json-copy";
 
 import { gt, diff, major, valid, compare } from "semver";
 import traverse from "traverse";

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/array.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/array.spec.ts
@@ -9,7 +9,7 @@
  */
 import isEmpty from "lodash/isEmpty";
 import isNumber from "lodash/isNumber";
-import cloneDeep from "lodash/cloneDeep";
+import {copy as cloneDeep} from "fastest-json-copy";
 import range from "lodash/range";
 
 

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/reversibleCs.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/reversibleCs.spec.ts
@@ -7,7 +7,7 @@
  * @fileoverview In this file, we will test the path helper
  *    functions described in /src/properties/path_helper.js
  */
-import cloneDeep from "lodash/cloneDeep";
+import {copy as cloneDeep} from "fastest-json-copy";
 
 import { ChangeSet } from "../changeset";
 

--- a/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/utils.ts
@@ -6,7 +6,7 @@
 import { ConsoleUtils, constants } from "@fluid-experimental/property-common";
 import { eachOfSeries, eachSeries, ErrorCallback, series, timesSeries, whilst } from "async";
 
-import cloneDeep from "lodash/cloneDeep";
+import {copy as cloneDeep} from "fastest-json-copy";
 import isNumber from "lodash/isNumber";
 import isString from "lodash/isString";
 import isEmpty from "lodash/isEmpty";

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -60,7 +60,8 @@
     "lodash": "^4.17.21",
     "murmurhash3js": "3.0.1",
     "semver": "^7.3.4",
-    "traverse": "0.6.6"
+    "traverse": "0.6.6",
+    "fastest-json-copy": "^1.0.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -57,11 +57,11 @@
     "async": "^3.2.0",
     "base64-js": "1.3.0",
     "events": "^3.1.0",
+    "fastest-json-copy": "^1.0.1",
     "lodash": "^4.17.21",
     "murmurhash3js": "3.0.1",
     "semver": "^7.3.4",
-    "traverse": "0.6.6",
-    "fastest-json-copy": "^1.0.1"
+    "traverse": "0.6.6"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -39,6 +39,7 @@
     "@fluidframework/protocol-definitions": "^0.1025.0",
     "@fluidframework/shared-object-base": "^0.51.0",
     "axios": "^0.21.1",
+    "fastest-json-copy": "^1.0.1",
     "lodash": "^4.17.21",
     "uuid": "^8.3.1"
   },

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -34,6 +34,7 @@
     "@fluid-experimental/property-changeset": "^0.51.0",
     "@fluid-experimental/property-properties": "^0.51.0",
     "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/core-interfaces": "^0.40.0-0",
     "@fluidframework/datastore-definitions": "^0.51.0",
     "@fluidframework/protocol-definitions": "^0.1025.0",
@@ -46,7 +47,6 @@
   "devDependencies": {
     "@fluid-experimental/property-common": "^0.51.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/container-definitions": "^0.41.0-0",
     "@fluidframework/driver-definitions": "^0.41.0-0",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@fluidframework/local-driver": "^0.51.0",

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -32,7 +32,7 @@ import { IFluidSerializer } from "@fluidframework/core-interfaces";
 import {
 	ChangeSet,
 	Utils as ChangeSetUtils,
-    rebaseToRemoteChanges,
+	rebaseToRemoteChanges,
 } from "@fluid-experimental/property-changeset";
 
 import { PropertyFactory, BaseProperty, NodeProperty } from "@fluid-experimental/property-properties";
@@ -164,15 +164,15 @@ export class SharedPropertyTree extends SharedObject {
 	}
 
 	public _reportDirtinessToView() {
-        // Check whether anybody is listening. If not, we don't want to pay the price
-        // for the serialization of the data structure
-        if (this.listenerCount("localModification") > 0) {
-            const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
-            const _changeSet = new ChangeSet(changes);
-            if (!isEmpty(_changeSet.getSerializedChangeSet())) {
-                this.emit("localModification", _changeSet);
-            }
-        }
+		// Check whether anybody is listening. If not, we don't want to pay the price
+		// for the serialization of the data structure
+		if (this.listenerCount("localModification") > 0) {
+			const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
+			const _changeSet = new ChangeSet(changes);
+			if (!isEmpty(_changeSet.getSerializedChangeSet())) {
+				this.emit("localModification", _changeSet);
+			}
+		}
 		this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
 	}
 
@@ -181,12 +181,12 @@ export class SharedPropertyTree extends SharedObject {
 		return this.tipView;
 	}
 
-    public get activeCommit(): IPropertyTreeMessage {
-        if(this.localChanges.length > 0) {
-            return this.localChanges[this.localChanges.length - 1];
-        } else {
-            return this.remoteChanges[this.remoteChanges.length - 1];
-        }
+	public get activeCommit(): IPropertyTreeMessage {
+		if(this.localChanges.length > 0) {
+			return this.localChanges[this.localChanges.length - 1];
+		} else {
+			return this.remoteChanges[this.remoteChanges.length - 1];
+		}
 	}
 	public get root(): NodeProperty {
 		return this._root as NodeProperty;
@@ -195,17 +195,17 @@ export class SharedPropertyTree extends SharedObject {
 	public commit(metadata?: Metadata, submitEmptyChange?: boolean) {
 		const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.PENDING_CHANGE);
 
-        let doSubmit = !!submitEmptyChange;
+		let doSubmit = !!submitEmptyChange;
 
-        // if no override provided dont submit unless metadata are provided
-        if (submitEmptyChange === undefined) {
-            doSubmit =  metadata !== undefined;
-        }
+		// if no override provided dont submit unless metadata are provided
+		if (submitEmptyChange === undefined) {
+			doSubmit =  metadata !== undefined;
+		}
 
-        if (doSubmit || !isEmpty(changes)) {
-            this.applyChangeSet(changes, metadata || {});
-            this.root.cleanDirty();
-        }
+		if (doSubmit || !isEmpty(changes)) {
+			this.applyChangeSet(changes, metadata || {});
+			this.root.cleanDirty();
+		}
 	}
 
 	private applyChangeSet(changeSet: SerializedChangeSet, metadata: Metadata) {
@@ -346,11 +346,11 @@ export class SharedPropertyTree extends SharedObject {
 					visitedRemoteChanges.add(visitor.referenceGuid);
 				}
 
-                // If we have a change that refers to the start of the history (remoteHeadGuid === ""), we have to
-                // keep all remote Changes until this change has been processed
-                if (visitor.remoteHeadGuid === "") {
-                    visitedRemoteChanges.add(remoteChanges[0].guid);
-                }
+				// If we have a change that refers to the start of the history (remoteHeadGuid === ""), we have to
+				// keep all remote Changes until this change has been processed
+				if (visitor.remoteHeadGuid === "") {
+					visitedRemoteChanges.add(remoteChanges[0].guid);
+				}
 			}
 		}
 		let pruned = 0;
@@ -566,11 +566,11 @@ export class SharedPropertyTree extends SharedObject {
 			this.remoteChanges = [];
 		} finally {
 			this._root.deserialize(this.tipView, undefined, false, false);
-            const _changeSet = new ChangeSet(this.tipView);
-            if (!isEmpty(_changeSet.getSerializedChangeSet())) {
-                this.emit("localModification", _changeSet);
-            }
-            this.root.cleanDirty();
+			const _changeSet = new ChangeSet(this.tipView);
+			if (!isEmpty(_changeSet.getSerializedChangeSet())) {
+				this.emit("localModification", _changeSet);
+			}
+			this.root.cleanDirty();
 		}
 	}
 
@@ -581,12 +581,12 @@ export class SharedPropertyTree extends SharedObject {
 		const changeSetWrapper = new ChangeSet(this.tipView);
 		changeSetWrapper.applyChangeSet(change.changeSet);
 
-        if (this.runtime.attachState === AttachState.Detached) {
-            const remoteChangeSetWrapper = new ChangeSet(this.remoteTipView);
-            remoteChangeSetWrapper.applyChangeSet(change.changeSet);
-        } else {
-            this.localChanges.push(change);
-        }
+		if (this.runtime.attachState === AttachState.Detached) {
+			const remoteChangeSetWrapper = new ChangeSet(this.remoteTipView);
+			remoteChangeSetWrapper.applyChangeSet(change.changeSet);
+		} else {
+			this.localChanges.push(change);
+		}
 	}
 
 	private _applyRemoteChangeSet(change: IRemotePropertyTreeMessage) {
@@ -633,8 +633,8 @@ export class SharedPropertyTree extends SharedObject {
 
 	getRebasedChanges(startGuid: string, endGuid?: string) {
 		const startIndex = findIndex(this.remoteChanges, (c) => c.guid === startGuid);
-        if (endGuid !== undefined) {
-            const endIndex = findIndex(this.remoteChanges, (c) => c.guid === endGuid);
+		if (endGuid !== undefined) {
+			const endIndex = findIndex(this.remoteChanges, (c) => c.guid === endGuid);
 			return this.remoteChanges.slice(startIndex + 1, endIndex + 1);
 		}
 		return this.remoteChanges.slice(startIndex + 1);
@@ -705,12 +705,12 @@ export class SharedPropertyTree extends SharedObject {
 
 		// Update the tip view
 		if (!this.tipView) {
-            this.tipView = cloneDeep(this.remoteTipView);
-            const changeSet = new ChangeSet(this.tipView);
-            changeSet.applyChangeSet(accumulatedChanges);
-        } else {
-            new ChangeSet(this.tipView).applyChangeSet(newTipDelta);
-        }
+			this.tipView = cloneDeep(this.remoteTipView);
+			const changeSet = new ChangeSet(this.tipView);
+			changeSet.applyChangeSet(accumulatedChanges);
+		} else {
+			new ChangeSet(this.tipView).applyChangeSet(newTipDelta);
+		}
 
 		return true;
 	}

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -403,8 +403,8 @@ export class SharedPropertyTree extends SharedObject {
 				unrebasedRemoteChanges: this.unrebasedRemoteChanges,
 			};
 			const chunkSize = 5000 * 1024; // Default limit seems to be 5MB
-			let serializedSummary =
-				serializer !== undefined ? serializer.stringify(summary, this.handle) : JSON.stringify(summary);
+			let serializedSummary = JSON.stringify(summary);
+				// serializer !== undefined ? serializer.stringify(summary, this.handle) : JSON.stringify(summary);
 
 			// JSON.stringify does not escape unicode characters. As a consequence,
 			// the chunking code below could create chunks which are bigger than the
@@ -471,8 +471,8 @@ export class SharedPropertyTree extends SharedObject {
 				);
 
 				const serializedSummary = chunks.reduce((a, b) => a + b, "");
-				const snapshotSummary: ISnapshotSummary =
-					serializer !== undefined ? serializer.parse(serializedSummary) : JSON.parse(serializedSummary);
+				const snapshotSummary: ISnapshotSummary = JSON.parse(serializedSummary);
+					// serializer !== undefined ? serializer.parse(serializedSummary) : JSON.parse(serializedSummary);
 				if (
 					snapshotSummary.remoteChanges === undefined ||
 					snapshotSummary.remoteTipView === undefined ||

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -9,6 +9,7 @@ import findIndex from "lodash/findIndex";
 import range from "lodash/range";
 import {copy as cloneDeep} from "fastest-json-copy";
 
+import { AttachState } from "@fluidframework/container-definitions";
 import {
 	ISequencedDocumentMessage,
 	ITree,
@@ -576,7 +577,12 @@ export class SharedPropertyTree extends SharedObject {
 		const changeSetWrapper = new ChangeSet(this.tipView);
 		changeSetWrapper.applyChangeSet(change.changeSet);
 
-		this.localChanges.push(change);
+        if (this.runtime.attachState === AttachState.Detached) {
+            const remoteChangeSetWrapper = new ChangeSet(this.remoteTipView);
+            remoteChangeSetWrapper.applyChangeSet(change.changeSet);
+        } else {
+            this.localChanges.push(change);
+        }
 	}
 
 	private _applyRemoteChangeSet(change: IRemotePropertyTreeMessage) {

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -560,8 +560,12 @@ export class SharedPropertyTree extends SharedObject {
 			this.remoteTipView = {};
 			this.remoteChanges = [];
 		} finally {
-			this._root.deserialize(this.tipView);
-			this.root.cleanDirty();
+			this._root.deserialize(this.tipView, undefined, false, false);
+            const _changeSet = new ChangeSet(this.tipView);
+            if (!isEmpty(_changeSet.getSerializedChangeSet())) {
+                this.emit("localModification", _changeSet);
+            }
+            this.root.cleanDirty();
 		}
 	}
 

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -5,9 +5,9 @@
 
 /* eslint-disable import/no-internal-modules */
 import isEmpty from "lodash/isEmpty";
-import cloneDeep from "lodash/cloneDeep";
 import findIndex from "lodash/findIndex";
 import range from "lodash/range";
+import {copy as cloneDeep} from "fastest-json-copy";
 
 import {
 	ISequencedDocumentMessage,

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -164,11 +164,15 @@ export class SharedPropertyTree extends SharedObject {
 	}
 
 	public _reportDirtinessToView() {
-		const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
-		const _changeSet = new ChangeSet(changes);
-		if (!isEmpty(_changeSet.getSerializedChangeSet())) {
-			this.emit("localModification", _changeSet);
-		}
+        // Check whether anybody is listening. If not, we don't want to pay the price
+        // for the serialization of the data structure
+        if (this.listenerCount("localModification") > 0) {
+            const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
+            const _changeSet = new ChangeSet(changes);
+            if (!isEmpty(_changeSet.getSerializedChangeSet())) {
+                this.emit("localModification", _changeSet);
+            }
+        }
 		this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
 	}
 

--- a/experimental/PropertyDDS/packages/property-properties/src/containerSerializer.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/containerSerializer.js
@@ -148,7 +148,7 @@ export function deserialize(in_data, in_scope, in_filteringOptions) {
 
             scopeProperty._append(entity, false);
 
-            entity.deserialize(classed[classKeys[iClass]], filteringOptions);
+            entity.deserialize(classed[classKeys[iClass]], filteringOptions, false);
 
             scopeProperty._remove(id);
 
@@ -189,7 +189,7 @@ export function deserializeNonPrimitiveArrayElements(in_data, in_scope) {
 
         scopeProperty._append(createdProperty, false);
 
-        createdProperty._deserialize(in_data[i], false);
+        createdProperty._deserialize(in_data[i], false, undefined, false);
 
         scopeProperty._remove(id);
 

--- a/experimental/PropertyDDS/packages/property-properties/src/enableValidations.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/enableValidations.ts
@@ -1,0 +1,13 @@
+export let validationsEnabled = {
+    enabled: true
+}
+
+/**
+ * Switch off validation to increase performance (but you risk modifying read only properties, creating cycles in
+ * the tree, etc...)
+ *
+ * @param enabled - Are the validations enabled?
+ */
+export function enableValidations(enabled : boolean) {
+    validationsEnabled.enabled = enabled;
+}

--- a/experimental/PropertyDDS/packages/property-properties/src/enableValidations.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/enableValidations.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export let validationsEnabled = {
     enabled: true
 }

--- a/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.d.ts
@@ -2676,6 +2676,13 @@ declare module "@fluid-experimental/property-properties" {
 
         }
 
+        /**
+         * Switch off validation to increase performance (but you risk modifying read only properties, creating cycles in
+         * the tree, etc...)
+         *
+         * @param enabled - Are the validations enabled?
+         */
+        function enableValidations(enabled : boolean);
     }
     export = PROPERTY_TREE_NS;
 }

--- a/experimental/PropertyDDS/packages/property-properties/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/index.ts
@@ -21,6 +21,7 @@ import { Int64Property, Uint64Property } from './properties/intProperties';
 import { ValueArrayProperty } from './properties/valueArrayProperty';
 import { ValueMapProperty } from './properties/valueMapProperty';
 import { ValueProperty } from './properties/valueProperty';
+import { enableValidations } from './enableValidations';
 
 
 export {
@@ -42,5 +43,6 @@ export {
     Int64Property,
     ValueArrayProperty,
     ValueMapProperty,
-    ValueProperty
+    ValueProperty,
+    enableValidations
 }

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -20,6 +20,7 @@ const { LazyLoadedProperties: Property } = require('./lazyLoadedProperties');
 const { UniversalDataArray, ConsoleUtils } = require('@fluid-experimental/property-common');
 const fastestJSONCopy = require('fastest-json-copy');
 const deepCopy = fastestJSONCopy.copy;
+const { validationsEnabled } = require('../enableValidations');
 
 
 var MODIFIED_STATE_FLAGS = BaseProperty.MODIFIED_STATE_FLAGS;
@@ -601,12 +602,14 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
             throw new Error(MSG.IN_ARRAY_NOT_ARRAY + 'ArrayProperty.insertRange');
         }
 
-        for (var i = 0; i < in_array.length; i++) {
-            if (in_array[i] instanceof BaseProperty) {
-                in_array[i]._validateInsertIn(this)
-            }
-        }
-        this._checkIsNotReadOnly(true);
+	    if (validationsEnabled.enabled) {
+	        for (var i = 0; i < in_array.length; i++) {
+	            if (in_array[i] instanceof BaseProperty) {
+	                in_array[i]._validateInsertIn(this)
+	            }
+	        }
+	        this._checkIsNotReadOnly(true);
+	    }
         this._insertRangeWithoutDirtying(in_offset, in_array);
         this._setDirty();
     };

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -18,7 +18,8 @@ const {
 const { MSG } = require('@fluid-experimental/property-common').constants;
 const { LazyLoadedProperties: Property } = require('./lazyLoadedProperties');
 const { UniversalDataArray, ConsoleUtils } = require('@fluid-experimental/property-common');
-const deepCopy = _.cloneDeep;
+const fastestJSONCopy = require('fastest-json-copy');
+const deepCopy = fastestJSONCopy.copy;
 
 
 var MODIFIED_STATE_FLAGS = BaseProperty.MODIFIED_STATE_FLAGS;

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -1211,7 +1211,8 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
             // Recursively check the entries within the segment for modifications
             for (var j = 0; j < segmentLength; j++) {
                 var existingEntry = this._dataArrayGetValue(startPointInInitialArray + j + offset);
-                var entryChanges = existingEntry._deserialize(targetArray[startPointInTargetArray + j], false);
+                var entryChanges = existingEntry._deserialize(targetArray[startPointInTargetArray + j],
+                                                              false, undefined, true);
 
                 // We had changes which we have to report back
                 if (!ChangeSet.isEmptyChangeSet(entryChanges)) {
@@ -1297,7 +1298,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     /**
      * @inheritdoc
      */
-    _deserialize(in_serializedObj, in_reportToView) {
+    _deserialize(in_serializedObj, in_reportToView, in_filteringOptions, in_createChangeSet) {
         this._checkIsNotReadOnly(false);
 
         if ((in_serializedObj.remove && in_serializedObj.remove.length > 0) ||
@@ -1339,7 +1340,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
 
             // The changes we will report as result of this function
             var simpleChanges = {
-                insert: deepCopy(in_serializedObj.insert)
+                insert: in_createChangeSet ? deepCopy(in_serializedObj.insert) : in_serializedObj.insert
             };
             if (arrayLength > 0) {
                 simpleChanges.remove = [[0, arrayLength]];
@@ -1353,7 +1354,7 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
                     var createdProperty = Property.PropertyFactory._createProperty(
                         propertyDescriptions[i]['typeid'], null, undefined, scope);
                     createdProperty._setParent(this);
-                    createdProperty._deserialize(propertyDescriptions[i], false);
+                    createdProperty._deserialize(propertyDescriptions[i], false, in_filteringOptions, false);
                     result.push(createdProperty);
                 }
                 this._clearRange(0, this._dataArrayGetLength());

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -1276,9 +1276,15 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
     _serializeArray(in_array) {
         var len = in_array.length;
         var result = new Array(len);
+    if (this._isPrimitive) {
         for (var i = 0; i < len; i++) {
             result[i] = this._serializeValue(in_array[i]);
         }
+    } else {
+        for (var i = 0; i < len; i++) {
+            result[i] = {};
+        }
+    }
         return result;
     };
 

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/baseProperty.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/baseProperty.ts
@@ -1065,6 +1065,9 @@ export abstract class BaseProperty {
      *    The filtering options to consider while deserializing the property.
      * @param in_createChangeSet
      *    Should a changeset be created for this deserialization?
+     * @param in_reportToView
+     *    Usually the dirtying should be reported to the view and trigger a modified
+     *    event there. This can be prevented via this flag.
      * @throws if called on a read-only property.
      * @returns ChangeSet with the changes that actually were performed during the
      *     deserialization
@@ -1072,10 +1075,11 @@ export abstract class BaseProperty {
     deserialize(
         in_serializedObj: SerializedChangeSet,
         in_filteringOptions = {},
-        in_createChangeSet = true
+        in_createChangeSet = true,
+        in_reportToView = false
     ): SerializedChangeSet {
         this._checkIsNotReadOnly(false);
-        return this._deserialize(in_serializedObj, true, in_filteringOptions, in_createChangeSet);
+        return this._deserialize(in_serializedObj, in_reportToView, in_filteringOptions, in_createChangeSet);
     };
 
     /**
@@ -1083,8 +1087,8 @@ export abstract class BaseProperty {
      *
      * @param in_serializedObj - The serialized changeset to apply. This
      *     has to be a normalized change-set (only containing inserts. Removes and Modifies are forbidden).
-     * @param in_reportToView - Usually the dirtying should be reported to the checkout view
-     *     and  a modified event there. When batching updates, this can be prevented via this flag.
+     * @param in_reportToView - Usually the dirtying should be reported to the view
+     *     and trigger a modified event there. When batching updates, this can be prevented via this flag.
      * @param in_filteringOptions
      *    The filtering options to consider while deserializing the property.
      * @param in_createChangeSet
@@ -1096,7 +1100,7 @@ export abstract class BaseProperty {
         in_serializedObj: SerializedChangeSet,
         in_reportToView: boolean,
         in_filteringOptions = {},
-        in_createChangeSet = true
+        in_createChangeSet = true,
     ): SerializedChangeSet {
         return {};
     };

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/baseProperty.ts
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/baseProperty.ts
@@ -1063,16 +1063,19 @@ export abstract class BaseProperty {
      *     must not appear)
      * @param in_filteringOptions
      *    The filtering options to consider while deserializing the property.
+     * @param in_createChangeSet
+     *    Should a changeset be created for this deserialization?
      * @throws if called on a read-only property.
      * @returns ChangeSet with the changes that actually were performed during the
      *     deserialization
      */
     deserialize(
         in_serializedObj: SerializedChangeSet,
-        in_filteringOptions = {}
+        in_filteringOptions = {},
+        in_createChangeSet = true
     ): SerializedChangeSet {
         this._checkIsNotReadOnly(false);
-        return this._deserialize(in_serializedObj, true, in_filteringOptions);
+        return this._deserialize(in_serializedObj, true, in_filteringOptions, in_createChangeSet);
     };
 
     /**
@@ -1084,13 +1087,16 @@ export abstract class BaseProperty {
      *     and  a modified event there. When batching updates, this can be prevented via this flag.
      * @param in_filteringOptions
      *    The filtering options to consider while deserializing the property.
+     * @param in_createChangeSet
+     *    Should a changeset be created for this deserialization?
      * @returns ChangeSet with the changes that actually were performed during the
      *     deserialization
      */
     _deserialize(
         in_serializedObj: SerializedChangeSet,
         in_reportToView: boolean,
-        in_filteringOptions = {}
+        in_filteringOptions = {},
+        in_createChangeSet = true
     ): SerializedChangeSet {
         return {};
     };

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/containerProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/containerProperty.js
@@ -12,6 +12,7 @@ const { AbstractStaticCollectionProperty } = require('./abstractStaticCollection
 const { MSG } = require('@fluid-experimental/property-common').constants;
 const { ConsoleUtils } = require('@fluid-experimental/property-common');
 const { IndexedCollectionBaseProperty } = require('./indexedCollectionBaseProperty');
+const { validationsEnabled } = require('../enableValidations');
 
 /**
  * A property object that allows to add child properties dynamically.
@@ -84,12 +85,16 @@ export class ContainerProperty extends IndexedCollectionBaseProperty {
             if (this._dynamicChildren[in_id] !== undefined) {
                 throw new Error(MSG.PROPERTY_ALREADY_EXISTS + in_id);
             }
-            in_property._validateInsertIn(this);
+            if (validationsEnabled.enabled) {
+                in_property._validateInsertIn(this);
+            }
             // If an id is passed, it is stored in the child property object
             in_property._setId(in_id);
         }
 
-        this._validateInsert(in_property.getId(), in_property);
+        if (validationsEnabled.enabled) {
+            this._validateInsert(in_property.getId(), in_property);
+        }
 
         // Add the child property to the dynamic properties
         this._insert(in_property.getId(), in_property, true);
@@ -194,7 +199,9 @@ export class ContainerProperty extends IndexedCollectionBaseProperty {
      *     When batching updates, this can be prevented via this flag.
      */
     _insert(in_key, in_property, in_reportToView) {
-        this._checkIsNotReadOnly(true);
+        if (validationsEnabled.enabled) {
+            this._checkIsNotReadOnly(true);
+        }
 
         // Add the child property to the dynamic properties
         IndexedCollectionBaseProperty.prototype._insert.call(this, in_key, in_property, false);

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/indexedCollectionBaseProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/indexedCollectionBaseProperty.js
@@ -366,12 +366,14 @@ export class IndexedCollectionBaseProperty extends AbstractStaticCollectionPrope
      * @inheritdoc
      */
     // eslint-disable-next-line complexity
-    _deserialize(in_serializedObj, in_reportToView) {
+    _deserialize(in_serializedObj, in_reportToView,
+                 in_filteringOptions, in_createChangeSet) {
 
         var currentEntries = this._dynamicChildren;
         var allInsertedKeys = {};
 
-        var appliedChangeset = AbstractStaticCollectionProperty.prototype._deserialize.call(this, in_serializedObj, false);
+        var appliedChangeset = AbstractStaticCollectionProperty.prototype._deserialize.call(
+           this, in_serializedObj, false, in_filteringOptions, in_createChangeSet);
 
         // Perform updates to the children
 
@@ -504,8 +506,9 @@ export class IndexedCollectionBaseProperty extends AbstractStaticCollectionPrope
                         }
                     }
                 } else {
-                    changes = this._dynamicChildren[modifiedKeys[i]]
-                        ._deserialize(modifiedEntries[typeid][modifiedKeys[i]], false);
+                    changes = this._dynamicChildren[modifiedKeys[i]]._deserialize(
+                        modifiedEntries[typeid][modifiedKeys[i]],
+                        false, in_filteringOptions, in_createChangeSet);
                     valueWasChanged = !ChangeSet.isEmptyChangeSet(changes);
 
                     modifiedEntries[typeid] = modifiedEntries[typeid] || {};

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/indexedCollectionBaseProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/indexedCollectionBaseProperty.js
@@ -89,28 +89,33 @@ export class IndexedCollectionBaseProperty extends AbstractStaticCollectionPrope
     cleanDirty(in_flags) {
         in_flags = in_flags !== undefined ? in_flags : BaseProperty.MODIFIED_STATE_FLAGS.DIRTY |
             BaseProperty.MODIFIED_STATE_FLAGS.PENDING_CHANGE;
-        // Clean all entries inside of the collection
-        var entryKeys;
-        if (in_flags === BaseProperty.MODIFIED_STATE_FLAGS.DIRTY) {
-            // Only use the dirty entries
-            entryKeys = _.keys(this._dirtyChanges.insert).concat(_.keys(this._dirtyChanges.modify));
-        } else if (in_flags === BaseProperty.MODIFIED_STATE_FLAGS.PENDING_CHANGE) {
-            // Only use the pending changes
-            entryKeys = _.keys(this._pendingChanges.insert).concat(_.keys(this._pendingChanges.modify));
-        } else {
-            entryKeys = _.keys(this._pendingChanges.insert)
-                .concat(_.keys(this._pendingChanges.modify))
-                .concat(_.keys(this._dirtyChanges.insert)
-                    .concat(_.keys(this._dirtyChanges.modify)));
-        }
 
-        var entry;
-        if (!this._containsPrimitiveTypes) {
-            for (var i = 0; i < entryKeys.length; i++) {
-                entry = this._dynamicChildren[entryKeys[i]];
+        // Clean all entries inside of the collection
+        let cleanDirtiness = (collection) => {
+            var entry;
+
+            for (let key in collection) {
+                entry = this._dynamicChildren[key];
                 if (entry._isDirty(in_flags)) {
                     entry.cleanDirty(in_flags);
                 }
+            }
+        };
+
+        if (!this._containsPrimitiveTypes) {
+            if (in_flags === BaseProperty.MODIFIED_STATE_FLAGS.DIRTY) {
+                // Only use the dirty entries
+                cleanDirtiness(this._dirtyChanges.insert);
+                cleanDirtiness(this._dirtyChanges.modify);
+            } else if (in_flags === BaseProperty.MODIFIED_STATE_FLAGS.PENDING_CHANGE) {
+                // Only use the pending changes
+                cleanDirtiness(this._pendingChanges.insert);
+                cleanDirtiness(this._pendingChanges.modify);
+            } else {
+                cleanDirtiness(this._pendingChanges.insert);
+                cleanDirtiness(this._pendingChanges.modify);
+                cleanDirtiness(this._dirtyChanges.insert);
+                cleanDirtiness(this._dirtyChanges.modify);
             }
         }
 

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/indexedCollectionBaseProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/indexedCollectionBaseProperty.js
@@ -13,6 +13,8 @@ const { deserialize } = require('../containerSerializer');
 const { ChangeSet } = require('@fluid-experimental/property-changeset');
 const { ConsoleUtils } = require('@fluid-experimental/property-common');
 const { MSG } = require('@fluid-experimental/property-common').constants;
+const { validationsEnabled } = require('../enableValidations');
+
 /**
  * typedef {property-properties.BaseProperty|string|number|boolean} property-properties.IndexedCollectionBaseProperty~ValueType
  *
@@ -138,11 +140,13 @@ export class IndexedCollectionBaseProperty extends AbstractStaticCollectionPrope
      *     When batching updates, this can be prevented via this flag.
      */
     _insert(in_key, in_value, in_reportToView) {
-        this._checkIsNotReadOnly(false);
+	    if (validationsEnabled.enabled) {
+	        this._checkIsNotReadOnly(false);
+	    }
 
         if (!this.has(in_key)) {
             // Make sure, the property we are inserting is not already part of some other collection
-            if (!this._containsPrimitiveTypes) {
+            if (validationsEnabled.enabled && !this._containsPrimitiveTypes) {
                 in_value._validateInsertIn(this)
             }
 
@@ -154,7 +158,7 @@ export class IndexedCollectionBaseProperty extends AbstractStaticCollectionPrope
             this._setDirty(false);
 
             if (!this._containsPrimitiveTypes) {
-                // Dirty the tree
+                // Dirty the tree (TODO: is this needed?)
                 in_value._setDirtyTree(false);
 
                 in_value._setParent(this);

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/intProperties.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/intProperties.js
@@ -182,7 +182,8 @@ export class Integer64Property extends ValueProperty {
     /**
      * @inheritdoc
      */
-    _deserialize(in_serializedObj, in_reportToView, in_filteringOptions) {
+    _deserialize(in_serializedObj, in_reportToView,
+                 in_filteringOptions, in_createChangeSet) {
         if (ChangeSet.isEmptyChangeSet(in_serializedObj)) {
             return undefined;
         } else {

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/stringProperty.js
@@ -217,7 +217,8 @@ export class StringProperty extends ValueArrayProperty {
     /**
      * @inheritdoc
      */
-    _deserialize(in_serializedObj, in_reportToView) {
+    _deserialize(in_serializedObj, in_reportToView,
+                 in_filteringOptions, in_createChangeSet) {
         if ((in_serializedObj.remove && in_serializedObj.remove.length > 0) ||
             (in_serializedObj.modify && in_serializedObj.modify.length > 0) ||
             (in_serializedObj.insert &&

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/valueMapProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/valueMapProperty.js
@@ -13,6 +13,8 @@ const { BaseProperty } = require('./baseProperty');
 const { MapProperty } = require('./mapProperty');
 const { Int64, Uint64 } = require('@fluid-experimental/property-common');
 const { Int64Property, Uint64Property } = require('../properties/intProperties');
+const { validationsEnabled } = require('../enableValidations');
+
 
 /**
  * A ValueMapProperty is a collection class that can contain an dictionary that maps from strings to primitive types.
@@ -104,11 +106,15 @@ export class ValueMapProperty extends MapProperty {
      * @param {string} in_key the key under which the entry is set
      * @param {*} in_value the value to be set
      */
-    set(in_key, in_value) {
-        this._checkIsNotReadOnly(true);
-        var castedValue = this._castFunctor ? this._castFunctor(in_value) : in_value;
-        if (this._dynamicChildren[in_key] !== castedValue) {
-            this._checkIsNotReadOnly(true);
+	set(in_key, in_value) {
+	    if (validationsEnabled.enabled) {
+	        this._checkIsNotReadOnly(true);
+	    }
+	        var castedValue = this._castFunctor ? this._castFunctor(in_value) : in_value;
+	    if (this._dynamicChildren[in_key] !== castedValue) {
+	        if (validationsEnabled.enabled) {
+	            this._checkIsNotReadOnly(true);
+	        }
             if (this._dynamicChildren[in_key] !== undefined) {
                 this._removeByKey(in_key, false);
             }

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/valueProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/valueProperty.js
@@ -102,7 +102,8 @@ export class ValueProperty extends BaseProperty {
     /**
      * @inheritdoc
      */
-    _deserialize(in_serializedObj, in_reportToView, in_filteringOptions) {
+    _deserialize(in_serializedObj, in_reportToView,
+                 in_filteringOptions, in_createChangeSet) {
         if (ChangeSet.isEmptyChangeSet(in_serializedObj)) {
             console.warn(MSG.DESERIALIZE_EMPTY_CHANGESET);
             return undefined;

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyFactory.js
@@ -9,7 +9,8 @@
  * Responsible for creating property sets and registering property templates
  */
 const _ = require('lodash');
-const deepCopy = _.cloneDeep;
+const fastestJSONCopy = require('fastest-json-copy');
+const deepCopy = fastestJSONCopy.copy;
 
 const {
     Collection,

--- a/experimental/PropertyDDS/packages/property-properties/src/propertyTemplate.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/propertyTemplate.js
@@ -9,7 +9,8 @@
  */
 const _ = require('lodash');
 const { TypeIdHelper } = require('@fluid-experimental/property-changeset');
-const deepCopy = _.cloneDeep;
+const fastestJSONCopy = require('fastest-json-copy');
+const deepCopy = fastestJSONCopy.copy;
 const { ConsoleUtils } = require('@fluid-experimental/property-common');
 const { MSG } = require('@fluid-experimental/property-common').constants;
 

--- a/experimental/PropertyDDS/packages/property-query/src/materialized_history_service/leaf_node.js
+++ b/experimental/PropertyDDS/packages/property-query/src/materialized_history_service/leaf_node.js
@@ -14,11 +14,12 @@
       getBaseNodeRef = require('../utils/node_refs').getBaseNodeRef,
       StorageManager = require('./storage_backends/storage_manager'),
       NodeDependencyManager = require('./node_dependency_manager'),
-      deepCopy = _.cloneDeep,
       ConsoleUtils = require('@fluid-experimental/property-common').ConsoleUtils,
       OperationError = require('@fluid-experimental/property-common').OperationError,
       HTTPStatus = require('http-status'),
       { ChangeSet } = require('@fluid-experimental/property-changeset');
+  const fastestJSONCopy = require('fastest-json-copy');
+  const deepCopy = fastestJSONCopy.copy;
 
   let NodeStatus = NodeDependencyManager.NodeStatus;
 

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -14374,6 +14374,15 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"blob": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -20392,6 +20401,11 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
+		"fastest-json-copy": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fastest-json-copy/-/fastest-json-copy-1.0.1.tgz",
+			"integrity": "sha512-Y4/wf9ARleMh4so64oyOt+tUAae8HN1W8P4tZfmnTkWjqKPuqZo7HxFQRFiQ/kGH8VRDYPNuh25eHCLxEKRPSA=="
+		},
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -20551,6 +20565,12 @@
 					}
 				}
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
 		},
 		"filesize": {
 			"version": "6.1.0",
@@ -33818,13 +33838,6 @@
 			"integrity": "sha1-dU22HynuZHarVDxFtGTSH171VoY=",
 			"requires": {
 				"when": "^3.7.8"
-			},
-			"dependencies": {
-				"when": {
-					"version": "3.7.8",
-					"resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-					"integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
-				}
 			}
 		},
 		"prompts": {
@@ -42302,6 +42315,7 @@
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				},
@@ -42841,6 +42855,7 @@
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				},
@@ -43340,6 +43355,11 @@
 				"tr46": "^1.0.1",
 				"webidl-conversions": "^4.0.2"
 			}
+		},
+		"when": {
+			"version": "3.7.8",
+			"resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+			"integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
 		},
 		"which": {
 			"version": "1.3.1",


### PR DESCRIPTION
This branch contains several performance improvements for the PropertyDDS:

* Use of fastest-json-copy to clone changesets
* Fewer copies during the deserialization
* More efficient array deserialization
* Made some validations during deserialization optional
* Faster cleaning of dirtiness
* No serialization of changes if no listener is attached
* Enable creation of a PropertyDDS while still in detached mode

@nedalhy @karlbom @evaliyev PTAL