### PR TITLE
Improve error/telemetry when failing to get a share link

### DIFF
--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -7,6 +7,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, delay, PromiseCache } from "@fluidframework/common-utils";
 import { canRetryOnError, getRetryDelayFromError } from "@fluidframework/driver-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
+import { fetchIncorrectResponse, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import {
     IOdspUrlParts,
     OdspResourceTokenFetchOptions,
@@ -16,7 +17,6 @@ import {
 } from "@fluidframework/odsp-driver-definitions";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
 import { fetchHelper, getWithRetryForTokenRefresh } from "./odspUtils";
-import { fetchIncorrectResponse, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 
 // Store cached responses for the lifetime of web session as file link remains the same for given file item
 const fileLinkCache = new PromiseCache<string, string>();
@@ -154,7 +154,7 @@ const isFileItemLite = (maybeFileItemLite: any): maybeFileItemLite is FileItemLi
         return false;
     }
     return true;
-}
+};
 
 async function getFileItemLite(
     getToken: TokenFetcher<OdspResourceTokenFetchOptions>,

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -116,16 +116,6 @@ async function getFileLinkCore(
                 const response = await fetchHelper(url, requestInit);
                 additionalProps = response.commonSpoHeaders;
 
-                // We actually already know the response is ok, or else the fetchHelper would have thrown
-                // (it does an even more thorough check).  Keeping it here though for layers of protection.
-                if (!response.content.ok) {
-                    throwOdspNetworkError(
-                        `odspFetchError [${response.content.status}]`,
-                        response.content.status,
-                        response.content,
-                        await response.content.text(),
-                    );
-                }
                 const sharingInfo = await response.content.json();
                 const directUrl = sharingInfo?.d?.directUrl;
                 if (typeof directUrl !== "string") {
@@ -178,16 +168,6 @@ async function getFileItemLite(
                 const response = await fetchHelper(url, requestInit);
                 additionalProps = response.commonSpoHeaders;
 
-                // We actually already know the response is ok, or else the fetchHelper would have thrown
-                // (it does an even more thorough check).  Keeping it here though for layers of protection.
-                if (!response.content.ok) {
-                    throwOdspNetworkError(
-                        `odspFetchError [${response.content.status}]`,
-                        response.content.status,
-                        response.content,
-                        await response.content.text(),
-                    );
-                }
                 const responseJson = await response.content.json();
                 if (!isFileItemLite(responseJson)) {
                     // This will retry once in getWithRetryForTokenRefresh

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -7,7 +7,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, delay, PromiseCache } from "@fluidframework/common-utils";
 import { canRetryOnError, getRetryDelayFromError } from "@fluidframework/driver-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { fetchIncorrectResponse, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
+import { throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import {
     IOdspUrlParts,
     OdspResourceTokenFetchOptions,
@@ -131,7 +131,11 @@ async function getFileLinkCore(
                 const sharingInfo = await response.content.json();
                 const directUrl = sharingInfo?.d?.directUrl;
                 if (typeof directUrl !== "string") {
-                    throwOdspNetworkError("malformedGetSharingInformationResponse", fetchIncorrectResponse);
+                    // Here use a generic error.  fetchIncorrectResponse might be preferable but will result in a
+                    // retry, which we don't want.  Both because we don't have a reason to expect a different
+                    // response on retry, and also because the retry loop in in getFileLink doesn't have the same
+                    // "retry once" logic that getWithRetryForTokenRefresh does.
+                    throwOdspNetworkError("malformedGetSharingInformationResponse", 400);
                 }
                 return directUrl;
             });
@@ -191,7 +195,11 @@ async function getFileItemLite(
                 }
                 const responseJson = await response.content.json();
                 if (!isFileItemLite(responseJson)) {
-                    throwOdspNetworkError("malformedGetFileItemLiteResponse", fetchIncorrectResponse);
+                    // Here use a generic error.  fetchIncorrectResponse might be preferable but will result in a
+                    // retry, which we don't want.  Both because we don't have a reason to expect a different
+                    // response on retry, and also because the retry loop in in getFileLink doesn't have the same
+                    // "retry once" logic that getWithRetryForTokenRefresh does.
+                    throwOdspNetworkError("malformedGetFileItemLiteResponse", 400);
                 }
                 return responseJson;
             });

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -7,7 +7,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, delay, PromiseCache } from "@fluidframework/common-utils";
 import { canRetryOnError, getRetryDelayFromError } from "@fluidframework/driver-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
+import { fetchIncorrectResponse, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
 import {
     IOdspUrlParts,
     OdspResourceTokenFetchOptions,
@@ -131,11 +131,8 @@ async function getFileLinkCore(
                 const sharingInfo = await response.content.json();
                 const directUrl = sharingInfo?.d?.directUrl;
                 if (typeof directUrl !== "string") {
-                    // Here use a generic error.  fetchIncorrectResponse might be preferable but will result in a
-                    // retry, which we don't want.  Both because we don't have a reason to expect a different
-                    // response on retry, and also because the retry loop in in getFileLink doesn't have the same
-                    // "retry once" logic that getWithRetryForTokenRefresh does.
-                    throwOdspNetworkError("malformedGetSharingInformationResponse", 400);
+                    // This will retry once in getWithRetryForTokenRefresh
+                    throwOdspNetworkError("malformedGetSharingInformationResponse", fetchIncorrectResponse);
                 }
                 return directUrl;
             });
@@ -195,11 +192,8 @@ async function getFileItemLite(
                 }
                 const responseJson = await response.content.json();
                 if (!isFileItemLite(responseJson)) {
-                    // Here use a generic error.  fetchIncorrectResponse might be preferable but will result in a
-                    // retry, which we don't want.  Both because we don't have a reason to expect a different
-                    // response on retry, and also because the retry loop in in getFileLink doesn't have the same
-                    // "retry once" logic that getWithRetryForTokenRefresh does.
-                    throwOdspNetworkError("malformedGetFileItemLiteResponse", 400);
+                    // This will retry once in getWithRetryForTokenRefresh
+                    throwOdspNetworkError("malformedGetFileItemLiteResponse", fetchIncorrectResponse);
                 }
                 return responseJson;
             });

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -203,12 +203,8 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
             resolvedUrl,
             this.shareLinkFetcherProps.identityType,
             this.logger,
-        ).then((fileLink) => {
-            if (!fileLink) {
-                throw new Error("Failed to get share link");
-            }
-            return fileLink;
-        }).catch((error) => {
+        ).catch((error) => {
+            // This should imply that error is a non-retriable error.
             this.logger.sendErrorEvent({ eventName: "FluidFileUrlError" }, error);
             this.sharingLinkCache.remove(key);
             throw error;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -300,7 +300,6 @@ export function toInstrumentedOdspTokenFetcher(
                 const tokenError = wrapError(
                     error,
                     (errorMessage) => createOdspNetworkError("tokenFetcherFailed", errorMessage, fetchTokenErrorCode));
-                // eslint-disable-next-line @typescript-eslint/no-throw-literal
                 throw tokenError;
             }),
             { cancel: "generic" });

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -26,20 +26,18 @@ describe("getFileLink", () => {
         assert.strictEqual(result, fileItemResponse.webUrl, "File link for Consumer user should match webUrl");
     });
 
-    it("should return undefined for Consumer user if file web url is missing", async () => {
-        const result = await mockFetchOk(
+    it("should reject for Consumer user if file web url is missing", async () => {
+        await assert.rejects(mockFetchOk(
             async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId2"}, "Consumer", logger),
-        );
-        assert.strictEqual(result, undefined, "File link should be undefined");
+        ), "Should reject for unexpected empty response");
     });
 
-    it("should return undefined for Consumer user if file item is not found", async () => {
-        const result = await mockFetchSingle(async () => {
+    it("should reject for Consumer user if file item is not found", async () => {
+        await assert.rejects(mockFetchSingle(async () => {
                 return getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId3"}, "Consumer", logger);
             },
             notFound,
-        );
-        assert.strictEqual(result, undefined, "File link should be undefined");
+        ), "File link should reject when not found");
     });
 
     it("should return share link with existing access for Enterprise user", async () => {
@@ -54,18 +52,17 @@ describe("getFileLink", () => {
             result, "sharelink", "File link for Enterprise user should match url returned from sharing information");
     });
 
-    it("should return undefined for Enterprise user if file web dav url is missing", async () => {
-        const result = await mockFetchOk(
+    it("should reject for Enterprise user if file web dav url is missing", async () => {
+        await assert.rejects(mockFetchOk(
             async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId5"}, "Enterprise", logger),
-        );
-        assert.strictEqual(result, undefined, "File link should be undefined");
+        ), "File link should reject for malformed url");
     });
 
-    it("should return undefined for Enterprise user if file item is not found", async () => {
-        const result = await mockFetchSingle(async () => {
+    it("should reject for Enterprise user if file item is not found", async () => {
+        await assert.rejects(mockFetchSingle(async () => {
             return getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId6"}, "Enterprise", logger);
             },
-            notFound);
-        assert.strictEqual(result, undefined, "File link should be undefined");
+            notFound,
+        ), "File link should reject when not found");
     });
 });

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -27,8 +27,13 @@ describe("getFileLink", () => {
     });
 
     it("should reject for Consumer user if file web url is missing", async () => {
-        await assert.rejects(mockFetchOk(
+        await assert.rejects(mockFetchMultiple(
             async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId2"}, "Consumer", logger),
+            [
+                async () => okResponse({}, {}),
+                // We retry once on malformed response from server, so need a second response mocked.
+                async () => okResponse({}, {}),
+            ],
         ), "Should reject for unexpected empty response");
     });
 
@@ -53,8 +58,13 @@ describe("getFileLink", () => {
     });
 
     it("should reject for Enterprise user if file web dav url is missing", async () => {
-        await assert.rejects(mockFetchOk(
+        await assert.rejects(mockFetchMultiple(
             async () => getFileLink(storageTokenFetcher, {siteUrl, driveId, itemId: "itemId5"}, "Enterprise", logger),
+            [
+                async () => okResponse({}, {}),
+                // We retry once on malformed response from server, so need a second response mocked.
+                async () => okResponse({}, {}),
+            ],
         ), "File link should reject for malformed url");
     });
 

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -488,7 +488,6 @@ function throwBufferParseException(
             nodeType: getNodeType(node),
             expectedNodeType,
         });
-    // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw error;
 }
 

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -208,7 +208,7 @@ export function createOdspNetworkError(
             break;
         case fetchIncorrectResponse:
             // Note that getWithRetryForTokenRefresh will retry it once, then it becomes non-retryable error
-            error = new RetryableError(
+            error = new NonRetryableError(
                 fluidErrorCode, errorMessage, DriverErrorType.incorrectServerResponse, { statusCode });
             break;
         case fetchTimeoutStatusCode:


### PR DESCRIPTION
Fixes #8195 

We recently hit an issue where we believe the fetch to get the share link was returning code 200 but malformed content.  Since validation of that content happened after the fetch completed and returned, `undefined` could be stored in the link cache and blow up after the fact (and then, only with an error of "Failed to get share link" losing some of the context).  We were able to learn that it was a 200 response because the _cancel performance event was absent (instead we got an _end indicating "successful" completion), but this is not a very strong signal and non-obvious to any new investigator that hits the issue.

This PR intends to be stricter on validation of the response and more descriptive in errors returned so we can more easily detect and diagnose this in the future.