### PR TITLE
Fix driver type in order to skip blob related tests for FRS

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -54,7 +54,7 @@ describeFullCompat("blobs", (getTestObjectProvider) => {
     beforeEach(async function() {
         provider = getTestObjectProvider();
         // Currently FRS does not support blob API.
-        if (provider.driver.type === "r11s" && provider.driver.endpointName === "frs") {
+        if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
             this.skip();
         }
     });
@@ -222,7 +222,7 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
     beforeEach(async function() {
         provider = getTestObjectProvider();
         // Currently FRS does not support blob API.
-        if (provider.driver.type === "r11s" && provider.driver.endpointName === "frs") {
+        if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
             this.skip();
         }
     });


### PR DESCRIPTION
In #7960 we added a temporary rule in order to skip blob-related tests for FRS. The rule was not working because it was using an incorrect testDriver type (we used `"r11s"` while `RouterliciousTestDriver` uses `"routerlicious"`. See https://github.com/microsoft/FluidFramework/blob/8b739091960b4ab24660d85069ba5eca91140a7f/packages/test/test-drivers/src/routerliciousTestDriver.ts#L102).

 Fixing that in this PR.