### PR TITLE
Remove DeltaConnectionError telemetry

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1154,10 +1154,6 @@ export class DeltaManager
     };
 
     private readonly errorHandler = (error) => {
-        // Observation based on early pre-production telemetry:
-        // We are getting transport errors from WebSocket here, right before or after "disconnect".
-        // This happens only in Firefox.
-        logNetworkFailure(this.logger, { eventName: "DeltaConnectionError" }, error);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.reconnectOnError(
             this.defaultReconnectionMode,


### PR DESCRIPTION
Looking at code, prod telemetry and ODSP telemetry, this error duplicates Disconnected event and does not carry any more info than existing disconnected event. Also it's not really an error in a sense that it's expected condition, thus not worth having in error table.