### PR TITLE
Converting overwrite duration value to number in Lumber

### DIFF
--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -148,7 +148,8 @@ export class Lumber<T extends string = LumberEventName> {
             this._exception = new Error(safeStringify(exception));
         }
 
-        this._durationInMs = this.properties.get("durationInMs") ?? performance.now() - this._startTime;
+        const durationOverwrite = parseFloat(this.properties.get("durationInMs"));
+        this._durationInMs = isNaN(durationOverwrite) ?  performance.now() - this._startTime : durationOverwrite;
 
         this._engineList.forEach((engine) => engine.emit(this));
         this._completed = true;


### PR DESCRIPTION
Making sure we only use the overwrite `durationInMs` property in `Lumber` if it is indeed a number.

Validated with some local logs:

1. When durationOverwrite is not present or not appropriate (not a number):

alfred_1       | [DEBUG DEBUG DEBUG] Current durationOverwrite: NaN}
alfred_1       | [DEBUG DEBUG DEBUG] Current _durationInMs: 0.05050000548362732} // used the default value

2. When durationOverwrite is present and should be used instead of the default value:

alfred_1       | [DEBUG DEBUG DEBUG] Current durationOverwrite: 5.259}
alfred_1       | [DEBUG DEBUG DEBUG] Current _durationInMs: 5.259}
