### PR TITLE
Add fetch reason string to storage and deltastorage apis

### DIFF
--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -150,16 +150,16 @@ export interface IDocumentServicePolicies {
 
 // @public
 export interface IDocumentStorageService extends Partial<IDisposable> {
-    createBlob(file: ArrayBufferLike, fetchReason?: string): Promise<ICreateBlobResponse>;
-    downloadSummary(handle: ISummaryHandle, fetchReason?: string): Promise<ISummaryTree>;
-    getSnapshotTree(version?: IVersion, fetchReason?: string): Promise<ISnapshotTree | null>;
-    getVersions(versionId: string | null, count: number, fetchReason?: string): Promise<IVersion[]>;
+    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
+    getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null>;
+    getVersions(versionId: string | null, count: number): Promise<IVersion[]>;
     readonly policies?: IDocumentStorageServicePolicies;
-    readBlob(id: string, fetchReason?: string): Promise<ArrayBufferLike>;
+    readBlob(id: string): Promise<ArrayBufferLike>;
     // (undocumented)
     repositoryUrl: string;
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext, fetchReason?: string): Promise<string>;
-    write(root: ITree, parents: string[], message: string, ref: string, fetchReason?: string): Promise<IVersion>;
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
+    write(root: ITree, parents: string[], message: string, ref: string): Promise<IVersion>;
 }
 
 // @public (undocumented)

--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -82,7 +82,8 @@ export interface IDeltasFetchResult {
 // @public
 export interface IDeltaStorageService {
     get(tenantId: string, id: string, from: number, // inclusive
-    to: number): Promise<IDeltasFetchResult>;
+    to: number, // exclusive
+    fetchReason?: string): Promise<IDeltasFetchResult>;
 }
 
 // @public (undocumented)
@@ -121,7 +122,7 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
 
 // @public
 export interface IDocumentDeltaStorageService {
-    fetchMessages(from: number, to: number | undefined, abortSignal?: AbortSignal, cachedOnly?: boolean): IStream<ISequencedDocumentMessage[]>;
+    fetchMessages(from: number, to: number | undefined, abortSignal?: AbortSignal, cachedOnly?: boolean, fetchReason?: string): IStream<ISequencedDocumentMessage[]>;
 }
 
 // @public (undocumented)
@@ -149,16 +150,16 @@ export interface IDocumentServicePolicies {
 
 // @public
 export interface IDocumentStorageService extends Partial<IDisposable> {
-    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
-    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
-    getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null>;
-    getVersions(versionId: string | null, count: number): Promise<IVersion[]>;
+    createBlob(file: ArrayBufferLike, fetchReason?: string): Promise<ICreateBlobResponse>;
+    downloadSummary(handle: ISummaryHandle, fetchReason?: string): Promise<ISummaryTree>;
+    getSnapshotTree(version?: IVersion, fetchReason?: string): Promise<ISnapshotTree | null>;
+    getVersions(versionId: string | null, count: number, fetchReason?: string): Promise<IVersion[]>;
     readonly policies?: IDocumentStorageServicePolicies;
-    readBlob(id: string): Promise<ArrayBufferLike>;
+    readBlob(id: string, fetchReason?: string): Promise<ArrayBufferLike>;
     // (undocumented)
     repositoryUrl: string;
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
-    write(root: ITree, parents: string[], message: string, ref: string): Promise<IVersion>;
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext, fetchReason?: string): Promise<string>;
+    write(root: ITree, parents: string[], message: string, ref: string, fetchReason?: string): Promise<IVersion>;
 }
 
 // @public (undocumented)

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -89,7 +89,7 @@ export interface IDocumentDeltaStorageService {
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
         fetchReason?: string,
-    ): IStream<ISequencedDocumentMessage[]>;S
+    ): IStream<ISequencedDocumentMessage[]>;
 }
 
 export interface IDocumentStorageServicePolicies {

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -49,7 +49,8 @@ export interface IDeltaStorageService {
         tenantId: string,
         id: string,
         from: number, // inclusive
-        to: number // exclusive
+        to: number, // exclusive
+        reason?: string,
     ): Promise<IDeltasFetchResult>;
 }
 
@@ -77,6 +78,7 @@ export interface IDocumentDeltaStorageService {
         to: number | undefined,
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
+        reason?: string,
     ): IStream<ISequencedDocumentMessage[]>;
 }
 
@@ -102,27 +104,27 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
     /**
      * Returns the snapshot tree.
      */
-    getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null>;
+    getSnapshotTree(version?: IVersion, reason?: string): Promise<ISnapshotTree | null>;
 
     /**
      * Retrieves all versions of the document starting at the specified versionId - or null if from the head
      */
-    getVersions(versionId: string | null, count: number): Promise<IVersion[]>;
+    getVersions(versionId: string | null, count: number, reason?: string): Promise<IVersion[]>;
 
     /**
      * Writes to the object with the given ID
      */
-    write(root: ITree, parents: string[], message: string, ref: string): Promise<IVersion>;
+    write(root: ITree, parents: string[], message: string, ref: string, reason?: string): Promise<IVersion>;
 
     /**
      * Creates a blob out of the given buffer
      */
-    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+    createBlob(file: ArrayBufferLike, reason?: string): Promise<ICreateBlobResponse>;
 
     /**
      * Reads the object with the given ID, returns content in arrayBufferLike
      */
-    readBlob(id: string): Promise<ArrayBufferLike>;
+    readBlob(id: string, reason?: string): Promise<ArrayBufferLike>;
 
     /**
      * Uploads a summary tree to storage using the given context for reference of previous summary handle.
@@ -130,13 +132,13 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
      * referencing from the previously acked summary.
      * Returns the uploaded summary handle.
      */
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext, reason?: string): Promise<string>;
 
     /**
      * Retrieves the commit that matches the packfile handle. If the packfile has already been committed and the
      * server has deleted it this call may result in a broken promise.
      */
-    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
+    downloadSummary(handle: ISummaryHandle, reason?: string): Promise<ISummaryTree>;
 }
 
 export interface IDocumentDeltaConnectionEvents extends IErrorEvent {

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -104,27 +104,27 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
     /**
      * Returns the snapshot tree.
      */
-    getSnapshotTree(version?: IVersion, fetchReason?: string): Promise<ISnapshotTree | null>;
+    getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null>;
 
     /**
      * Retrieves all versions of the document starting at the specified versionId - or null if from the head
      */
-    getVersions(versionId: string | null, count: number, fetchReason?: string): Promise<IVersion[]>;
+    getVersions(versionId: string | null, count: number): Promise<IVersion[]>;
 
     /**
      * Writes to the object with the given ID
      */
-    write(root: ITree, parents: string[], message: string, ref: string, fetchReason?: string): Promise<IVersion>;
+    write(root: ITree, parents: string[], message: string, ref: string): Promise<IVersion>;
 
     /**
      * Creates a blob out of the given buffer
      */
-    createBlob(file: ArrayBufferLike, fetchReason?: string): Promise<ICreateBlobResponse>;
+    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
 
     /**
      * Reads the object with the given ID, returns content in arrayBufferLike
      */
-    readBlob(id: string, fetchReason?: string): Promise<ArrayBufferLike>;
+    readBlob(id: string): Promise<ArrayBufferLike>;
 
     /**
      * Uploads a summary tree to storage using the given context for reference of previous summary handle.
@@ -132,13 +132,13 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
      * referencing from the previously acked summary.
      * Returns the uploaded summary handle.
      */
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext, fetchReason?: string): Promise<string>;
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
 
     /**
      * Retrieves the commit that matches the packfile handle. If the packfile has already been committed and the
      * server has deleted it this call may result in a broken promise.
      */
-    downloadSummary(handle: ISummaryHandle, fetchReason?: string): Promise<ISummaryTree>;
+    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
 }
 
 export interface IDocumentDeltaConnectionEvents extends IErrorEvent {

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -44,6 +44,13 @@ export interface IDeltasFetchResult {
 export interface IDeltaStorageService {
     /**
      * Retrieves all the delta operations within the inclusive sequence number range
+     * @param tenantId - Id of the tenant.
+     * @param id - document id.
+     * @param from - first op to retrieve (inclusive)
+     * @param to - first op not to retrieve (exclusive end)
+     * @param fetchReason - Reason for fetching the messages. Example, gap between seq number
+     *  of Op on wire and known seq number. It should not contain any PII. It can be logged by
+     *  spo which could help in debugging sessions if any issue occurs.
      */
     get(
         tenantId: string,
@@ -73,13 +80,16 @@ export interface IDocumentDeltaStorageService {
      * @param to - first op not to retrieve (exclusive end)
      * @param abortSignal - signal that aborts operation
      * @param cachedOnly - return only cached ops, i.e. ops available locally on client.
+     * @param fetchReason - Reason for fetching the messages. Example, gap between seq number
+     *  of Op on wire and known seq number. It should not contain any PII. It can be logged by
+     *  spo which could help in debugging sessions if any issue occurs.
      */
      fetchMessages(from: number,
         to: number | undefined,
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
         fetchReason?: string,
-    ): IStream<ISequencedDocumentMessage[]>;
+    ): IStream<ISequencedDocumentMessage[]>;S
 }
 
 export interface IDocumentStorageServicePolicies {

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -50,7 +50,7 @@ export interface IDeltaStorageService {
         id: string,
         from: number, // inclusive
         to: number, // exclusive
-        reason?: string,
+        fetchReason?: string,
     ): Promise<IDeltasFetchResult>;
 }
 
@@ -78,7 +78,7 @@ export interface IDocumentDeltaStorageService {
         to: number | undefined,
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
-        reason?: string,
+        fetchReason?: string,
     ): IStream<ISequencedDocumentMessage[]>;
 }
 
@@ -104,27 +104,27 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
     /**
      * Returns the snapshot tree.
      */
-    getSnapshotTree(version?: IVersion, reason?: string): Promise<ISnapshotTree | null>;
+    getSnapshotTree(version?: IVersion, fetchReason?: string): Promise<ISnapshotTree | null>;
 
     /**
      * Retrieves all versions of the document starting at the specified versionId - or null if from the head
      */
-    getVersions(versionId: string | null, count: number, reason?: string): Promise<IVersion[]>;
+    getVersions(versionId: string | null, count: number, fetchReason?: string): Promise<IVersion[]>;
 
     /**
      * Writes to the object with the given ID
      */
-    write(root: ITree, parents: string[], message: string, ref: string, reason?: string): Promise<IVersion>;
+    write(root: ITree, parents: string[], message: string, ref: string, fetchReason?: string): Promise<IVersion>;
 
     /**
      * Creates a blob out of the given buffer
      */
-    createBlob(file: ArrayBufferLike, reason?: string): Promise<ICreateBlobResponse>;
+    createBlob(file: ArrayBufferLike, fetchReason?: string): Promise<ICreateBlobResponse>;
 
     /**
      * Reads the object with the given ID, returns content in arrayBufferLike
      */
-    readBlob(id: string, reason?: string): Promise<ArrayBufferLike>;
+    readBlob(id: string, fetchReason?: string): Promise<ArrayBufferLike>;
 
     /**
      * Uploads a summary tree to storage using the given context for reference of previous summary handle.
@@ -132,13 +132,13 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
      * referencing from the previously acked summary.
      * Returns the uploaded summary handle.
      */
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext, reason?: string): Promise<string>;
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext, fetchReason?: string): Promise<string>;
 
     /**
      * Retrieves the commit that matches the packfile handle. If the packfile has already been committed and the
      * server has deleted it this call may result in a broken promise.
      */
-    downloadSummary(handle: ISummaryHandle, reason?: string): Promise<ISummaryTree>;
+    downloadSummary(handle: ISummaryHandle, fetchReason?: string): Promise<ISummaryTree>;
 }
 
 export interface IDocumentDeltaConnectionEvents extends IErrorEvent {


### PR DESCRIPTION
Refer: https://github.com/microsoft/FluidFramework/issues/6483
Api changes to add fetch reason to storage api calls so that server can record in telemetry and it can then help in debugging different scenarios.