### PR TITLE
Remove Deprecated Close Functions

### DIFF
--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -219,12 +219,6 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
      * Submit a new signal to the server
      */
     submitSignal(message: any): void;
-
-    /**
-     * Disconnects the given delta connection
-     * @deprecated in 0.45, please use dispose()
-     */
-    close(): void;
 }
 
 export enum LoaderCachingPolicy {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -334,9 +334,6 @@ export class DocumentDeltaConnection
             createGenericNetworkError("clientClosingConnection", undefined, true /* canRetry */));
     }
 
-    // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
-    public close() { this.dispose(); }
-
     protected disposeCore(socketProtocolError: boolean, err: any) {
         // Can't check this.disposed here, as we get here on socket closure,
         // so _disposed & socket.connected might be not in sync while processing

--- a/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
@@ -205,7 +205,4 @@ export class ReplayFileDeltaConnection
     private _disposed = false;
     public get disposed() { return this._disposed; }
     public dispose() { this._disposed = true; }
-
-    // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
-    public close(): void { this.dispose(); }
 }

--- a/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
+++ b/packages/drivers/iframe-driver/src/innerDocumentDeltaConnection.ts
@@ -195,7 +195,4 @@ export class InnerDocumentDeltaConnection
     public dispose() {
         throw new Error("InnerDocumentDeltaConnection: close() not implemented Yet");
     }
-
-    // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
-    public close(): void { this.dispose(); }
 }

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -292,9 +292,6 @@ export class ReplayDocumentDeltaConnection
     public get disposed() { return this._disposed; }
     public dispose() { this._disposed = true; }
 
-    // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
-    public close(): void { this.dispose(); }
-
     /**
      * This gets the specified ops from the delta storage endpoint and replays them in the replayer.
      */

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -157,9 +157,6 @@ class NoDeltaStream
     private _disposed = false;
     public get disposed() { return this._disposed; }
     public dispose() { this._disposed = true; }
-
-    // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
-    public close(): void { this.dispose(); }
 }
 
 /**

--- a/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
+++ b/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
@@ -82,9 +82,6 @@ export class MockDocumentDeltaConnection
         this.emit("disconnect", error?.message ?? "mock close() called");
     }
 
-    // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
-    public close(error?: Error): void { this.dispose(error); }
-
     // Mock methods for raising events
     public emitOp(documentId: string, messages: Partial<ISequencedDocumentMessage>[]) {
         this.emit("op", documentId, messages);

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -126,7 +126,7 @@ extends EventForwarder<IDocumentDeltaConnectionEvents> implements IDocumentDelta
     /**
      * Disconnects the given delta connection
      */
-    dispose(): void {
+    public dispose(): void {
         this._disposed = true;
         const disposable = this.internal as Partial<IDisposable>;
         if (disposable.dispose !== undefined)

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -138,9 +138,6 @@ extends EventForwarder<IDocumentDeltaConnectionEvents> implements IDocumentDelta
         }
     }
 
-    // back-compat: became @deprecated in 0.45 / driver-definitions 0.40
-    public close(): void { this.dispose(); }
-
     public injectNack(docId: string, canRetry: boolean | undefined) {
         assert(!this.disposed, "cannot inject nack into closed delta connection");
         const nack: Partial<INack> = {


### PR DESCRIPTION
This PR removes deprecated `close()` functions which have been replaced with `dispose()` functions.

Linked Issue: https://github.com/microsoft/FluidFramework/issues/8185