### PR TITLE
offline blob upload

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -156,6 +156,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
     get reSubmitFn(): (type: ContainerMessageType, content: any, localOpMetadata: unknown, opMetadata: Record<string, unknown> | undefined) => void;
+    // (undocumented)
+    reuploadBlob(metadata: Record<string, unknown>): Promise<Record<string, unknown>>;
     // @internal @deprecated (undocumented)
     readonly runtimeVersion: string;
     // (undocumented)
@@ -610,7 +612,7 @@ export type OpActionEventName = MessageType.Summarize | MessageType.SummaryAck |
 
 // @public
 export class PendingStateManager implements IDisposable {
-    constructor(containerRuntime: ContainerRuntime, applyStashedOp: (type: any, content: any) => Promise<unknown>, initialState: IPendingLocalState | undefined);
+    constructor(containerRuntime: ContainerRuntime, applyStashedOp: (type: any, content: any, metadata: any) => Promise<unknown>, initialState: IPendingLocalState | undefined);
     applyStashedOpsAt(seqNum: number): Promise<void>;
     // (undocumented)
     readonly dispose: () => void;
@@ -626,8 +628,8 @@ export class PendingStateManager implements IDisposable {
         localAck: boolean;
         localOpMetadata: unknown;
     };
-    replayPendingStates(): void;
-}
+    replayPendingStates(): Promise<void>;
+    }
 
 // @public (undocumented)
 export class ScheduleManager {


### PR DESCRIPTION
#7724
Currently, when `uploadBlob()` is called while offline, it will hang until we reconnect since we must be online to upload the blob and wait for the `BlobAttach` op to round-trip. In order to support offline work, it is necessary to be able to return a blob handle from `uploadBlob()` while not connected and eventually upload the blob when we reconnect (on the same container or a different one supplied with stashed ops and offline blob storage).

In order to do this, I have made `PendingStateManager.replayPendingStates()` async. I'm not sure of the full consequences of this, so ultimately this may not be a real option. However, it is necessary since we cannot resubmit any ops behind a pending/stashed `BlobAttach` op until the blob has been reuploaded. This is for the same reason as the limitation stated above, i.e., we cannot otherwise guarantee that an invalid handle will not be attached, which would break the document.

Note that I have not done the work of piping the offline blob storage down from `Loader.rehydrateContainer()` since this is covered in #7721 and is not really necessary to test the functionality added here.