### PR TITLE
Update most framework packages to use FluidObject over IFluidObject

### DIFF
--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -9,6 +9,7 @@ import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { DependencyContainerRegistry } from '@fluidframework/synthesize';
 import { EventForwarder } from '@fluidframework/common-utils';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { FluidObjectKey } from '@fluidframework/synthesize';
 import { FluidObjectSymbolProvider } from '@fluidframework/synthesize';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
@@ -77,7 +78,10 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
 }
 
 // @public (undocumented)
-export type ContainerServiceRegistryEntries = Iterable<[string, (runtime: IContainerRuntime) => Promise<IFluidObject>]>;
+export type ContainerServiceRegistryEntries = Iterable<[
+    string,
+    (runtime: IContainerRuntime) => Promise<IFluidObject & FluidObject>
+]>;
 
 // @public
 export abstract class DataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent> extends PureDataObject<O, S, E> {
@@ -95,7 +99,7 @@ export class DataObjectFactory<TObj extends DataObject<O, S, E>, O, S, E extends
 }
 
 // @public
-export function defaultFluidObjectRequestHandler(fluidObject: IFluidObject, request: IRequest): IResponse;
+export function defaultFluidObjectRequestHandler(fluidObject: FluidObject, request: IRequest): IResponse;
 
 // @public
 export const defaultRouteRequestHandler: (defaultRootId: string) => (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse | undefined>;
@@ -104,13 +108,13 @@ export const defaultRouteRequestHandler: (defaultRootId: string) => (request: IR
 export const generateContainerServicesRequestHandler: (serviceRegistry: ContainerServiceRegistryEntries) => RuntimeRequestHandler;
 
 // @public
-export function getDefaultObjectFromContainer<T = IFluidObject>(container: IContainer): Promise<T>;
+export function getDefaultObjectFromContainer<T = IFluidObject & FluidObject>(container: IContainer): Promise<T>;
 
 // @public
-export function getObjectFromContainer<T = IFluidObject>(path: string, container: IContainer): Promise<T>;
+export function getObjectFromContainer<T = IFluidObject & FluidObject>(path: string, container: IContainer): Promise<T>;
 
 // @public
-export function getObjectWithIdFromContainer<T = IFluidObject>(id: string, container: IContainer): Promise<T>;
+export function getObjectWithIdFromContainer<T = IFluidObject & FluidObject>(id: string, container: IContainer): Promise<T>;
 
 // @public (undocumented)
 export interface IDataObjectProps<O = object, S = undefined> {
@@ -143,7 +147,7 @@ export abstract class PureDataObject<O extends IFluidObject = object, S = undefi
     finishInitialization(existing: boolean): Promise<void>;
     // (undocumented)
     static getDataObject(runtime: IFluidDataStoreRuntime): Promise<PureDataObject<object, undefined, IEvent>>;
-    getFluidObjectFromDirectory<T extends IFluidObject & IFluidLoadable>(key: string, directory: IDirectory, getObjectFromDirectory?: (id: string, directory: IDirectory) => string | IFluidHandle | undefined): Promise<T | undefined>;
+    getFluidObjectFromDirectory<T extends IFluidObject & FluidObject & IFluidLoadable>(key: string, directory: IDirectory, getObjectFromDirectory?: (id: string, directory: IDirectory) => string | IFluidHandle | undefined): Promise<T | undefined>;
     protected getService<T extends IFluidObject>(id: string): Promise<T>;
     get handle(): IFluidHandle<this>;
     protected hasInitialized(): Promise<void>;

--- a/api-report/data-object-base.api.md
+++ b/api-report/data-object-base.api.md
@@ -7,6 +7,7 @@
 import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { EventForwarder } from '@fluidframework/common-utils';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IContainerContext } from '@fluidframework/container-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
@@ -57,7 +58,7 @@ export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = IShared
 export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> implements IFluidDataStoreFactory {
     constructor(type: string, ctor: new (context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, root: ISharedObject) => T, root: IChannelFactory, sharedObjects?: readonly IChannelFactory[], storeFactories?: readonly IFluidDataStoreFactory[]);
     // (undocumented)
-    create(parentContext: IFluidDataStoreContext, props?: any): Promise<IFluidObject>;
+    create(parentContext: IFluidDataStoreContext, props?: any): Promise<IFluidObject & FluidObject>;
     // (undocumented)
     get IFluidDataStoreFactory(): this;
     // (undocumented)

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -6,7 +6,6 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
-import { FluidObject } from '@fluidframework/core-interfaces';
 import { FluidSerializer } from '@fluidframework/runtime-utils';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IChannel } from '@fluidframework/datastore-definitions';
@@ -125,7 +124,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
 }
 
 // @public (undocumented)
-export class FluidObjectHandle<T extends FluidObject = IFluidObject> implements IFluidHandle {
+export class FluidObjectHandle<T extends IFluidObject = IFluidObject> implements IFluidHandle {
     constructor(value: T, path: string, routeContext: IFluidHandleContext);
     // (undocumented)
     readonly absolutePath: string;

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -6,6 +6,7 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { FluidSerializer } from '@fluidframework/runtime-utils';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IChannel } from '@fluidframework/datastore-definitions';
@@ -124,7 +125,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
 }
 
 // @public (undocumented)
-export class FluidObjectHandle<T extends IFluidObject = IFluidObject> implements IFluidHandle {
+export class FluidObjectHandle<T extends FluidObject = IFluidObject> implements IFluidHandle {
     constructor(value: T, path: string, routeContext: IFluidHandleContext);
     // (undocumented)
     readonly absolutePath: string;

--- a/api-report/request-handler.api.md
+++ b/api-report/request-handler.api.md
@@ -19,9 +19,9 @@ export function buildRuntimeRequestHandler(...handlers: RuntimeRequestHandler[])
 
 // @public (undocumented)
 export const createFluidObjectResponse: (fluidObject: FluidObject) => {
-    status: number;
-    mimeType: string;
-    value: Partial<Pick<unknown, never>>;
+    status: 200;
+    mimeType: "fluid/object";
+    value: FluidObject;
 };
 
 // @public (undocumented)

--- a/api-report/request-handler.api.md
+++ b/api-report/request-handler.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
@@ -17,14 +18,14 @@ import { RequestParser } from '@fluidframework/runtime-utils';
 export function buildRuntimeRequestHandler(...handlers: RuntimeRequestHandler[]): (request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>;
 
 // @public (undocumented)
-export const createFluidObjectResponse: (fluidObject: IFluidObject) => {
+export const createFluidObjectResponse: (fluidObject: FluidObject) => {
     status: number;
     mimeType: string;
-    value: IFluidObject;
+    value: Partial<Pick<unknown, never>>;
 };
 
 // @public (undocumented)
-export function handleFromLegacyUri<T = IFluidObject & IFluidLoadable>(uri: string, runtime: IContainerRuntimeBase): IFluidHandle<T>;
+export function handleFromLegacyUri<T = IFluidObject & FluidObject & IFluidLoadable>(uri: string, runtime: IContainerRuntimeBase): IFluidHandle<T>;
 
 // @public @deprecated (undocumented)
 export const innerRequestHandler: (request: IRequest, runtime: IContainerRuntimeBase) => Promise<IResponse>;

--- a/api-report/view-adapters.api.md
+++ b/api-report/view-adapters.api.md
@@ -24,7 +24,7 @@ export class HTMLViewAdapter implements IFluidHTMLView {
 
 // @public (undocumented)
 export interface IReactViewAdapterProps {
-    view: FluidObject<IFluidHTMLView>;
+    view: FluidObject;
 }
 
 // @public

--- a/api-report/view-adapters.api.md
+++ b/api-report/view-adapters.api.md
@@ -4,16 +4,16 @@
 
 ```ts
 
+import { FluidObject } from '@fluidframework/core-interfaces';
 import { IFluidHTMLOptions } from '@fluidframework/view-interfaces';
 import { IFluidHTMLView } from '@fluidframework/view-interfaces';
 import { IFluidMountableView } from '@fluidframework/view-interfaces';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { default as React_2 } from 'react';
 
 // @public
 export class HTMLViewAdapter implements IFluidHTMLView {
-    constructor(view: IFluidObject);
-    static canAdapt(view: IFluidObject): boolean;
+    constructor(view: FluidObject);
+    static canAdapt(view: FluidObject): boolean;
     // (undocumented)
     get IFluidHTMLView(): this;
     // (undocumented)
@@ -24,14 +24,14 @@ export class HTMLViewAdapter implements IFluidHTMLView {
 
 // @public (undocumented)
 export interface IReactViewAdapterProps {
-    view: IFluidObject;
+    view: FluidObject<IFluidHTMLView>;
 }
 
 // @public
 export class MountableView implements IFluidMountableView {
-    constructor(view: IFluidObject);
+    constructor(view: FluidObject);
     // (undocumented)
-    static canMount(view: IFluidObject): boolean;
+    static canMount(view: FluidObject): boolean;
     // (undocumented)
     get IFluidMountableView(): this;
     // (undocumented)
@@ -43,7 +43,7 @@ export class MountableView implements IFluidMountableView {
 // @public
 export class ReactViewAdapter extends React_2.Component<IReactViewAdapterProps> {
     constructor(props: IReactViewAdapterProps);
-    static canAdapt(view: IFluidObject): boolean;
+    static canAdapt(view: FluidObject): boolean;
     // (undocumented)
     render(): JSX.Element;
 }

--- a/packages/framework/aqueduct/src/container-services/containerServices.ts
+++ b/packages/framework/aqueduct/src/container-services/containerServices.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IResponse, IFluidObject, IFluidRouter, IRequest } from "@fluidframework/core-interfaces";
+import { IResponse, IFluidObject, IFluidRouter, IRequest, FluidObject } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { RuntimeRequestHandler } from "@fluidframework/request-handler";
 import {
@@ -15,7 +15,8 @@ import {
 // TODO: should this just be "s"?
 export const serviceRoutePathRoot = "_services";
 
-export type ContainerServiceRegistryEntries = Iterable<[string, (runtime: IContainerRuntime) => Promise<IFluidObject>]>;
+export type ContainerServiceRegistryEntries = Iterable<[string, (runtime: IContainerRuntime) =>
+    Promise<IFluidObject & FluidObject>]>;
 
 /**
  * This class is a simple starter class for building a Container Service. It simply provides routing
@@ -39,13 +40,13 @@ export abstract class BaseContainerService implements IFluidRouter {
  * ContainerService Factory that will only create one instance of the service for the Container.
  */
 class SingletonContainerServiceFactory {
-    private service: Promise<IFluidObject> | undefined;
+    private service: Promise<FluidObject> | undefined;
 
     public constructor(
-        private readonly serviceFn: (runtime: IContainerRuntime) => Promise<IFluidObject>,
+        private readonly serviceFn: (runtime: IContainerRuntime) => Promise<FluidObject>,
     ) { }
 
-    public async getService(runtime: IContainerRuntime): Promise<IFluidObject> {
+    public async getService(runtime: IContainerRuntime): Promise<IFluidObject & FluidObject> {
         if (!this.service) {
             this.service = this.serviceFn(runtime);
         }

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -11,6 +11,7 @@ import {
     IProvideFluidHandle,
     IRequest,
     IResponse,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import { AsyncFluidObjectProvider, FluidObjectKey } from "@fluidframework/synthesize";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
@@ -173,7 +174,7 @@ export abstract class PureDataObject<O extends IFluidObject = object, S = undefi
      * @param getObjectFromDirectory - optional callback for fetching object from the directory, allows users to
      * define custom types/getters for object retrieval
      */
-    public async getFluidObjectFromDirectory<T extends IFluidObject & IFluidLoadable>(
+    public async getFluidObjectFromDirectory<T extends IFluidObject & FluidObject & IFluidLoadable>(
         key: string,
         directory: IDirectory,
         getObjectFromDirectory?: (id: string, directory: IDirectory) => string | IFluidHandle | undefined):

--- a/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
+++ b/packages/framework/aqueduct/src/request-handlers/requestHandlers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject, IRequest, IRequestHeader, IResponse } from "@fluidframework/core-interfaces";
+import { FluidObject, IRequest, IRequestHeader, IResponse } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IFluidMountableViewClass } from "@fluidframework/view-interfaces";
 import { RuntimeRequestHandler, buildRuntimeRequestHandler } from "@fluidframework/request-handler";
@@ -73,7 +73,7 @@ export const defaultRouteRequestHandler = (defaultRootId: string) => {
  *  3. the request url starts with "/" and is followed by a query param, such as /?key=value
  * Returns a 404 error for any other url.
  */
-export function defaultFluidObjectRequestHandler(fluidObject: IFluidObject, request: IRequest): IResponse {
+export function defaultFluidObjectRequestHandler(fluidObject: FluidObject, request: IRequest): IResponse {
     if (request.url === "" || request.url === "/" || request.url.startsWith("/?")) {
         return { mimeType: "fluid/object", status: 200, value: fluidObject };
     } else {

--- a/packages/framework/aqueduct/src/test/defaultRoute.spec.ts
+++ b/packages/framework/aqueduct/src/test/defaultRoute.spec.ts
@@ -11,7 +11,6 @@ import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import {
     IRequest,
     IResponse,
-    IFluidObject,
     IFluidRouter,
 } from "@fluidframework/core-interfaces";
 import { createFluidObjectResponse } from "@fluidframework/request-handler";
@@ -25,7 +24,7 @@ class MockRuntime {
             return {
                 request: async (r) => {
                     if (r.url === "/" || r.url === "/route") {
-                        return createFluidObjectResponse({ route: r.url } as IFluidObject);
+                        return createFluidObjectResponse({ route: r.url });
                     }
                     return create404Response(r);
                 },

--- a/packages/framework/aqueduct/src/utils/containerInteractions.ts
+++ b/packages/framework/aqueduct/src/utils/containerInteractions.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject, IFluidObject } from "@fluidframework/core-interfaces";
 import { IContainer } from "@fluidframework/container-definitions";
 
 /**
@@ -13,7 +13,7 @@ import { IContainer } from "@fluidframework/container-definitions";
  *
  * @param container - Container you're attempting to get the object from
  */
-export async function getDefaultObjectFromContainer<T = IFluidObject>(container: IContainer): Promise<T> {
+export async function getDefaultObjectFromContainer<T = IFluidObject & FluidObject>(container: IContainer): Promise<T> {
     const url = "/";
     const response = await container.request({ url });
 
@@ -37,7 +37,8 @@ export async function getDefaultObjectFromContainer<T = IFluidObject>(container:
  * @param id - Unique id of the FluidObject
  * @param container - Container you're attempting to get the object from
  */
-export async function getObjectWithIdFromContainer<T = IFluidObject>(id: string, container: IContainer): Promise<T> {
+export async function getObjectWithIdFromContainer<T = IFluidObject & FluidObject>(
+    id: string, container: IContainer): Promise<T> {
     const url = `/${id}`;
     const response = await container.request({ url });
 
@@ -61,7 +62,8 @@ export async function getObjectWithIdFromContainer<T = IFluidObject>(id: string,
  * @param path - Unique path/url of the FluidObject
  * @param container - Container you're attempting to get the object from
  */
-export async function getObjectFromContainer<T = IFluidObject>(path: string, container: IContainer): Promise<T> {
+export async function getObjectFromContainer<T = IFluidObject & FluidObject>(
+    path: string, container: IContainer): Promise<T> {
     const response = await container.request({ url: path });
 
     if (response.status !== 200 || response.mimeType !== "fluid/object") {

--- a/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject, IRequest } from "@fluidframework/core-interfaces";
+import { FluidObject, IFluidObject, IRequest } from "@fluidframework/core-interfaces";
 import { FluidDataStoreRuntime, ISharedObjectRegistry, mixinRequestHandler } from "@fluidframework/datastore";
 import { FluidDataStoreRegistry } from "@fluidframework/container-runtime";
 import {
@@ -67,7 +67,7 @@ export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> impleme
         return runtime;
     }
 
-    public async create(parentContext: IFluidDataStoreContext, props?: any): Promise<IFluidObject> {
+    public async create(parentContext: IFluidDataStoreContext, props?: any): Promise<IFluidObject & FluidObject> {
         const { containerRuntime, packagePath } = parentContext;
 
         const router = await containerRuntime.createDataStore(packagePath.concat(this.type));

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -10,6 +10,7 @@ import {
     IRequest,
     IFluidHandle,
     IFluidLoadable,
+    FluidObject,
 } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -56,11 +57,11 @@ export const rootDataStoreRequestHandler = async (request: IRequest, runtime: IC
     }
 };
 
-export const createFluidObjectResponse = (fluidObject: IFluidObject) => {
+export const createFluidObjectResponse = (fluidObject: FluidObject) => {
     return { status: 200, mimeType: "fluid/object", value: fluidObject };
 };
 
-class LegacyUriHandle<T = IFluidObject & IFluidLoadable> implements IFluidHandle<T> {
+class LegacyUriHandle<T = IFluidObject & FluidObject & IFluidLoadable> implements IFluidHandle<T> {
     public readonly isAttached = true;
 
     public get IFluidHandle(): IFluidHandle { return this; }
@@ -87,7 +88,7 @@ class LegacyUriHandle<T = IFluidObject & IFluidLoadable> implements IFluidHandle
 }
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function handleFromLegacyUri<T = IFluidObject & IFluidLoadable>(
+export function handleFromLegacyUri<T = IFluidObject & FluidObject & IFluidLoadable>(
     uri: string,
     runtime: IContainerRuntimeBase,
 ): IFluidHandle<T> {

--- a/packages/framework/request-handler/src/requestHandlers.ts
+++ b/packages/framework/request-handler/src/requestHandlers.ts
@@ -57,7 +57,8 @@ export const rootDataStoreRequestHandler = async (request: IRequest, runtime: IC
     }
 };
 
-export const createFluidObjectResponse = (fluidObject: FluidObject) => {
+export const createFluidObjectResponse = (fluidObject: FluidObject):
+    {status: 200, mimeType: "fluid/object", value: FluidObject} => {
     return { status: 200, mimeType: "fluid/object", value: fluidObject };
 };
 

--- a/packages/framework/request-handler/src/test/requestHandlers.spec.ts
+++ b/packages/framework/request-handler/src/test/requestHandlers.spec.ts
@@ -8,7 +8,6 @@ import { strict as assert } from "assert";
 import {
     IRequest,
     IResponse,
-    IFluidObject,
     IFluidRouter,
 } from "@fluidframework/core-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
@@ -28,7 +27,7 @@ class MockRuntime {
             const router: any = {
                 request: async (request: IRequest) => {
                     if (request.url === "" || request.url === "/route") {
-                        return createFluidObjectResponse({ route: request.url } as IFluidObject);
+                        return createFluidObjectResponse({ route: request.url });
                     }
                     return create404Response(request);
                 },

--- a/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
@@ -35,7 +35,7 @@ export class HTMLViewAdapter implements IFluidHTMLView {
      * the React case.  This also doubles as a way for us to know if we are mounted or not.
      */
     private containerNode: HTMLElement | undefined;
-    private readonly view: FluidObject<IFluidHTMLView>;
+    private readonly view: FluidObject;
 
     /**
      * @param view - The view to adapt into an IFluidHTMLView
@@ -51,8 +51,8 @@ export class HTMLViewAdapter implements IFluidHTMLView {
         // Note that if we're already mounted, this can cause multiple rendering with possibly unintended effects.
         // Probably try to avoid doing this.
         this.containerNode = elm;
-
-        const htmlView = this.view.IFluidHTMLView;
+        const maybeView: FluidObject<IFluidHTMLView> = this.view;
+        const htmlView = maybeView.IFluidHTMLView;
         if (htmlView !== undefined) {
             htmlView.render(elm, options);
             return;
@@ -87,7 +87,8 @@ export class HTMLViewAdapter implements IFluidHTMLView {
             return;
         }
 
-        const htmlView = this.view.IFluidHTMLView;
+        const maybeView: FluidObject<IFluidHTMLView> = this.view;
+        const htmlView = maybeView.IFluidHTMLView;
         if (htmlView !== undefined && htmlView.remove !== undefined) {
             htmlView.remove();
             this.containerNode = undefined;

--- a/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/htmlview/htmlViewAdapter.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject } from "@fluidframework/core-interfaces";
 import {
     IFluidHTMLView,
     IFluidHTMLOptions,
@@ -22,10 +22,11 @@ export class HTMLViewAdapter implements IFluidHTMLView {
      * Test whether the given view can be successfully adapted by an HTMLViewAdapter.
      * @param view - the view to test if it is adaptable.
      */
-    public static canAdapt(view: IFluidObject) {
+    public static canAdapt(view: FluidObject) {
+        const maybeView: FluidObject<IFluidHTMLView> = view;
         return (
             React.isValidElement(view)
-            || view.IFluidHTMLView !== undefined
+            || maybeView.IFluidHTMLView !== undefined
         );
     }
 
@@ -34,11 +35,14 @@ export class HTMLViewAdapter implements IFluidHTMLView {
      * the React case.  This also doubles as a way for us to know if we are mounted or not.
      */
     private containerNode: HTMLElement | undefined;
+    private readonly view: FluidObject<IFluidHTMLView>;
 
     /**
      * @param view - The view to adapt into an IFluidHTMLView
      */
-    constructor(private readonly view: IFluidObject) { }
+    constructor(view: FluidObject) {
+        this.view = view;
+     }
 
     /**
      * {@inheritDoc @fluidframework/view-interfaces#IFluidHTMLView.render}

--- a/packages/framework/view-adapters/src/mountableview/mountableView.tsx
+++ b/packages/framework/view-adapters/src/mountableview/mountableView.tsx
@@ -50,7 +50,7 @@ export class MountableView implements IFluidMountableView {
      */
     private reactView: JSX.Element | undefined;
 
-    private readonly view: FluidObject<IFluidHTMLView>;
+    private readonly view: FluidObject;
 
     /**
      * {@inheritDoc @fluidframework/view-interfaces#IFluidMountableViewClass.new}
@@ -74,7 +74,8 @@ export class MountableView implements IFluidMountableView {
 
         // Try to get an IFluidHTMLView if we don't have one already.
         if (this.htmlView === undefined) {
-            this.htmlView = this.view.IFluidHTMLView;
+            const maybeHtmlView: FluidObject<IFluidHTMLView> = this.view;
+            this.htmlView = maybeHtmlView.IFluidHTMLView;
         }
         // Render with IFluidHTMLView if possible.
         if (this.htmlView !== undefined) {

--- a/packages/framework/view-adapters/src/mountableview/mountableView.tsx
+++ b/packages/framework/view-adapters/src/mountableview/mountableView.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject } from "@fluidframework/core-interfaces";
 import {
     IFluidHTMLView,
     IFluidMountableView,
@@ -25,10 +25,11 @@ export class MountableView implements IFluidMountableView {
     /**
      * {@inheritDoc @fluidframework/view-interfaces#IFluidMountableViewClass.canMount}
      */
-    public static canMount(view: IFluidObject) {
+    public static canMount(view: FluidObject) {
+        const maybeView: FluidObject<IFluidHTMLView> = view;
         return (
             React.isValidElement(view)
-            || view.IFluidHTMLView !== undefined
+            || maybeView.IFluidHTMLView !== undefined
         );
     }
 
@@ -49,13 +50,16 @@ export class MountableView implements IFluidMountableView {
      */
     private reactView: JSX.Element | undefined;
 
+    private readonly view: FluidObject<IFluidHTMLView>;
+
     /**
      * {@inheritDoc @fluidframework/view-interfaces#IFluidMountableViewClass.new}
      */
-    constructor(private readonly view: IFluidObject) {
-        if (!MountableView.canMount(this.view)) {
+    constructor(view: FluidObject) {
+        if (!MountableView.canMount(view)) {
             throw new Error("Unmountable view type");
         }
+        this.view = view;
     }
 
     /**

--- a/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
@@ -11,7 +11,7 @@ export interface IReactViewAdapterProps {
     /**
      * The view to adapt into a React component.
      */
-    view: FluidObject<IFluidHTMLView>;
+    view: FluidObject;
 }
 
 /**
@@ -45,8 +45,8 @@ export class ReactViewAdapter extends React.Component<IReactViewAdapterProps> {
             this.element = this.props.view;
             return;
         }
-
-        const htmlView = this.props.view.IFluidHTMLView;
+        const maybeView: FluidObject<IFluidHTMLView> = this.props.view;
+        const htmlView = maybeView.IFluidHTMLView;
         if (htmlView !== undefined) {
             this.element = <HTMLViewEmbeddedComponent htmlView={htmlView} />;
             return;

--- a/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject } from "@fluidframework/core-interfaces";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
 
@@ -11,7 +11,7 @@ export interface IReactViewAdapterProps {
     /**
      * The view to adapt into a React component.
      */
-    view: IFluidObject;
+    view: FluidObject<IFluidHTMLView>;
 }
 
 /**
@@ -25,11 +25,11 @@ export class ReactViewAdapter extends React.Component<IReactViewAdapterProps> {
      * Test whether the given Fluid object can be successfully adapted by a ReactViewAdapter.
      * @param view - the fluid object to test if it is adaptable.
      */
-    public static canAdapt(view: IFluidObject) {
+    public static canAdapt(view: FluidObject) {
+        const maybeView: FluidObject<IFluidHTMLView> = view;
         return (
             React.isValidElement(view)
-            || view.IFluidHTMLView !== undefined
-            || view.IFluidHTMLView !== undefined
+            || maybeView.IFluidHTMLView !== undefined
         );
     }
 
@@ -46,7 +46,7 @@ export class ReactViewAdapter extends React.Component<IReactViewAdapterProps> {
             return;
         }
 
-        const htmlView = this.props.view.IFluidHTMLView ?? this.props.view.IFluidHTMLView;
+        const htmlView = this.props.view.IFluidHTMLView;
         if (htmlView !== undefined) {
             this.element = <HTMLViewEmbeddedComponent htmlView={htmlView} />;
             return;


### PR DESCRIPTION
This change updates most of the framework packages to use FluidObject over IFluidObject, specifically it doesn't move Synthesize to FluidObject, as that is a more involved change.

related to #8075 