### PR TITLE
remove deprecated / removed field missed in #8213

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -322,7 +322,6 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         // fix the branch name in attributes
         // this prevents issues when generating summaries
         const documentAttributes: api.IDocumentAttributes = JSON.parse(bufferToString(blob, "utf8"));
-        documentAttributes.branch = this.documentId;
         const content = JSON.stringify(documentAttributes);
         const patchedBlob = stringToBuffer(content, "utf8");
         return patchedBlob;

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -19,7 +19,6 @@ const createUtLocalCache = () => new LocalPersistentCache(2000);
 
 describe("Create New Utils Tests", () => {
     const documentAttributes: api.IDocumentAttributes = {
-        branch: "",
         minimumSequenceNumber: 0,
         sequenceNumber: 0,
         term: 1,

--- a/server/routerlicious/packages/protocol-base/src/scribeHelper.ts
+++ b/server/routerlicious/packages/protocol-base/src/scribeHelper.ts
@@ -15,7 +15,6 @@ export function getQuorumTreeEntries(
     quorumSnapshot: IQuorumSnapshot,
 ): ITreeEntry[] {
     const documentAttributes: IDocumentAttributes = {
-        branch: documentId,
         minimumSequenceNumber,
         sequenceNumber,
         term,

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -60,7 +60,6 @@ export class DocumentStorage implements IDocumentStorage {
         values: [string, ICommittedProposal][],
     ): ISummaryTree {
         const documentAttributes: IDocumentAttributes = {
-            branch: documentId,
             minimumSequenceNumber: sequenceNumber,
             sequenceNumber,
             term,


### PR DESCRIPTION
As mentioned above the PR #8213 removes the `branch` field and some packages fail to build with this change. 

It seems the packages were not build in the PRs CI/CD. (e.g. the main branch "should" be failing as is right now, maybe it is worthwhile to enable building all packages for main 🤔  )

(building locally fails when using the fluid-build tool with symlinks)