### PR TITLE
Deprecate data store IDs

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -10,6 +10,22 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
+## 0.52 Breaking changes
+
+- [`Deprecation of DataStoreRuntime id`](#Deprecation-of-DataStoreRuntime-id)
+
+### Deprecation of DataStoreRuntime id
+The following changes are made in this release:
+- IFluidDataStoreChannel.id removed
+- IFluidDataStoreRuntime.id deprecated
+- FluidDataStoreRuntime.id deprecated
+- PureDateObject.id deprecated 
+- DateObject.uniqueId is added
+
+FluidDataStoreRuntime.id is internal id used for internal routing. It should not be used for other purposes. Objects without data store could be always accessed through their handles (that they need to expose). If there is a need to have unique ID identifying data store, please consider using Aqueduct (DataObject and it's uniqueId property) or implement similar technique for your own data store.
+Theses changes are made due to upcoming changes that will change semantics and meaning of IDs. While some form of ID will likely be available, it might differ in how it works for root data objects, so it's better not to depend on such concepts.
+More info is to come...
+
 ## 0.51 Breaking changes
 - [`maxMessageSize` property has been deprecated from IConnectionDetails and IDocumentDeltaConnection](#maxmessagesize-property-has-been-deprecated-from-iconnectiondetails-and-idocumentdeltaconnection)
 - [_createDataStoreWithProps and IFluidDataStoreChannel](#createdatastorewithprops-and-ifluiddatastorechannel)

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -87,7 +87,9 @@ export abstract class DataObject<O extends IFluidObject = object, S = undefined,
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     protected get root(): ISharedDirectory;
-    }
+    // (undocumented)
+    get uniqueId(): string;
+}
 
 // @public
 export class DataObjectFactory<TObj extends DataObject<O, S, E>, O, S, E extends IEvent = IEvent> extends PureDataObjectFactory<TObj, O, S, E> {
@@ -147,7 +149,7 @@ export abstract class PureDataObject<O extends IFluidObject = object, S = undefi
     protected getService<T extends IFluidObject>(id: string): Promise<T>;
     get handle(): IFluidHandle<this>;
     protected hasInitialized(): Promise<void>;
-    // (undocumented)
+    // @deprecated (undocumented)
     get id(): string;
     // (undocumented)
     get IFluidHandle(): IFluidHandle<this>;

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -87,7 +87,6 @@ export abstract class DataObject<O extends IFluidObject = object, S = undefined,
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     protected get root(): ISharedDirectory;
-    // (undocumented)
     get uniqueId(): string;
 }
 

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -80,7 +80,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     getQuorum(): IQuorum;
     // (undocumented)
-    readonly id: string;
+    get id(): string;
     // (undocumented)
     get IFluidHandleContext(): this;
     // (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -123,8 +123,6 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     bindToContext(): void;
     getAttachSummary(): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    // (undocumented)
-    readonly id: string;
     process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processSignal(message: any, local: boolean): void;
     reSubmit(type: string, content: any, localOpMetadata: unknown): any;

--- a/examples/data-objects/codemirror/src/presence.ts
+++ b/examples/data-objects/codemirror/src/presence.ts
@@ -23,21 +23,21 @@ interface IColor {
     };
 }
 
+const presenceKey = `PresenceManager-6eb56a01-af1a-4b94-9d36-c62ec587caa6`;
+
 /**
  * This should be super generic and only do really generic things.
  * This will only take a dependency on the runtime.
  */
 class PresenceManager extends EventEmitter {
-    private readonly presenceKey: string;
     private readonly presenceMap: Map<string, IPresenceInfo> = new Map();
 
     public constructor(private readonly runtime: IFluidDataStoreRuntime) {
         super();
-        this.presenceKey = `presence-${runtime.id}`;
 
         runtime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
             // Only process presence keys that are not local while we are connected and have a non-null clientId
-            if (message.type === this.presenceKey && !local && runtime.connected && message.clientId) {
+            if (message.type === presenceKey && !local && runtime.connected && message.clientId) {
                 console.log(`received new presence signal: ${JSON.stringify(message)}`);
                 const presenceInfo = {
                     userId: message.clientId,
@@ -54,7 +54,7 @@ class PresenceManager extends EventEmitter {
     public send(location: {}) {
         if (this.runtime.connected) {
             console.log(`sending new presence signal: ${JSON.stringify(location)}`);
-            this.runtime.submitSignal(this.presenceKey, location);
+            this.runtime.submitSignal(presenceKey, location);
         }
     }
 

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -115,7 +115,7 @@ export class SharedTextRunner
             const insights = this.sharedTextDocument.createMap(insightsMapId);
             this.rootView.set(insightsMapId, insights.handle);
 
-            debug(`Not existing ${this.runtime.id} - ${performance.now()}`);
+            debug(`Not existing ${this.context.id} - ${performance.now()}`);
             this.rootView.set("users", this.sharedTextDocument.createMap().handle);
             const seq = SharedNumberSequence.create(this.sharedTextDocument.runtime);
             this.rootView.set("sequence-test", seq.handle);
@@ -149,15 +149,15 @@ export class SharedTextRunner
             insights.set(newString.id, this.sharedTextDocument.createMap().handle);
         }
 
-        debug(`collabDoc loaded ${this.runtime.id} - ${performance.now()}`);
-        debug(`Getting root ${this.runtime.id} - ${performance.now()}`);
+        debug(`collabDoc loaded ${this.context.id} - ${performance.now()}`);
+        debug(`Getting root ${this.context.id} - ${performance.now()}`);
 
         await this.rootView.wait("flowContainerMap");
 
         this.sharedString = await this.rootView.get<IFluidHandle<SharedString>>("text").get();
         this.insightsMap = await this.rootView.get<IFluidHandle<ISharedMap>>("insights").get();
         debug(`Shared string ready - ${performance.now()}`);
-        debug(`id is ${this.runtime.id}`);
+        debug(`id is ${this.context.id}`);
         debug(`Partial load fired: ${performance.now()}`);
 
         const agentSchedulerResponse = await this.context.containerRuntime.request({ url: "/_scheduler" });
@@ -235,7 +235,7 @@ export class SharedTextRunner
         this.sharedString.loaded.then(() => {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             theFlow.loadFinished(performance.now());
-            debug(`${this.runtime.id} fully loaded: ${performance.now()} `);
+            debug(`${this.context.id} fully loaded: ${performance.now()} `);
         });
     }
 }

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -83,7 +83,7 @@ export class TableDocument extends DataObject<{}, {}, ITableDocumentEvents> impl
         maxCol: number): Promise<ITable> {
         const component = await TableSlice.getFactory().createChildInstance(
             this.context,
-            { docId: this.runtime.id, name, minRow, minCol, maxRow, maxCol },
+            { docId: this.context.id, name, minRow, minCol, maxRow, maxCol },
         );
         this.root.set(sliceId, component.handle);
         return component;
@@ -152,7 +152,7 @@ export class TableDocument extends DataObject<{}, {}, ITableDocumentEvents> impl
         const matrix = SparseMatrix.create(this.runtime, "matrix");
         this.root.set("matrix", matrix.handle);
 
-        this.root.set(ConfigKey.docId, this.runtime.id);
+        this.root.set(ConfigKey.docId, this.context.id);
     }
 
     protected async hasInitialized() {

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -36,6 +36,11 @@ export abstract class DataObject<O extends IFluidObject = object, S = undefined,
     private internalRoot: ISharedDirectory | undefined;
     private readonly rootDirectoryId = "root";
 
+    /**
+     * Unique ID of this DataObject.
+     * This id is a random guid that is created when data store is initially created
+     * It is preserved in container and can be accessed next time this data object is loaded.
+     */
     public get uniqueId(): string {
         const id = this.internalRoot?.get(uniqueIdKey);
         assert(typeof id === "string", "string");

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -74,7 +74,10 @@ export abstract class PureDataObject<O extends IFluidObject = object, S = undefi
 
     public get disposed() { return this._disposed; }
 
-    public get id() { return this.runtime.id; }
+    /**
+     * @deprecated - internal routing IDs are become ambiguous. If you need unique ID, use DataObject.uniqueId
+     */
+    public get id() { return this.context.id; }
     public get IFluidRouter() { return this; }
     public get IFluidLoadable() { return this; }
     public get IFluidHandle() { return this.innerHandle; }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -117,7 +117,7 @@ export class DataStores implements IDisposable {
                     this.runtime.storage,
                     this.runtime.scope,
                     this.getCreateChildSummarizerNodeFn(key, { type: CreateSummarizerNodeSource.FromSummary }),
-                    (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
+                    (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr, key),
                     snapshotTree,
                     undefined,
                 );
@@ -196,8 +196,7 @@ export class DataStores implements IDisposable {
         Promise.resolve().then(async () => remotedFluidDataStoreContext.realize());
     }
 
-    public bindFluidDataStore(fluidDataStoreRuntime: IFluidDataStoreChannel): void {
-        const id = fluidDataStoreRuntime.id;
+    private bindFluidDataStore(fluidDataStoreRuntime: IFluidDataStoreChannel, id: string): void {
         const localContext = this.contexts.getUnbound(id);
         assert(!!localContext, 0x15f /* "Could not find unbound context to bind" */);
 
@@ -213,7 +212,7 @@ export class DataStores implements IDisposable {
             this.attachOpFiredForDataStore.add(id);
         }
 
-        this.contexts.bind(fluidDataStoreRuntime.id);
+        this.contexts.bind(id);
     }
 
     public createDetachedDataStoreCore(
@@ -228,7 +227,7 @@ export class DataStores implements IDisposable {
             this.runtime.storage,
             this.runtime.scope,
             this.getCreateChildSummarizerNodeFn(id, { type: CreateSummarizerNodeSource.Local }),
-            (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
+            (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr, id),
             isRoot,
         );
         this.contexts.addUnbound(context);
@@ -243,7 +242,7 @@ export class DataStores implements IDisposable {
             this.runtime.storage,
             this.runtime.scope,
             this.getCreateChildSummarizerNodeFn(id, { type: CreateSummarizerNodeSource.Local }),
-            (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
+            (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr, id),
             undefined,
             isRoot,
             props,

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -45,6 +45,8 @@ export interface IFluidDataStoreRuntime extends
     IDisposable,
     Partial<IProvideFluidDataStoreRegistry> {
 
+    // @deprecated - internal routing IDs are become ambiguous. If you need unique ID, please
+    // use DataObject.uniqueId or create your own in similar way
     readonly id: string;
 
     readonly IFluidSerializer: IFluidSerializer;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -136,7 +136,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public get absolutePath(): string {
-        return generateHandleContextPath(this.id, this.routeContext);
+        return generateHandleContextPath(this.dataStoreContext.id, this.routeContext);
     }
 
     public get routeContext(): IFluidHandleContext {
@@ -168,7 +168,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private boundhandles: Set<IFluidHandle> | undefined;
     private _attachState: AttachState;
 
-    public readonly id: string;
+    // @deprecated - internal routing IDs are become ambiguous. If you need unique ID, please
+    // use DataObject.uniqueId or create your own in similar way
+    public get id() { return this.dataStoreContext.id; }
+
     public readonly options: ILoaderOptions;
     public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     private readonly quorum: IQuorum;
@@ -197,7 +200,6 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
             {all:{ dataStoreId: uuid() }},
         );
 
-        this.id = dataStoreContext.id;
         this.options = dataStoreContext.options;
         this.deltaManager = dataStoreContext.deltaManager;
         this.quorum = dataStoreContext.getQuorum();

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -33,14 +33,12 @@ describe("FluidDataStoreRuntime Tests", () => {
 
     it("can create a data store runtime", () => {
         let failed: boolean = false;
-        let dataStoreRuntime: FluidDataStoreRuntime | undefined;
         try {
-            dataStoreRuntime = loadRuntime(dataStoreContext, sharedObjectRegistry);
+            void loadRuntime(dataStoreContext, sharedObjectRegistry);
         } catch (error) {
             failed = true;
         }
         assert.strictEqual(failed, false, "Data store runtime creation failed");
-        assert.strictEqual(dataStoreRuntime?.id, dataStoreContext.id, "Data store runtime's id in incorrect");
     });
 
     it("can summarize an empty data store runtime", async () => {

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -150,8 +150,6 @@ export interface IFluidDataStoreChannel extends
     IFluidRouter,
     IDisposable {
 
-    readonly id: string;
-
     /**
      * Indicates the attachment state of the channel to a host service.
      */

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -55,7 +55,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
             const response = await container.request({ url: "/" });
             assert.strictEqual(response.status, 200, `Component should exist!! ${response.value}`);
             const defaultDataStore = response.value as TestFluidObject;
-            assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
+            assert.strictEqual(defaultDataStore.context.id, "default", "Id should be default");
 
             // Check for dds
             const sharedMap = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
@@ -94,7 +94,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
             const response = await container2.request({ url: "/" });
             assert.strictEqual(response.status, 200, `Component should exist!! ${response.value}`);
             const defaultDataStore = response.value as TestFluidObject;
-            assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
+            assert.strictEqual(defaultDataStore.context.id, "default", "Id should be default");
 
             // Check for dds
             const sharedMap = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -238,7 +238,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             assertProtocolTree(snapshotTree);
             assertDatastoreTree(snapshotTree, "default");
 
-            assertDatastoreTree(snapshotTree, dataStore2.runtime.id, "Handle Bounded dataStore should be in summary");
+            assertDatastoreTree(snapshotTree, dataStore2.context.id, "Handle Bounded dataStore should be in summary");
         });
 
         it("Rehydrate container from snapshot and check contents before attach", async () => {
@@ -253,7 +253,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const response = await container2.request({ url: "/" });
             assert.strictEqual(response.status, 200, "Component should exist!!");
             const defaultDataStore = response.value as TestFluidObject;
-            assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
+            assert.strictEqual(defaultDataStore.context.id, "default", "Id should be default");
 
             // Check for dds
             const sharedMap = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
@@ -291,7 +291,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const response = await container2.request({ url: "/" });
             assert.strictEqual(response.status, 200, "Component should exist!!");
             const defaultDataStore = response.value as TestFluidObject;
-            assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
+            assert.strictEqual(defaultDataStore.context.id, "default", "Id should be default");
 
             // Check for dds
             const sharedMap = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
@@ -329,7 +329,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const response = await container1.request({ url: "/" });
             assert.strictEqual(response.status, 200, `Component should exist!! ${response.value}`);
             const defaultDataStore = response.value as TestFluidObject;
-            assert.strictEqual(defaultDataStore.runtime.id, "default", "Id should be default");
+            assert.strictEqual(defaultDataStore.context.id, "default", "Id should be default");
 
             // Check for dds
             const sharedMap = await defaultDataStore.getSharedObject<SharedMap>(sharedMapId);
@@ -590,7 +590,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const response = await rehydratedContainer.request({ url: `/${dataStore2.context.id}` });
             const dataStore2FromRC = response.value as TestFluidObject;
             assert(dataStore2FromRC, "DataStore2 should have been serialized properly");
-            assert.strictEqual(dataStore2FromRC.runtime.id, dataStore2.runtime.id, "DataStore2 id should match");
+            assert.strictEqual(dataStore2FromRC.context.id, dataStore2.context.id, "DataStore2 id should match");
         });
 
         it("Container rehydration with not bounded dds handle stored in root of bounded dataStore", async () => {
@@ -607,7 +607,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const snapshotTree = container.serialize();
             const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
-            const response = await rehydratedContainer.request({ url: `/${defaultDataStore.runtime.id}/${ddsId}` });
+            const response = await rehydratedContainer.request({ url: `/${defaultDataStore.context.id}/${ddsId}` });
             const ddd2FromRC = response.value as SharedString;
             assert(ddd2FromRC, "ddd2 should have been serialized properly");
             assert.strictEqual(ddd2FromRC.id, ddsId, "DDS id should match");
@@ -636,7 +636,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
             const responseForDDS =
-                await rehydratedContainer.request({ url: `/${defaultDataStore.runtime.id}/${ddsId}` });
+                await rehydratedContainer.request({ url: `/${defaultDataStore.context.id}/${ddsId}` });
             const ddd2FromRC = responseForDDS.value as SharedString;
             assert(ddd2FromRC, "ddd2 should have been serialized properly");
             assert.strictEqual(ddd2FromRC.id, ddsId, "DDS id should match");
@@ -645,7 +645,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const responseForDataStore = await rehydratedContainer.request({ url: `/${dataStore2.context.id}` });
             const dataStore2FromRC = responseForDataStore.value as TestFluidObject;
             assert(dataStore2FromRC, "DataStore2 should have been serialized properly");
-            assert.strictEqual(dataStore2FromRC.runtime.id, dataStore2.runtime.id, "DataStore2 id should match");
+            assert.strictEqual(dataStore2FromRC.context.id, dataStore2.context.id, "DataStore2 id should match");
         });
 
         it("Container rehydration with not bounded data store handle stored in root of bound dataStore. " +
@@ -670,7 +670,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const snapshotTree = container.serialize();
             const rehydratedContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
 
-            const responseForDDS = await rehydratedContainer.request({ url: `/${dataStore2.runtime.id}/${ddsId}` });
+            const responseForDDS = await rehydratedContainer.request({ url: `/${dataStore2.context.id}/${ddsId}` });
             const ddd2FromRC = responseForDDS.value as SharedString;
             assert(ddd2FromRC, "ddd2 should have been serialized properly");
             assert.strictEqual(ddd2FromRC.id, ddsId, "DDS id should match");
@@ -679,7 +679,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             const responseForDataStore = await rehydratedContainer.request({ url: `/${dataStore2.context.id}` });
             const dataStore2FromRC = responseForDataStore.value as TestFluidObject;
             assert(dataStore2FromRC, "DataStore2 should have been serialized properly");
-            assert.strictEqual(dataStore2FromRC.runtime.id, dataStore2.runtime.id, "DataStore2 id should match");
+            assert.strictEqual(dataStore2FromRC.context.id, dataStore2.context.id, "DataStore2 id should match");
         });
 
         it("Not bounded/Unreferenced data store should not get serialized on container serialization", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -57,7 +57,7 @@ describeFullCompat("FluidObjectHandle", (getTestObjectProvider) => {
 
     it("should generate the absolute path for FluidDataObjectRuntime correctly", function() {
         // The expected absolute path for the FluidDataObjectRuntime.
-        const absolutePath = `/${firstContainerObject1._runtime.id}`;
+        const absolutePath = `/${firstContainerObject1._context.id}`;
 
         // Verify that the local client's FluidDataObjectRuntime has the correct absolute path.
         const fluidHandleContext11 = firstContainerObject1._runtime.rootRoutingContext;
@@ -111,7 +111,7 @@ describeFullCompat("FluidObjectHandle", (getTestObjectProvider) => {
         const sharedMapHandle = sharedMap.handle;
 
         // The expected absolute path.
-        const absolutePath = `/${firstContainerObject2._runtime.id}/${sharedMap.id}`;
+        const absolutePath = `/${firstContainerObject2._context.id}/${sharedMap.id}`;
 
         // Verify that the local client's handle has the correct absolute path.
         assert.equal(sharedMapHandle.absolutePath, absolutePath, "The handle's path is incorrect");
@@ -136,7 +136,7 @@ describeFullCompat("FluidObjectHandle", (getTestObjectProvider) => {
 
     it("can store and retrieve a PureDataObject from handle in different data store runtime", async () => {
         // The expected absolute path.
-        const absolutePath = `/${firstContainerObject2._runtime.id}`;
+        const absolutePath = `/${firstContainerObject2._context.id}`;
 
         const dataObjectHandle = firstContainerObject2.handle;
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
@@ -31,6 +31,8 @@ class TestDataObject extends DataObject {
         return this.context;
     }
 
+    public get id() { return this.context.id; }
+
     private readonly matrixKey = "matrix";
     public matrix!: SharedMatrix;
     public undoRedoStackManager!: UndoRedoStackManager;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
@@ -31,6 +31,8 @@ class TestDataObject extends DataObject {
         return this.context;
     }
 
+    public get id() { return this.context.id; }
+
     private readonly matrixKey = "matrix";
     public matrix!: SharedMatrix;
     public undoRedoStackManager!: UndoRedoStackManager;

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
@@ -23,6 +23,8 @@ export class TestDataObject extends DataObject {
         return this.root;
     }
 
+    public get id() { return this.context.id; }
+
     public get containerRuntime(): ContainerRuntime {
         return this.context.containerRuntime as ContainerRuntime;
     }

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -59,8 +59,8 @@ class TestSharedDataObject2 extends DataObject {
         return this.context;
     }
 
-    public get _id() {
-        return this.id;
+    public get id() {
+        return this.context.id;
     }
 
     public async request(request: IRequest): Promise<IResponse> {
@@ -79,6 +79,8 @@ class TestSharedDataObject2 extends DataObject {
  * used to validate that headers are correctly propagated all the way in the stack.
  */
 class TestDataObjectWithRequestHeaders extends DataObject {
+    public get id() { return this.context.id; }
+
     public async request(request: IRequest): Promise<IResponse> {
         // If the request has headers, return a specialized response with the headers in the request.
         if (request.headers !== undefined) {

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -118,16 +118,12 @@ export class LoadTestDataStoreModel {
             // Force the new data store to be attached.
             root.set("Fake", gcDataStore.handle);
             root.delete("Fake");
-            root.set(gcDataStoreIdKey, gcDataStore.id);
+            root.set(gcDataStoreIdKey, gcDataStore.handle);
         }
         // If we did not create the data store above, load it by getting its url.
         if (gcDataStore === undefined) {
-            const gcDataStoreId = root.get(gcDataStoreIdKey);
-            const response = await containerRuntime.request({ url: `/${gcDataStoreId}` });
-            if (response.status !== 200 || response.mimeType !== "fluid/object") {
-                throw new Error("GC data store not available");
-            }
-            gcDataStore = response.value as LoadTestDataStore;
+            gcDataStore = await root.get<IFluidHandle<LoadTestDataStore>>(gcDataStoreIdKey)?.get();
+            assert(gcDataStore !== undefined, "no handle");
         }
         return gcDataStore;
     }


### PR DESCRIPTION
This will very likely be handy for https://github.com/microsoft/FluidFramework/pull/7940
But it's a good change even without it, as it exposes less of the internal concepts to the world.
The doc is due here describing more details (including next steps and guidance), and I'll publish it and go through some review process before merging.

The con: existing workflows that serialize ID outside of data store itself would have hard time moving forward. we might recommend for such flows to construct internal URI and leverage handleFromLegacyUri() as a possible transition flow (TBD).

**What:**

removing IFluidDataStoreChannel.id
deprecating IFluidDataStoreRuntime.id
deprecating FluidDataStoreRuntime.id

deprecating PureDateObject.id
exposing DateObject.uniqueId