### PR TITLE
Replace generateSummaries with disableSummaries

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -592,6 +592,8 @@ export interface ISummaryRuntimeOptions {
     // (undocumented)
     disableIsolatedChannels?: boolean;
     disableSummaries?: boolean;
+    // @deprecated (undocumented)
+    generateSummaries?: boolean;
     // (undocumented)
     initialSummarizerDelayMs?: number;
     // (undocumented)

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -180,6 +180,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     submitDataStoreSignal(address: string, type: string, content: any): void;
     submitSignal(type: string, content: any): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
+    // (undocumented)
+    summariesDisabled(): boolean;
     summarize(options: {
         summaryLogger: ITelemetryLogger;
         fullTree?: boolean;
@@ -589,7 +591,7 @@ export interface ISummaryOpMessage extends ISequencedDocumentMessage {
 export interface ISummaryRuntimeOptions {
     // (undocumented)
     disableIsolatedChannels?: boolean;
-    generateSummaries?: boolean;
+    disableSummaries?: boolean;
     // (undocumented)
     initialSummarizerDelayMs?: number;
     // (undocumented)

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2097,6 +2097,14 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1026.0-42695",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+					"integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0"
+					}
+				},
 				"@types/semver": {
 					"version": "6.2.3",
 					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
@@ -2139,6 +2147,16 @@
 				"debug": "^4.1.1",
 				"jsrsasign": "^10.2.0",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1026.0-42695",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+					"integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-memory-orderer": {
@@ -2164,6 +2182,16 @@
 				"moniker": "^0.1.2",
 				"uuid": "^8.3.1",
 				"ws": "^7.4.6"
+			},
+			"dependencies": {
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1026.0-42695",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+					"integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-services-client": {
@@ -2184,6 +2212,14 @@
 				"uuid": "^8.3.1"
 			},
 			"dependencies": {
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1026.0-42695",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+					"integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0"
+					}
+				},
 				"jwt-decode": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
@@ -2205,6 +2241,16 @@
 				"@types/node": "^12.19.0",
 				"debug": "^4.1.1",
 				"nconf": "^0.11.0"
+			},
+			"dependencies": {
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1026.0-42695",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+					"integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-services-shared": {
@@ -2514,6 +2560,16 @@
 				"lodash": "^4.17.21",
 				"string-hash": "^1.1.3",
 				"uuid": "^8.3.1"
+			},
+			"dependencies": {
+				"@fluidframework/protocol-definitions": {
+					"version": "0.1026.0-42695",
+					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+					"integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/test-tools": {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -224,10 +224,16 @@ export interface IGCRuntimeOptions {
 
 export interface ISummaryRuntimeOptions {
     /**
+     * Flag that disables summaries if it is set to true.
+     */
+    disableSummaries?: boolean;
+
+    /**
+     * @deprecated - To disable summaries, please set disableSummaries===true.
      * Flag that will generate summaries if connected to a service that supports them.
      * This defaults to true and must be explicitly set to false to disable.
      */
-    disableSummaries?: boolean;
+    generateSummaries?: boolean;
 
     /* Delay before first attempt to spawn summarizing container. */
     initialSummarizerDelayMs?: number;
@@ -1001,6 +1007,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.summaryCollection = new SummaryCollection(this.deltaManager, this.logger);
 
         // Only create a SummaryManager if summaries are enabled and we are not the summarizer client
+        // Map the deprecated generateSummaries flag to disableSummaries.
+        if (this.runtimeOptions.summaryOptions.generateSummaries === false) {
+            this.runtimeOptions.summaryOptions.disableSummaries = true;
+        }
         if (this.summariesDisabled()) {
             this._logger.sendTelemetryEvent({ eventName: "SummariesDisabled" });
         } else {

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -32,7 +32,7 @@ describe("Runtime", () => {
                         undefined, // requestHandler
                         {
                             summaryOptions: {
-                                generateSummaries: false,
+                                disableSummaries: true,
                             },
                         },
                     );

--- a/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
@@ -35,7 +35,7 @@ describeFullCompat("Audience correctness", (getTestObjectProvider) => {
         undefined,
         undefined,
         // Disable summaries so the summarizer client doesn't interfere with the audience
-        { summaryOptions: { generateSummaries: false }},
+        { summaryOptions: { disableSummaries: true }},
     );
 
     const createContainer = async (): Promise<Container> => await provider.createContainer(runtimeFactory) as Container;

--- a/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
@@ -41,7 +41,6 @@ describeNoCompat("Cache CreateNewSummary", (getTestObjectProvider) => {
     };
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: {
-            generateSummaries: true,
             initialSummarizerDelayMs: 10,
             summaryConfigOverrides,
         },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
@@ -39,7 +39,6 @@ describeFullCompat("GC Data Store Requests", (getTestObjectProvider) => {
     };
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: {
-            generateSummaries: true,
             initialSummarizerDelayMs: 10,
             summaryConfigOverrides,
         },
@@ -202,7 +201,6 @@ describeFullCompat("GC Data Store Requests", (getTestObjectProvider) => {
         // dataStore2 will have it marked as unreferenced.
         const gcDisabledRuntimeOptions: IContainerRuntimeOptions = {
             summaryOptions: {
-                generateSummaries: true,
                 initialSummarizerDelayMs: 10,
                 summaryConfigOverrides,
             },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -29,7 +29,7 @@ describeFullCompat("GC delete objects in test mode", (getTestObjectProvider) => 
             [],
             []);
         const runtimeOptions: IContainerRuntimeOptions = {
-            summaryOptions: { generateSummaries: false },
+            summaryOptions: { disableSummaries: true },
             gcOptions: { gcAllowed: true, runGCInTestMode: deleteUnreferencedContent },
         };
         const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -29,7 +29,7 @@ describeFullCompat("GC inactive data store tests", (getTestObjectProvider) => {
         []);
     const maxUnreferencedDurationMs = 2000;
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: true, maxUnreferencedDurationMs },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
@@ -78,7 +78,7 @@ describeFullCompat("GC reference updates in local summary", (getTestObjectProvid
         []);
 
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: true },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
@@ -87,7 +87,6 @@ describeFullCompat("GC reference updates in summarizer", (getTestObjectProvider)
     };
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: {
-            generateSummaries: true,
             initialSummarizerDelayMs: 10,
             summaryConfigOverrides,
         },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
@@ -34,7 +34,7 @@ describeFullCompat("GC state reset in summaries", (getTestObjectProvider) => {
         []);
 
     const defaultRuntimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
+        summaryOptions: { disableSummaries: true },
     };
 
     const logger = new TelemetryNullLogger();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -29,7 +29,7 @@ describeFullCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         [],
         []);
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: true },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
@@ -36,7 +36,7 @@ describeFullCompat("GC unreferenced flag in downloaded snapshot", (getTestObject
         []);
 
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: true },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -40,7 +40,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         []);
 
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: true },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
@@ -59,7 +59,7 @@ describeFullCompat("GC version upgrade", (getTestObjectProvider) => {
         []);
 
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false },
+        summaryOptions: { disableSummaries: true },
         gcOptions: { gcAllowed: true },
     };
     const defaultRuntimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
@@ -37,7 +37,7 @@ const testContainerConfig: ITestContainerConfig = {
     runtimeOptions: {
         // strictly control summarization
         summaryOptions: {
-            generateSummaries: false,
+            disableSummaries: true,
             initialSummarizerDelayMs: 0,
             summaryConfigOverrides: { maxOps },
         },
@@ -83,7 +83,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
                             ... testContainerConfig.runtimeOptions,
                             summaryOptions:{
                                 ... testContainerConfig.runtimeOptions?.summaryOptions,
-                                generateSummaries: true,
+                                disableSummaries: false,
                             },
                         },
                     })]],

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -27,7 +27,7 @@ const testContainerConfig: ITestContainerConfig = {
     runtimeOptions: {
         summaryOptions: {
             // currently these tests will break if we load from a summary that was too recent
-            generateSummaries: false,
+            disableSummaries: true,
         },
     },
 };

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -37,8 +37,7 @@ async function createContainer(
     ], []);
 
     // Force generateSummaries to false.
-    const summaryOptions: ISummaryRuntimeOptions = { ...summaryOpt };
-    summaryOptions.generateSummaries = false;
+    const summaryOptions: ISummaryRuntimeOptions = { ...summaryOpt, disableSummaries: true };
 
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
         factory,

--- a/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
@@ -48,7 +48,6 @@ describeNoCompat("Generate Summary Stats", (getTestObjectProvider) => {
     };
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: {
-            generateSummaries: true,
             initialSummarizerDelayMs: 10,
             summaryConfigOverrides,
         },

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -41,6 +41,7 @@ export function generateRuntimeOptions(seed: number) {
     const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
         disableIsolatedChannels: booleanCases,
         disableSummaries: [false],
+        generateSummaries: [true],
         initialSummarizerDelayMs: numberCases,
         summaryConfigOverrides: [undefined],
         maxOpsSinceLastSummary: numberCases,

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -40,7 +40,7 @@ const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
 export function generateRuntimeOptions(seed: number) {
     const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
         disableIsolatedChannels: booleanCases,
-        generateSummaries: [true],
+        disableSummaries: [false],
         initialSummarizerDelayMs: numberCases,
         summaryConfigOverrides: [undefined],
         maxOpsSinceLastSummary: numberCases,

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -115,7 +115,7 @@ export async function loadContainer(
     // Older snapshots may not contain summary acks, so the summarizer will throw error in case it faces more
     // ops than "maxOpsSinceLastSummary". So set it to a higher number to suppress those errors and run tests.
     const runtimeOptions: IContainerRuntimeOptions = {
-        summaryOptions: { generateSummaries: false, maxOpsSinceLastSummary: 100000 },
+        summaryOptions: { disableSummaries: true, maxOpsSinceLastSummary: 100000 },
     };
     const codeLoader = new ReplayCodeLoader(new ReplayRuntimeFactory(runtimeOptions, dataStoreRegistries));
 

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -238,6 +238,16 @@
         "@fluidframework/gitresources": "0.1034.0-42936",
         "@fluidframework/protocol-definitions": "^0.1026.0-0",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/protocol-definitions": {
@@ -272,6 +282,16 @@
         "semver": "^6.3.0",
         "sha.js": "^2.4.11",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-lambdas-driver": {
@@ -304,6 +324,16 @@
         "debug": "^4.1.1",
         "jsrsasign": "^10.2.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-memory-orderer": {
@@ -329,6 +359,16 @@
         "moniker": "^0.1.2",
         "uuid": "^8.3.1",
         "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-services-client": {
@@ -347,6 +387,16 @@
         "jwt-decode": "^3.0.0",
         "sillyname": "0.1.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-services-core": {
@@ -363,6 +413,16 @@
         "@types/node": "^12.19.0",
         "debug": "^4.1.1",
         "nconf": "^0.11.0"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-services-shared": {
@@ -390,6 +450,16 @@
         "socket.io-parser": "^4.0.4",
         "uuid": "^8.3.1",
         "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-services-telemetry": {
@@ -423,6 +493,16 @@
         "sillyname": "0.1.0",
         "uuid": "^8.3.1",
         "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@fluidframework/server-test-utils": {
@@ -441,6 +521,16 @@
         "lodash": "^4.17.21",
         "string-hash": "^1.1.3",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/protocol-definitions": {
+          "version": "0.1026.0-42695",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-42695.tgz",
+          "integrity": "sha512-rBU2C+MIlXUMUz03Fp2RT+8bkp9TRvqPikKgfZKVSd+6gtlJxieQAP9dZzfaH170XbNuM5puNS4NmOhUVmehMw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0"
+          }
+        }
       }
     },
     "@microsoft/api-extractor": {


### PR DESCRIPTION
In ContainerRuntime summary options, replace the generateSummaries flag with disableSummaries. If either this or the flag disableSummaries flag in ISummaryConfiguration is set on creation, the client will not participate in summarization or
summarizer client election. generateSummaries will be disabled for now, 