### PR TITLE
Stronger validation for interrupted batches

### DIFF
--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -186,9 +186,9 @@ export class MockDeltaManager extends TypedEventEmitter<IDeltaManagerEvents> imp
     // (undocumented)
     get IDeltaSender(): this;
     // (undocumented)
-    get inbound(): IDeltaQueue<ISequencedDocumentMessage>;
+    get inbound(): MockDeltaQueue<ISequencedDocumentMessage>;
     // (undocumented)
-    get inboundSignal(): IDeltaQueue<ISignalMessage>;
+    get inboundSignal(): MockDeltaQueue<ISignalMessage>;
     // (undocumented)
     initialSequenceNumber: number;
     // (undocumented)
@@ -202,7 +202,7 @@ export class MockDeltaManager extends TypedEventEmitter<IDeltaManagerEvents> imp
     // (undocumented)
     minimumSequenceNumber: number;
     // (undocumented)
-    get outbound(): IDeltaQueue<IDocumentMessage[]>;
+    get outbound(): MockDeltaQueue<IDocumentMessage[]>;
     // (undocumented)
     readonly readonly = false;
     // (undocumented)
@@ -215,6 +215,43 @@ export class MockDeltaManager extends TypedEventEmitter<IDeltaManagerEvents> imp
     submitSignal(content: any): void;
     // (undocumented)
     get version(): string;
+}
+
+// @public
+export class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
+    constructor();
+    // (undocumented)
+    dispose(): void;
+    // (undocumented)
+    get disposed(): any;
+    // (undocumented)
+    get idle(): boolean;
+    // (undocumented)
+    get length(): number;
+    // (undocumented)
+    pause(): Promise<void>;
+    // (undocumented)
+    protected pauseCount: number;
+    // (undocumented)
+    get paused(): boolean;
+    // (undocumented)
+    peek(): T | undefined;
+    // (undocumented)
+    pop(): T;
+    // (undocumented)
+    protected process(): void;
+    // (undocumented)
+    processCallback: (el: T) => void;
+    // (undocumented)
+    push(el: T): void;
+    // (undocumented)
+    protected readonly queue: T[];
+    // (undocumented)
+    resume(): void;
+    // (undocumented)
+    toArray(): T[];
+    // (undocumented)
+    waitTillProcessingDone(): Promise<void>;
 }
 
 // @public

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -369,10 +369,10 @@ class ScheduleManagerCore {
      public afterOpProcessing(sequenceNumber: number) {
         assert(!this.localPaused, "can't have op processing paused if we are processing an op");
 
-        // If no message has caused the pause flag to be set, or the next message up is not the one we need to pause at
-        // then we simply continue processing
+        // do we have incomplete batch to worry about?
         if (this.pauseSequenceNumber !== undefined) {
-            assert(sequenceNumber < this.pauseSequenceNumber, "processed op we should have not processed");
+            assert(sequenceNumber < this.pauseSequenceNumber, "we should never start processing incomplete batch!");
+            // If the next op is the start of incomplete batch, then we can't process it until it's fully in - pause!
             if (sequenceNumber + 1 === this.pauseSequenceNumber) {
                 this.setPaused(true);
             }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -369,16 +369,19 @@ class ScheduleManagerCore {
      public afterOpProcessing(sequenceNumber: number) {
         assert(!this.localPaused, "can't have op processing paused if we are processing an op");
 
+        // If no message has caused the pause flag to be set, or the next message up is not the one we need to pause at
+        // then we simply continue processing
+        if (this.pauseSequenceNumber !== undefined) {
+            assert(sequenceNumber < this.pauseSequenceNumber, "processed op we should have not processed");
+            if (sequenceNumber + 1 >= this.pauseSequenceNumber) {
+                this.setPaused(true);
+            }
+        }
+
         // If the inbound queue is ever empty we pause it and wait for new events
         if (this.deltaManager.inbound.length === 0) {
             this.setPaused(true);
             return;
-        }
-
-        // If no message has caused the pause flag to be set, or the next message up is not the one we need to pause at
-        // then we simply continue processing
-        if (this.pauseSequenceNumber !== undefined && sequenceNumber + 1 >= this.pauseSequenceNumber) {
-            this.setPaused(true);
         }
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -381,7 +381,6 @@ class ScheduleManagerCore {
         // If the inbound queue is ever empty we pause it and wait for new events
         if (this.deltaManager.inbound.length === 0) {
             this.setPaused(true);
-            return;
         }
     }
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -107,6 +107,7 @@ describe("Runtime", () => {
                     // Send a non-batch message.
                     processOp(message as ISequencedDocumentMessage);
 
+                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
                     assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin events");
                     assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd events");
                 });
@@ -126,6 +127,7 @@ describe("Runtime", () => {
                     processOp(message as ISequencedDocumentMessage);
                     processOp(message as ISequencedDocumentMessage);
 
+                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
                     assert.strictEqual(5, batchBegin, "Did not receive correct batchBegin events");
                     assert.strictEqual(5, batchEnd, "Did not receive correct batchEnd events");
                 });
@@ -142,6 +144,7 @@ describe("Runtime", () => {
                     processOp(message as ISequencedDocumentMessage);
 
                     // We should have a "batchBegin" and a "batchEnd" event for the batch.
+                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
                     assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
                     assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
                 });
@@ -172,9 +175,13 @@ describe("Runtime", () => {
                     processOp(batchBeginMessage as ISequencedDocumentMessage);
                     processOp(batchMessage as ISequencedDocumentMessage);
                     processOp(batchMessage as ISequencedDocumentMessage);
+
+                    assert.strictEqual(deltaManager.inbound.length, 3, "none of the batched ops are processed yet");
+
                     processOp(batchEndMessage as ISequencedDocumentMessage);
 
                     // We should have only received one "batchBegin" and one "batchEnd" event for the batch.
+                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
                     assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
                     assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
                 });
@@ -237,8 +244,11 @@ describe("Runtime", () => {
                             processOp(batchMessage as ISequencedDocumentMessage);
                             processOp(batchMessage as ISequencedDocumentMessage);
 
+                            assert.strictEqual(deltaManager.inbound.length, 3, "none of the batch ops are processed");
+
                             assert.throws(() => processOp(messageToFail as ISequencedDocumentMessage));
 
+                            assert.strictEqual(deltaManager.inbound.length, 4, "none of the ops are processed");
                             assert.strictEqual(0, batchBegin, "Did not receive correct batchBegin event for the batch");
                             assert.strictEqual(0, batchEnd, "Did not receive correct batchBegin event for the batch");
                         });

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -110,7 +110,7 @@ describe("Runtime", () => {
                     // Send a non-batch message.
                     processOp(message);
 
-                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
+                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
                     assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin events");
                     assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd events");
                 });
@@ -129,7 +129,7 @@ describe("Runtime", () => {
                     processOp(message);
                     processOp(message);
 
-                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
+                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
                     assert.strictEqual(5, batchBegin, "Did not receive correct batchBegin events");
                     assert.strictEqual(5, batchEnd, "Did not receive correct batchEnd events");
                 });
@@ -145,7 +145,7 @@ describe("Runtime", () => {
                     processOp(message);
 
                     // We should have a "batchBegin" and a "batchEnd" event for the batch.
-                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
+                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
                     assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
                     assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
                 });
@@ -174,12 +174,12 @@ describe("Runtime", () => {
                     processOp(batchMessage);
                     processOp(batchMessage);
 
-                    assert.strictEqual(deltaManager.inbound.length, 3, "none of the batched ops are processed yet");
+                    assert.strictEqual(deltaManager.inbound.length, 3, "Some of partial batch ops were processed yet");
 
                     processOp(batchEndMessage);
 
                     // We should have only received one "batchBegin" and one "batchEnd" event for the batch.
-                    assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
+                    assert.strictEqual(deltaManager.inbound.length, 0, "Did not process all ops");
                     assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin event for the batch");
                     assert.strictEqual(1, batchEnd, "Did not receive correct batchEnd event for the batch");
                 });
@@ -243,11 +243,12 @@ describe("Runtime", () => {
                             processOp(batchMessage);
                             processOp(batchMessage);
 
-                            assert.strictEqual(deltaManager.inbound.length, 3, "none of the batch ops are processed");
+                            assert.strictEqual(deltaManager.inbound.length, 3,
+                                "Some of partial batch ops were processed yet");
 
                             assert.throws(() => processOp(messageToFail));
 
-                            assert.strictEqual(deltaManager.inbound.length, 4, "none of the ops are processed");
+                            assert.strictEqual(deltaManager.inbound.length, 4, "Some of batch ops were processed");
                             assert.strictEqual(0, batchBegin, "Did not receive correct batchBegin event for the batch");
                             assert.strictEqual(0, batchEnd, "Did not receive correct batchBegin event for the batch");
                         });

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -94,10 +94,10 @@ describe("Runtime", () => {
                     seqNumber = 0;
                 });
 
-                function processOp(message: ISequencedDocumentMessage) {
+                function processOp(message: Partial<ISequencedDocumentMessage>) {
                     seqNumber++;
                     message.sequenceNumber = seqNumber;
-                    deltaManager.inbound.push(message);
+                    deltaManager.inbound.push(message as ISequencedDocumentMessage);
                 }
 
                 it("Single non-batch message", () => {
@@ -108,7 +108,7 @@ describe("Runtime", () => {
                     };
 
                     // Send a non-batch message.
-                    processOp(message as ISequencedDocumentMessage);
+                    processOp(message);
 
                     assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
                     assert.strictEqual(1, batchBegin, "Did not receive correct batchBegin events");
@@ -123,11 +123,11 @@ describe("Runtime", () => {
                     };
 
                     // Sent 5 non-batch messages.
-                    processOp(message as ISequencedDocumentMessage);
-                    processOp(message as ISequencedDocumentMessage);
-                    processOp(message as ISequencedDocumentMessage);
-                    processOp(message as ISequencedDocumentMessage);
-                    processOp(message as ISequencedDocumentMessage);
+                    processOp(message);
+                    processOp(message);
+                    processOp(message);
+                    processOp(message);
+                    processOp(message);
 
                     assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
                     assert.strictEqual(5, batchBegin, "Did not receive correct batchBegin events");
@@ -142,7 +142,7 @@ describe("Runtime", () => {
                         metadata: { foo: 1 },
                     };
 
-                    processOp(message as ISequencedDocumentMessage);
+                    processOp(message);
 
                     // We should have a "batchBegin" and a "batchEnd" event for the batch.
                     assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
@@ -170,13 +170,13 @@ describe("Runtime", () => {
                     };
 
                     // Send a batch with 4 messages.
-                    processOp(batchBeginMessage as ISequencedDocumentMessage);
-                    processOp(batchMessage as ISequencedDocumentMessage);
-                    processOp(batchMessage as ISequencedDocumentMessage);
+                    processOp(batchBeginMessage);
+                    processOp(batchMessage);
+                    processOp(batchMessage);
 
                     assert.strictEqual(deltaManager.inbound.length, 3, "none of the batched ops are processed yet");
 
-                    processOp(batchEndMessage as ISequencedDocumentMessage);
+                    processOp(batchEndMessage);
 
                     // We should have only received one "batchBegin" and one "batchEnd" event for the batch.
                     assert.strictEqual(deltaManager.inbound.length, 0, "processed all ops");
@@ -239,13 +239,13 @@ describe("Runtime", () => {
                         counter++;
                         it(`Partial batch messages, case ${counter}`, () => {
                             // Send a batch with 3 messages from first client but don't send batch end message.
-                            processOp(batchBeginMessage as ISequencedDocumentMessage);
-                            processOp(batchMessage as ISequencedDocumentMessage);
-                            processOp(batchMessage as ISequencedDocumentMessage);
+                            processOp(batchBeginMessage);
+                            processOp(batchMessage);
+                            processOp(batchMessage);
 
                             assert.strictEqual(deltaManager.inbound.length, 3, "none of the batch ops are processed");
 
-                            assert.throws(() => processOp(messageToFail as ISequencedDocumentMessage));
+                            assert.throws(() => processOp(messageToFail));
 
                             assert.strictEqual(deltaManager.inbound.length, 4, "none of the ops are processed");
                             assert.strictEqual(0, batchBegin, "Did not receive correct batchBegin event for the batch");

--- a/packages/runtime/test-runtime-utils/src/mockDeltas.ts
+++ b/packages/runtime/test-runtime-utils/src/mockDeltas.ts
@@ -12,50 +12,74 @@ import {
     ISignalMessage,
     MessageType,
 } from "@fluidframework/protocol-definitions";
-
 import {
     IDeltaManager,
     IDeltaManagerEvents,
     IDeltaQueue,
     ReadOnlyInfo,
 } from "@fluidframework/container-definitions";
-import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 
 /**
  * Mock implementation of IDeltaQueue for testing that does nothing
  */
-class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
+export class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
+    protected readonly queue: T[] = [];
+    protected pauseCount = 0;
+
+    public processCallback: (el: T) => void = () => {};
+
     public get disposed() { return undefined; }
 
     public get paused(): boolean {
-        return false;
+        return this.pauseCount !== 0;
     }
 
-    public get length(): number {
-        return 0;
-    }
+    public get length() { return this.queue.length; }
 
     public get idle(): boolean {
-        return false;
+        return this.queue.length === 0;
+    }
+
+    protected process() {
+        while (this.pauseCount === 0 && this.length > 0) {
+            this.processCallback(this.pop());
+        }
+    }
+
+    public push(el: T) {
+        this.queue.push(el);
+        this.emit("push", el);
+        this.process();
+    }
+
+    public pop() {
+        return this.queue.shift();
     }
 
     public async pause(): Promise<void> {
+        this.pauseCount++;
         return;
     }
 
-    public resume(): void { }
+    public resume(): void {
+        this.pauseCount--;
+        this.process();
+    }
 
     public peek(): T | undefined {
-        return undefined;
+        return this.queue[0];
     }
 
     public toArray(): T[] {
-        return [];
+        return this.queue;
     }
 
     public dispose() { }
 
-    public async waitTillProcessingDone() { }
+    public async waitTillProcessingDone() {
+        assert(false, "NYI");
+    }
 
     constructor() {
         super();
@@ -79,15 +103,15 @@ export class MockDeltaManager extends TypedEventEmitter<IDeltaManagerEvents>
     private readonly _inboundSignal: MockDeltaQueue<ISignalMessage>;
     private readonly _outbound: MockDeltaQueue<IDocumentMessage[]>;
 
-    public get inbound(): IDeltaQueue<ISequencedDocumentMessage> {
+    public get inbound(): MockDeltaQueue<ISequencedDocumentMessage> {
         return this._inbound;
     }
 
-    public get outbound(): IDeltaQueue<IDocumentMessage[]> {
+    public get outbound(): MockDeltaQueue<IDocumentMessage[]> {
         return this._outbound;
     }
 
-    public get inboundSignal(): IDeltaQueue<ISignalMessage> {
+    public get inboundSignal(): MockDeltaQueue<ISignalMessage> {
         return this._inboundSignal;
     }
     public minimumSequenceNumber = 0;


### PR DESCRIPTION
If batch is interrupted by another client op, or by new batch from same client, then it causes data corruption, instead of prior behavior of silently closing batch.
This will ensure we find and identify any bugs we might have anywhere in the system that cause batch functionality to be broken.
It also helps with validating any future changes that would be needed to overcome 1Mb socket.io / Kafka limits
