### PR TITLE
layer-check -- dev layers shouldn't specify allowed deps

### DIFF
--- a/tools/build-tools/data/layerInfo.json
+++ b/tools/build-tools/data/layerInfo.json
@@ -146,14 +146,6 @@
                 "dev": true,
                 "packages": [
                     "@fluid-experimental/get-container"
-                ],
-                "deps": [
-                    "Framework",
-                    "Loader",
-                    "Routerlicious-Driver",
-                    "Server-Libs",
-                    "Server-Shared-Utils",
-                    "Test"
                 ]
             },
             "Runtime": {
@@ -215,12 +207,6 @@
                     "experimental/examples/",
                     "experimental/PropertyDDS/examples/",
                     "experimental/PropertyDDS/services/"
-                ],
-                "deps": [
-                    "Framework",
-                    "Driver",
-                    "Routerlicious-Driver",
-                    "Test"
                 ]
             },
             "Build": {

--- a/tools/build-tools/src/layerCheck/layerGraph.ts
+++ b/tools/build-tools/src/layerCheck/layerGraph.ts
@@ -293,6 +293,10 @@ export class LayerGraph {
                 if (layerInfo.packages) {
                     layerInfo.packages.forEach(pkg => this.createPackageNode(pkg, layerNode));
                 }
+
+                if (layerInfo.dev && layerInfo.deps) {
+                    throw new Error(`ERROR: dev layers should not specify allowed deps since verification is skipped for dev layers (${layerName})`);
+                }
             }
         }
 


### PR DESCRIPTION
Because verification is skipped for them