### PR TITLE
Fluid build directory config: Ignore `tools` from `services`

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,9 @@
       "services": {
         "directory": "server",
         "ignoredDirs": [
-          "routerlicious"
+          "routerlicious",
+          "tinylicious",
+          "azure-local-service"
         ]
       }
     },


### PR DESCRIPTION
`tinylicious` and `azure-local-services` are specified int he `tools` group.  It should be excluded from the `service` group.

This fix `fluid-build --reinstall --services`