### PR TITLE
Use require.resolve to determine paths to Webpack loaders

### DIFF
--- a/docs/themes/thxvscode/assets/js/webpack.config.js
+++ b/docs/themes/thxvscode/assets/js/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
         test: /\.js$/,
         exclude: /(node_modules)/,
         use: {
-          loader: 'babel-loader',
+          loader: require.resolve('babel-loader'),
           options: {
             presets: ['@babel/preset-env'],
             compact: false

--- a/examples/apps/collaborative-textarea/webpack.config.js
+++ b/examples/apps/collaborative-textarea/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/apps/collaborative-textarea/webpack.test.js
+++ b/examples/apps/collaborative-textarea/webpack.test.js
@@ -21,11 +21,11 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader'],
+                use: [require.resolve('style-loader'), require.resolve('css-loader')],
             }]
         },
         output: {

--- a/examples/apps/contact-collection/webpack.config.js
+++ b/examples/apps/contact-collection/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/apps/contact-collection/webpack.test.js
+++ b/examples/apps/contact-collection/webpack.test.js
@@ -18,7 +18,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,

--- a/examples/apps/likes-and-comments/webpack.config.js
+++ b/examples/apps/likes-and-comments/webpack.config.js
@@ -18,11 +18,11 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader'],
+                use: [require.resolve('style-loader'), require.resolve('css-loader')],
             }]
         },
         output: {

--- a/examples/apps/likes-and-comments/webpack.test.js
+++ b/examples/apps/likes-and-comments/webpack.test.js
@@ -18,11 +18,11 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader'],
+                use: [require.resolve('style-loader'), require.resolve('css-loader')],
             }]
         },
         output: {

--- a/examples/apps/spaces/webpack.config.js
+++ b/examples/apps/spaces/webpack.config.js
@@ -24,13 +24,13 @@ module.exports = (env) => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    loader: "ts-loader",
+                    loader: require.resolve("ts-loader"),
                 },
                 {
                     test: /\.css$/,
                     use: [
-                        "style-loader", // creates style nodes from JS strings
-                        "css-loader", // translates CSS into CommonJS
+                        require.resolve("style-loader"), // creates style nodes from JS strings
+                        require.resolve("css-loader"), // translates CSS into CommonJS
                     ],
                 },
             ],

--- a/examples/apps/spaces/webpack.test.js
+++ b/examples/apps/spaces/webpack.test.js
@@ -21,11 +21,11 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader'],
+                use: [require.resolve('style-loader'), require.resolve('css-loader')],
             }]
         },
         output: {

--- a/examples/apps/view-framework-sampler/webpack.config.js
+++ b/examples/apps/view-framework-sampler/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/apps/view-framework-sampler/webpack.test.js
+++ b/examples/apps/view-framework-sampler/webpack.test.js
@@ -18,7 +18,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,

--- a/examples/data-objects/badge/webpack.config.js
+++ b/examples/data-objects/badge/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader",
+                loader: require.resolve("ts-loader"),
             }]
         },
         output: {

--- a/examples/data-objects/canvas/webpack.config.js
+++ b/examples/data-objects/canvas/webpack.config.js
@@ -30,21 +30,21 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.less$/,
                 use: [{
-                    loader: 'style-loader' // creates style nodes from JS strings
+                    loader: require.resolve('style-loader') // creates style nodes from JS strings
                 }, {
-                    loader: 'css-loader' // translates CSS into CommonJS
+                    loader: require.resolve('css-loader') // translates CSS into CommonJS
                 }, {
-                    loader: 'less-loader' // compiles Less to CSS
+                    loader: require.resolve('less-loader') // compiles Less to CSS
                 }]
             },
             {
                 test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-                loader: 'url-loader',
+                loader: require.resolve('url-loader'),
                 options: {
                     limit: 10000
                 }

--- a/examples/data-objects/clicker-react/clicker-context/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-context/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/clicker-react/clicker-function/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-function/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/clicker-react/clicker-react/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-react/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/clicker-react/clicker-reducer/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-reducer/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/clicker-react/clicker-with-hook/webpack.config.js
+++ b/examples/data-objects/clicker-react/clicker-with-hook/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/clicker/webpack.config.js
+++ b/examples/data-objects/clicker/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/codemirror/webpack.config.js
+++ b/examples/data-objects/codemirror/webpack.config.js
@@ -24,13 +24,13 @@ module.exports = env => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    loader: "ts-loader"
+                    loader: require.resolve("ts-loader")
                 },
                 {
                     test: /\.css$/,
                     use: [
-                        "style-loader", // creates style nodes from JS strings
-                        "css-loader", // translates CSS into CommonJS
+                        require.resolve("style-loader"), // creates style nodes from JS strings
+                        require.resolve("css-loader"), // translates CSS into CommonJS
                     ]
                 },
             ]

--- a/examples/data-objects/diceroller/webpack.config.js
+++ b/examples/data-objects/diceroller/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/focus-tracker/webpack.config.js
+++ b/examples/data-objects/focus-tracker/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/image-gallery/webpack.config.js
+++ b/examples/data-objects/image-gallery/webpack.config.js
@@ -24,12 +24,15 @@ module.exports = env => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    use: 'ts-loader',
+                    use: require.resolve('ts-loader'),
                     exclude: /node_modules/
                 },
                 {
                     test: /\.css$/,
-                    use: [ 'style-loader', 'css-loader' ]
+                    use: [
+                        require.resolve("style-loader"), // creates style nodes from JS strings
+                        require.resolve("css-loader"), // translates CSS into CommonJS
+                    ]
                 },
             ]
         },

--- a/examples/data-objects/key-value-cache/webpack.config.js
+++ b/examples/data-objects/key-value-cache/webpack.config.js
@@ -24,12 +24,12 @@ module.exports = env => {
             rules: [
                 {
                     test: /\.ts$/,
-                    loader: "ts-loader",
+                    loader: require.resolve("ts-loader"),
                     exclude: /node_modules/
                 },
                 {
                     test: /\.js$/,
-                    use: ["source-map-loader"],
+                    use: [require.resolve("source-map-loader")],
                     enforce: "pre"
                 }
             ]

--- a/examples/data-objects/monaco/webpack.config.js
+++ b/examples/data-objects/monaco/webpack.config.js
@@ -59,7 +59,7 @@ module.exports = env => {
                 },
                 {
                     test: /\.html$/,
-                    loader: 'html-loader'
+                    loader: require.resolve('html-loader')
                 }
             ]
         },

--- a/examples/data-objects/monaco/webpack.config.js
+++ b/examples/data-objects/monaco/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
                 {
                     test: /\.tsx?$/,
                     use: [{
-                        loader:'ts-loader',
+                        loader: require.resolve("ts-loader"),
                         options: {
                             compilerOptions: {
                                 module: "esnext"
@@ -32,14 +32,14 @@ module.exports = env => {
                 },
                 {
                     test: /\.js$/,
-                    use: ["source-map-loader"],
+                    use: [require.resolve("source-map-loader")],
                     enforce: "pre"
                 },
                 {
                     test: /\.css$/,
                     use: [
-                        "style-loader", // creates style nodes from JS strings
-                        "css-loader", // translates CSS into CommonJS
+                        require.resolve("style-loader"), // creates style nodes from JS strings
+                        require.resolve("css-loader"), // translates CSS into CommonJS
                     ]
                 },
                 {
@@ -52,7 +52,7 @@ module.exports = env => {
                 },
                 {
                     test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-                    loader: 'url-loader',
+                    loader: require.resolve('url-loader'),
                     options: {
                         limit: 10000
                     }

--- a/examples/data-objects/multiview/constellation-model/webpack.config.js
+++ b/examples/data-objects/multiview/constellation-model/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/multiview/constellation-view/webpack.config.js
+++ b/examples/data-objects/multiview/constellation-view/webpack.config.js
@@ -20,13 +20,13 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/,
                 use: [
-                    "style-loader", // creates style nodes from JS strings
-                    "css-loader", // translates CSS into CommonJS
+                    require.resolve("style-loader"), // creates style nodes from JS strings
+                    require.resolve("css-loader"), // translates CSS into CommonJS
                 ]
             }]
         },

--- a/examples/data-objects/multiview/container/webpack.config.js
+++ b/examples/data-objects/multiview/container/webpack.config.js
@@ -20,13 +20,13 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/,
                 use: [
-                    "style-loader", // creates style nodes from JS strings
-                    "css-loader", // translates CSS into CommonJS
+                    require.resolve("style-loader"), // creates style nodes from JS strings
+                    require.resolve("css-loader"), // translates CSS into CommonJS
                 ]
             }]
         },

--- a/examples/data-objects/multiview/coordinate-model/webpack.config.js
+++ b/examples/data-objects/multiview/coordinate-model/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/multiview/interface/webpack.config.js
+++ b/examples/data-objects/multiview/interface/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/multiview/plot-coordinate-view/webpack.config.js
+++ b/examples/data-objects/multiview/plot-coordinate-view/webpack.config.js
@@ -20,13 +20,13 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/,
                 use: [
-                    "style-loader", // creates style nodes from JS strings
-                    "css-loader", // translates CSS into CommonJS
+                    require.resolve("style-loader"), // creates style nodes from JS strings
+                    require.resolve("css-loader"), // translates CSS into CommonJS
                 ]
             }]
         },

--- a/examples/data-objects/multiview/slider-coordinate-view/webpack.config.js
+++ b/examples/data-objects/multiview/slider-coordinate-view/webpack.config.js
@@ -20,13 +20,13 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/,
                 use: [
-                    "style-loader", // creates style nodes from JS strings
-                    "css-loader", // translates CSS into CommonJS
+                    require.resolve("style-loader"), // creates style nodes from JS strings
+                    require.resolve("css-loader"), // translates CSS into CommonJS
                 ]
             }]
         },

--- a/examples/data-objects/multiview/triangle-view/webpack.config.js
+++ b/examples/data-objects/multiview/triangle-view/webpack.config.js
@@ -20,13 +20,13 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/,
                 use: [
-                    "style-loader", // creates style nodes from JS strings
-                    "css-loader", // translates CSS into CommonJS
+                    require.resolve("style-loader"), // creates style nodes from JS strings
+                    require.resolve("css-loader"), // translates CSS into CommonJS
                 ]
             }]
         },

--- a/examples/data-objects/musica/webpack.config.js
+++ b/examples/data-objects/musica/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = env => {
             test: /\.js$/,
             exclude: /node_modules/,
             use: {
-              loader: 'babel-loader'
+              loader: require.resolve('babel-loader')
             }
           },
           {

--- a/examples/data-objects/musica/webpack.config.js
+++ b/examples/data-objects/musica/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = env => {
         rules: [
           {
             test: /\.tsx?$/,
-            loader: 'ts-loader'
+            loader: require.resolve("ts-loader")
           },
           {
             test: /\.css$/,
@@ -43,7 +43,7 @@ module.exports = env => {
           },
           {
             test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-            loader: 'url-loader',
+            loader: require.resolve('url-loader'),
             options: {
               limit: 10000
             }

--- a/examples/data-objects/pond/webpack.config.js
+++ b/examples/data-objects/pond/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/primitives/webpack.config.js
+++ b/examples/data-objects/primitives/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/prosemirror/webpack.config.js
+++ b/examples/data-objects/prosemirror/webpack.config.js
@@ -24,13 +24,13 @@ module.exports = env => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    loader: "ts-loader"
+                    loader: require.resolve("ts-loader")
                 },
                 {
                     test: /\.css$/,
                     use: [
-                        "style-loader", // creates style nodes from JS strings
-                        "css-loader", // translates CSS into CommonJS
+                        require.resolve("style-loader"), // creates style nodes from JS strings
+                        require.resolve("css-loader"), // translates CSS into CommonJS
                     ]
                 },
             ]

--- a/examples/data-objects/scribe/webpack.config.js
+++ b/examples/data-objects/scribe/webpack.config.js
@@ -24,18 +24,18 @@ module.exports = env => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    loader: "ts-loader"
+                    loader: require.resolve("ts-loader")
                 },
                 {
                     test: /\.css$/,
                     use: [
-                        "style-loader", // creates style nodes from JS strings
-                        "css-loader", // translates CSS into CommonJS
+                        require.resolve("style-loader"), // creates style nodes from JS strings
+                        require.resolve("css-loader"), // translates CSS into CommonJS
                     ]
                 },
                 {
                     test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-                    loader: 'url-loader',
+                    loader: require.resolve('url-loader'),
                     options: {
                         limit: 10000
                     }

--- a/examples/data-objects/shared-text/webpack.config.js
+++ b/examples/data-objects/shared-text/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = env => {
                     {
                         test: /\.tsx?$/,
                         use: [{
-                            loader: 'ts-loader',
+                            loader: require.resolve("ts-loader"),
                             options: {
                                 compilerOptions: {
                                     module: "esnext"
@@ -36,7 +36,7 @@ module.exports = env => {
                     },
                     {
                         test: /\.js$/,
-                        use: ["source-map-loader"],
+                        use: [require.resolve("source-map-loader")],
                         enforce: "pre"
                     },
                     {
@@ -56,7 +56,7 @@ module.exports = env => {
                     },
                     {
                         test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-                        loader: 'url-loader',
+                        loader: require.resolve('url-loader'),
                         options: {
                             limit: 10000
                         }

--- a/examples/data-objects/shared-text/webpack.config.js
+++ b/examples/data-objects/shared-text/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = env => {
                     },
                     {
                         test: /\.html$/,
-                        loader: 'html-loader'
+                        loader: require.resolve('html-loader')
                     }
                 ]
             },

--- a/examples/data-objects/simple-fluidobject-embed/webpack.config.js
+++ b/examples/data-objects/simple-fluidobject-embed/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/smde/webpack.config.js
+++ b/examples/data-objects/smde/webpack.config.js
@@ -24,13 +24,13 @@ module.exports = env => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    loader: "ts-loader"
+                    loader: require.resolve("ts-loader")
                 },
                 {
                     test: /\.css$/,
                     use: [
-                        "style-loader", // creates style nodes from JS strings
-                        "css-loader", // translates CSS into CommonJS
+                        require.resolve("style-loader"), // creates style nodes from JS strings
+                        require.resolve("css-loader"), // translates CSS into CommonJS
                     ]
                 },
             ]

--- a/examples/data-objects/table-view/webpack.config.js
+++ b/examples/data-objects/table-view/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = env => {
                     {
                         test: /\.tsx?$/,
                         use: [{
-                            loader:'ts-loader',
+                            loader: require.resolve("ts-loader"),
                             options: {
                                 compilerOptions: {
                                     module: "esnext"
@@ -37,14 +37,14 @@ module.exports = env => {
                     },
                     {
                         test: /\.js$/,
-                        use: ["source-map-loader"],
+                        use: [require.resolve("source-map-loader")],
                         enforce: "pre"
                     },
                     {
                         test: /\.css$/,
                         use: [
                             "style-loader", {
-                                loader: "css-loader",
+                                loader: require.resolve("css-loader"),
                                 options: {
                                     modules: true,
                                     localIdentName: styleLocalIdentName
@@ -54,7 +54,7 @@ module.exports = env => {
                     },
                     {
                         test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-                        loader: 'url-loader',
+                        loader: require.resolve('url-loader'),
                         options: {
                             limit: 10000
                         }

--- a/examples/data-objects/table-view/webpack.config.js
+++ b/examples/data-objects/table-view/webpack.config.js
@@ -61,7 +61,7 @@ module.exports = env => {
                     },
                     {
                         test: /\.html$/,
-                        loader: 'html-loader'
+                        loader: require.resolve('html-loader')
                     }
                 ]
             },

--- a/examples/data-objects/task-selection/webpack.config.js
+++ b/examples/data-objects/task-selection/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/data-objects/task-selection/webpack.test.js
+++ b/examples/data-objects/task-selection/webpack.test.js
@@ -18,7 +18,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,

--- a/examples/data-objects/todo/webpack.config.js
+++ b/examples/data-objects/todo/webpack.config.js
@@ -23,11 +23,11 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.js$/,
-                use: ["source-map-loader"],
+                use: [require.resolve("source-map-loader")],
                 enforce: "pre"
             },
             ]

--- a/examples/data-objects/vltava/webpack.config.js
+++ b/examples/data-objects/vltava/webpack.config.js
@@ -23,13 +23,13 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/,
                 use: [
-                    "style-loader", // creates style nodes from JS strings
-                    "css-loader", // translates CSS into CommonJS
+                    require.resolve("style-loader"), // creates style nodes from JS strings
+                    require.resolve("css-loader"), // translates CSS into CommonJS
                 ]
             },]
         },

--- a/examples/data-objects/webflow/webpack.config.js
+++ b/examples/data-objects/webflow/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = env => {
                     {
                         test: /\.tsx?$/,
                         use: [{
-                            loader:'ts-loader',
+                            loader: require.resolve("ts-loader"),
                             options: {
                                 compilerOptions: {
                                     module: "esnext"
@@ -37,14 +37,14 @@ module.exports = env => {
                     },
                     {
                         test: /\.js$/,
-                        use: ["source-map-loader"],
+                        use: [require.resolve("source-map-loader")],
                         enforce: "pre"
                     },
                     {
                         test: /\.css$/,
                         use: [
                             "style-loader", {
-                                loader: "css-loader",
+                                loader: require.resolve("css-loader"),
                                 options: {
                                     modules: true,
                                     localIdentName: styleLocalIdentName
@@ -54,7 +54,7 @@ module.exports = env => {
                     },
                     {
                         test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-                        loader: 'url-loader',
+                        loader: require.resolve('url-loader'),
                         options: {
                             limit: 10000
                         }

--- a/examples/data-objects/webflow/webpack.config.js
+++ b/examples/data-objects/webflow/webpack.config.js
@@ -61,7 +61,7 @@ module.exports = env => {
                     },
                     {
                         test: /\.html$/,
-                        loader: 'html-loader'
+                        loader: require.resolve('html-loader')
                     }
                 ]
             },

--- a/examples/hosts/app-integration/container-views/webpack.config.js
+++ b/examples/hosts/app-integration/container-views/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/hosts/app-integration/external-controller/webpack.config.js
+++ b/examples/hosts/app-integration/external-controller/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/hosts/app-integration/external-controller/webpack.test.js
+++ b/examples/hosts/app-integration/external-controller/webpack.test.js
@@ -18,11 +18,11 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader'],
+                use: [require.resolve('style-loader'), require.resolve('css-loader')],
             }]
         },
         output: {

--- a/examples/hosts/app-integration/external-views/webpack.config.js
+++ b/examples/hosts/app-integration/external-views/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/examples/hosts/app-integration/external-views/webpack.test.js
+++ b/examples/hosts/app-integration/external-views/webpack.test.js
@@ -18,11 +18,11 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader'],
+                use: [require.resolve('style-loader'), require.resolve('css-loader')],
             }]
         },
         output: {

--- a/examples/hosts/hosts-sample/webpack.config.js
+++ b/examples/hosts/hosts-sample/webpack.config.js
@@ -15,12 +15,12 @@ module.exports = {
         rules: [
             {
                 test: /\.tsx?$/,
-                use: 'ts-loader',
+                use: require.resolve('ts-loader'),
                 exclude: /node_modules/
             },
             {
                 test: /\.js$/,
-                use: ["source-map-loader"],
+                use: [require.resolve("source-map-loader")],
                 enforce: "pre"
             }
         ]

--- a/examples/hosts/iframe-host/webpack.config.js
+++ b/examples/hosts/iframe-host/webpack.config.js
@@ -19,11 +19,11 @@ module.exports = env => {
             rules: [
                 {
                     test: /\.ts$/,
-                    loader: 'ts-loader',
+                    loader: require.resolve("ts-loader"),
                 },
                 {
                     test: /\.tsx$/,
-                    loader: 'ts-loader',
+                    loader: require.resolve("ts-loader"),
                 }
             ]
         },

--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -23,12 +23,12 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: require.resolve('ts-loader'),
         exclude: /node_modules/,
       },
       {
         test: /\.js$/,
-        use: ["source-map-loader"],
+        use: [require.resolve("source-map-loader")],
         enforce: "pre"
       },
     ],

--- a/experimental/PropertyDDS/examples/partial-checkout/webpack.config.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = env => {
                 },
                 {
                     test: /\.tsx?$/,
-                    loader: "ts-loader"
+                    loader: require.resolve("ts-loader")
                 }
             ]
         },

--- a/experimental/PropertyDDS/examples/partial-checkout/webpack.test.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/webpack.test.js
@@ -18,7 +18,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,

--- a/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
+++ b/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = env => {
                 },
                 {
                     test: /\.tsx?$/,
-                    loader: "ts-loader"
+                    loader: require.resolve("ts-loader")
                 },
                 {
                     test: /\.js$/,

--- a/experimental/PropertyDDS/examples/property-inspector/webpack.test.js
+++ b/experimental/PropertyDDS/examples/property-inspector/webpack.test.js
@@ -18,7 +18,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             },
             {
                 test: /\.css$/i,

--- a/experimental/PropertyDDS/packages/property-inspector-table/webpack.base.js
+++ b/experimental/PropertyDDS/packages/property-inspector-table/webpack.base.js
@@ -53,7 +53,7 @@ module.exports.TSConfig = function(fileType, generateDeclarations, distTypesPath
             test: /\.tsx?$/,
             exclude: [/node_modules/],
             use: {
-              loader: 'ts-loader',
+              loader: require.resolve('ts-loader'),
               options: options
             }
           }

--- a/experimental/PropertyDDS/packages/property-inspector-table/webpack.common.js
+++ b/experimental/PropertyDDS/packages/property-inspector-table/webpack.common.js
@@ -19,10 +19,10 @@ module.exports = () => ({
         test: /\.svg$/,
         use: [
           {
-            loader: 'svg-sprite-loader'
+            loader: require.resolve('svg-sprite-loader')
           },
           {
-            loader: 'svgo-loader',
+            loader: require.resolve('svgo-loader'),
             options: require('./svgo.plugins.js')
           }
         ]

--- a/experimental/PropertyDDS/packages/property-inspector-table/webpack.prod.js
+++ b/experimental/PropertyDDS/packages/property-inspector-table/webpack.prod.js
@@ -127,7 +127,7 @@ const CommonWebpackLibTSConfig = function (args) {
           test: /\.[tj]sx?$/,
           exclude: [/node_modules/, /\.min\.js$/],
           use: {
-            loader: 'babel-loader',
+            loader: require.resolve('babel-loader'),
             options: {
               babelrc: false,
               presets: [

--- a/experimental/examples/bubblebench/baseline/webpack.config.js
+++ b/experimental/examples/bubblebench/baseline/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader")
             }]
         },
         output: {

--- a/experimental/examples/bubblebench/ot/webpack.config.js
+++ b/experimental/examples/bubblebench/ot/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader"),
             }]
         },
         output: {

--- a/experimental/examples/bubblebench/sharedtree/webpack.config.js
+++ b/experimental/examples/bubblebench/sharedtree/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader"
+                loader: require.resolve("ts-loader"),
             }]
         },
         output: {

--- a/packages/tools/webpack-fluid-loader/webpack.config.js
+++ b/packages/tools/webpack-fluid-loader/webpack.config.js
@@ -18,12 +18,12 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: require.resolve('ts-loader'),
         exclude: /node_modules/,
       },
       {
         test: /\.js$/,
-        use: ["source-map-loader"],
+        use: [require.resolve("source-map-loader")],
         enforce: "pre"
       },
     ],

--- a/server/routerlicious/packages/lambdas/src/test/webpack.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/webpack.spec.ts
@@ -17,12 +17,12 @@ const options: webpack.Configuration = {
         rules: [
             {
                 test: /\.tsx?$/,
-                use: 'ts-loader',
+                use: require.resolve('ts-loader'),
                 exclude: /node_modules/,
             },
             {
                 test: /\.js$/,
-                use: ["source-map-loader"],
+                use: [require.resolve("source-map-loader")],
                 enforce: "pre"
             },
         ],

--- a/server/routerlicious/packages/local-server/webpack.config.js
+++ b/server/routerlicious/packages/local-server/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
         rules: [
             {
                 test: /\.tsx?$/,
-                use: 'ts-loader',
+                use: require.resolve('ts-loader'),
                 exclude: /node_modules/
             },
         ]

--- a/tools/generator-fluid/app/templates/webpack.config.js
+++ b/tools/generator-fluid/app/templates/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.tsx?$/,
-                loader: "ts-loader",
+                loader: require.resolve("ts-loader"),
             }]
         },
         output: {


### PR DESCRIPTION
Package hoisting with tools like yarn makes it impossible to be sure that the layout of the node_modules folder will always be the same. In fact, depending on the exact install strategy, the node_modules folders may not even exist. More info at <https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules>.

By using require.resolve, we protect against this.

Fixes #8090.