### PR TITLE
Deprecate IFluidObject Module Augmentation

### DIFF
--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -26,7 +26,7 @@ import { IRequest } from '@fluidframework/core-interfaces';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const IContainerRuntime: keyof IProvideContainerRuntime;
 
 // @public (undocumented)
@@ -76,9 +76,9 @@ export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     (event: "localHelp", listener: (message: IHelpMessage) => void): any;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IProvideContainerRuntime {
-    // (undocumented)
+    // @deprecated (undocumented)
     IContainerRuntime: IContainerRuntime;
 }
 

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -430,9 +430,9 @@ export interface IPendingMessage {
 // @public (undocumented)
 export type IPendingState = IPendingMessage | IPendingFlushMode | IPendingFlush;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IProvideSummarizer {
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly ISummarizer: ISummarizer;
 }
 
@@ -483,11 +483,11 @@ export interface ISummarizeOptions {
     readonly refreshLatestAck?: boolean;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const ISummarizer: keyof IProvideSummarizer;
 
 // @public (undocumented)
-export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable {
+export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable, Partial<IProvideSummarizer> {
     enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult;
     // (undocumented)
     run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;

--- a/api-report/view-interfaces.api.md
+++ b/api-report/view-interfaces.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { IFluidObject } from '@fluidframework/core-interfaces';
+import { FluidObject } from '@fluidframework/core-interfaces';
 
 // @public (undocumented)
 export interface IFluidHTMLOptions {
@@ -33,8 +33,8 @@ export interface IFluidMountableView extends IProvideFluidMountableView {
 // @public
 export interface IFluidMountableViewClass {
     // (undocumented)
-    new (view: IFluidObject): IFluidMountableView;
-    canMount(view: IFluidObject): boolean;
+    new (view: FluidObject): IFluidMountableView;
+    canMount(view: FluidObject): boolean;
 }
 
 // @public (undocumented)

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -287,7 +287,7 @@ export interface IDeltaQueueEvents<T> extends IErrorEvent {
     (event: "idle", listener: (count: number, duration: number) => void): any;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const IDeltaSender: keyof IProvideDeltaSender;
 
 // @public
@@ -330,10 +330,10 @@ export interface IFluidModule {
     fluidExport: IFluidObject & Partial<Readonly<IProvideFluidCodeDetailsComparer>>;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const IFluidTokenProvider: keyof IProvideFluidTokenProvider;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IFluidTokenProvider extends IProvideFluidTokenProvider {
     // (undocumented)
     intelligence: {
@@ -355,8 +355,10 @@ export interface IHostLoader extends ILoader {
     rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer>;
 }
 
+// Warning: (ae-forgotten-export) The symbol "IProvideLoader" needs to be exported by the entry point index.d.ts
+//
 // @public
-export interface ILoader extends IFluidRouter {
+export interface ILoader extends IFluidRouter, Partial<IProvideLoader> {
     resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
 }
 
@@ -395,13 +397,13 @@ export interface IPendingLocalState {
     url: string;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IProvideDeltaSender {
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly IDeltaSender: IDeltaSender;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IProvideFluidTokenProvider {
     // (undocumented)
     readonly IFluidTokenProvider: IFluidTokenProvider;

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -355,8 +355,6 @@ export interface IHostLoader extends ILoader {
     rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer>;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IProvideLoader" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface ILoader extends IFluidRouter, Partial<IProvideLoader> {
     resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
@@ -407,6 +405,12 @@ export interface IProvideDeltaSender {
 export interface IProvideFluidTokenProvider {
     // (undocumented)
     readonly IFluidTokenProvider: IFluidTokenProvider;
+}
+
+// @public (undocumented)
+export interface IProvideLoader {
+    // (undocumented)
+    readonly ILoader: ILoader;
 }
 
 // @public (undocumented)

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -56,13 +56,24 @@ export interface IDeltaHandlerStrategy {
 }
 
 declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface IFluidObject extends Readonly<Partial<IProvideDeltaSender>> { }
+    interface IFluidObject  {
+        /** @deprecated - use `FluidObject<IDeltaSender>` instead */
+        readonly IDeltaSender?: IDeltaSender
+     }
 }
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export const IDeltaSender: keyof IProvideDeltaSender = "IDeltaSender";
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export interface IProvideDeltaSender {
+    /**
+     * @deprecated - This will be removed in a later release.
+     */
     readonly IDeltaSender: IDeltaSender;
 }
 

--- a/common/lib/container-definitions/src/index.ts
+++ b/common/lib/container-definitions/src/index.ts
@@ -2,17 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
-import { IProvideRuntimeFactory } from "./runtime";
-import { IProvideFluidTokenProvider } from "./tokenProvider";
-
-declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<
-        IProvideRuntimeFactory &
-        IProvideFluidTokenProvider>> { }
-}
-
 export * from "./audience";
 export * from "./browserPackage";
 // eslint-disable-next-line import/no-internal-modules

--- a/common/lib/container-definitions/src/legacy/chaincode.ts
+++ b/common/lib/container-definitions/src/legacy/chaincode.ts
@@ -5,12 +5,21 @@
 
 import { IRuntimeFactory } from "../runtime";
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export const IFluidTokenProvider: keyof IProvideFluidTokenProvider = "IFluidTokenProvider";
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export interface IProvideFluidTokenProvider {
     readonly IFluidTokenProvider: IFluidTokenProvider;
 }
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export interface IFluidTokenProvider extends IProvideFluidTokenProvider {
     intelligence: { [service: string]: any };
 }

--- a/common/lib/container-definitions/src/legacy/chaincode.ts
+++ b/common/lib/container-definitions/src/legacy/chaincode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IProvideRuntimeFactory } from "../runtime";
+import { IRuntimeFactory } from "../runtime";
 
 export const IFluidTokenProvider: keyof IProvideFluidTokenProvider = "IFluidTokenProvider";
 
@@ -16,9 +16,10 @@ export interface IFluidTokenProvider extends IProvideFluidTokenProvider {
 }
 
 declare module "@fluidframework/core-interfaces" {
-    /* eslint-disable @typescript-eslint/no-empty-interface */
-    export interface IFluidObject extends Readonly<Partial<
-        IProvideRuntimeFactory &
-        IProvideFluidTokenProvider>> { }
-    /* eslint-enable @typescript-eslint/no-empty-interface */
+    export interface IFluidObject  {
+        /** @deprecated - use `FluidObject<IRuntimeFactory>` instead */
+        readonly IRuntimeFactory?: IRuntimeFactory;
+        /** @deprecated - use `FluidObject<IFluidTokenProvider>` instead */
+        readonly IFluidTokenProvider?: IFluidTokenProvider;
+    }
 }

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -353,7 +353,7 @@ export interface ILoaderHeader {
     [LoaderHeader.version]: string | undefined;
 }
 
-interface IProvideLoader {
+export interface IProvideLoader {
     readonly ILoader: ILoader;
 }
 

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -202,7 +202,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
 /**
  * The Runtime's view of the Loader, used for loading Containers
  */
-export interface ILoader extends IFluidRouter {
+export interface ILoader extends IFluidRouter, Partial<IProvideLoader> {
     /**
      * Resolves the resource specified by the URL + headers contained in the request object
      * to the underlying container that will resolve the request.
@@ -361,8 +361,12 @@ declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface IRequestHeader extends Partial<ILoaderHeader> { }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideLoader>> { }
+    export interface IFluidObject  {
+        /**
+         * @deprecated - use `FluidObject<ILoader>` instead
+         */
+        readonly ILoader?: ILoader;
+    }
 }
 
 export interface IPendingLocalState {

--- a/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
+++ b/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
@@ -12,8 +12,10 @@ import {
 } from "./types";
 
 declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideFluidDependencySynthesizer>> { }
+    export interface IFluidObject {
+        /** @deprecated - use `FluidObject<IFluidDependencySynthesizer>` instead */
+        readonly IFluidDependencySynthesizer?: IFluidDependencySynthesizer;
+    }
 }
 
 export const IFluidDependencySynthesizer: keyof IProvideFluidDependencySynthesizer

--- a/packages/framework/view-interfaces/src/htmlView.ts
+++ b/packages/framework/view-interfaces/src/htmlView.ts
@@ -37,8 +37,8 @@ export interface IFluidHTMLView extends IProvideFluidHTMLView {
 }
 
 declare module "@fluidframework/core-interfaces" {
-    /* eslint-disable @typescript-eslint/no-empty-interface */
-    export interface IFluidObject extends
-        Readonly<Partial<IProvideFluidHTMLView>> { }
-    /* eslint-enable @typescript-eslint/no-empty-interface */
+    export interface IFluidObject{
+        /** @deprecated - use `FluidObject<IFluidHTMLView>` instead */
+        readonly IFluidHTMLView?: IFluidHTMLView;
+    }
 }

--- a/packages/framework/view-interfaces/src/mountableView.ts
+++ b/packages/framework/view-interfaces/src/mountableView.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject } from "@fluidframework/core-interfaces";
 
 export const IFluidMountableView: keyof IProvideFluidMountableView = "IFluidMountableView";
 
@@ -18,12 +18,12 @@ export interface IFluidMountableViewClass {
     /**
      * @param view - The view to make mountable
      */
-    new(view: IFluidObject): IFluidMountableView;
+    new(view: FluidObject): IFluidMountableView;
     /**
      * Test whether the given view can be successfully mounted by a MountableView.
      * @param view - the view to test if it can be mounted.
      */
-    canMount(view: IFluidObject): boolean;
+    canMount(view: FluidObject): boolean;
 }
 
 /**
@@ -51,6 +51,8 @@ export interface IFluidMountableView extends IProvideFluidMountableView {
 }
 
 declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideFluidMountableView>> { }
+    export interface IFluidObject {
+        /** @deprecated - use `FluidObject<IFluidMountableView> instead */
+        readonly IFluidMountableView?: IFluidMountableView;
+     }
 }

--- a/packages/runtime/agent-scheduler/src/agent.ts
+++ b/packages/runtime/agent-scheduler/src/agent.ts
@@ -66,7 +66,10 @@ export interface IAgentScheduler extends IProvideAgentScheduler, IEventProvider<
 }
 
 declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends
-        Readonly<Partial<IProvideAgentScheduler>> { }
+    export interface IFluidObject{
+        /**
+         * @deprecated - use `FluidObject<IAgentScheduler>` instead
+         */
+        readonly IAgentScheduler?: IAgentScheduler;
+    }
 }

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -34,8 +34,13 @@ import {
  } from "@fluidframework/runtime-definitions";
 
 declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideContainerRuntime>> { }
+    export interface IFluidObject {
+        /**
+         * @deprecated - use `FluidObject<IContainerRuntime>` instead
+         */
+        readonly IContainerRuntime?: IContainerRuntime;
+
+     }
 }
 
 export const IContainerRuntime: keyof IProvideContainerRuntime = "IContainerRuntime";

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -43,9 +43,18 @@ declare module "@fluidframework/core-interfaces" {
      }
 }
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export const IContainerRuntime: keyof IProvideContainerRuntime = "IContainerRuntime";
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export interface IProvideContainerRuntime {
+    /**
+     * @deprecated - This will be removed in a later release.
+     */
     IContainerRuntime: IContainerRuntime;
 }
 

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -29,9 +29,18 @@ declare module "@fluidframework/core-interfaces" {
      }
 }
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export const ISummarizer: keyof IProvideSummarizer = "ISummarizer";
 
+/**
+ * @deprecated - This will be removed in a later release.
+ */
 export interface IProvideSummarizer {
+    /**
+     * @deprecated - This will be removed in a later release.
+     */
     readonly ISummarizer: ISummarizer;
 }
 

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -22,8 +22,11 @@ import { ISummaryStats } from "@fluidframework/runtime-definitions";
 import { ISummaryAckMessage, ISummaryNackMessage, ISummaryOpMessage } from "./summaryCollection";
 
 declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideSummarizer>> { }
+    export interface IFluidObject {
+        /** @deprecated - use `FluidObject<ISummarizer>` instead */
+        readonly ISummarizer?: ISummarizer;
+
+     }
 }
 
 export const ISummarizer: keyof IProvideSummarizer = "ISummarizer";
@@ -283,7 +286,8 @@ export interface ISummarizerEvents extends IEvent {
     (event: "summarizingError", listener: (error: ISummarizingWarning) => void);
 }
 
-export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable {
+export interface ISummarizer extends
+    IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable, Partial<IProvideSummarizer>{
     stop(reason: SummarizerStopReason): void;
     run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;
 

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -6,14 +6,19 @@
 import { IDisposable, IEvent, IEventProvider, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { TypedEventEmitter, assert } from "@fluidframework/common-utils";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { IFluidRouter, IRequest } from "@fluidframework/core-interfaces";
+import { FluidObject, IFluidRouter, IRequest } from "@fluidframework/core-interfaces";
 import { LoaderHeader } from "@fluidframework/container-definitions";
 import { DriverHeader, DriverErrorType } from "@fluidframework/driver-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { createSummarizingWarning } from "./summarizer";
 import { ISummarizerClientElection, summarizerClientType } from "./summarizerClientElection";
 import { IThrottler } from "./throttler";
-import { ISummarizer, ISummarizerOptions, ISummarizingWarning, SummarizerStopReason } from "./summarizerTypes";
+import {
+    ISummarizer,
+    ISummarizerOptions,
+    ISummarizingWarning,
+    SummarizerStopReason,
+} from "./summarizerTypes";
 import { SummaryCollection } from "./summaryCollection";
 
 const defaultInitialDelayMs = 5000;
@@ -401,7 +406,7 @@ export const formRequestSummarizerFn = (
         url: "/_summarizer",
     };
 
-    const fluidObject = await requestFluidObject(loaderRouter, request);
+    const fluidObject = await requestFluidObject<FluidObject<ISummarizer>>(loaderRouter, request);
     const summarizer = fluidObject.ISummarizer;
 
     if (!summarizer) {

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -6,8 +6,12 @@
 import { IFluidDataStoreContext, IFluidDataStoreChannel } from "./dataStoreContext";
 
 declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideFluidDataStoreFactory>> { }
+    export interface IFluidObject  {
+        /**
+         * @deprecated - use `FluidObject<IFluidDataStoreFactory>` instead
+         */
+        readonly IFluidDataStoreFactory?: IFluidDataStoreFactory;
+    }
 }
 
 export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory = "IFluidDataStoreFactory";

--- a/packages/test/test-utils/src/interfaces.ts
+++ b/packages/test/test-utils/src/interfaces.ts
@@ -8,11 +8,6 @@ import { ISharedMap } from "@fluidframework/map";
 import { IFluidDataStoreContext, IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 
-declare module "@fluidframework/core-interfaces" {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IFluidObject extends Readonly<Partial<IProvideTestFluidObject>> { }
-}
-
 export interface IProvideTestFluidObject {
     readonly ITestFluidObject: ITestFluidObject;
 }


### PR DESCRIPTION
This change deprecates all the augmented properties on fluid objects and redirects uses to use the utility type FluidObject.

related #8077 #8073 