### PR TITLE
SequenceDelta: Fix first and last typing and improve comments

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -352,10 +352,10 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
     readonly deltaArgs: IMergeTreeDeltaCallbackArgs<TOperation>;
     // (undocumented)
     readonly deltaOperation: TOperation;
-    get first(): Readonly<ISequenceDeltaRange<TOperation>>;
+    get first(): Readonly<ISequenceDeltaRange<TOperation>> | undefined;
     // (undocumented)
     readonly isEmpty: boolean;
-    get last(): Readonly<ISequenceDeltaRange<TOperation>>;
+    get last(): Readonly<ISequenceDeltaRange<TOperation>> | undefined;
     get ranges(): readonly Readonly<ISequenceDeltaRange<TOperation>>[];
     }
 

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -27,8 +27,8 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
     public readonly isEmpty: boolean;
     public readonly deltaOperation: TOperation;
     private readonly sortedRanges: Lazy<SortedSegmentSet<ISequenceDeltaRange<TOperation>>>;
-    private readonly pFirst: Lazy<ISequenceDeltaRange<TOperation>>;
-    private readonly pLast: Lazy<ISequenceDeltaRange<TOperation>>;
+    private readonly pFirst: Lazy<ISequenceDeltaRange<TOperation> | undefined>;
+    private readonly pLast: Lazy<ISequenceDeltaRange<TOperation> | undefined>;
 
     constructor(
         public readonly deltaArgs: IMergeTreeDeltaCallbackArgs<TOperation>,
@@ -71,7 +71,7 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
 
     /**
      * The in-order ranges affected by this delta.
-     * These may not be continous.
+     * These may not be continuos.
      */
     public get ranges(): readonly Readonly<ISequenceDeltaRange<TOperation>>[] {
         return this.sortedRanges.value.items;
@@ -85,16 +85,18 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
     }
 
     /**
-     * The first of the modified ranges.
+     * The first of the modified ranges. Undefined if delta is empty,
+     * like in the case where a delete comes in for a previously deleted range
      */
-    public get first(): Readonly<ISequenceDeltaRange<TOperation>> {
+    public get first(): Readonly<ISequenceDeltaRange<TOperation>> | undefined {
         return this.pFirst.value;
     }
 
     /**
-     * The last of the modified ranges.
+     * The last of the modified ranges. Undefined if delta is empty,
+     * like in the case where a delete comes in for a previously deleted range
      */
-    public get last(): Readonly<ISequenceDeltaRange<TOperation>> {
+    public get last(): Readonly<ISequenceDeltaRange<TOperation>> | undefined {
         return this.pLast.value;
     }
 }


### PR DESCRIPTION
It has always been possible for first and last to be undefined, but this was not represented in the typing. This fixes the typing issue, and adds comments about the case.