### PR TITLE
Abstract out GitRest's whole summary logic

### DIFF
--- a/server/routerlicious/packages/services-shared/src/index.ts
+++ b/server/routerlicious/packages/services-shared/src/index.ts
@@ -8,3 +8,5 @@ export * from "./restLessServer";
 export * from "./runner";
 export * from "./storage";
 export * from "./webServer";
+export * from "./wholeSummaryReadGitManager";
+export * from "./wholeSummaryWriteGitManager";

--- a/server/routerlicious/packages/services-shared/src/wholeSummaryReadGitManager.ts
+++ b/server/routerlicious/packages/services-shared/src/wholeSummaryReadGitManager.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IBlob, ITree } from "@fluidframework/gitresources";
+import {
+    IWholeFlatSummary,
+    IWholeFlatSummaryBlob,
+    IWholeFlatSummaryTreeEntry,
+} from "@fluidframework/server-services-client";
+
+export class WholeSummaryReadGitManager {
+    constructor(
+        /**
+         * Find the sha for latest version of a document's summary.
+         */
+        private readonly getLatestVersion: () => Promise<string>,
+        /**
+         * Read blob from storage.
+         */
+        private readonly readBlob: (sha: string) => Promise<IBlob>,
+        /**
+         * Read tree recursively from storage.
+         */
+        private readonly readTreeRecursive: (sha: string) => Promise<ITree>,
+    ) {}
+
+    public async readSummary(sha: string): Promise<IWholeFlatSummary> {
+        let versionId = sha;
+        if (versionId === "latest") {
+            versionId = await this.getLatestVersion();
+        }
+        const rawTree = await this.readTreeRecursive(sha);
+        const wholeFlatSummaryTreeEntries: IWholeFlatSummaryTreeEntry[] = [];
+        const wholeFlatSummaryBlobPs: Promise<IWholeFlatSummaryBlob>[] = [];
+        rawTree.tree.forEach((treeEntry) => {
+            if (treeEntry.type === "blob") {
+                wholeFlatSummaryTreeEntries.push({
+                    type: "blob",
+                    id: treeEntry.sha,
+                    path: treeEntry.path,
+                });
+                wholeFlatSummaryBlobPs.push(
+                    this.getBlob(
+                        treeEntry.sha,
+                    ),
+                );
+            } else {
+                wholeFlatSummaryTreeEntries.push({
+                    type: "tree",
+                    path: treeEntry.path,
+                });
+            }
+        });
+        const wholeFlatSummaryBlobs = await Promise.all(wholeFlatSummaryBlobPs);
+        return {
+            id: rawTree.sha,
+            trees: [
+                {
+                    id: rawTree.sha,
+                    entries: wholeFlatSummaryTreeEntries,
+                    // We don't store sequence numbers in git
+                    sequenceNumber: -1,
+                },
+            ],
+            blobs: wholeFlatSummaryBlobs,
+        };
+    }
+
+    private async getBlob(sha: string): Promise<IWholeFlatSummaryBlob> {
+        const blob = await this.readBlob(
+            sha,
+        );
+        return {
+            content: blob.content,
+            encoding: blob.encoding === "base64" ? "base64" : "utf-8",
+            id: blob.sha,
+            size: blob.size,
+        };
+    }
+}

--- a/server/routerlicious/packages/services-shared/src/wholeSummaryWriteGitManager.ts
+++ b/server/routerlicious/packages/services-shared/src/wholeSummaryWriteGitManager.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ICreateBlobParams, ICreateTreeEntry, ICreateTreeParams } from "@fluidframework/gitresources";
+import { getGitMode, getGitType } from "@fluidframework/protocol-base";
+import { SummaryObject, SummaryType } from "@fluidframework/protocol-definitions";
+import {
+    IWholeSummaryBlob,
+    IWholeSummaryPayload,
+    IWholeSummaryTree,
+    IWholeSummaryTreeHandleEntry,
+    IWholeSummaryTreeValueEntry,
+    NetworkError,
+    WholeSummaryTreeEntry,
+} from "@fluidframework/server-services-client";
+
+function getSummaryObjectFromWholeSummaryTreeEntry(entry: WholeSummaryTreeEntry): SummaryObject {
+    if ((entry as IWholeSummaryTreeHandleEntry).id !== undefined) {
+        return {
+            type: SummaryType.Handle,
+            handleType: entry.type === "tree" ? SummaryType.Tree : SummaryType.Blob,
+            handle: (entry as IWholeSummaryTreeHandleEntry).id,
+        };
+    }
+    if (entry.type === "blob") {
+        return {
+            type: SummaryType.Blob,
+            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
+            content: "",
+        };
+    }
+    if (entry.type === "tree") {
+        return {
+            type: SummaryType.Tree,
+            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
+            tree: {},
+            unreferenced: (entry as IWholeSummaryTreeValueEntry).unreferenced,
+        };
+    }
+    throw new NetworkError(400, `Unknown entry type: ${entry.type}`);
+}
+
+export class WholeSummaryWriteGitManager {
+    constructor(
+        /**
+         * Write blob to storage and return the git sha.
+         */
+        private readonly writeBlob: (blob: ICreateBlobParams) => Promise<string>,
+        /**
+         * Write tree to storage and return the git sha.
+         */
+        private readonly writeTree: (tree: ICreateTreeParams) => Promise<string>,
+    ) {}
+
+    public async writeSummary(payload: IWholeSummaryPayload): Promise<string> {
+        return this.writeSummaryTreeCore(payload.entries);
+    }
+
+    private async writeSummaryTreeCore(
+        wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
+    ): Promise<string> {
+        const entries: ICreateTreeEntry[] = await Promise.all(wholeSummaryTreeEntries.map(async (entry) => {
+            const summaryObject = getSummaryObjectFromWholeSummaryTreeEntry(entry);
+            const pathHandle = await this.writeSummaryTreeObject(entry, summaryObject);
+            return {
+                mode: getGitMode(summaryObject),
+                path: entry.path,
+                sha: pathHandle,
+                type: getGitType(summaryObject),
+            };
+        }));
+
+        const treeHandle = await this.writeTree(
+            { tree: entries },
+        );
+        return treeHandle;
+    }
+
+    private async writeSummaryTreeObject(
+        wholeSummaryTreeEntry: WholeSummaryTreeEntry,
+        summaryObject: SummaryObject,
+    ): Promise<string> {
+        switch(summaryObject.type) {
+            case SummaryType.Blob:
+                return this.writeSummaryBlob(
+                    ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryBlob),
+                );
+            case SummaryType.Tree:
+                return this.writeSummaryTreeCore(
+                    ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryTree).entries ?? [],
+                );
+            case SummaryType.Handle:
+                return (wholeSummaryTreeEntry as IWholeSummaryTreeHandleEntry).id;
+            default:
+                throw new NetworkError(501, "Not Implemented");
+        }
+    }
+
+    private async writeSummaryBlob(blob: IWholeSummaryBlob): Promise<string> {
+        const blobSha = await this.writeBlob(
+            {
+                content: blob.content,
+                encoding: blob.encoding,
+            },
+        );
+        return blobSha;
+    }
+}


### PR DESCRIPTION
If we ever want to add WholeSummary up/download logic to T9s, it will be nice to have the logic in a shared place.