### PR TITLE
fix(r11s-driver): don't return latest for cached snapshot id

### DIFF
--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -171,7 +171,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
     private async fetchAndCacheSnapshotTree(versionId: string): Promise<{ id: string, snapshotTree: ISnapshotTree }> {
         const cachedSnapshotTree = await this.snapshotTreeCache.get(versionId);
         if (cachedSnapshotTree !== undefined) {
-            return { id: versionId, snapshotTree: cachedSnapshotTree };
+            return { id: cachedSnapshotTree.id!, snapshotTree: cachedSnapshotTree };
         }
 
         const wholeFlatSummary = await PerformanceEvent.timedExecAsync(


### PR DESCRIPTION
versionId can be "latest", but "latest" isn't the snapshot tree id, so we can't be using the versionId as the snapshotTree Id when returning a cached snapshot.