### PR TITLE
Add functionality to AgentScheduler and its factory to make it easier to use as a child instance

### DIFF
--- a/packages/runtime/agent-scheduler/README.md
+++ b/packages/runtime/agent-scheduler/README.md
@@ -1,5 +1,31 @@
 # @fluidframework/agent-scheduler
 
-A Fluid object designed for scheduling agents to run tasks. Used as part of the core runtime.
+## AgentScheduler
+
+The `AgentScheduler` is a data object that can be used to assign tasks to unique clients.
+
+### Creation
+
+To create an `AgentScheduler` as a child instance of your data object, add the factory to your registry and call the static `createChildInstance` function on the factory.  You can then retrieve and store its handle to access it later:
+
+```typescript
+// In your Data Object
+protected async initializingFirstTime() {
+    const agentScheduler = await AgentSchedulerFactory.createChildInstance(this.context);
+    this.root.set("agentScheduler", agentScheduler.handle);
+}
+
+// When creating your DataObjectFactory
+export const MyDataObjectFactory = new DataObjectFactory<MyDataObject, undefined, undefined, IEvent>
+(
+    "my-data-object",
+    MyDataObject,
+    [],
+    {},
+    new Map([
+        AgentSchedulerFactory.registryEntry,
+    ]),
+);
+```
 
 See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.

--- a/packages/runtime/agent-scheduler/src/scheduler.ts
+++ b/packages/runtime/agent-scheduler/src/scheduler.ts
@@ -8,7 +8,11 @@ import {
     IFluidHandle,
     IRequest,
 } from "@fluidframework/core-interfaces";
-import { FluidDataStoreRuntime, ISharedObjectRegistry } from "@fluidframework/datastore";
+import {
+    FluidDataStoreRuntime,
+    FluidObjectHandle,
+    ISharedObjectRegistry,
+} from "@fluidframework/datastore";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
@@ -18,13 +22,14 @@ import {
     IFluidDataStoreFactory,
     NamedFluidDataStoreRegistryEntry,
 } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { v4 as uuid } from "uuid";
 import { IAgentScheduler, IAgentSchedulerEvents } from "./agent";
 
 // Note: making sure this ID is unique and does not collide with storage provided clientID
 const UnattachedClientId = `${uuid()}_unattached`;
 
-class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements IAgentScheduler {
+export class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements IAgentScheduler {
     public static async load(runtime: IFluidDataStoreRuntime, context: IFluidDataStoreContext, existing: boolean) {
         let root: ISharedMap;
         let consensusRegisterCollection: ConsensusRegisterCollection<string | null>;
@@ -72,11 +77,19 @@ class AgentScheduler extends TypedEventEmitter<IAgentSchedulerEvents> implements
     // It's subset of this.locallyRunnableTasks
     private runningTasks = new Set<string>();
 
+    private readonly _handle: IFluidHandle<this>;
+
     constructor(
         private readonly runtime: IFluidDataStoreRuntime,
         private readonly context: IFluidDataStoreContext,
-        private readonly consensusRegisterCollection: ConsensusRegisterCollection<string | null>) {
+        private readonly consensusRegisterCollection: ConsensusRegisterCollection<string | null>,
+    ) {
         super();
+        this._handle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
+    }
+
+    public get handle() {
+        return this._handle;
     }
 
     public async register(...taskUrls: string[]): Promise<void> {
@@ -379,6 +392,12 @@ export class AgentSchedulerFactory implements IFluidDataStoreFactory {
 
     public static get registryEntry(): NamedFluidDataStoreRegistryEntry {
         return [this.type, Promise.resolve(new AgentSchedulerFactory())];
+    }
+
+    public static async createChildInstance(parentContext: IFluidDataStoreContext): Promise<AgentScheduler> {
+        const packagePath = [...parentContext.packagePath, AgentSchedulerFactory.type];
+        const router = await parentContext.containerRuntime.createDataStore(packagePath);
+        return requestFluidObject<AgentScheduler>(router, "/");
     }
 
     public async instantiateDataStore(context: IFluidDataStoreContext, existing: boolean) {


### PR DESCRIPTION
`AgentScheduler` historically has been used globally as a root data store.  However, it's reasonable to want to use it as a child instance and some of our partners are interested in doing so.

There are two challenges in doing so:
- `AgentScheduler` isn't using `DataObjectFactory` so it doesn't have the nice functions available like `createChildInstance`
- `AgentScheduler` doesn't create its own handle (no `agentScheduler.handle` property) so the customer has to create their own handler from the outside.  This is particularly awkward since it wants access to the `AgentScheduler`'s `IFluidDataStoreRuntime` to get the `objectsRoutingContext`.

So to do this currently, it looks something like:
```ts
protected async initializingFirstTime() {
    const packagePath = [...this.context.packagePath, AgentSchedulerFactory.type];
    const router = await this.context.containerRuntime.createDataStore(packagePath);
    const agentScheduler = await requestFluidObject<IAgentScheduler>(router, "/");
    const handle = new FluidObjectHandle(
        agentScheduler,
        "",
        // kind of a nasty cast, but we know createDataStore will return the DS's runtime
        (router as IFluidDataStoreRuntime).objectsRoutingContext,
    );
    this.root.set("agentScheduler", handle);
}
```

This PR instead mimics the handle property from `PureDataObject` and `createChildInstance` from `PureDataObjectFactory` to simplify, such that the above becomes:

```ts
protected async initializingFirstTime() {
    const agentScheduler = await AgentSchedulerFactory.createChildInstance(this.context);
    this.root.set("agentScheduler", agentScheduler.handle);
}
```