### PR TITLE
Update `new Error` calls in Container class to use fluid error classes

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -172,7 +172,7 @@ export enum ConnectionState {
 export async function waitContainerToCatchUp(container: Container) {
     // Make sure we stop waiting if container is closed.
     if (container.closed) {
-        throw new Error("Container is closed");
+        throw new UsageError("refusingToWaitForClosedContainer");
     }
 
     return new Promise<boolean>((accept, reject) => {
@@ -354,9 +354,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     // Active chaincode and associated runtime
     private _storageService: IDocumentStorageService & IDisposable | undefined;
     private get storageService(): IDocumentStorageService  {
-        if (this._storageService === undefined) {
-            throw new Error("Attempted to access storageService before it was defined");
-        }
+        assert(this._storageService !== undefined, "Attempted to access storageService before it was defined");
         return this._storageService;
     }
 
@@ -367,16 +365,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     private _context: ContainerContext | undefined;
     private get context() {
-        if (this._context === undefined) {
-            throw new Error("Attempted to access context before it was defined");
-        }
+        assert(this._context !== undefined, "Attempted to access context before it was defined");
         return this._context;
     }
     private _protocolHandler: ProtocolOpHandler | undefined;
     private get protocolHandler() {
-        if (this._protocolHandler === undefined) {
-            throw new Error("Attempted to access protocolHandler before it was defined");
-        }
+        assert(this._protocolHandler !== undefined, "Attempted to access protocolHandler before it was defined");
         return this._protocolHandler;
     }
 
@@ -623,7 +617,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.logger.sendErrorEvent({
                         eventName: "NoRealStorageInDetachedContainer",
                     });
-                    throw new Error("Real storage calls not allowed in Unattached container");
+                    throw new UsageError("noRealStorageInDetachedContainer");
                 }
                 return this.storageService;
             },
@@ -703,7 +697,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
                 this._protocolHandler?.close();
 
-                this._context?.dispose(error !== undefined ? new Error(error.message) : undefined);
+                this._context?.dispose(error === undefined ? undefined : normalizeError(error));
 
                 assert(this.connectionState === ConnectionState.Disconnected,
                     0x0cf /* "disconnect event was not raised!" */);
@@ -909,7 +903,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     public setAutoReconnect(reconnect: boolean) {
         if (this.closed) {
-            throw new Error("Attempting to setAutoReconnect() a closed Container");
+            throw new UsageError("cannotSetAutoReconnectOnAClosedContainer");
         }
         const mode = reconnect ? ReconnectMode.Enabled : ReconnectMode.Disabled;
         const currentMode = this._deltaManager.reconnectMode;
@@ -1001,7 +995,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     public async proposeCodeDetails(codeDetails: IFluidCodeDetails) {
         if (!isFluidCodeDetails(codeDetails)) {
-            throw new Error("Provided codeDetails are not IFluidCodeDetails");
+            throw new UsageError("providedCodeDetailsAreNotIFluidCodeDetails");
         }
 
         if (this.codeLoader.IFluidCodeDetailsComparer) {
@@ -1009,7 +1003,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 codeDetails,
                 this.getCodeDetailsFromQuorum());
             if (comparision !== undefined && comparision <= 0) {
-                throw new Error("Proposed code details should be greater than the current");
+                throw new UsageError("proposedCodeDetailsShouldBeGreaterThanTheCurrent");
             }
         }
 
@@ -1150,7 +1144,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         pendingLocalState?: unknown,
     ) {
         if (this._resolvedUrl === undefined) {
-            throw new Error("Attempting to load without a resolved url");
+            throw new UsageError("attemptingToLoadWithNoResolvedUrl");
         }
         this.service = await this.serviceFactory.createDocumentService(this._resolvedUrl, this.subLogger);
 
@@ -1257,7 +1251,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // service, but caller does not know that (callers do expect container to be not closed on successful path
         // and listen only on "closed" event)
         if (this.closed) {
-            throw new Error("Container was closed while load()");
+            throw new GenericError("containerClosedDuringLoad");
         }
 
         return {
@@ -1827,7 +1821,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     ) {
         const codeDetails = this.getCodeDetailsFromQuorum();
         if (codeDetails === undefined) {
-            throw new Error("pkg should be provided in create flow!!");
+            // pkg should be provided in create flow!!
+            throw new GenericError("instantiateContextDetachedMissingCodeDetails");
         }
 
         await this.instantiateContext(


### PR DESCRIPTION
One caveat - I'm adding more usages of `UsageError` here, which may be updated/renamed in accordance with pending discussions about error shapes. But it's already used in the file so I figure no real harm in it, and these new cases match the semantics elsewhere in the file (if I'm interpreting these codepaths properly). 