### PR TITLE
Fix newListener bug for dirty/saved events

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -875,7 +875,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 newError.addTelemetryProperties({ resolvedUrl: resolvedUrl.url });
             }
             this.close(newError);
-            // eslint-disable-next-line @typescript-eslint/no-throw-literal
             throw newError;
         }
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -175,7 +175,7 @@ export async function waitContainerToCatchUp(container: Container) {
         throw new Error("Container is closed");
     }
 
-    return new Promise<boolean>((accept, reject) => {
+    return new Promise<boolean>((resolve, reject) => {
         const deltaManager = container.deltaManager;
 
         container.on("closed", reject);
@@ -189,12 +189,12 @@ export async function waitContainerToCatchUp(container: Container) {
             assert(deltaManager.lastSequenceNumber <= connectionOpSeqNumber,
                 0x266 /* "lastKnownSeqNumber should never be below last processed sequence number" */);
             if (deltaManager.lastSequenceNumber === connectionOpSeqNumber) {
-                accept(hasCheckpointSequenceNumber);
+                resolve(hasCheckpointSequenceNumber);
                 return;
             }
             const callbackOps = (message: ISequencedDocumentMessage) => {
                 if (connectionOpSeqNumber <= message.sequenceNumber) {
-                    accept(hasCheckpointSequenceNumber);
+                    resolve(hasCheckpointSequenceNumber);
                     deltaManager.off("op", callbackOps);
                 }
             };
@@ -656,12 +656,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 switch (event) {
                     case dirtyContainerEvent:
                         if (this._dirtyContainer) {
-                            listener(this._dirtyContainer);
+                            listener(dirtyContainerEvent);
                         }
                         break;
                     case savedContainerEvent:
                         if (!this._dirtyContainer) {
-                            listener(this._dirtyContainer);
+                            listener(savedContainerEvent);
                         }
                         break;
                     case connectedEventName:
@@ -875,6 +875,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 newError.addTelemetryProperties({ resolvedUrl: resolvedUrl.url });
             }
             this.close(newError);
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
             throw newError;
         }
     }


### PR DESCRIPTION
From code inspection, it looks like the measure added to fire the `dirty`/`saved` event when a new listener is added would not work properly - it's emitting a bool instead of the event name.