### PR TITLE
perf(r11s-driver): Add in-memory caching for Node.js and RestLess

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -38,8 +38,23 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
         blobCache?: ICache<ArrayBufferLike>,
         snapshotTreeCache?: ICache<ISnapshotTree>): IDocumentStorageService {
         const storageService = driverPolicies?.enableWholeSummaryUpload ?
-            new WholeSummaryDocumentStorageService(id, manager, logger, policies, blobCache, snapshotTreeCache) :
-            new ShreddedSummaryDocumentStorageService(id, manager, logger, policies);
+            new WholeSummaryDocumentStorageService(
+                id,
+                manager,
+                logger,
+                policies,
+                blobCache,
+                snapshotTreeCache,
+            ) :
+            new ShreddedSummaryDocumentStorageService(
+                id,
+                manager,
+                logger,
+                policies,
+                driverPolicies,
+                blobCache,
+                snapshotTreeCache,
+            );
         // TODO: worth prefetching latest summary making version + snapshot call with WholeSummary storage?
         if (!driverPolicies?.enableWholeSummaryUpload && policies.caching === LoaderCachingPolicy.Prefetch) {
             return new PrefetchDocumentStorageService(storageService);

--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -16,6 +16,7 @@ import {
 import { buildHierarchy } from "@fluidframework/protocol-base";
 import {
     ICreateBlobResponse,
+    ISnapshotTree,
     ISnapshotTreeEx,
     ISummaryHandle,
     ISummaryTree,
@@ -28,7 +29,12 @@ import {
     SummaryTreeUploadManager,
 } from "@fluidframework/server-services-client";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
+import { IRouterliciousDriverPolicies } from "./policies";
+import { ICache, InMemoryCache } from "./cache";
 import { RetriableGitManager } from "./retriableGitManager";
+
+// eslint-disable-next-line no-new-func,@typescript-eslint/no-implied-eval
+const isNode = (new Function("try {return this===global;}catch(e){ return false;}"))();
 
 /**
  * Document access to underlying storage for routerlicious driver.
@@ -39,6 +45,8 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
     // The values of this cache is useless. We only need the keys. So we are always putting
     // empty strings as values.
     protected readonly blobsShaCache = new Map<string, string>();
+    private readonly blobCache: ICache<ArrayBufferLike> | undefined;
+    private readonly snapshotTreeCache: ICache<ISnapshotTreeEx> | undefined;
     private readonly summaryUploadManager: ISummaryUploadManager;
 
     public get repositoryUrl(): string {
@@ -49,12 +57,19 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
         protected readonly id: string,
         protected readonly manager: GitManager,
         protected readonly logger: ITelemetryLogger,
-        public readonly policies: IDocumentStorageServicePolicies = {}) {
+        public readonly policies: IDocumentStorageServicePolicies = {},
+        driverPolicies?: IRouterliciousDriverPolicies,
+        blobCache?: ICache<ArrayBufferLike>,
+        snapshotTreeCache?: ICache<ISnapshotTree>) {
         this.summaryUploadManager = new SummaryTreeUploadManager(
                 new RetriableGitManager(manager, logger),
                 this.blobsShaCache,
                 this.getPreviousFullSnapshot.bind(this),
             );
+        if (driverPolicies?.enableRestLess === true || isNode) {
+            this.blobCache = blobCache ?? new InMemoryCache();
+            this.snapshotTreeCache = (snapshotTreeCache ?? new InMemoryCache()) as ICache<ISnapshotTreeEx>;
+        }
     }
 
     public async getVersions(versionId: string, count: number): Promise<IVersion[]> {
@@ -86,6 +101,11 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
             requestVersion = versions[0];
         }
 
+        const cachedSnapshotTree = await this.snapshotTreeCache?.get(requestVersion.treeId);
+        if (cachedSnapshotTree) {
+            return cachedSnapshotTree;
+        }
+
         const rawTree = await PerformanceEvent.timedExecAsync(
             this.logger,
             {
@@ -101,10 +121,16 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
             },
         );
         const tree = buildHierarchy(rawTree, this.blobsShaCache, true);
+        await this.snapshotTreeCache?.put(tree.id, tree);
         return tree;
     }
 
     public async readBlob(blobId: string): Promise<ArrayBufferLike> {
+        const cachedBlob = await this.blobCache?.get(blobId);
+        if (cachedBlob) {
+            return cachedBlob;
+        }
+
         const value = await PerformanceEvent.timedExecAsync(
             this.logger,
             {
@@ -120,7 +146,9 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
             },
         );
         this.blobsShaCache.set(value.sha, "");
-        return stringToBuffer(value.content, value.encoding);
+        const bufferContent = stringToBuffer(value.content, value.encoding);
+        await this.blobCache?.put(value.sha, bufferContent);
+        return bufferContent;
     }
 
     public async write(tree: ITree, parents: string[], message: string, ref: string): Promise<IVersion> {


### PR DESCRIPTION
R11s driver by default relies heavily on built-in Browser network caching. However, in Node.js scenarios (e.g. e2e tests), the R11s driver has no caching for Git storage (shredded summary) scenarios. By adding this cache at the document service factory level for shredded summary scenarios, we can reduce the `getSnapshotTree` and `readBlob` calls in the E2E tests by ~30% (tested locally against tinylicious). This is still a long way from "a few requests per session" (as requested in #7061) but it is a step in the right direction.

Also enabled this in-memory caching for when RestLess is enabled. RestLess uses POST requests, which are not cacheable by Browser network cache, so we should manually cache those results.