### PR TITLE
Don't generate PACKAGES.md file when running layer-check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean:nyc": "rimraf nyc/**",
     "clean:r11s": "cd server/routerlicious && npm run clean",
     "postinstall": "npm run postinstall:lerna",
-    "layer-check": "fluid-layer-check --info tools/build-tools/data/layerInfo.json --md",
+    "layer-check": "fluid-layer-check --info tools/build-tools/data/layerInfo.json",
     "lint": "lerna run lint --no-sort --stream -- -- -- --color",
     "lint:fix": "lerna run lint:fix --no-sort --stream -- -- -- --color",
     "policy-check": "fluid-repo-policy-check",


### PR DESCRIPTION
This script is run as part of CI, which is wasting time generating this file.

Also, apparently it has a bug, see CI failures in https://github.com/microsoft/FluidFramework/pull/8085
> Edit: Not a bug!  It's actually finding that there's a circular dependency between layers.