### PR TITLE
Add FluidObject to Scope and FluidModule and usages

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -7,6 +7,7 @@
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
 import { EventEmitterWithErrorHandling } from '@fluidframework/telemetry-utils';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
@@ -21,7 +22,6 @@ import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IFluidCodeDetails } from '@fluidframework/core-interfaces';
 import { IFluidModule } from '@fluidframework/container-definitions';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidResolvedUrl } from '@fluidframework/driver-definitions';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IHostLoader } from '@fluidframework/container-definitions';
@@ -172,7 +172,7 @@ export interface ILoaderProps {
     readonly logger?: ITelemetryBaseLogger;
     readonly options?: ILoaderOptions;
     readonly proxyLoaderFactories?: Map<string, IProxyLoaderFactory>;
-    readonly scope?: IFluidObject;
+    readonly scope?: FluidObject;
     readonly urlResolver: IUrlResolver;
 }
 
@@ -183,7 +183,7 @@ export interface ILoaderServices {
     readonly documentServiceFactory: IDocumentServiceFactory;
     readonly options: ILoaderOptions;
     readonly proxyLoaderFactories: Map<string, IProxyLoaderFactory>;
-    readonly scope: IFluidObject;
+    readonly scope: FluidObject;
     readonly subLogger: ITelemetryLogger;
     readonly urlResolver: IUrlResolver;
 }

--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -6,6 +6,7 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { FlushMode } from '@fluidframework/runtime-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
@@ -56,7 +57,7 @@ export interface IContainerRuntime extends IProvideContainerRuntime, IProvideFlu
     raiseContainerWarning(warning: ContainerWarning): void;
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
-    readonly scope: IFluidObject;
+    readonly scope: IFluidObject & FluidObject;
     // (undocumented)
     readonly storage: IDocumentStorageService;
 }

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -8,6 +8,7 @@ import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
 import { EventEmitter } from 'events';
 import { FluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { FlushMode } from '@fluidframework/runtime-definitions';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
@@ -142,7 +143,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     get IFluidTokenProvider(): IFluidTokenProvider | undefined;
     get isDirty(): boolean;
-    static load(context: IContainerContext, registryEntries: NamedFluidDataStoreRegistryEntries, requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>, runtimeOptions?: IContainerRuntimeOptions, containerScope?: IFluidObject, existing?: boolean): Promise<ContainerRuntime>;
+    static load(context: IContainerContext, registryEntries: NamedFluidDataStoreRegistryEntries, requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>, runtimeOptions?: IContainerRuntimeOptions, containerScope?: FluidObject, existing?: boolean): Promise<ContainerRuntime>;
     // (undocumented)
     readonly logger: ITelemetryLogger;
     // (undocumented)
@@ -163,7 +164,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // @internal @deprecated (undocumented)
     readonly runtimeVersion: string;
     // (undocumented)
-    get scope(): IFluidObject;
+    get scope(): IFluidObject & FluidObject;
     // (undocumented)
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
     // (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -6,6 +6,7 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
@@ -168,7 +169,7 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     readonly options: ILoaderOptions;
     readonly packagePath: readonly string[];
     raiseContainerWarning(warning: ContainerWarning): void;
-    readonly scope: IFluidObject;
+    readonly scope: IFluidObject & FluidObject;
     setChannelDirty(address: string): void;
     // (undocumented)
     readonly storage: IDocumentStorageService;

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -9,6 +9,7 @@ import { ContainerWarning } from '@fluidframework/container-definitions';
 import { CreateChildSummarizerNodeFn } from '@fluidframework/runtime-definitions';
 import { CreateChildSummarizerNodeParam } from '@fluidframework/runtime-definitions';
 import { EventEmitter } from 'events';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { FluidSerializer } from '@fluidframework/runtime-utils';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IChannel } from '@fluidframework/datastore-definitions';
@@ -31,7 +32,6 @@ import { IFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IGarbageCollectionSummaryDetails } from '@fluidframework/runtime-definitions';
 import { ILoader } from '@fluidframework/container-definitions';
@@ -325,7 +325,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     raiseContainerWarning(warning: ContainerWarning): void;
     // (undocumented)
-    scope: IFluidObject;
+    scope: FluidObject;
     // (undocumented)
     setChannelDirty(address: string): void;
     // (undocumented)

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -6,6 +6,7 @@
 
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { EventEmitter } from 'events';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
@@ -169,7 +170,7 @@ export interface IContainerContext extends IDisposable {
     readonly quorum: IQuorum;
     // (undocumented)
     raiseContainerWarning(warning: ContainerWarning): void;
-    readonly scope: IFluidObject;
+    readonly scope: IFluidObject & FluidObject;
     // (undocumented)
     readonly serviceConfiguration: IClientConfiguration | undefined;
     // (undocumented)
@@ -327,7 +328,7 @@ export interface IFluidCodeResolver {
 // @public (undocumented)
 export interface IFluidModule {
     // (undocumented)
-    fluidExport: IFluidObject & Partial<Readonly<IProvideFluidCodeDetailsComparer>>;
+    fluidExport: IFluidObject & FluidObject<IRuntimeFactory & IProvideFluidCodeDetailsComparer>;
 }
 
 // @public @deprecated (undocumented)

--- a/common/lib/container-definitions/src/fluidModule.ts
+++ b/common/lib/container-definitions/src/fluidModule.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject, IProvideFluidCodeDetailsComparer } from "@fluidframework/core-interfaces";
+import { FluidObject, IFluidObject, IProvideFluidCodeDetailsComparer } from "@fluidframework/core-interfaces";
+import { IRuntimeFactory } from "./runtime";
 
 export interface IFluidModule {
-    fluidExport: IFluidObject & Partial<Readonly<IProvideFluidCodeDetailsComparer>>;
+    fluidExport: IFluidObject & FluidObject<IRuntimeFactory & IProvideFluidCodeDetailsComparer>;
 }

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -9,6 +9,7 @@ import {
     IFluidConfiguration,
     IRequest,
     IResponse,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
@@ -150,7 +151,7 @@ export interface IContainerContext extends IDisposable {
     /**
      * Ambient services provided with the context
      */
-    readonly scope: IFluidObject;
+    readonly scope: IFluidObject & FluidObject;
 
     raiseContainerWarning(warning: ContainerWarning): void;
 

--- a/examples/data-objects/prosemirror/src/prosemirror.ts
+++ b/examples/data-objects/prosemirror/src/prosemirror.ts
@@ -13,6 +13,7 @@ import {
     IRequest,
     IResponse,
     IFluidHandle,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle, mixinRequestHandler } from "@fluidframework/datastore";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
@@ -28,6 +29,7 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { IFluidHTMLOptions, IFluidHTMLView } from "@fluidframework/view-interfaces";
 import { EditorView } from "prosemirror-view";
+import { ILoader } from "@fluidframework/container-definitions";
 import { nodeTypeKey } from "./fluidBridge";
 import { FluidCollabManager, IProvideRichTextEditor } from "./fluidCollabManager";
 
@@ -151,10 +153,11 @@ export class ProseMirror extends EventEmitter
         this.root = await this.runtime.getChannel("root") as ISharedMap;
         this.text = await this.root.get<IFluidHandle<SharedString>>("text")!.get();
 
-        if (this.context.scope.ILoader === undefined) {
+        const scope: FluidObject<ILoader> = this.context.scope;
+        if (scope.ILoader === undefined) {
             throw new Error("scope must include ILoader");
         }
-        this.collabManager = new FluidCollabManager(this.text, this.context.scope.ILoader);
+        this.collabManager = new FluidCollabManager(this.text, scope.ILoader);
 
         // Access for debugging
         // eslint-disable-next-line @typescript-eslint/dot-notation

--- a/examples/data-objects/scribe/src/scribe.ts
+++ b/examples/data-objects/scribe/src/scribe.ts
@@ -17,7 +17,7 @@ import {
     FluidObject,
 } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle, mixinRequestHandler } from "@fluidframework/datastore";
-import { IContainerContext } from "@fluidframework/container-definitions";
+import { IContainerContext, ILoader } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IDocumentFactory } from "@fluid-example/host-service-interfaces";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
@@ -275,13 +275,14 @@ function initialize(
             }
             typingDetails.classList.remove("hidden");
 
-            if (context.scope.ILoader === undefined) {
+            const scope: FluidObject<ILoader> = context.scope;
+            if (scope.ILoader === undefined) {
                 throw new Error("scope must contain ILoader");
             }
 
             // Start typing and register to update the UI
             const typeP = scribe.type(
-                context.scope.ILoader,
+                scope.ILoader,
                 url,
                 root,
                 runtime,

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2004,9 +2004,9 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.42.0-43895",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.42.0-43895.tgz",
-			"integrity": "sha512-7s7KBYUHPGn3E96RNjRoWYBsQHJnvKqL7hd7BPKpYH0eoYJxrmazIEOvHzpb5Wg4bOSbUuHpVNxnNZ1eB3NBKA==",
+			"version": "0.42.0-44121",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.42.0-44121.tgz",
+			"integrity": "sha512-OmZpQarN3sDQEokRY/a/bJsRsAW43f6JNOhvwG10mPL/GF7e8Dc+AWtmPCz2YnjEDSHvw6R7NTI8+XfhZQzzLA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.41.0-0",

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -28,6 +28,7 @@ import {
     IProvideFluidDependencySynthesizer,
 } from "@fluidframework/synthesize";
 import { RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
+import { FluidObject } from "@fluidframework/core-interfaces";
 
 /**
  * BaseContainerRuntimeFactory produces container runtimes with a given data store and service registry, as well as
@@ -69,7 +70,7 @@ export class BaseContainerRuntimeFactory
         context: IContainerContext,
         existing: boolean,
     ): Promise<ContainerRuntime> {
-        const scope: Partial<IProvideFluidDependencySynthesizer> = context.scope;
+        const scope: FluidObject<IProvideFluidDependencySynthesizer> = context.scope;
         const parentDependencyContainer = scope.IFluidDependencySynthesizer;
         const dc = new DependencyContainer(parentDependencyContainer);
         for (const entry of Array.from(this.providerEntries)) {

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, IFluidRouter } from "@fluidframework/core-interfaces";
+import { IRequest, IFluidRouter, FluidObject } from "@fluidframework/core-interfaces";
 import {
     FluidDataStoreRuntime,
     ISharedObjectRegistry,
@@ -26,6 +26,7 @@ import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import {
     FluidObjectSymbolProvider,
     DependencyContainer,
+    IFluidDependencySynthesizer,
 } from "@fluidframework/synthesize";
 
 import {
@@ -77,7 +78,8 @@ async function createDataObject<TObj extends PureDataObject<O, S, E>, O, S, E ex
     // becomes globally available. But it's not full initialization - constructor can't
     // access DDSs or other services of runtime as objects are not fully initialized.
     // In order to use object, we need to go through full initialization by calling finishInitialization().
-    const dependencyContainer = new DependencyContainer(context.scope.IFluidDependencySynthesizer);
+    const scope: FluidObject<IFluidDependencySynthesizer> = context.scope;
+    const dependencyContainer = new DependencyContainer(scope.IFluidDependencySynthesizer);
     const providers = dependencyContainer.synthesize<O>(optionalProviders, {});
     const instance = new ctor({ runtime, context, providers, initProps });
 

--- a/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
+++ b/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject, IRequest, IRequestHeader, IResponse } from "@fluidframework/core-interfaces";
+import { FluidObject, IRequest, IRequestHeader, IResponse } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidMountableViewClass } from "@fluidframework/view-interfaces";
 import { RuntimeRequestHandler, buildRuntimeRequestHandler } from "@fluidframework/request-handler";
@@ -73,7 +73,8 @@ export const defaultRouteRequestHandler = (defaultRootId: string) => {
  *  3. the request url starts with "/" and is followed by a query param, such as /?key=value
  * Returns a 404 error for any other url.
  */
-export function defaultFluidObjectRequestHandler(fluidObject: IFluidObject, request: IRequest): IResponse {
+export function defaultFluidObjectRequestHandler(
+    fluidObject: FluidObject, request: IRequest): IResponse {
     if (request.url === "" || request.url === "/" || request.url.startsWith("/?")) {
         return { mimeType: "fluid/object", status: 200, value: fluidObject };
     } else {

--- a/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
+++ b/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { FluidObject, IRequest, IRequestHeader, IResponse } from "@fluidframework/core-interfaces";
+import { IFluidObject, IRequest, IRequestHeader, IResponse } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidMountableViewClass } from "@fluidframework/view-interfaces";
 import { RuntimeRequestHandler, buildRuntimeRequestHandler } from "@fluidframework/request-handler";
@@ -73,8 +73,7 @@ export const defaultRouteRequestHandler = (defaultRootId: string) => {
  *  3. the request url starts with "/" and is followed by a query param, such as /?key=value
  * Returns a 404 error for any other url.
  */
-export function defaultFluidObjectRequestHandler(
-    fluidObject: FluidObject, request: IRequest): IResponse {
+export function defaultFluidObjectRequestHandler(fluidObject: IFluidObject, request: IRequest): IResponse {
     if (request.url === "" || request.url === "/" || request.url.startsWith("/?")) {
         return { mimeType: "fluid/object", status: 200, value: fluidObject };
     } else {

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -10,6 +10,7 @@ import {
     IRequest,
     IFluidHandle,
     IFluidLoadable,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -56,7 +57,7 @@ export const rootDataStoreRequestHandler = async (request: IRequest, runtime: IC
     }
 };
 
-export const createFluidObjectResponse = (fluidObject: IFluidObject) => {
+export const createFluidObjectResponse = (fluidObject: FluidObject) => {
     return { status: 200, mimeType: "fluid/object", value: fluidObject };
 };
 

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -10,7 +10,6 @@ import {
     IRequest,
     IFluidHandle,
     IFluidLoadable,
-    FluidObject,
 } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -57,7 +56,7 @@ export const rootDataStoreRequestHandler = async (request: IRequest, runtime: IC
     }
 };
 
-export const createFluidObjectResponse = (fluidObject: FluidObject) => {
+export const createFluidObjectResponse = (fluidObject: IFluidObject) => {
     return { status: 200, mimeType: "fluid/object", value: fluidObject };
 };
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -12,6 +12,7 @@ import {
     IFluidCodeDetails,
     IFluidCodeDetailsComparer,
     IProvideFluidCodeDetailsComparer,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
@@ -51,7 +52,7 @@ const PackageNotFactoryError = "Code package does not implement IRuntimeFactory"
 export class ContainerContext implements IContainerContext {
     public static async createOrLoad(
         container: Container,
-        scope: IFluidObject,
+        scope: FluidObject,
         codeLoader: ICodeDetailsLoader | ICodeLoader,
         codeDetails: IFluidCodeDetails,
         baseSnapshot: ISnapshotTree | undefined,
@@ -166,7 +167,7 @@ export class ContainerContext implements IContainerContext {
 
     constructor(
         private readonly container: Container,
-        public readonly scope: IFluidObject,
+        public readonly scope: IFluidObject & FluidObject,
         private readonly codeLoader: ICodeDetailsLoader | ICodeLoader,
         private readonly _codeDetails: IFluidCodeDetails,
         private readonly _baseSnapshot: ISnapshotTree | undefined,
@@ -299,7 +300,7 @@ export class ContainerContext implements IContainerContext {
     // #region private
 
     private async getRuntimeFactory(): Promise<IRuntimeFactory> {
-        const fluidExport: Partial<IProvideRuntimeFactory> | undefined =
+        const fluidExport: FluidObject<IProvideRuntimeFactory> | undefined =
             (await this._fluidModuleP).module?.fluidExport;
         const runtimeFactory = fluidExport?.IRuntimeFactory;
         if (runtimeFactory === undefined) {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -6,8 +6,8 @@
 import { v4 as uuid } from "uuid";
 import { ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
+    FluidObject,
     IFluidCodeDetails,
-    IFluidObject,
     IFluidRouter,
     IProvideFluidCodeDetailsComparer,
     IRequest,
@@ -184,7 +184,7 @@ export interface ILoaderProps {
      * Scope is provided to all container and is a set of shared
      * services for container's to integrate with their host environment.
      */
-    readonly scope?: IFluidObject;
+    readonly scope?: FluidObject;
 
     /**
      * Proxy loader factories for loading containers via proxy in other contexts,
@@ -235,7 +235,7 @@ export interface ILoaderServices {
      * Scope is provided to all container and is a set of shared
      * services for container's to integrate with their host environment.
      */
-    readonly scope: IFluidObject;
+    readonly scope: FluidObject;
 
     /**
      * Proxy loader factories for loading containers via proxy in other contexts,
@@ -275,10 +275,10 @@ export class Loader implements IHostLoader {
     private readonly logger: ITelemetryLogger;
 
     constructor(loaderProps: ILoaderProps) {
-        const scope = { ...loaderProps.scope };
-        if (loaderProps.options?.provideScopeLoader !== false) {
-            scope.ILoader = this;
-        }
+        const scope: FluidObject<ILoader> = {
+            ...loaderProps.scope,
+            ILoader: loaderProps.options?.provideScopeLoader !== false ? this : undefined,
+        };
 
         this.services = {
             urlResolver: createCachedResolver(MultiUrlResolver.create(loaderProps.urlResolver)),

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -275,11 +275,10 @@ export class Loader implements IHostLoader {
     private readonly logger: ITelemetryLogger;
 
     constructor(loaderProps: ILoaderProps) {
-        const scope: FluidObject<ILoader> = {
-            ...loaderProps.scope,
-            ILoader: loaderProps.options?.provideScopeLoader !== false ? this : undefined,
-        };
-
+        const scope = { ...loaderProps.scope as FluidObject<ILoader> };
+        if (loaderProps.options?.provideScopeLoader !== false) {
+            scope.ILoader = this;
+        }
         this.services = {
             urlResolver: createCachedResolver(MultiUrlResolver.create(loaderProps.urlResolver)),
             documentServiceFactory: MultiDocumentServiceFactory.create(loaderProps.documentServiceFactory),

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -16,6 +16,7 @@ import {
     IFluidObject,
     IFluidRouter,
     IFluidCodeDetails,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
@@ -85,7 +86,7 @@ export interface IContainerRuntime extends
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly storage: IDocumentStorageService;
     readonly flushMode: FlushMode;
-    readonly scope: IFluidObject;
+    readonly scope: IFluidObject & FluidObject;
     /**
      * Indicates the attachment state of the container to a host service.
      */

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -14,6 +14,7 @@ import {
     IResponse,
     IFluidHandle,
     IFluidConfiguration,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
@@ -609,7 +610,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         registryEntries: NamedFluidDataStoreRegistryEntries,
         requestHandler?: (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>,
         runtimeOptions: IContainerRuntimeOptions = {},
-        containerScope: IFluidObject = context.scope,
+        containerScope: FluidObject = context.scope,
         existing?: boolean,
     ): Promise<ContainerRuntime> {
         // If taggedLogger exists, use it. Otherwise, wrap the vanilla logger:
@@ -783,7 +784,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this._flushMode;
     }
 
-    public get scope(): IFluidObject {
+    public get scope(): IFluidObject & FluidObject {
         return this.containerScope;
     }
 
@@ -889,7 +890,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         electedSummarizerData: ISerializedElection | undefined,
         chunks: [string, string[]][],
         private readonly runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>,
-        private readonly containerScope: IFluidObject,
+        private readonly containerScope: FluidObject,
         public readonly logger: ITelemetryLogger,
         existing: boolean,
         blobManagerSnapshot: IBlobManagerLoadInfo,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -5,7 +5,7 @@
 
 import { IDisposable, ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
-    IFluidObject,
+    FluidObject,
     IRequest,
     IResponse,
     IFluidHandle,
@@ -212,7 +212,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         public readonly id: string,
         private readonly existing: boolean,
         public readonly storage: IDocumentStorageService,
-        public readonly scope: IFluidObject,
+        public readonly scope: FluidObject | FluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         private bindState: BindState,
         public readonly isLocalDataStore: boolean,
@@ -677,7 +677,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
         private readonly initSnapshotValue: ISnapshotTree | string | undefined,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IFluidObject,
+        scope: FluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         pkg?: string[],
     ) {
@@ -794,7 +794,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         pkg: Readonly<string[]> | undefined,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IFluidObject,
+        scope: FluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         private readonly snapshotTree: ISnapshotTree | undefined,
@@ -914,7 +914,7 @@ export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
         pkg: string[] | undefined,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IFluidObject & IFluidObject,
+        scope: FluidObject & FluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         snapshotTree: ISnapshotTree | undefined,
@@ -953,7 +953,7 @@ export class LocalDetachedFluidDataStoreContext
         pkg: Readonly<string[]>,
         runtime: ContainerRuntime,
         storage: IDocumentStorageService,
-        scope: IFluidObject & IFluidObject,
+        scope: FluidObject & FluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         isRootDataStore: boolean,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { BlobCacheStorageService } from "@fluidframework/driver-utils";
 import {
@@ -48,7 +48,7 @@ describe("Data Store Context Tests", () => {
     describe("LocalFluidDataStoreContext", () => {
         let localDataStoreContext: LocalFluidDataStoreContext;
         let storage: IDocumentStorageService;
-        let scope: IFluidObject;
+        let scope: FluidObject;
         const attachCb = (mR: IFluidDataStoreChannel) => { };
         let containerRuntime: ContainerRuntime;
         let summarizerNode: IRootSummarizerNodeWithGC;
@@ -293,7 +293,7 @@ describe("Data Store Context Tests", () => {
         let remotedDataStoreContext: RemotedFluidDataStoreContext;
         let dataStoreAttributes: ReadFluidDataStoreAttributes;
         const storage: Partial<IDocumentStorageService> = {};
-        let scope: IFluidObject;
+        let scope: FluidObject;
         let summarizerNode: IRootSummarizerNodeWithGC;
 
         function mockContainerRuntime(disableIsolatedChannels = true): ContainerRuntime {

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -14,7 +14,7 @@ import {
     CreateChildSummarizerNodeFn,
     CreateSummarizerNodeSource,
 } from "@fluidframework/runtime-definitions";
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { createRootSummarizerNodeWithGC } from "@fluidframework/runtime-utils";
@@ -38,7 +38,7 @@ describe("Data Store Creation Tests", () => {
          */
 
         let storage: IDocumentStorageService;
-        let scope: IFluidObject;
+        let scope: FluidObject;
         const attachCb = (mR: IFluidDataStoreChannel) => { };
         let containerRuntime: ContainerRuntime;
         const defaultName = "default";

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -11,6 +11,7 @@ import {
     IFluidHandle,
     IRequest,
     IResponse,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
@@ -283,7 +284,7 @@ export interface IFluidDataStoreContext extends
     /**
      * Ambient services provided with the context
      */
-    readonly scope: IFluidObject;
+    readonly scope: IFluidObject & FluidObject;
 
     /**
      * Returns the current quorum.

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -7,7 +7,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import {
     IFluidHandle,
     IFluidHandleContext,
-    IFluidObject,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
@@ -66,7 +66,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
      * @deprecated 0.16 Issue #1635, #3631
      */
     public createProps?: any;
-    public scope: IFluidObject;
+    public scope: FluidObject;
 
     constructor(
         public readonly id: string = uuid(),


### PR DESCRIPTION
FluidObject and IFluidObject are intentionally compatible. This change adds FluidObject to the type signature of our scope and fluid export properties, to ease the transition. I've also updated our internal usages to use scope and fluid export via FluidObject.

related to #8076 