### PR TITLE
add global db connection to alfred

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -20,7 +20,9 @@ data:
             "label": "winston"
         },
         "mongo": {
-            "endpoint": "{{ .Values.mongodb.url }}",
+            "operationsDbEndpoint": "{{ .Values.mongodb.operationsDbEndpoint }}",
+            "globalDbEndpoint": "{{ .Values.mongodb.globalDbEndpoint }}",
+            "globalDbEnabled": {{ .Values.mongodb.globalDbEnabled }},
             "expireAfterSeconds": {{ .Values.mongodb.expireAfterSeconds }},
             "createCosmosDBIndexes": {{ .Values.mongodb.createCosmosDBIndexes }},
             "softDeletionRetentionPeriodMs": {{ .Values.mongodb.softDeletionRetentionPeriodMs }},

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -68,7 +68,9 @@ zookeeper:
   url: zookeeper_url:port
 
 mongodb:
-  url: mongodb_url
+  operationsDbEndpoint: mongodb_url
+  globalDbEndpoint: mongoglobaldb_url
+  globalDbEnabled: false
   expireAfterSeconds: -1
   createCosmosDBIndexes: false
   softDeletionRetentionPeriodMs: 2592000000

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -47,8 +47,9 @@ export function create(
     singleUseTokenCache: ICache,
     storage: IDocumentStorage,
     appTenants: IAlfredTenant[],
-    mongoManager: MongoManager,
-    producer: IProducer) {
+    operationsDbMongoManager: MongoManager,
+    producer: IProducer,
+    globalDbMongoManager?: MongoManager) {
     // Maximum REST request size
     const requestSize = config.get("alfred:restJsonSize");
 
@@ -105,10 +106,11 @@ export function create(
         tenantManager,
         throttler,
         singleUseTokenCache,
-        mongoManager,
+        operationsDbMongoManager,
         storage,
         producer,
-        appTenants);
+        appTenants,
+        globalDbMongoManager);
 
     app.use("/public", cors(), express.static(path.join(__dirname, "../../public")));
     app.use(routes.api);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -4,7 +4,13 @@
  */
 
 import * as crypto from "crypto";
-import { IDocumentStorage, IThrottler, ITenantManager, ICache } from "@fluidframework/server-services-core";
+import {
+    IDocumentStorage,
+    IThrottler,
+    ITenantManager,
+    ICache,
+    MongoManager,
+} from "@fluidframework/server-services-core";
 import {
     verifyStorageToken,
     throttle,
@@ -24,7 +30,8 @@ export function create(
     throttler: IThrottler,
     singleUseTokenCache: ICache,
     config: Provider,
-    tenantManager: ITenantManager): Router {
+    tenantManager: ITenantManager,
+    globalDbMongoManager?: MongoManager): Router {
     const router: Router = Router();
 
     // Whether to enforce server-generated document ids in create doc flow

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
@@ -25,12 +25,20 @@ export function create(
     throttler: IThrottler,
     singleUseTokenCache: ICache,
     storage: IDocumentStorage,
-    mongoManager: MongoManager,
+    operationsDbMongoManager: MongoManager,
     producer: IProducer,
-    appTenants: IAlfredTenant[]): Router {
+    appTenants: IAlfredTenant[],
+    globalDbMongoManager?: MongoManager): Router {
     const router: Router = Router();
-    const deltasRoute = deltas.create(config, tenantManager, mongoManager, appTenants, throttler);
-    const documentsRoute = documents.create(storage, appTenants, throttler, singleUseTokenCache, config, tenantManager);
+    const deltasRoute = deltas.create(config, tenantManager, operationsDbMongoManager, appTenants, throttler);
+    const documentsRoute = documents.create(
+        storage,
+        appTenants,
+        throttler,
+        singleUseTokenCache,
+        config,
+        tenantManager,
+        globalDbMongoManager);
     const apiRoute = api.create(config, producer, tenantManager, storage, throttler);
 
     router.use(cors());

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
@@ -27,10 +27,11 @@ export function create(
     tenantManager: ITenantManager,
     throttler: IThrottler,
     singleUseTokenCache: ICache,
-    mongoManager: MongoManager,
+    operationsDbMongoManager: MongoManager,
     storage: IDocumentStorage,
     producer: IProducer,
-    appTenants: IAlfredTenant[]) {
+    appTenants: IAlfredTenant[],
+    globalDbMongoManager?: MongoManager) {
     return {
         api: api.create(
             config,
@@ -38,9 +39,10 @@ export function create(
             throttler,
             singleUseTokenCache,
             storage,
-            mongoManager,
+            operationsDbMongoManager,
             producer,
             appTenants,
+            globalDbMongoManager,
         ),
     };
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -42,9 +42,10 @@ export class AlfredRunner implements IRunner {
         private readonly storage: IDocumentStorage,
         private readonly clientManager: IClientManager,
         private readonly appTenants: IAlfredTenant[],
-        private readonly mongoManager: MongoManager,
+        private readonly operationsDbMongoManager: MongoManager,
         private readonly producer: IProducer,
-        private readonly metricClientConfig: any) {
+        private readonly metricClientConfig: any,
+        private readonly globalDbMongoManager?: MongoManager) {
     }
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -59,8 +60,9 @@ export class AlfredRunner implements IRunner {
             this.singleUseTokenCache,
             this.storage,
             this.appTenants,
-            this.mongoManager,
-            this.producer);
+            this.operationsDbMongoManager,
+            this.producer,
+            this.globalDbMongoManager);
         alfred.set("port", this.port);
 
         this.server = this.serverFactory.create(alfred);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -41,7 +41,7 @@ export class RiddlerResources implements IResources {
 export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResources> {
     public async create(config: Provider): Promise<RiddlerResources> {
         // Database connection
-        const mongoUrl = config.get("mongo:endpoint") as string;
+        const mongoUrl = config.get("mongo:operationsDbEndpoint") as string;
         const mongoFactory = new services.MongoDbFactory(mongoUrl);
         const mongoManager = new MongoManager(mongoFactory);
         const tenantsCollectionName = config.get("mongo:collectionNames:tenants");

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -8,7 +8,9 @@
         "label": "winston"
     },
     "mongo": {
-        "endpoint": "mongodb://mongodb:27017",
+        "operationsDbEndpoint": "mongodb://mongodb:27017",
+        "globalDbEndpoint": "mongodb://mongodb:27017",
+        "globalDbEnabled": false,
         "expireAfterSeconds": -1,
         "createCosmosDBIndexes": false,
         "softDeletionRetentionPeriodMs": 2592000000,

--- a/server/routerlicious/packages/routerlicious/src/copier/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/copier/index.ts
@@ -11,7 +11,7 @@ import { Provider } from "nconf";
 // Establish a connection to Mongo, get the 'rawdeltas' collection and invoke
 // the rest of the Copier instantiation:
 export async function create(config: Provider): Promise<IPartitionLambdaFactory> {
-    const mongoUrl = config.get("mongo:endpoint") as string;
+    const mongoUrl = config.get("mongo:operationsDbEndpoint") as string;
     const collectionName = config.get("mongo:collectionNames:rawdeltas");
     const mongoFactory = new services.MongoDbFactory(mongoUrl);
     const mongoManager = new MongoManager(mongoFactory, false);

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -14,7 +14,7 @@ import { RedisOptions } from "ioredis";
 import * as winston from "winston";
 
 export async function deliCreate(config: Provider): Promise<core.IPartitionLambdaFactory> {
-    const mongoUrl = config.get("mongo:endpoint") as string;
+    const mongoUrl = config.get("mongo:operationsDbEndpoint") as string;
     const kafkaEndpoint = config.get("kafka:lib:endpoint");
     const kafkaLibrary = config.get("kafka:lib:name");
     const kafkaProducerPollIntervalMs = config.get("kafka:lib:producerPollIntervalMs");

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -17,7 +17,7 @@ import { Provider } from "nconf";
 
 export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFactory> {
     // Access config values
-    const mongoUrl = config.get("mongo:endpoint") as string;
+    const mongoUrl = config.get("mongo:operationsDbEndpoint") as string;
     const documentsCollectionName = config.get("mongo:collectionNames:documents");
     const messagesCollectionName = config.get("mongo:collectionNames:scribeDeltas");
     const createCosmosDBIndexes = config.get("mongo:createCosmosDBIndexes");

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -10,7 +10,7 @@ import { deleteSummarizedOps, executeOnInterval, FluidServiceErrorCode } from "@
 import { Provider } from "nconf";
 
 export async function create(config: Provider): Promise<IPartitionLambdaFactory> {
-    const mongoUrl = config.get("mongo:endpoint") as string;
+    const mongoUrl = config.get("mongo:operationsDbEndpoint") as string;
     const mongoExpireAfterSeconds = config.get("mongo:expireAfterSeconds") as number;
     const deltasCollectionName = config.get("mongo:collectionNames:deltas");
     const documentsCollectionName = config.get("mongo:collectionNames:documents");


### PR DESCRIPTION
In FRS, we will have two database instances - one will be a global db holding session info and tenant data, one will be an operations db. This PR is to create a connection to global db, to be used in alfred. For tenant data, will create a separate PR