### PR TITLE
remove deprecated close() from driver-definitions

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,6 +12,7 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)
+- [close() removed from IDocumentDeltaConnection](#close-removed-from-IDocumentDeltaConnection)
 
 ### `chaincodePackage` removed from `Container`
 The `chaincodePackage` property on `Container` was deprecated in 0.28, and has now been removed.  Two new APIs have been added to replace its functionality, `getSpecifiedCodeDetails()` and `getLoadedCodeDetails()`.  Use `getSpecifiedCodeDetails()` to get the code details currently specified for the `Container`, or `getLoadedCodeDetails()` to get the code details that were used to load the `Container`.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,8 +12,8 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)
-- [close() removed from IDocumentDeltaConnection](#close-removed-from-IDocumentDeltaConnection)
 - [OdspDocumentInfo type replaced with OdspFluidDataStoreLocator interface](#OdspDocumentInfo-type-replaced-with-OdspFluidDataStoreLocator-interface)
+- [close() removed from IDocumentDeltaConnection](#close-removed-from-IDocumentDeltaConnection)
 
 ### `chaincodePackage` removed from `Container`
 The `chaincodePackage` property on `Container` was deprecated in 0.28, and has now been removed.  Two new APIs have been added to replace its functionality, `getSpecifiedCodeDetails()` and `getLoadedCodeDetails()`.  Use `getSpecifiedCodeDetails()` to get the code details currently specified for the `Container`, or `getLoadedCodeDetails()` to get the code details that were used to load the `Container`.

--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -90,8 +90,6 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     checkpointSequenceNumber?: number;
     claims: ITokenClaims;
     clientId: string;
-    // @deprecated
-    close(): void;
     existing: boolean;
     initialClients: ISignalClient[];
     initialMessages: ISequencedDocumentMessage[];

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -75,7 +75,8 @@
           "backCompat": false
         },
         "InterfaceDeclaration_IDocumentDeltaConnection": {
-          "forwardCompat": false
+          "forwardCompat": false,
+          "backCompat": false
         },
         "InterfaceDeclaration_IDocumentService": {
           "forwardCompat": false,
@@ -99,6 +100,37 @@
           "backCompat": false
         },
         "InterfaceDeclaration_IThrottlingWarning": {
+          "backCompat": false
+        },
+        "get_current_InterfaceDeclaration_IDocumentDeltaConnection": {
+          "backCompat": false
+        }
+      },
+      "0.40.0": {
+        "InterfaceDeclaration_IDocumentDeltaConnection": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IDocumentService": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IDocumentServiceFactory": {
+          "backCompat": false
+        },
+        "get_current_InterfaceDeclaration_IDocumentDeltaConnection": {
+          "backCompat": false
+        }
+      },
+      "0.41.0": {
+        "InterfaceDeclaration_IDocumentDeltaConnection": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IDocumentService": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IDocumentServiceFactory": {
+          "backCompat": false
+        },
+        "get_current_InterfaceDeclaration_IDocumentDeltaConnection": {
           "backCompat": false
         }
       }

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -219,12 +219,6 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
      * Submit a new signal to the server
      */
     submitSignal(message: any): void;
-
-    /**
-     * Disconnects the given delta connection
-     * @deprecated in 0.45, please use dispose()
-     */
-    close(): void;
 }
 
 export enum LoaderCachingPolicy {

--- a/common/lib/driver-definitions/src/test/types/validate0.39.8.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.39.8.ts
@@ -193,13 +193,13 @@ use_current_InterfaceDeclaration_IDocumentDeltaConnection(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.39.8:
 * "InterfaceDeclaration_IDocumentDeltaConnection": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IDocumentDeltaConnection():
     current.IDocumentDeltaConnection;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     use: old.IDocumentDeltaConnection);
 use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     get_current_InterfaceDeclaration_IDocumentDeltaConnection());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/common/lib/driver-definitions/src/test/types/validate0.40.0.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.40.0.ts
@@ -265,13 +265,13 @@ use_current_InterfaceDeclaration_IDocumentService(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IDocumentService": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IDocumentService():
     current.IDocumentService;
 declare function use_old_InterfaceDeclaration_IDocumentService(
     use: old.IDocumentService);
 use_old_InterfaceDeclaration_IDocumentService(
     get_current_InterfaceDeclaration_IDocumentService());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/common/lib/driver-definitions/src/test/types/validate0.40.0.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.40.0.ts
@@ -193,13 +193,13 @@ use_current_InterfaceDeclaration_IDocumentDeltaConnection(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IDocumentDeltaConnection": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IDocumentDeltaConnection():
     current.IDocumentDeltaConnection;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     use: old.IDocumentDeltaConnection);
 use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     get_current_InterfaceDeclaration_IDocumentDeltaConnection());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -289,13 +289,13 @@ use_current_InterfaceDeclaration_IDocumentServiceFactory(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.40.0:
 * "InterfaceDeclaration_IDocumentServiceFactory": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IDocumentServiceFactory():
     current.IDocumentServiceFactory;
 declare function use_old_InterfaceDeclaration_IDocumentServiceFactory(
     use: old.IDocumentServiceFactory);
 use_old_InterfaceDeclaration_IDocumentServiceFactory(
     get_current_InterfaceDeclaration_IDocumentServiceFactory());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/common/lib/driver-definitions/src/test/types/validate0.41.0.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.41.0.ts
@@ -193,13 +193,13 @@ use_current_InterfaceDeclaration_IDocumentDeltaConnection(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.41.0:
 * "InterfaceDeclaration_IDocumentDeltaConnection": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IDocumentDeltaConnection():
     current.IDocumentDeltaConnection;
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     use: old.IDocumentDeltaConnection);
 use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     get_current_InterfaceDeclaration_IDocumentDeltaConnection());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -265,13 +265,13 @@ use_current_InterfaceDeclaration_IDocumentService(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.41.0:
 * "InterfaceDeclaration_IDocumentService": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IDocumentService():
     current.IDocumentService;
 declare function use_old_InterfaceDeclaration_IDocumentService(
     use: old.IDocumentService);
 use_old_InterfaceDeclaration_IDocumentService(
     get_current_InterfaceDeclaration_IDocumentService());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -289,13 +289,13 @@ use_current_InterfaceDeclaration_IDocumentServiceFactory(
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.41.0:
 * "InterfaceDeclaration_IDocumentServiceFactory": {"backCompat": false}
-*/
 declare function get_current_InterfaceDeclaration_IDocumentServiceFactory():
     current.IDocumentServiceFactory;
 declare function use_old_InterfaceDeclaration_IDocumentServiceFactory(
     use: old.IDocumentServiceFactory);
 use_old_InterfaceDeclaration_IDocumentServiceFactory(
     get_current_InterfaceDeclaration_IDocumentServiceFactory());
+*/
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
This PR removes the `close()` function from the `IDocumentDeltaConnection` interface. `dispose()` can be used in place of the removed function. 

Issue: https://github.com/microsoft/FluidFramework/issues/8185