### PR TITLE
Repalce OdspDocumentInfo type with OdspFluidDataStoreLocator interface 

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,7 +18,7 @@ There are a few steps you can take to write a good change note and avoid needing
 The `chaincodePackage` property on `Container` was deprecated in 0.28, and has now been removed.  Two new APIs have been added to replace its functionality, `getSpecifiedCodeDetails()` and `getLoadedCodeDetails()`.  Use `getSpecifiedCodeDetails()` to get the code details currently specified for the `Container`, or `getLoadedCodeDetails()` to get the code details that were used to load the `Container`.
 
 ### `OdspDocumentInfo` type replaced with `OdspFluidDataStoreLocator` interface
-The `OdspDocumentInfo` type is removed from `odsp-driver` package It is removed from `packages\drivers\odsp-driver\src\contractsPublic.ts` and replaced with `OdspFluidDataStoreLocator` interface as parameter in `OdspDriverUrlResolverForShareLink.createDocumentUrl()`. If there are any instances of `OdspDocumentInfo` type used, it can be simply replaced with `OdspFluidDataStoreLocator` interface.
+The `OdspDocumentInfo` type is removed from `odsp-driver` package. It is removed from `packages\drivers\odsp-driver\src\contractsPublic.ts` and replaced with `OdspFluidDataStoreLocator` interface as parameter in `OdspDriverUrlResolverForShareLink.createDocumentUrl()`. If there are any instances of `OdspDocumentInfo` type used, it can be simply replaced with `OdspFluidDataStoreLocator` interface.
 
 ## 0.51 Breaking changes
 - [`maxMessageSize` property has been deprecated from IConnectionDetails and IDocumentDeltaConnection](#maxmessagesize-property-has-been-deprecated-from-iconnectiondetails-and-idocumentdeltaconnection)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,7 +18,7 @@ There are a few steps you can take to write a good change note and avoid needing
 The `chaincodePackage` property on `Container` was deprecated in 0.28, and has now been removed.  Two new APIs have been added to replace its functionality, `getSpecifiedCodeDetails()` and `getLoadedCodeDetails()`.  Use `getSpecifiedCodeDetails()` to get the code details currently specified for the `Container`, or `getLoadedCodeDetails()` to get the code details that were used to load the `Container`.
 
 ### `OdspDocumentInfo` type replaced with `OdspFluidDataStoreLocator` interface
-The `OdspDocumentInfo` type is removed from `odsp-driver` package It is removed from `packages\drivers\odsp-driver\src\contractsPublic.ts` and replaced with `OdspFluidDataStoreLocator` interface as parameter in `OdspDriverUrlResolverForShareLink.createDocumentUrl()`.
+The `OdspDocumentInfo` type is removed from `odsp-driver` package It is removed from `packages\drivers\odsp-driver\src\contractsPublic.ts` and replaced with `OdspFluidDataStoreLocator` interface as parameter in `OdspDriverUrlResolverForShareLink.createDocumentUrl()`. If there are any instances of `OdspDocumentInfo` type used, it can be simply replaced with `OdspFluidDataStoreLocator` interface.
 
 ## 0.51 Breaking changes
 - [`maxMessageSize` property has been deprecated from IConnectionDetails and IDocumentDeltaConnection](#maxmessagesize-property-has-been-deprecated-from-iconnectiondetails-and-idocumentdeltaconnection)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,9 +12,13 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)
+- [OdspDocumentInfo type replaced with OdspFluidDataStoreLocator interface](#OdspDocumentInfo-type-replaced-with-OdspFluidDataStoreLocator-interface)
 
 ### `chaincodePackage` removed from `Container`
 The `chaincodePackage` property on `Container` was deprecated in 0.28, and has now been removed.  Two new APIs have been added to replace its functionality, `getSpecifiedCodeDetails()` and `getLoadedCodeDetails()`.  Use `getSpecifiedCodeDetails()` to get the code details currently specified for the `Container`, or `getLoadedCodeDetails()` to get the code details that were used to load the `Container`.
+
+### `OdspDocumentInfo` type replaced with `OdspFluidDataStoreLocator` interface
+The `OdspDocumentInfo` type is removed from `odsp-driver` package It is removed from `packages\drivers\odsp-driver\src\contractsPublic.ts` and replaced with `OdspFluidDataStoreLocator` interface as parameter in `OdspDriverUrlResolverForShareLink.createDocumentUrl()`.
 
 ## 0.51 Breaking changes
 - [`maxMessageSize` property has been deprecated from IConnectionDetails and IDocumentDeltaConnection](#maxmessagesize-property-has-been-deprecated-from-iconnectiondetails-and-idocumentdeltaconnection)

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -71,9 +71,6 @@ export const OdcApiSiteOrigin = "https://api.onedrive.com";
 // @public (undocumented)
 export const OdcFileSiteOrigin = "https://1drv.ms";
 
-// @public @deprecated (undocumented)
-export type OdspDocumentInfo = OdspFluidDataStoreLocator;
-
 // @public
 export class OdspDocumentServiceFactory extends OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
     constructor(getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined, persistedCache?: IPersistedCache, hostPolicy?: HostStoragePolicy);
@@ -114,7 +111,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     appendDataStorePath(requestUrl: URL, pathToAppend: string): string | undefined;
     // @deprecated (undocumented)
     createCreateNewRequest(siteUrl: string, driveId: string, filePath: string, fileName: string): IRequest;
-    static createDocumentUrl(baseUrl: string, driverInfo: OdspDocumentInfo): string;
+    static createDocumentUrl(baseUrl: string, driverInfo: OdspFluidDataStoreLocator): string;
     static createNavParam(locator: OdspFluidDataStoreLocator): string;
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, dataStorePath: string, codeDetails?: IFluidCodeDetails): Promise<string>;
     resolve(request: IRequest): Promise<IOdspResolvedUrl>;

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -5,11 +5,6 @@
 
 import { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions";
 
-/**
- * @deprecated - use OdspFluidDataStoreLocator
- */
-export type OdspDocumentInfo = OdspFluidDataStoreLocator;
-
 export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
     dataStorePath: string;
     appName?: string;

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -22,7 +22,7 @@ import {
     encodeOdspFluidDataStoreLocator,
     locatorQueryParamName,
 } from "./odspFluidFileLink";
-import { OdspDocumentInfo, OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic";
+import { OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic";
 import { createOdspCreateContainerRequest } from "./createOdspCreateContainerRequest";
 import { createOdspUrl } from "./createOdspUrl";
 import { OdspDriverUrlResolver } from "./odspDriverUrlResolver";
@@ -254,7 +254,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     /**
      * Crafts a supported document/driver URL
      */
-    public static createDocumentUrl(baseUrl: string, driverInfo: OdspDocumentInfo) {
+    public static createDocumentUrl(baseUrl: string, driverInfo: OdspFluidDataStoreLocator) {
         const url = new URL(baseUrl);
 
         storeLocatorInOdspUrl(url, driverInfo);


### PR DESCRIPTION
The aim of this PR is to remove/replace one of the deprecated type `OdspDocumentInfo`. It is removed from `packages\drivers\odsp-driver\src\contractsPublic.ts` and replaced in `OdspDriverUrlResolverForShareLink.createDocumentUrl()` with `OdspFluidDataStoreLocator` interface.

Fixes https://github.com/microsoft/FluidFramework/issues/8192