### PR TITLE
Scope public exposure on merge-tree package

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -956,8 +956,8 @@ export class LocalReferenceCollection {
         next(): IteratorResult<LocalReference>;
         [Symbol.iterator](): any;
     };
-    // Warning: (ae-forgotten-export) The symbol "IRefsAtOffest" needs to be exported by the entry point index.d.ts
-    constructor(segment: ISegment, initialRefsByfOffset?: (IRefsAtOffest | undefined)[]);
+    // Warning: (ae-forgotten-export) The symbol "IRefsAtOffset" needs to be exported by the entry point index.d.ts
+    constructor(segment: ISegment, initialRefsByfOffset?: (IRefsAtOffset | undefined)[]);
     // (undocumented)
     addAfterTombstones(...refs: Iterable<LocalReference>[]): void;
     // (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -328,8 +328,6 @@ export class Heap<T> {
     // (undocumented)
     get(): T;
     // (undocumented)
-    L: T[];
-    // (undocumented)
     peek(): T;
 }
 
@@ -1412,8 +1410,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     // (undocumented)
     nodeFloor(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
-    nodeGather(node: RBNode<TKey, TData> | undefined, results: RBNode<TKey, TData>[], key: TKey, matcher: IRBMatcher<TKey, TData>): void;
-    // (undocumented)
     nodeGet(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
     nodeHeight(node: RBNode<TKey, TData> | undefined): number;
@@ -1728,7 +1724,6 @@ export const TreeMaintenanceSequenceNumber = -2;
 
 // @public (undocumented)
 export class TST<T> {
-    constructor();
     // (undocumented)
     collect(x: TSTNode<T> | undefined, prefix: TSTPrefix, q: string[]): void;
     // (undocumented)
@@ -1749,8 +1744,6 @@ export class TST<T> {
     neighbors(text: string, distance?: number): ProxString<T>[];
     // (undocumented)
     nodeGet(x: TSTNode<T> | undefined, key: string, d: number): TSTNode<T> | undefined;
-    // (undocumented)
-    nodeProximity(x: TSTNode<T> | undefined, prefix: TSTPrefix, d: number, pattern: string, distance: number, q: ProxString<T>[]): void;
     // (undocumented)
     nodePut(x: TSTNode<T> | undefined, key: string, val: T, d: number): TSTNode<T>;
     // (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -867,6 +867,9 @@ export class List<T> {
 }
 
 // @public (undocumented)
+export function ListMakeHead<U>(): List<U>;
+
+// @public (undocumented)
 export function loadSegments(content: string, segLimit: number, markers?: boolean, withProps?: boolean): ISegment[];
 
 // @public (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -776,13 +776,9 @@ export interface KeyComparer<TKey> {
 export class List<T> {
     constructor(isHead: boolean, data: T | undefined);
     // (undocumented)
-    add(data: T): List<T>;
-    // (undocumented)
     clear(): void;
     // (undocumented)
     count(): number;
-    // (undocumented)
-    data: T | undefined;
     // (undocumented)
     dequeue(): T | undefined;
     // (undocumented)
@@ -796,8 +792,6 @@ export class List<T> {
     // (undocumented)
     insertBefore(data: T): List<T>;
     // (undocumented)
-    insertEntry(entry: List<T>): List<T>;
-    // (undocumented)
     insertEntryBefore(entry: List<T>): List<T>;
     // (undocumented)
     isHead: boolean;
@@ -806,13 +800,9 @@ export class List<T> {
     // (undocumented)
     next: List<T>;
     // (undocumented)
-    popEntry(head: List<T>): List<T> | undefined;
-    // (undocumented)
     prev: List<T>;
     // (undocumented)
     push(data: T): void;
-    // (undocumented)
-    pushEntry(entry: List<T>): void;
     // (undocumented)
     some(fn: (data: T, l: List<T>) => boolean, rev?: boolean): T[];
     // (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -788,12 +788,6 @@ export class List<T> {
     // (undocumented)
     first(): T | undefined;
     // (undocumented)
-    insertAfter(data: T): List<T>;
-    // (undocumented)
-    insertBefore(data: T): List<T>;
-    // (undocumented)
-    insertEntryBefore(entry: List<T>): List<T>;
-    // (undocumented)
     isHead: boolean;
     // (undocumented)
     last(): T | undefined;

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -643,16 +643,7 @@ export interface InsertContext {
 }
 
 // @public (undocumented)
-export function integerRangeComparer(a: IIntegerRange, b: IIntegerRange): number;
-
-// @public (undocumented)
-export const integerRangeCopy: (r: IIntegerRange) => IIntegerRange;
-
-// @public (undocumented)
 export type IntegerRangeNode = RBNode<IIntegerRange, AugIntegerRangeNode>;
-
-// @public (undocumented)
-export function integerRangeOverlaps(a: IIntegerRange, b: IIntegerRange): boolean;
 
 // @public (undocumented)
 export const integerRangeToString: (range: IIntegerRange) => string;
@@ -683,14 +674,8 @@ export class IntegerRangeTree implements IRBAugmentation<IIntegerRange, AugInteg
     update(node: IntegerRangeNode): void;
 }
 
-// @public
-export function integerRangeUnion(a: IIntegerRange, b: IIntegerRange): IIntegerRange;
-
 // @public (undocumented)
 export function internedSpaces(n: number): string;
-
-// @public (undocumented)
-export const intervalComparer: (a: IInterval, b: IInterval) => number;
 
 // @public (undocumented)
 export type IntervalConflictResolver<TInterval> = (a: TInterval, b: TInterval) => TInterval;
@@ -835,9 +820,6 @@ export interface KeyComparer<TKey> {
 }
 
 // @public (undocumented)
-export function LinearDictionary<TKey, TData>(compareKeys: KeyComparer<TKey>): SortedDictionary<TKey, TData>;
-
-// @public (undocumented)
 export class List<T> {
     constructor(isHead: boolean, data: T | undefined);
     // (undocumented)
@@ -883,15 +865,6 @@ export class List<T> {
     // (undocumented)
     walk(fn: (data: T, l: List<T>) => void): void;
 }
-
-// @public (undocumented)
-export function ListMakeEntry<U>(data: U): List<U>;
-
-// @public (undocumented)
-export function ListMakeHead<U>(): List<U>;
-
-// @public (undocumented)
-export function ListRemoveEntry<U>(entry: List<U>): List<U> | undefined;
 
 // @public (undocumented)
 export function loadSegments(content: string, segLimit: number, markers?: boolean, withProps?: boolean): ISegment[];
@@ -1323,9 +1296,6 @@ export interface NodeAction<TClientData> {
 export const NonCollabClient = -2;
 
 // @public (undocumented)
-export const numberComparer: Comparer<number>;
-
-// @public (undocumented)
 export function ordinalToArray(ord: string): number[];
 
 // @public (undocumented)
@@ -1655,8 +1625,6 @@ export class SnapshotLegacy {
     constructor(mergeTree: MergeTree, logger: ITelemetryLogger, filename?: string | undefined, onCompletion?: (() => void) | undefined);
     // (undocumented)
     static readonly body = "body";
-    // (undocumented)
-    static readonly catchupOps = "catchupOps";
     emit(catchUpMsgs: ISequencedDocumentMessage[], serializer: IFluidSerializer, bind: IFluidHandle): ITree;
     // (undocumented)
     extractSync(): IJSONSegment[];
@@ -1671,15 +1639,6 @@ export class SnapshotLegacy {
     // (undocumented)
     static readonly sizeOfFirstChunk: number;
 }
-
-// @public (undocumented)
-export class SnapshotLoader {
-    constructor(runtime: IFluidDataStoreRuntime, client: Client, mergeTree: MergeTree, logger: ITelemetryLogger, serializer: IFluidSerializer);
-    // (undocumented)
-    initialize(services: IChannelStorageService): Promise<{
-        catchupOpsP: Promise<ISequencedDocumentMessage[]>;
-    }>;
-    }
 
 // @public (undocumented)
 export interface SortedDictionary<TKey, TData> extends Dictionary<TKey, TData> {

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1356,8 +1356,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     // (undocumented)
     aug?: IRBAugmentation<TKey, TData> | undefined;
     // (undocumented)
-    balance(input: RBNode<TKey, TData>): RBNode<TKey, TData>;
-    // (undocumented)
     ceil(key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
     compareKeys: KeyComparer<TKey>;
@@ -1365,8 +1363,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     contains(key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
     diag(): void;
-    // (undocumented)
-    flipColors(node: RBNode<TKey, TData>): void;
     // (undocumented)
     floor(key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
@@ -1392,10 +1388,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     // (undocumented)
     min(): RBNode<TKey, TData> | undefined;
     // (undocumented)
-    moveRedLeft(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
-    // (undocumented)
-    moveRedRight(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
-    // (undocumented)
     nodeCeil(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
     nodeFloor(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
@@ -1403,10 +1395,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     nodeGet(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
     nodeHeight(node: RBNode<TKey, TData> | undefined): number;
-    // (undocumented)
-    nodeMax(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
-    // (undocumented)
-    nodeMin(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
     // (undocumented)
     nodePut(node: RBNode<TKey, TData> | undefined, key: TKey, data: TData, conflict?: ConflictAction<TKey, TData>): RBNode<TKey, TData>;
     // (undocumented)
@@ -1422,8 +1410,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     // (undocumented)
     nodeWalkExactMatchesForward(node: RBNode<TKey, TData> | undefined, compareFn: (node: RBNode<TKey, TData>) => number, actionFn: (node: RBNode<TKey, TData>) => void, continueLeftFn: (number: number) => boolean, continueRightFn: (number: number) => boolean): void;
     // (undocumented)
-    oppositeColor(c: RBColor): RBColor;
-    // (undocumented)
     put(key: TKey, data: TData, conflict?: ConflictAction<TKey, TData>): void;
     // (undocumented)
     remove(key: TKey): void;
@@ -1433,10 +1419,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     removeMax(): void;
     // (undocumented)
     removeMin(): void;
-    // (undocumented)
-    rotateLeft(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
-    // (undocumented)
-    rotateRight(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
     // (undocumented)
     size(): number;
     // (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -17,12 +17,6 @@ import { Trace } from '@fluidframework/common-utils';
 export function addProperties(oldProps: PropertySet | undefined, newProps: PropertySet, op?: ICombiningOp, seq?: number): PropertySet;
 
 // @public (undocumented)
-export interface AugIntegerRangeNode {
-    // (undocumented)
-    minmax: IIntegerRange;
-}
-
-// @public (undocumented)
 export interface AugmentedIntervalNode {
     // (undocumented)
     minmax: IInterval;
@@ -639,9 +633,6 @@ export interface InsertContext {
     // (undocumented)
     structureChange?: boolean;
 }
-
-// @public (undocumented)
-export type IntegerRangeNode = RBNode<IIntegerRange, AugIntegerRangeNode>;
 
 // @public (undocumented)
 export const integerRangeToString: (range: IIntegerRange) => string;
@@ -1676,12 +1667,6 @@ export interface TSTNode<T> {
     right?: TSTNode<T>;
     // (undocumented)
     val?: T;
-}
-
-// @public (undocumented)
-export interface TSTPrefix {
-    // (undocumented)
-    text: string;
 }
 
 // @public (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -660,8 +660,6 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
     // (undocumented)
     continueSubtree(node: IntervalNode<T> | undefined, key: T): boolean;
     // (undocumented)
-    diag: boolean;
-    // (undocumented)
     intervals: RedBlackTree<T, AugmentedIntervalNode>;
     // (undocumented)
     map(fn: (x: T) => void): void;
@@ -674,19 +672,11 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
     // (undocumented)
     matchNode(node: IntervalNode<T> | undefined, key: T): boolean;
     // (undocumented)
-    printTiming(): void;
-    // (undocumented)
     put(x: T, conflict?: IntervalConflictResolver<T>): void;
-    // (undocumented)
-    putCount: number;
-    // (undocumented)
-    putTime: number;
     // (undocumented)
     remove(x: T): void;
     // (undocumented)
     removeExisting(x: T): void;
-    // (undocumented)
-    timePut: boolean;
     // (undocumented)
     update(node: IntervalNode<T>): void;
 }

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1356,8 +1356,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     // (undocumented)
     ceil(key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
-    contains(key: TKey): RBNode<TKey, TData> | undefined;
-    // (undocumented)
     diag(): void;
     // (undocumented)
     floor(key: TKey): RBNode<TKey, TData> | undefined;
@@ -1383,10 +1381,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     remove(key: TKey): void;
     // (undocumented)
     removeExisting(key: TKey): void;
-    // (undocumented)
-    removeMax(): void;
-    // (undocumented)
-    removeMin(): void;
     // (undocumented)
     size(): number;
     walk(actions: RBNodeActions<TKey, TData>): void;

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -9,7 +9,6 @@ import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
-import { IsoBuffer } from '@fluidframework/common-utils';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { Trace } from '@fluidframework/common-utils';
@@ -1652,39 +1651,10 @@ export class SegmentGroupCollection {
 }
 
 // @public (undocumented)
-export interface SnapChunk {
-    // (undocumented)
-    buffer?: IsoBuffer;
-    // (undocumented)
-    lengthBytes: number;
-    position: number;
-    // (undocumented)
-    sequenceLength: number;
-}
-
-// @public (undocumented)
-export interface SnapshotHeader {
-    // (undocumented)
-    chunkCount?: number;
-    // (undocumented)
-    indexOffset?: number;
-    // (undocumented)
-    minSeq?: number;
-    // (undocumented)
-    segmentsOffset?: number;
-    // (undocumented)
-    segmentsTotalLength: number;
-    // (undocumented)
-    seq: number;
-}
-
-// @public (undocumented)
 export class SnapshotLegacy {
     constructor(mergeTree: MergeTree, logger: ITelemetryLogger, filename?: string | undefined, onCompletion?: (() => void) | undefined);
     // (undocumented)
     static readonly body = "body";
-    // (undocumented)
-    buffer: IsoBuffer | undefined;
     // (undocumented)
     static readonly catchupOps = "catchupOps";
     emit(catchUpMsgs: ISequencedDocumentMessage[], serializer: IFluidSerializer, bind: IFluidHandle): ITree;
@@ -1692,28 +1662,12 @@ export class SnapshotLegacy {
     extractSync(): IJSONSegment[];
     // (undocumented)
     filename?: string | undefined;
-    // Warning: (ae-forgotten-export) The symbol "MergeTreeChunkLegacy" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    getSeqLengthSegs(allSegments: IJSONSegment[], allLengths: number[], approxSequenceLength: number, startIndex?: number): MergeTreeChunkLegacy;
     // (undocumented)
     static readonly header = "header";
-    // (undocumented)
-    header: SnapshotHeader | undefined;
-    // (undocumented)
-    logger: ITelemetryLogger;
     // (undocumented)
     mergeTree: MergeTree;
     // (undocumented)
     onCompletion?: (() => void) | undefined;
-    // (undocumented)
-    pendingChunk: SnapChunk | undefined;
-    // (undocumented)
-    segmentLengths: number[] | undefined;
-    // (undocumented)
-    segments: IJSONSegment[] | undefined;
-    // (undocumented)
-    seq: number | undefined;
     // (undocumented)
     static readonly sizeOfFirstChunk: number;
 }

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1725,31 +1725,15 @@ export const TreeMaintenanceSequenceNumber = -2;
 // @public (undocumented)
 export class TST<T> {
     // (undocumented)
-    collect(x: TSTNode<T> | undefined, prefix: TSTPrefix, q: string[]): void;
-    // (undocumented)
-    collectPairs(x: TSTNode<T> | undefined, prefix: TSTPrefix, q: TSTResult<T>[]): void;
-    // (undocumented)
-    contains(key: string): T | undefined;
-    // (undocumented)
     get(key: string): T | undefined;
     // (undocumented)
     keysWithPrefix(text: string): string[];
     // (undocumented)
     map(fn: (key: string, val: T) => void): void;
     // (undocumented)
-    mapNode(x: TSTNode<T> | undefined, prefix: TSTPrefix, fn: (key: string, val: T) => void): void;
-    // (undocumented)
-    match(pattern: string): string[];
-    // (undocumented)
     neighbors(text: string, distance?: number): ProxString<T>[];
     // (undocumented)
-    nodeGet(x: TSTNode<T> | undefined, key: string, d: number): TSTNode<T> | undefined;
-    // (undocumented)
-    nodePut(x: TSTNode<T> | undefined, key: string, val: T, d: number): TSTNode<T>;
-    // (undocumented)
     pairsWithPrefix(text: string): TSTResult<T>[];
-    // (undocumented)
-    patternCollect(x: TSTNode<T> | undefined, prefix: TSTPrefix, d: number, pattern: string, q: string[]): void;
     // (undocumented)
     put(key: string, val: T): void;
     // (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -649,32 +649,6 @@ export type IntegerRangeNode = RBNode<IIntegerRange, AugIntegerRangeNode>;
 export const integerRangeToString: (range: IIntegerRange) => string;
 
 // @public (undocumented)
-export class IntegerRangeTree implements IRBAugmentation<IIntegerRange, AugIntegerRangeNode>, IRBMatcher<IIntegerRange, AugIntegerRangeNode> {
-    // (undocumented)
-    continueSubtree(node: IntegerRangeNode | undefined, key: IIntegerRange): boolean;
-    // (undocumented)
-    diag: boolean;
-    // (undocumented)
-    match(r: IIntegerRange): RBNode<IIntegerRange, AugIntegerRangeNode>[];
-    // (undocumented)
-    matchNode(node: IntegerRangeNode | undefined, key: IIntegerRange): boolean;
-    // (undocumented)
-    matchPos(pos: number): RBNode<IIntegerRange, AugIntegerRangeNode>[];
-    // (undocumented)
-    nodeToString(node: IntegerRangeNode | undefined): string;
-    // (undocumented)
-    put(r: IIntegerRange): void;
-    // (undocumented)
-    ranges: RedBlackTree<IIntegerRange, AugIntegerRangeNode>;
-    // (undocumented)
-    remove(r: IIntegerRange): void;
-    // (undocumented)
-    toString(): string;
-    // (undocumented)
-    update(node: IntegerRangeNode): void;
-}
-
-// @public (undocumented)
 export function internedSpaces(n: number): string;
 
 // @public (undocumented)

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1354,11 +1354,7 @@ export interface RBNodeActions<TKey, TData> {
 export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> {
     constructor(compareKeys: KeyComparer<TKey>, aug?: IRBAugmentation<TKey, TData> | undefined);
     // (undocumented)
-    aug?: IRBAugmentation<TKey, TData> | undefined;
-    // (undocumented)
     ceil(key: TKey): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    compareKeys: KeyComparer<TKey>;
     // (undocumented)
     contains(key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
@@ -1370,15 +1366,9 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     // (undocumented)
     get(key: TKey): RBNode<TKey, TData> | undefined;
     // (undocumented)
-    height(): number;
-    // (undocumented)
     isEmpty(): boolean;
     // (undocumented)
-    isRed(node: RBNode<TKey, TData> | undefined): boolean;
-    // (undocumented)
     keys(): TKey[];
-    // (undocumented)
-    makeNode(key: TKey, data: TData, color: RBColor, size: number): RBNode<TKey, TData>;
     // (undocumented)
     map<TAccum>(action: PropertyAction<TKey, TData>, accum?: TAccum): void;
     // (undocumented)
@@ -1387,28 +1377,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     max(): RBNode<TKey, TData> | undefined;
     // (undocumented)
     min(): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    nodeCeil(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    nodeFloor(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    nodeGet(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    nodeHeight(node: RBNode<TKey, TData> | undefined): number;
-    // (undocumented)
-    nodePut(node: RBNode<TKey, TData> | undefined, key: TKey, data: TData, conflict?: ConflictAction<TKey, TData>): RBNode<TKey, TData>;
-    // (undocumented)
-    nodeRemove(node: RBNode<TKey, TData>, key: TKey): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    nodeRemoveMax(node: RBNode<TKey, TData>): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    nodeRemoveMin(node: RBNode<TKey, TData>): RBNode<TKey, TData> | undefined;
-    // (undocumented)
-    nodeSize(node: RBNode<TKey, TData> | undefined): number;
-    // (undocumented)
-    nodeWalkExactMatchesBackward(node: RBNode<TKey, TData> | undefined, compareFn: (node: RBNode<TKey, TData>) => number, actionFn: (node: RBNode<TKey, TData>) => void, continueLeftFn: (cmp: number) => boolean, continueRightFn: (cmp: number) => boolean): void;
-    // (undocumented)
-    nodeWalkExactMatchesForward(node: RBNode<TKey, TData> | undefined, compareFn: (node: RBNode<TKey, TData>) => number, actionFn: (node: RBNode<TKey, TData>) => void, continueLeftFn: (number: number) => boolean, continueRightFn: (number: number) => boolean): void;
     // (undocumented)
     put(key: TKey, data: TData, conflict?: ConflictAction<TKey, TData>): void;
     // (undocumented)
@@ -1421,8 +1389,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     removeMin(): void;
     // (undocumented)
     size(): number;
-    // (undocumented)
-    updateLocal(node: RBNode<TKey, TData>): void;
     walk(actions: RBNodeActions<TKey, TData>): void;
     // (undocumented)
     walkBackward(actions: RBNodeActions<TKey, TData>): void;

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -1404,8 +1404,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     // (undocumented)
     nodeHeight(node: RBNode<TKey, TData> | undefined): number;
     // (undocumented)
-    nodeMap<TAccum>(node: RBNode<TKey, TData> | undefined, action: PropertyAction<TKey, TData>, accum?: TAccum, start?: TKey, end?: TKey): boolean;
-    // (undocumented)
     nodeMax(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
     // (undocumented)
     nodeMin(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
@@ -1419,10 +1417,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     nodeRemoveMin(node: RBNode<TKey, TData>): RBNode<TKey, TData> | undefined;
     // (undocumented)
     nodeSize(node: RBNode<TKey, TData> | undefined): number;
-    // (undocumented)
-    nodeWalk(node: RBNode<TKey, TData> | undefined, actions: RBNodeActions<TKey, TData>): boolean;
-    // (undocumented)
-    nodeWalkBackward(node: RBNode<TKey, TData> | undefined, actions: RBNodeActions<TKey, TData>): boolean;
     // (undocumented)
     nodeWalkExactMatchesBackward(node: RBNode<TKey, TData> | undefined, compareFn: (node: RBNode<TKey, TData>) => number, actionFn: (node: RBNode<TKey, TData>) => void, continueLeftFn: (cmp: number) => boolean, continueRightFn: (cmp: number) => boolean): void;
     // (undocumented)
@@ -1439,8 +1433,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     removeMax(): void;
     // (undocumented)
     removeMin(): void;
-    // (undocumented)
-    root: RBNode<TKey, TData> | undefined;
     // (undocumented)
     rotateLeft(node: RBNode<TKey, TData>): RBNode<TKey, TData>;
     // (undocumented)

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -58,22 +58,22 @@ export function ListMakeHead<U>(): List<U> {
 }
 
 export class List<T> {
-    next: List<T>;
-    prev: List<T>;
+    public next: List<T>;
+    public prev: List<T>;
 
-    constructor(public isHead: boolean, public data: T | undefined) {
+    constructor(public isHead: boolean, private data: T | undefined) {
         this.prev = this;
         this.next = this;
     }
 
-    clear(): void {
+    public clear(): void {
         if (this.isHead) {
             this.prev = this;
             this.next = this;
         }
     }
 
-    add(data: T): List<T> {
+    private add(data: T): List<T> {
         const entry = ListMakeEntry(data);
         this.prev.next = entry;
         entry.next = this;
@@ -82,7 +82,7 @@ export class List<T> {
         return (entry);
     }
 
-    dequeue(): T | undefined {
+    public dequeue(): T | undefined {
         if (!this.empty()) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const removedEntry = ListRemoveEntry(this.next)!;
@@ -90,18 +90,18 @@ export class List<T> {
         }
     }
 
-    enqueue(data: T): List<T> {
+    public enqueue(data: T): List<T> {
         return this.add(data);
     }
 
-    walk(fn: (data: T, l: List<T>) => void): void {
+    public walk(fn: (data: T, l: List<T>) => void): void {
         for (let entry = this.next; !(entry.isHead); entry = entry.next) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             fn(entry.data!, entry);
         }
     }
 
-    some(fn: (data: T, l: List<T>) => boolean, rev?: boolean): T[] {
+    public some(fn: (data: T, l: List<T>) => boolean, rev?: boolean): T[] {
         const rtn: T[] = [];
         const start = rev ? this.prev : this.next;
         for (let entry = start; !(entry.isHead); entry = rev ? entry.prev : entry.next) {
@@ -119,7 +119,7 @@ export class List<T> {
         return rtn;
     }
 
-    count(): number {
+    public count(): number {
         let entry: List<T>;
         let i: number;
 
@@ -146,15 +146,7 @@ export class List<T> {
         return (this.next === this);
     }
 
-    pushEntry(entry: List<T>): void {
-        entry.isHead = false;
-        entry.next = this.next;
-        entry.prev = this;
-        this.next = entry;
-        entry.next.prev = entry;
-    }
-
-    push(data: T): void {
+    public push(data: T): void {
         const entry = ListMakeEntry(data);
         entry.data = data;
         entry.isHead = false;
@@ -162,24 +154,6 @@ export class List<T> {
         entry.prev = this;
         this.next = entry;
         entry.next.prev = entry;
-    }
-
-    popEntry(head: List<T>): List<T> | undefined {
-        if (this.next.isHead) {
-            return undefined;
-        }
-        else {
-            return ListRemoveEntry(this.next);
-        }
-    }
-
-    insertEntry(entry: List<T>): List<T> {
-        entry.isHead = false;
-        this.prev.next = entry;
-        entry.next = this;
-        entry.prev = this.prev;
-        this.prev = entry;
-        return entry;
     }
 
     insertAfter(data: T): List<T> {
@@ -212,7 +186,7 @@ export interface Comparer<T> {
 
 export class Heap<T> {
     private L: T[];
-    count() {
+    public count() {
         return this.L.length - 1;
     }
     constructor(a: T[], public comp: Comparer<T>) {
@@ -221,11 +195,11 @@ export class Heap<T> {
             this.add(a[i]);
         }
     }
-    peek() {
+    public peek() {
         return this.L[1];
     }
 
-    get() {
+    public get() {
         const x = this.L[1];
         this.L[1] = this.L[this.count()];
         this.L.pop();
@@ -233,7 +207,7 @@ export class Heap<T> {
         return x;
     }
 
-    add(x: T) {
+    public add(x: T) {
         this.L.push(x);
         this.fixup(this.count());
     }

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -38,7 +38,7 @@ export class Stack<T> {
     }
 }
 
-export function ListRemoveEntry<U>(entry: List<U>): List<U> | undefined {
+function ListRemoveEntry<U>(entry: List<U>): List<U> | undefined {
     if (entry === undefined) {
         return undefined;
     }
@@ -52,7 +52,7 @@ export function ListRemoveEntry<U>(entry: List<U>): List<U> | undefined {
     return (entry);
 }
 
-export function ListMakeEntry<U>(data: U): List<U> {
+function ListMakeEntry<U>(data: U): List<U> {
     return new List<U>(false, data);
 }
 
@@ -212,11 +212,6 @@ export interface Comparer<T> {
     compare(a: T, b: T): number;
     min: T;
 }
-
-export const numberComparer: Comparer<number> = {
-    min: Number.MIN_VALUE,
-    compare: (a, b) => a - b,
-};
 
 export class Heap<T> {
     L: T[];
@@ -1047,18 +1042,18 @@ export interface AugmentedIntervalNode {
  * @param a - A range
  * @param b - A range
  */
-export function integerRangeUnion(a: IIntegerRange, b: IIntegerRange) {
+function integerRangeUnion(a: IIntegerRange, b: IIntegerRange) {
     return <IIntegerRange>{
         start: Math.min(a.start, b.start),
         end: Math.max(a.end, b.end),
     };
 }
 
-export function integerRangeOverlaps(a: IIntegerRange, b: IIntegerRange) {
+function integerRangeOverlaps(a: IIntegerRange, b: IIntegerRange) {
     return (a.start < b.end) && (a.end > b.start);
 }
 
-export function integerRangeComparer(a: IIntegerRange, b: IIntegerRange) {
+function integerRangeComparer(a: IIntegerRange, b: IIntegerRange) {
     if (a.start === b.start) {
         return a.end - b.end;
     } else {
@@ -1066,7 +1061,7 @@ export function integerRangeComparer(a: IIntegerRange, b: IIntegerRange) {
     }
 }
 
-export const integerRangeCopy = (r: IIntegerRange) => <IIntegerRange>{ start: r.start, end: r.end };
+const integerRangeCopy = (r: IIntegerRange) => <IIntegerRange>{ start: r.start, end: r.end };
 
 export const integerRangeToString = (range: IIntegerRange) => `[${range.start},${range.end})`;
 
@@ -1164,7 +1159,7 @@ export interface IInterval {
     union(b: IInterval): IInterval;
 }
 
-export const intervalComparer = (a: IInterval, b: IInterval) => a.compare(b);
+const intervalComparer = (a: IInterval, b: IInterval) => a.compare(b);
 export type IntervalNode<T extends IInterval> = RBNode<T, AugmentedIntervalNode>;
 export type IntervalConflictResolver<TInterval> = (a: TInterval, b: TInterval) => TInterval;
 

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -212,7 +212,7 @@ export interface Comparer<T> {
 }
 
 export class Heap<T> {
-    L: T[];
+    private L: T[];
     count() {
         return this.L.length - 1;
     }
@@ -352,7 +352,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return results;
     }
 
-    nodeGather(
+    private nodeGather(
         node: RBNode<TKey, TData> | undefined,
         results: RBNode<TKey, TData>[],
         key: TKey,
@@ -1097,10 +1097,6 @@ export class TST<T> {
     private n = 0;
     private root: TSTNode<T> | undefined;
 
-    constructor() {
-
-    }
-
     size() {
         return this.n;
     }
@@ -1259,7 +1255,7 @@ export class TST<T> {
         }
     }
 
-    nodeProximity(
+    private nodeProximity(
         x: TSTNode<T> | undefined,
         prefix: TSTPrefix,
         d: number,

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -1097,15 +1097,15 @@ export class TST<T> {
     private n = 0;
     private root: TSTNode<T> | undefined;
 
-    size() {
+    public size() {
         return this.n;
     }
 
-    contains(key: string) {
+    private contains(key: string) {
         return this.get(key);
     }
 
-    get(key: string) {
+    public get(key: string) {
         const x = this.nodeGet(this.root, key, 0);
         if (x === undefined) {
             return undefined;
@@ -1113,7 +1113,7 @@ export class TST<T> {
         return x.val;
     }
 
-    nodeGet(x: TSTNode<T> | undefined, key: string, d: number): TSTNode<T> | undefined {
+    private nodeGet(x: TSTNode<T> | undefined, key: string, d: number): TSTNode<T> | undefined {
         if (x === undefined) {
             return undefined;
         }
@@ -1130,7 +1130,7 @@ export class TST<T> {
         else { return x; }
     }
 
-    put(key: string, val: T) {
+    public put(key: string, val: T) {
         if (!this.contains(key)) {
             this.n++;
         }
@@ -1138,7 +1138,7 @@ export class TST<T> {
         // console.log(`put ${key}`);
     }
 
-    nodePut(x: TSTNode<T> | undefined, key: string, val: T, d: number) {
+    private nodePut(x: TSTNode<T> | undefined, key: string, val: T, d: number) {
         let _x = x;
         const c = key.charAt(d);
         if (_x === undefined) {
@@ -1159,14 +1159,14 @@ export class TST<T> {
         return _x;
     }
 
-    neighbors(text: string, distance = 2) {
+    public neighbors(text: string, distance = 2) {
         let q = <ProxString<T>[]>[];
         this.nodeProximity(this.root, { text: "" }, 0, text, distance, q);
         q = q.filter((value) => (value.text.length > 0));
         return q;
     }
 
-    keysWithPrefix(text: string) {
+    public keysWithPrefix(text: string) {
         const q = <string[]>[];
         const x = this.nodeGet(this.root, text, 0);
         if (x === undefined) {
@@ -1179,7 +1179,7 @@ export class TST<T> {
         return q;
     }
 
-    collect(x: TSTNode<T> | undefined, prefix: TSTPrefix, q: string[]) {
+    private collect(x: TSTNode<T> | undefined, prefix: TSTPrefix, q: string[]) {
         if (x === undefined) {
             return;
         }
@@ -1191,7 +1191,7 @@ export class TST<T> {
         this.collect(x.right, prefix, q);
     }
 
-    mapNode(x: TSTNode<T> | undefined, prefix: TSTPrefix, fn: (key: string, val: T) => void) {
+    private mapNode(x: TSTNode<T> | undefined, prefix: TSTPrefix, fn: (key: string, val: T) => void) {
         if (x === undefined) {
             return;
         }
@@ -1204,11 +1204,11 @@ export class TST<T> {
         this.mapNode(x.right, prefix, fn);
     }
 
-    map(fn: (key: string, val: T) => void) {
+    public map(fn: (key: string, val: T) => void) {
         this.mapNode(this.root, { text: "" }, fn);
     }
 
-    pairsWithPrefix(text: string) {
+    public pairsWithPrefix(text: string) {
         const q = <TSTResult<T>[]>[];
         const x = this.nodeGet(this.root, text, 0);
         if (x === undefined) {
@@ -1221,7 +1221,7 @@ export class TST<T> {
         return q;
     }
 
-    collectPairs(x: TSTNode<T> | undefined, prefix: TSTPrefix, q: TSTResult<T>[]) {
+    private collectPairs(x: TSTNode<T> | undefined, prefix: TSTPrefix, q: TSTResult<T>[]) {
         if (x === undefined) {
             return;
         }
@@ -1231,28 +1231,6 @@ export class TST<T> {
         }
         this.collectPairs(x.mid, { text: prefix.text + x.c }, q);
         this.collectPairs(x.right, prefix, q);
-    }
-
-    patternCollect(x: TSTNode<T> | undefined, prefix: TSTPrefix, d: number, pattern: string, q: string[]) {
-        if (x === undefined) {
-            return;
-        }
-        const c = pattern.charAt(d);
-        if ((c === ".") || (c < x.c)) {
-            this.patternCollect(x.left, prefix, d, pattern, q);
-        }
-        else if ((c === ".") || (c === x.c)) {
-            if ((d === (pattern.length - 1)) && (x.val !== undefined)) {
-                q.push(prefix.text + x.c);
-            }
-            else if (d < (pattern.length - 1)) {
-                this.patternCollect(x.mid, { text: prefix.text + x.c },
-                    d + 1, pattern, q);
-            }
-        }
-        if ((c === ".") || (c > x.c)) {
-            this.patternCollect(x.right, prefix, d, pattern, q);
-        }
     }
 
     private nodeProximity(
@@ -1289,11 +1267,5 @@ export class TST<T> {
         if ((distance > 0) || (c > x.c)) {
             this.nodeProximity(x.right, prefix, d, pattern, distance, q);
         }
-    }
-
-    match(pattern: string) {
-        const q = <string[]>[];
-        this.patternCollect(this.root, { text: "" }, 0, pattern, q);
-        return q;
     }
 }

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -130,19 +130,19 @@ export class List<T> {
         return (i);
     }
 
-    first(): T | undefined {
+    public first(): T | undefined {
         if (!this.empty()) {
             return (this.next.data);
         }
     }
 
-    last(): T | undefined {
+    public last(): T | undefined {
         if (!this.empty()) {
             return (this.prev.data);
         }
     }
 
-    empty(): boolean {
+    public empty(): boolean {
         return (this.next === this);
     }
 
@@ -154,28 +154,6 @@ export class List<T> {
         entry.prev = this;
         this.next = entry;
         entry.next.prev = entry;
-    }
-
-    insertAfter(data: T): List<T> {
-        const entry: List<T> = ListMakeEntry(data);
-        entry.next = this.next;
-        entry.prev = this;
-        this.next = entry;
-        entry.next.prev = entry;
-        return (entry);
-    }
-
-    insertBefore(data: T): List<T> {
-        const entry = ListMakeEntry(data);
-        return this.insertEntryBefore(entry);
-    }
-
-    insertEntryBefore(entry: List<T>): List<T> {
-        this.prev.next = entry;
-        entry.next = this;
-        entry.prev = this.prev;
-        this.prev = entry;
-        return (entry);
     }
 }
 

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -315,10 +315,10 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     private nodeSize(node: RBNode<TKey, TData> | undefined) {
         return node ? node.size : 0;
     }
-    size() {
+    public size() {
         return this.nodeSize(this.root);
     }
-    isEmpty() {
+    public isEmpty() {
         return !this.root;
     }
     public get(key: TKey) {
@@ -341,11 +341,11 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
             }
         }
     }
-    contains(key: TKey) {
+    private contains(key: TKey) {
         return this.get(key);
     }
 
-    gather(key: TKey, matcher: IRBMatcher<TKey, TData>) {
+    public gather(key: TKey, matcher: IRBMatcher<TKey, TData>) {
         const results = [] as RBNode<TKey, TData>[];
         if (key !== undefined) {
             this.nodeGather(this.root, results, key, matcher);
@@ -371,7 +371,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    walkExactMatchesForward(
+    public walkExactMatchesForward(
         compareFn: (node: RBNode<TKey, TData>) => number,
         actionFn: (node: RBNode<TKey, TData>) => void,
         continueLeftFn: (number: number) => boolean,
@@ -400,7 +400,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    walkExactMatchesBackward(
+    public walkExactMatchesBackward(
         compareFn: (node: RBNode<TKey, TData>) => number,
         actionFn: (node: RBNode<TKey, TData>) => void,
         continueLeftFn: (number: number) => boolean,
@@ -506,19 +506,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    removeMin() {
-        if (this.root) {
-            if ((!this.isRed(this.root.left)) && (!this.isRed(this.root.right))) {
-                this.root.color = RBColor.RED;
-            }
-
-            this.root = this.nodeRemoveMin(this.root);
-            if (this.root) {
-                this.root.color = RBColor.BLACK;
-            }
-        }
-        // TODO: error on empty
-    }
     private nodeRemoveMin(node: RBNode<TKey, TData>) {
         let _node = node;
         if (_node.left) {
@@ -532,41 +519,6 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    removeMax() {
-        if (this.root) {
-            if ((!this.isRed(this.root.left)) && (!this.isRed(this.root.right))) {
-                this.root.color = RBColor.RED;
-            }
-
-            this.root = this.nodeRemoveMax(this.root);
-            if (this.root) {
-                this.root.color = RBColor.BLACK;
-            }
-        }
-        // TODO: error on empty
-    }
-
-    private nodeRemoveMax(node: RBNode<TKey, TData>) {
-        let _node = node;
-
-        if (this.isRed(_node.left)) {
-            _node = this.rotateRight(_node);
-        }
-
-        if (!_node.right) {
-            return undefined;
-        }
-
-        if ((!this.isRed(_node.right)) && (!this.isRed(_node.right.left))) {
-            _node = this.moveRedRight(_node);
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        _node.right = this.nodeRemoveMax(_node.right!);
-
-        return this.balance(_node);
-    }
-
     public remove(key: TKey) {
         if (key !== undefined) {
             if (!this.contains(key)) {
@@ -578,7 +530,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         // TODO: error on undefined key
     }
 
-    removeExisting(key: TKey) {
+    public removeExisting(key: TKey) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if ((!this.isRed(this.root!.left)) && (!this.isRed(this.root!.right))) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -17,20 +17,20 @@ import {
 } from "./base";
 
 export class Stack<T> {
-    items: T[] = [];
-    push(val: T) {
+    public items: T[] = [];
+    public push(val: T) {
         this.items.push(val);
     }
 
-    empty() {
+    public empty() {
         return this.items.length === 0;
     }
 
-    top(): T | undefined {
+    public top(): T | undefined {
         return this.items[this.items.length - 1];
     }
 
-    pop(): T | undefined {
+    public pop(): T | undefined {
         return this.items.pop();
     }
 }

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -299,17 +299,20 @@ export interface RBNodeActions<TKey, TData> {
 export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> {
     private root: RBNode<TKey, TData> | undefined;
 
-    constructor(public compareKeys: KeyComparer<TKey>, public aug?: IRBAugmentation<TKey, TData>) { }
+    constructor(
+        private readonly compareKeys: KeyComparer<TKey>,
+        private readonly aug?: IRBAugmentation<TKey, TData>,
+    ) { }
 
-    makeNode(key: TKey, data: TData, color: RBColor, size: number) {
+    private makeNode(key: TKey, data: TData, color: RBColor, size: number) {
         return <RBNode<TKey, TData>>{ key, data, color, size };
     }
 
-    isRed(node: RBNode<TKey, TData> | undefined) {
+    private isRed(node: RBNode<TKey, TData> | undefined) {
         return !!node && (node.color == RBColor.RED);
     }
 
-    nodeSize(node: RBNode<TKey, TData> | undefined) {
+    private nodeSize(node: RBNode<TKey, TData> | undefined) {
         return node ? node.size : 0;
     }
     size() {
@@ -323,7 +326,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
             return this.nodeGet(this.root, key);
         }
     }
-    nodeGet(node: RBNode<TKey, TData> | undefined, key: TKey) {
+    private nodeGet(node: RBNode<TKey, TData> | undefined, key: TKey) {
         let _node = node;
         while (_node) {
             const cmp = this.compareKeys(key, _node.key);
@@ -376,7 +379,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         this.nodeWalkExactMatchesForward(this.root, compareFn, actionFn, continueLeftFn, continueRightFn);
     }
 
-    nodeWalkExactMatchesForward(
+    private nodeWalkExactMatchesForward(
         node: RBNode<TKey, TData> | undefined,
         compareFn: (node: RBNode<TKey, TData>) => number,
         actionFn: (node: RBNode<TKey, TData>) => void,
@@ -405,7 +408,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         this.nodeWalkExactMatchesBackward(this.root, compareFn, actionFn, continueLeftFn, continueRightFn);
     }
 
-    nodeWalkExactMatchesBackward(
+    private nodeWalkExactMatchesBackward(
         node: RBNode<TKey, TData> | undefined,
         compareFn: (node: RBNode<TKey, TData>) => number,
         actionFn: (node: RBNode<TKey, TData>) => void,
@@ -438,7 +441,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    nodePut(
+    private nodePut(
         node: RBNode<TKey, TData> | undefined,
         key: TKey, data: TData,
         conflict?: ConflictAction<TKey, TData>,
@@ -489,7 +492,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    updateLocal(node: RBNode<TKey, TData>) {
+    private updateLocal(node: RBNode<TKey, TData>) {
         if (this.aug) {
             if (this.isRed(node.left)) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -516,7 +519,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
         // TODO: error on empty
     }
-    nodeRemoveMin(node: RBNode<TKey, TData>) {
+    private nodeRemoveMin(node: RBNode<TKey, TData>) {
         let _node = node;
         if (_node.left) {
             if ((!this.isRed(_node.left)) && (!this.isRed(_node.left.left))) {
@@ -543,7 +546,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         // TODO: error on empty
     }
 
-    nodeRemoveMax(node: RBNode<TKey, TData>) {
+    private nodeRemoveMax(node: RBNode<TKey, TData>) {
         let _node = node;
 
         if (this.isRed(_node.left)) {
@@ -586,7 +589,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         this.root = this.nodeRemove(this.root!, key);
     }
 
-    nodeRemove(node: RBNode<TKey, TData>, key: TKey) {
+    private nodeRemove(node: RBNode<TKey, TData>, key: TKey) {
         let _node = node;
         if (this.compareKeys(key, _node.key) < 0) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -622,10 +625,10 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
         return this.balance(_node);
     }
-    height() {
+    private height() {
         return this.nodeHeight(this.root);
     }
-    nodeHeight(node: RBNode<TKey, TData> | undefined): number {
+    private nodeHeight(node: RBNode<TKey, TData> | undefined): number {
         if (node === undefined) {
             return -1;
         }
@@ -640,7 +643,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    nodeFloor(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined {
+    private nodeFloor(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined {
         if (node) {
             const cmp = this.compareKeys(key, node.key);
             if (cmp == 0) {
@@ -667,7 +670,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    nodeCeil(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined {
+    private nodeCeil(node: RBNode<TKey, TData> | undefined, key: TKey): RBNode<TKey, TData> | undefined {
         if (node) {
             const cmp = this.compareKeys(key, node.key);
             if (cmp == 0) {
@@ -688,7 +691,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    min() {
+    public min() {
         if (this.root) {
             return this.nodeMin(this.root);
         }
@@ -703,7 +706,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    max() {
+    public max() {
         if (this.root) {
             return this.nodeMax(this.root);
         }

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -889,17 +889,11 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     }
 }
 
-export interface AugIntegerRangeNode {
-    minmax: IIntegerRange;
-}
-
 export interface AugmentedIntervalNode {
     minmax: IInterval;
 }
 
 export const integerRangeToString = (range: IIntegerRange) => `[${range.start},${range.end})`;
-
-export type IntegerRangeNode = RBNode<IIntegerRange, AugIntegerRangeNode>;
 
 export interface IInterval {
     clone(): IInterval;
@@ -1014,7 +1008,7 @@ export interface TSTNode<T> {
     val?: T;
 }
 
-export interface TSTPrefix {
+interface TSTPrefix {
     text: string;
 }
 

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -694,7 +694,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    nodeMin(node: RBNode<TKey, TData>): RBNode<TKey, TData> {
+    private nodeMin(node: RBNode<TKey, TData>): RBNode<TKey, TData> {
         if (!node.left) {
             return node;
         }
@@ -709,7 +709,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    nodeMax(node: RBNode<TKey, TData>): RBNode<TKey, TData> {
+    private nodeMax(node: RBNode<TKey, TData>): RBNode<TKey, TData> {
         if (!node.right) {
             return node;
         }
@@ -718,7 +718,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    rotateRight(node: RBNode<TKey, TData>) {
+    private rotateRight(node: RBNode<TKey, TData>) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const leftChild = node.left!;
         node.left = leftChild.right;
@@ -734,7 +734,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return leftChild;
     }
 
-    rotateLeft(node: RBNode<TKey, TData>) {
+    private rotateLeft(node: RBNode<TKey, TData>) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const rightChild = node.right!;
         node.right = rightChild.left;
@@ -750,11 +750,11 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return rightChild;
     }
 
-    oppositeColor(c: RBColor) {
+    private oppositeColor(c: RBColor) {
         return (c == RBColor.BLACK) ? RBColor.RED : RBColor.BLACK;
     }
 
-    flipColors(node: RBNode<TKey, TData>) {
+    private flipColors(node: RBNode<TKey, TData>) {
         node.color = this.oppositeColor(node.color);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         node.left!.color = this.oppositeColor(node.left!.color);
@@ -762,7 +762,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         node.right!.color = this.oppositeColor(node.right!.color);
     }
 
-    moveRedLeft(node: RBNode<TKey, TData>) {
+    private moveRedLeft(node: RBNode<TKey, TData>) {
         let _node = node;
         this.flipColors(_node);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -775,7 +775,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return _node;
     }
 
-    moveRedRight(node: RBNode<TKey, TData>) {
+    private moveRedRight(node: RBNode<TKey, TData>) {
         let _node = node;
         this.flipColors(_node);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -786,7 +786,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return _node;
     }
 
-    balance(input: RBNode<TKey, TData>) {
+    private balance(input: RBNode<TKey, TData>) {
         let node: RBNode<TKey, TData> | undefined = input;
         if (this.isRed(node.right)) {
             node = this.rotateLeft(node);
@@ -805,7 +805,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return node;
     }
 
-    mapRange<TAccum>(action: PropertyAction<TKey, TData>, accum?: TAccum, start?: TKey, end?: TKey) {
+    public mapRange<TAccum>(action: PropertyAction<TKey, TData>, accum?: TAccum, start?: TKey, end?: TKey) {
         this.nodeMap(this.root, action, start, end);
     }
 
@@ -814,7 +814,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         this.nodeMap(this.root, action, accum);
     }
 
-    keys() {
+    public keys() {
         const keyList = <TKey[]>[];
         const actions = <RBNodeActions<TKey, TData>>{
             showStructure: true,

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -297,10 +297,9 @@ export interface RBNodeActions<TKey, TData> {
 }
 
 export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> {
-    root: RBNode<TKey, TData> | undefined;
-    constructor(public compareKeys: KeyComparer<TKey>, public aug?: IRBAugmentation<TKey, TData>) {
+    private root: RBNode<TKey, TData> | undefined;
 
-    }
+    constructor(public compareKeys: KeyComparer<TKey>, public aug?: IRBAugmentation<TKey, TData>) { }
 
     makeNode(key: TKey, data: TData, color: RBColor, size: number) {
         return <RBNode<TKey, TData>>{ key, data, color, size };
@@ -319,7 +318,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     isEmpty() {
         return !this.root;
     }
-    get(key: TKey) {
+    public get(key: TKey) {
         if (key !== undefined) {
             return this.nodeGet(this.root, key);
         }
@@ -427,7 +426,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    put(key: TKey, data: TData, conflict?: ConflictAction<TKey, TData>) {
+    public put(key: TKey, data: TData, conflict?: ConflictAction<TKey, TData>) {
         if (key !== undefined) {
             if (data === undefined) {
                 this.remove(key);
@@ -565,7 +564,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return this.balance(_node);
     }
 
-    remove(key: TKey) {
+    public remove(key: TKey) {
         if (key !== undefined) {
             if (!this.contains(key)) {
                 return;
@@ -635,7 +634,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    floor(key: TKey) {
+    public floor(key: TKey) {
         if (!this.isEmpty()) {
             return this.nodeFloor(this.root, key);
         }
@@ -662,7 +661,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
     }
 
-    ceil(key: TKey) {
+    public ceil(key: TKey) {
         if (!this.isEmpty()) {
             return this.nodeCeil(this.root, key);
         }
@@ -810,7 +809,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         this.nodeMap(this.root, action, start, end);
     }
 
-    map<TAccum>(action: PropertyAction<TKey, TData>, accum?: TAccum) {
+    public map<TAccum>(action: PropertyAction<TKey, TData>, accum?: TAccum) {
         // TODO: optimize to avoid comparisons
         this.nodeMap(this.root, action, accum);
     }
@@ -833,15 +832,15 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
      * false, traversal is halted.
      * @param action - action to apply to each node
      */
-    walk(actions: RBNodeActions<TKey, TData>) {
+    public walk(actions: RBNodeActions<TKey, TData>) {
         this.nodeWalk(this.root, actions);
     }
 
-    walkBackward(actions: RBNodeActions<TKey, TData>) {
+    public walkBackward(actions: RBNodeActions<TKey, TData>) {
         this.nodeWalkBackward(this.root, actions);
     }
 
-    nodeWalk(node: RBNode<TKey, TData> | undefined, actions: RBNodeActions<TKey, TData>): boolean {
+    private nodeWalk(node: RBNode<TKey, TData> | undefined, actions: RBNodeActions<TKey, TData>): boolean {
         let go = true;
         if (node) {
             if (actions.pre) {
@@ -869,7 +868,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return go;
     }
 
-    nodeWalkBackward(node: RBNode<TKey, TData> | undefined, actions: RBNodeActions<TKey, TData>): boolean {
+    private nodeWalkBackward(node: RBNode<TKey, TData> | undefined, actions: RBNodeActions<TKey, TData>): boolean {
         let go = true;
         if (node) {
             if (actions.pre) {
@@ -897,7 +896,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         return go;
     }
 
-    nodeMap<TAccum>(
+    private nodeMap<TAccum>(
         node: RBNode<TKey, TData> | undefined,
         action: PropertyAction<TKey, TData>,
         accum?: TAccum,
@@ -930,7 +929,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
         }
         return go;
     }
-    diag() {
+    public diag() {
         console.log(`Height is ${this.height()}`);
     }
 }

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/consistent-type-assertions, eqeqeq, object-shorthand */
+/* eslint-disable @typescript-eslint/consistent-type-assertions, eqeqeq */
 /* eslint-disable no-bitwise */
 
 /* Remove once strictNullCheck is enabled */
@@ -13,7 +13,6 @@ import {
     ConflictAction,
     IIntegerRange,
     KeyComparer,
-    Property,
     PropertyAction,
     SortedDictionary,
 } from "./base";
@@ -267,98 +266,6 @@ export class Heap<T> {
             _k = j;
         }
     }
-}
-
-// For testing
-export function LinearDictionary<TKey, TData>(compareKeys: KeyComparer<TKey>): SortedDictionary<TKey, TData> {
-    const props: Property<TKey, TData>[] = [];
-    const compareProps = (a: Property<TKey, TData>, b: Property<TKey, TData>) => compareKeys(a.key, b.key);
-    function diag() {
-        console.log(`size is ${props.length}`);
-    }
-    function mapRange<TAccum>(action: PropertyAction<TKey, TData>, accum?: TAccum, start?: TKey, end?: TKey) {
-        let _start = start;
-        let _end = end;
-
-        if (props.length !== 0) { return; }
-
-        if (_start === undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            _start = min()!.key;
-        }
-        if (_end === undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            _end = max()!.key;
-        }
-        for (let i = 0, len = props.length; i < len; i++) {
-            if (compareKeys(_start, props[i].key) <= 0) {
-                const ecmp = compareKeys(_end, props[i].key);
-                if (ecmp < 0) {
-                    break;
-                }
-                if (!action(props[i], accum)) {
-                    break;
-                }
-            }
-        }
-    }
-
-    function map<TAccum>(action: PropertyAction<TKey, TData>, accum?: TAccum) {
-        mapRange(action, accum);
-    }
-
-    function min() {
-        if (props.length > 0) {
-            return props[0];
-        }
-    }
-    function max() {
-        if (props.length > 0) {
-            return props[props.length - 1];
-        }
-    }
-
-    function get(key: TKey) {
-        for (let i = 0, len = props.length; i < len; i++) {
-            if (props[i].key == key) {
-                return props[i];
-            }
-        }
-    }
-
-    function put(key: TKey, data: TData) {
-        if (key !== undefined) {
-            if (data === undefined) {
-                remove(key);
-            }
-            else {
-                props.push({ key, data });
-                props.sort(compareProps); // Go to insertion sort if too slow
-            }
-        }
-    }
-    function remove(key: TKey) {
-        if (key !== undefined) {
-            for (let i = 0, len = props.length; i < len; i++) {
-                if (props[i].key == key) {
-                    props[i] = props[len - 1];
-                    props.length--;
-                    props.sort(compareProps);
-                    break;
-                }
-            }
-        }
-    }
-    return {
-        min: min,
-        max: max,
-        map: map,
-        mapRange: mapRange,
-        remove: remove,
-        get: get,
-        put: put,
-        diag: diag,
-    };
 }
 
 export const enum RBColor {

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -8,7 +8,6 @@
 
 /* Remove once strictNullCheck is enabled */
 
-import { Trace } from "@fluidframework/common-utils";
 import {
     ConflictAction,
     IIntegerRange,
@@ -964,25 +963,17 @@ export type IntervalConflictResolver<TInterval> = (a: TInterval, b: TInterval) =
 
 export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, AugmentedIntervalNode>,
     IRBMatcher<T, AugmentedIntervalNode> {
-    intervals = new RedBlackTree<T, AugmentedIntervalNode>(intervalComparer, this);
-    diag = false;
-    timePut = false;
-    putTime = 0;
-    putCount = 0;
+    public intervals = new RedBlackTree<T, AugmentedIntervalNode>(intervalComparer, this);
 
-    printTiming() {
-        console.log(`put total = ${this.putTime} avg=${(this.putTime / this.putCount).toFixed(2)}`);
-    }
-
-    remove(x: T) {
+    public remove(x: T) {
         this.intervals.remove(x);
     }
 
-    removeExisting(x: T) {
+    public removeExisting(x: T) {
         this.intervals.removeExisting(x);
     }
 
-    put(x: T, conflict?: IntervalConflictResolver<T>) {
+    public put(x: T, conflict?: IntervalConflictResolver<T>) {
         let rbConflict: ConflictAction<T, AugmentedIntervalNode> | undefined;
         if (conflict) {
             rbConflict = (key: T, currentKey: T) => {
@@ -992,17 +983,10 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
                 };
             };
         }
-        if (this.timePut) {
-            const trace = Trace.start();
-            this.intervals.put(x, { minmax: x.clone() }, rbConflict);
-            this.putTime += trace.trace().duration * 1000;
-            this.putCount++;
-        } else {
-            this.intervals.put(x, { minmax: x.clone() }, rbConflict);
-        }
+        this.intervals.put(x, { minmax: x.clone() }, rbConflict);
     }
 
-    map(fn: (x: T) => void) {
+    public map(fn: (x: T) => void) {
         const actions = <RBNodeActions<T, AugmentedIntervalNode>>{
             infix: (node) => {
                 fn(node.key);
@@ -1013,7 +997,7 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
         this.intervals.walk(actions);
     }
 
-    mapUntil(fn: (X: T) => boolean) {
+    public mapUntil(fn: (X: T) => boolean) {
         const actions = <RBNodeActions<T, AugmentedIntervalNode>>{
             infix: (node) => {
                 return fn(node.key);
@@ -1023,7 +1007,7 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
         this.intervals.walk(actions);
     }
 
-    mapBackward(fn: (x: T) => void) {
+    public mapBackward(fn: (x: T) => void) {
         const actions = <RBNodeActions<T, AugmentedIntervalNode>>{
             infix: (node) => {
                 fn(node.key);
@@ -1034,27 +1018,20 @@ export class IntervalTree<T extends IInterval> implements IRBAugmentation<T, Aug
         this.intervals.walkBackward(actions);
     }
 
-   // TODO: toString()
-    match(x: T) {
+    // TODO: toString()
+    public match(x: T) {
         return this.intervals.gather(x, this);
     }
 
-    matchNode(node: IntervalNode<T> | undefined, key: T) {
+    public matchNode(node: IntervalNode<T> | undefined, key: T) {
         return !!node && node.key.overlaps(key);
     }
 
-    continueSubtree(node: IntervalNode<T> | undefined, key: T) {
-        const cont = !!node && node.data.minmax.overlaps(key);
-        if (this.diag && (!cont)) {
-            if (node) {
-                console.log(`skipping subtree of size ${node.size} key ${key.toString()}`);
-                // console.log(this.nodeToString(node));
-            }
-        }
-        return cont;
+    public continueSubtree(node: IntervalNode<T> | undefined, key: T) {
+        return !!node && node.data.minmax.overlaps(key);
     }
 
-    update(node: IntervalNode<T>) {
+    public update(node: IntervalNode<T>) {
         if (node.left && node.right) {
             node.data.minmax = node.key.union(
                 node.left.data.minmax.union(node.right.data.minmax));

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -5,32 +5,7 @@
 
 export * from "./base";
 export * from "./client";
-export {
-    AugIntegerRangeNode,
-    AugmentedIntervalNode,
-    Comparer,
-    Heap,
-    IInterval,
-    IntegerRangeNode,
-    integerRangeToString,
-    IntegerRangeTree,
-    IntervalConflictResolver,
-    IntervalNode,
-    IntervalTree,
-    IRBAugmentation,
-    IRBMatcher,
-    List,
-    ProxString,
-    RBColor,
-    RBNode,
-    RBNodeActions,
-    RedBlackTree,
-    Stack,
-    TST,
-    TSTNode,
-    TSTPrefix,
-    TSTResult,
-} from "./collections";
+export * from "./collections";
 export * from "./constants";
 export * from "./localReference";
 export * from "./mergeTree";

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
+export * from "./base";
+export * from "./client";
+export * from "./collections";
+export * from "./constants";
+export * from "./localReference";
 export * from "./mergeTree";
+export * from "./mergeTreeDeltaCallback";
+export * from "./mergeTreeTracking";
+export * from "./opBuilder";
 export * from "./ops";
 export * from "./properties";
-export * from "./snapshotlegacy";
-export * from "./collections";
-export * from "./base";
-export { loadSegments } from "./text";
-export * from "./client";
 export * from "./segmentGroupCollection";
-export * from "./mergeTreeDeltaCallback";
-export * from "./opBuilder";
-export * from "./mergeTreeTracking";
 export * from "./segmentPropertiesManager";
-export * from "./sortedSegmentSet";
-export * from "./textSegment";
-export * from "./localReference";
+export * from "./snapshotlegacy";
 export * from "./snapshotLoader";
-export * from "./constants";
+export * from "./sortedSegmentSet";
+export { loadSegments } from "./text";
+export * from "./textSegment";

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -5,7 +5,32 @@
 
 export * from "./base";
 export * from "./client";
-export * from "./collections";
+export {
+    AugIntegerRangeNode,
+    AugmentedIntervalNode,
+    Comparer,
+    Heap,
+    IInterval,
+    IntegerRangeNode,
+    integerRangeToString,
+    IntegerRangeTree,
+    IntervalConflictResolver,
+    IntervalNode,
+    IntervalTree,
+    IRBAugmentation,
+    IRBMatcher,
+    List,
+    ProxString,
+    RBColor,
+    RBNode,
+    RBNodeActions,
+    RedBlackTree,
+    Stack,
+    TST,
+    TSTNode,
+    TSTPrefix,
+    TSTResult,
+} from "./collections";
 export * from "./constants";
 export * from "./localReference";
 export * from "./mergeTree";
@@ -17,7 +42,6 @@ export * from "./properties";
 export * from "./segmentGroupCollection";
 export * from "./segmentPropertiesManager";
 export * from "./snapshotlegacy";
-export * from "./snapshotLoader";
 export * from "./sortedSegmentSet";
 export { loadSegments } from "./text";
 export * from "./textSegment";

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -122,7 +122,7 @@ export class LocalReference implements ReferencePosition {
     }
 }
 
-interface IRefsAtOffest {
+interface IRefsAtOffset {
     before?: LocalReference[];
     at?: LocalReference[];
     after?: LocalReference[];
@@ -139,12 +139,12 @@ export class LocalReferenceCollection {
     }
 
     public hierRefCount: number = 0;
-    private readonly refsByOffset: (IRefsAtOffest | undefined)[];
+    private readonly refsByOffset: (IRefsAtOffset | undefined)[];
     private refCount: number = 0;
 
     constructor(
         private readonly segment: ISegment,
-        initialRefsByfOffset = new Array<IRefsAtOffest | undefined>(segment.cachedLength)) {
+        initialRefsByfOffset = new Array<IRefsAtOffset | undefined>(segment.cachedLength)) {
         // Since javascript arrays are sparse the above won't populate any of the
         // indicies, but it will ensure the length property of the array matches
         // the length of the segment.

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -110,7 +110,6 @@ export class LocalReference implements ReferencePosition {
     }
 
     public getOffset() {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (this.segment?.removedSeq) {
             return 0;
         }

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -73,7 +73,7 @@ export class SnapshotV1 {
         this.segmentLengths = [];
     }
 
-    getSeqLengthSegs(
+    private getSeqLengthSegs(
         allSegments: JsonSegmentSpecs[],
         allLengths: number[],
         approxSequenceLength: number,

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert, IsoBuffer } from "@fluidframework/common-utils";
+import { assert } from "@fluidframework/common-utils";
 import {
     IFluidHandle,
     IFluidSerializer,
@@ -25,18 +25,7 @@ import {
     serializeAsMinSupportedVersion,
 } from "./snapshotChunks";
 
-// first three are index entry
-export interface SnapChunk {
-    /**
-     * Offset from beginning of segments.
-     */
-    position: number;
-    lengthBytes: number;
-    sequenceLength: number;
-    buffer?: IsoBuffer;
-}
-
-export interface SnapshotHeader {
+interface SnapshotHeader {
     chunkCount?: number;
     segmentsTotalLength: number;
     indexOffset?: number;
@@ -60,13 +49,11 @@ export class SnapshotLegacy {
     // for very chunky text, blob size can easily be 4x-8x of that number.
     public static readonly sizeOfFirstChunk: number = 10000;
 
-    header: SnapshotHeader | undefined;
-    seq: number | undefined;
-    buffer: IsoBuffer | undefined;
-    pendingChunk: SnapChunk | undefined;
-    segments: IJSONSegment[] | undefined;
-    segmentLengths: number[] | undefined;
-    logger: ITelemetryLogger;
+    private header: SnapshotHeader | undefined;
+    private seq: number | undefined;
+    private segments: IJSONSegment[] | undefined;
+    private segmentLengths: number[] | undefined;
+    private readonly logger: ITelemetryLogger;
     private readonly chunkSize: number;
 
     constructor(public mergeTree: MergeTree, logger: ITelemetryLogger, public filename?: string,
@@ -75,7 +62,7 @@ export class SnapshotLegacy {
         this.chunkSize = mergeTree?.options?.mergeTreeSnapshotChunkSize ?? SnapshotLegacy.sizeOfFirstChunk;
     }
 
-    getSeqLengthSegs(
+    private getSeqLengthSegs(
         allSegments: IJSONSegment[],
         allLengths: number[],
         approxSequenceLength: number,

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -39,7 +39,7 @@ interface SnapshotHeader {
 export class SnapshotLegacy {
     public static readonly header = "header";
     public static readonly body = "body";
-    public static readonly catchupOps = "catchupOps";
+    private static readonly catchupOps = "catchupOps";
 
     // Split snapshot into two entries - headers (small) and body (overflow) for faster loading initial content
     // Please note that this number has no direct relationship to anything other than size of raw text (characters).

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -13,11 +13,38 @@ import { DebugLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import JsDiff from "diff";
 import random from "random-js";
-import * as MergeTree from "../";
-import * as Base from "../base";
+import { Property } from "../base";
+import {
+    LinearDictionary,
+    ProxString,
+    RedBlackTree,
+    Stack,
+    TST,
+} from "../collections";
 import { LocalClientId, UnassignedSequenceNumber, UniversalSequenceNumber } from "../constants";
+import {
+    IJSONMarkerSegment,
+    IMergeNode,
+    ISegment,
+    Marker,
+    MergeTree,
+    reservedMarkerIdKey,
+    reservedRangeLabelsKey,
+    reservedTileLabelsKey,
+} from "../mergeTree";
+import { IMergeTreeDeltaOpArgs } from "../mergeTreeDeltaCallback";
 import { createRemoveRangeOp } from "../opBuilder";
-import { TextSegment } from "../textSegment";
+import {
+    IMergeTreeOp,
+    MergeTreeDeltaType,
+    ReferenceType,
+} from "../ops";
+import { SnapshotLegacy } from "../snapshotlegacy";
+import {
+    IJSONTextSegment,
+    MergeTreeTextHelper,
+    TextSegment,
+} from "../textSegment";
 import { specToSegment, TestClient } from "./testClient";
 import { TestServer } from "./testServer";
 import { insertText, loadTextFromFile, nodeOrdinalsHaveIntegrity } from "./testUtils";
@@ -33,12 +60,12 @@ const compareStrings = (a: string, b: string) => a.localeCompare(b);
 
 const compareNumbers = (a: number, b: number) => a - b;
 
-function printStringProperty(p: Base.Property<string, string>) {
+function printStringProperty(p: Property<string, string>) {
     log(`[${p.key}, ${p.data}]`);
     return true;
 }
 
-function printStringNumProperty(p: Base.Property<string, number>) {
+function printStringNumProperty(p: Property<string, number>) {
     log(`[${p.key}, ${p.data}]`);
     return true;
 }
@@ -51,7 +78,7 @@ export function simpleTest() {
         "Dingo", "wild",
     ];
 
-    const beast = new MergeTree.RedBlackTree<string, string>(compareStrings);
+    const beast = new RedBlackTree<string, string>(compareStrings);
     for (let i = 0; i < a.length; i += 2) {
         beast.put(a[i], a[i + 1]);
     }
@@ -81,7 +108,7 @@ export function integerTest1() {
     const imax = 10000000;
     const intCount = 1100000;
     const distribution = random.integer(imin, imax);
-    const beast = new MergeTree.RedBlackTree<number, number>(compareNumbers);
+    const beast = new RedBlackTree<number, number>(compareNumbers);
 
     const randInt = () => distribution(mt);
     const pos = new Array<number>(intCount);
@@ -126,8 +153,8 @@ export function fileTest1() {
     log(`len: ${a.length}`);
 
     for (let k = 0; k < iterCount; k++) {
-        const beast = new MergeTree.RedBlackTree<string, number>(compareStrings);
-        const linearBeast = MergeTree.LinearDictionary<string, number>(compareStrings);
+        const beast = new RedBlackTree<string, number>(compareStrings);
+        const linearBeast = LinearDictionary<string, number>(compareStrings);
         for (let i = 0, len = a.length; i < len; i++) {
             a[i] = a[i].trim();
             if (a[i].length > 0) {
@@ -168,18 +195,18 @@ export function fileTest1() {
     }
 }
 
-function printTextSegment(textSegment: MergeTree.ISegment, pos: number) {
+function printTextSegment(textSegment: ISegment, pos: number) {
     log(textSegment.toString());
     log(`at [${pos}, ${pos + textSegment.cachedLength})`);
     return true;
 }
 
-export function makeTextSegment(text: string): MergeTree.IMergeNode {
-    return new MergeTree.TextSegment(text);
+export function makeTextSegment(text: string): IMergeNode {
+    return new TextSegment(text);
 }
 
 function makeCollabTextSegment(text: string) {
-    return new MergeTree.TextSegment(text);
+    return new TextSegment(text);
 }
 
 function editFlat(source: string, s: number, dl: number, nt = "") {
@@ -189,16 +216,16 @@ function editFlat(source: string, s: number, dl: number, nt = "") {
 let accumTime = 0;
 
 function checkInsertMergeTree(
-    mergeTree: MergeTree.MergeTree,
-    pos: number, textSegment: MergeTree.TextSegment,
+    mergeTree: MergeTree,
+    pos: number, textSegment: TextSegment,
     verbose = false) {
-    let checkText = new MergeTree.MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
+    let checkText = new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
     checkText = editFlat(checkText, pos, 0, textSegment.text);
     const clockStart = clock();
     insertText(mergeTree, pos, UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber,
         textSegment.text, undefined, undefined);
     accumTime += elapsedMicroseconds(clockStart);
-    const updatedText = new MergeTree.MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
+    const updatedText = new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId);
     const result = (checkText == updatedText);
     if ((!result) && verbose) {
         log(`mismatch(o): ${checkText}`);
@@ -207,8 +234,8 @@ function checkInsertMergeTree(
     return result;
 }
 
-function checkMarkRemoveMergeTree(mergeTree: MergeTree.MergeTree, start: number, end: number, verbose = false) {
-    const helper = new MergeTree.MergeTreeTextHelper(mergeTree);
+function checkMarkRemoveMergeTree(mergeTree: MergeTree, start: number, end: number, verbose = false) {
+    const helper = new MergeTreeTextHelper(mergeTree);
     const origText = helper.getText(UniversalSequenceNumber, LocalClientId);
     const checkText = editFlat(origText, start, end - start);
     const clockStart = clock();
@@ -225,7 +252,7 @@ function checkMarkRemoveMergeTree(mergeTree: MergeTree.MergeTree, start: number,
 }
 
 export function mergeTreeTest1() {
-    const mergeTree = new MergeTree.MergeTree();
+    const mergeTree = new MergeTree();
     mergeTree.insertSegments(0, [TextSegment.make("the cat is on the mat")], UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, undefined);
     mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId, undefined);
     let fuzzySeg = makeCollabTextSegment("fuzzy, fuzzy ");
@@ -238,13 +265,13 @@ export function mergeTreeTest1() {
     mergeTree.map({ leaf: printTextSegment }, UniversalSequenceNumber, LocalClientId, undefined);
     const segoff = mergeTree.getContainingSegment(4, UniversalSequenceNumber, LocalClientId);
     log(mergeTree.getPosition(segoff.segment, UniversalSequenceNumber, LocalClientId));
-    log(new MergeTree.MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId));
+    log(new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId));
     log(mergeTree.toString());
     TestPack().firstTest();
 }
 
 export function mergeTreeLargeTest() {
-    const mergeTree = new MergeTree.MergeTree();
+    const mergeTree = new MergeTree();
     mergeTree.insertSegments(0, [TextSegment.make("the cat is on the mat")], UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, undefined);
     const insertCount = 1000000;
     const removeCount = 980000;
@@ -305,7 +332,7 @@ export function mergeTreeLargeTest() {
 }
 
 export function mergeTreeCheckedTest() {
-    const mergeTree = new MergeTree.MergeTree();
+    const mergeTree = new MergeTree();
     mergeTree.insertSegments(0, [TextSegment.make("the cat is on the mat")], UniversalSequenceNumber, LocalClientId, UniversalSequenceNumber, undefined);
     const insertCount = 2000;
     const removeCount = 1400;
@@ -458,7 +485,7 @@ export function mergeTreeCheckedTest() {
     return errorCount;
 }
 
-type SharedStringJSONSegment = MergeTree.IJSONTextSegment & MergeTree.IJSONMarkerSegment;
+type SharedStringJSONSegment = IJSONTextSegment & IJSONMarkerSegment;
 
 // enum AsyncRoundState {
 //     Insert,
@@ -536,9 +563,9 @@ export function TestPack(verbose = true) {
 
     function manyMergeTrees() {
         const mergeTreeCount = 2000000;
-        const a = <MergeTree.MergeTree[]>Array(mergeTreeCount);
+        const a = <MergeTree[]>Array(mergeTreeCount);
         for (let i = 0; i < mergeTreeCount; i++) {
-            a[i] = new MergeTree.MergeTree();
+            a[i] = new MergeTree();
         }
         for (; ;) { }
     }
@@ -648,8 +675,8 @@ export function TestPack(verbose = true) {
             const preLen = client.getLength();
             const pos = random.integer(0, preLen)(mt);
             if (includeMarkers) {
-                const insertMarkerOp = client.insertMarkerLocal(pos, MergeTree.ReferenceType.Tile,
-                    { [MergeTree.reservedTileLabelsKey]: "test" });
+                const insertMarkerOp = client.insertMarkerLocal(pos, ReferenceType.Tile,
+                    { [reservedTileLabelsKey]: "test" });
                 server.enqueueMsg(client.makeOpMessage(insertMarkerOp, UnassignedSequenceNumber));
             }
             const insertTextOp = client.insertTextLocal(pos, text);
@@ -1097,7 +1124,7 @@ export function TestPack(verbose = true) {
                 }
             }
         }
-        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTree.MergeTreeDeltaType.INSERT, 3));
+        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTreeDeltaType.INSERT, 3));
         if (verbose) {
             log(cli.mergeTree.toString());
             for (let clientId = 0; clientId < 4; clientId++) {
@@ -1106,8 +1133,8 @@ export function TestPack(verbose = true) {
                 }
             }
         }
-        cli.insertMarkerRemote(0, { refType: MergeTree.ReferenceType.Tile },
-            { [MergeTree.reservedTileLabelsKey]: ["peach"] },
+        cli.insertMarkerRemote(0, { refType: ReferenceType.Tile },
+            { [reservedTileLabelsKey]: ["peach"] },
             5, 0, "2");
         cli.insertTextRemote(6, "very ", undefined, 6, 2, "2");
         if (verbose) {
@@ -1118,7 +1145,7 @@ export function TestPack(verbose = true) {
                 }
             }
         }
-        const segs = <SharedStringJSONSegment[]>new MergeTree.SnapshotLegacy(cli.mergeTree, DebugLogger.create("fluid:snapshot")).extractSync();
+        const segs = <SharedStringJSONSegment[]>new SnapshotLegacy(cli.mergeTree, DebugLogger.create("fluid:snapshot")).extractSync();
         if (verbose) {
             for (const seg of segs) {
                 log(`${specToSegment(seg)}`);
@@ -1137,7 +1164,7 @@ export function TestPack(verbose = true) {
         cli.insertTextRemote(4, "HAS", undefined, 5, 1, "5");
         cli.insertTextLocal(19, " LANDED");
         cli.insertTextRemote(0, "yowza: ", undefined, 6, 4, "2");
-        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTree.MergeTreeDeltaType.INSERT, 7));
+        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTreeDeltaType.INSERT, 7));
         if (verbose) {
             log(cli.mergeTree.toString());
             for (let clientId = 0; clientId < 6; clientId++) {
@@ -1187,7 +1214,7 @@ export function TestPack(verbose = true) {
         }
         cli.insertTextRemote(9, " chaser", undefined, 3, 2, "3");
         cli.removeRangeLocal(12, 14);
-        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTree.MergeTreeDeltaType.REMOVE, 4));
+        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTreeDeltaType.REMOVE, 4));
         if (verbose) {
             log(cli.mergeTree.toString());
             for (let clientId = 0; clientId < 4; clientId++) {
@@ -1198,9 +1225,9 @@ export function TestPack(verbose = true) {
         }
         cli.insertTextLocal(14, "*yolumba*");
         cli.insertTextLocal(17, "-zanzibar-");
-        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTree.MergeTreeDeltaType.INSERT, 5));
+        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTreeDeltaType.INSERT, 5));
         cli.insertTextRemote(2, "(aaa)", undefined, 6, 4, "2");
-        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTree.MergeTreeDeltaType.INSERT, 7));
+        cli.mergeTree.ackPendingSegment(createLocalOpArgs(MergeTreeDeltaType.INSERT, 7));
         if (verbose) {
             log(cli.mergeTree.toString());
             for (let clientId = 0; clientId < 4; clientId++) {
@@ -1253,14 +1280,14 @@ export function TestPack(verbose = true) {
     };
 }
 
-function compareProxStrings(a: MergeTree.ProxString<number>, b: MergeTree.ProxString<number>) {
+function compareProxStrings(a: ProxString<number>, b: ProxString<number>) {
     const ascore = (a.invDistance * 200) + a.val;
     const bscore = (b.invDistance * 200) + b.val;
     return bscore - ascore;
 }
 
-const createLocalOpArgs = (type: MergeTree.MergeTreeDeltaType, sequenceNumber: number): MergeTree.IMergeTreeDeltaOpArgs => ({
-    op: { type } as MergeTree.IMergeTreeOp,
+const createLocalOpArgs = (type: MergeTreeDeltaType, sequenceNumber: number): IMergeTreeDeltaOpArgs => ({
+    op: { type } as IMergeTreeOp,
     sequencedMessage: {
         sequenceNumber,
     } as ISequencedDocumentMessage,
@@ -1287,7 +1314,7 @@ function shuffle<T>(a: T[]) {
 }
 
 function tst() {
-    const tree = new MergeTree.TST<boolean>();
+    const tree = new TST<boolean>();
     const entries = ["giraffe", "hut", "aardvark", "gold", "hover", "yurt", "hot", "antelope", "gift", "banana"];
     for (const entry of entries) {
         tree.put(entry, true);
@@ -1301,14 +1328,14 @@ function tst() {
     log(p2);
     const p3 = tree.neighbors("hat");
     log(p3);
-    const ntree = new MergeTree.TST<number>();
+    const ntree = new TST<number>();
     const filename = path.join(__dirname, "../../public/literature/dict.txt");
     const content = fs.readFileSync(filename, "utf8");
     const splitContent = content.split(/\r\n|\n/g);
     let corpusFilename = path.join(__dirname, "../../../public/literature/pp.txt");
     let corpusContent = fs.readFileSync(corpusFilename, "utf8");
-    const corpusTree = new MergeTree.TST<number>();
-    function addCorpus(corpusContent: string, corpusTree: MergeTree.TST<number>) {
+    const corpusTree = new TST<number>();
+    function addCorpus(corpusContent: string, corpusTree: TST<number>) {
         let count = 0;
         const re = /\b\w+\b/g;
         let result: RegExpExecArray;
@@ -1419,9 +1446,9 @@ export class DocumentTree {
         } else {
             let id: number;
             if (docNode.name === "pg") {
-                client.insertMarkerLocal(this.pos, MergeTree.ReferenceType.Tile,
+                client.insertMarkerLocal(this.pos, ReferenceType.Tile,
                     {
-                        [MergeTree.reservedTileLabelsKey]: [docNode.name],
+                        [reservedTileLabelsKey]: [docNode.name],
                     },
                 );
                 this.pos++;
@@ -1431,13 +1458,13 @@ export class DocumentTree {
                 docNode.id = trid;
                 id = this.ids[docNode.name]++;
                 const props = {
-                    [MergeTree.reservedMarkerIdKey]: trid,
-                    [MergeTree.reservedRangeLabelsKey]: [docNode.name],
+                    [reservedMarkerIdKey]: trid,
+                    [reservedRangeLabelsKey]: [docNode.name],
                 };
-                let behaviors = MergeTree.ReferenceType.NestBegin;
+                let behaviors = ReferenceType.NestBegin;
                 if (docNode.name === "row") {
-                    props[MergeTree.reservedTileLabelsKey] = ["pg"];
-                    behaviors |= MergeTree.ReferenceType.Tile;
+                    props[reservedTileLabelsKey] = ["pg"];
+                    behaviors |= ReferenceType.Tile;
                 }
 
                 client.insertMarkerLocal(this.pos, behaviors, props);
@@ -1448,10 +1475,10 @@ export class DocumentTree {
             }
             if (docNode.name !== "pg") {
                 const etrid = `end-${docNode.name}${id.toString()}`;
-                client.insertMarkerLocal(this.pos, MergeTree.ReferenceType.NestEnd,
+                client.insertMarkerLocal(this.pos, ReferenceType.NestEnd,
                     {
-                        [MergeTree.reservedMarkerIdKey]: etrid,
-                        [MergeTree.reservedRangeLabelsKey]: [docNode.name],
+                        [reservedMarkerIdKey]: etrid,
+                        [reservedRangeLabelsKey]: [docNode.name],
                     },
                 );
                 this.pos++;
@@ -1464,11 +1491,11 @@ export class DocumentTree {
         let pos = 0;
         const verbose = false;
         const stacks = {
-            box: new MergeTree.Stack<string>(),
-            row: new MergeTree.Stack<string>(),
+            box: new Stack<string>(),
+            row: new Stack<string>(),
         };
 
-        function printStack(stack: MergeTree.Stack<string>) {
+        function printStack(stack: Stack<string>) {
             // eslint-disable-next-line @typescript-eslint/no-for-in-array, guard-for-in, no-restricted-syntax
             for (const item in stack.items) {
                 log(item);
@@ -1482,7 +1509,7 @@ export class DocumentTree {
             }
         }
 
-        function checkTreeStackEmpty(treeStack: MergeTree.Stack<string>) {
+        function checkTreeStackEmpty(treeStack: Stack<string>) {
             if (!treeStack.empty()) {
                 errorCount++;
                 log("mismatch: client stack empty; tree stack not");
@@ -1500,7 +1527,7 @@ export class DocumentTree {
                 const cliStacks = client.getStackContext(pos, ["box", "row"]);
                 for (const name of ["box", "row"]) {
                     const cliStack = cliStacks[name];
-                    const treeStack = <MergeTree.Stack<string>>stacks[name];
+                    const treeStack = <Stack<string>>stacks[name];
                     if (cliStack) {
                         const len = cliStack.items.length;
                         if (len > 0) {
@@ -1509,7 +1536,7 @@ export class DocumentTree {
                                 errorCount++;
                             }
                             for (let i = 0; i < len; i++) {
-                                const cliMarkerId = (cliStack.items[i] as MergeTree.Marker).getId();
+                                const cliMarkerId = (cliStack.items[i] as Marker).getId();
                                 const treeMarkerId = treeStack.items[i];
                                 if (cliMarkerId !== treeMarkerId) {
                                     errorCount++;
@@ -1550,7 +1577,7 @@ export class DocumentTree {
                 if ((typeof prevChild !== "string") && (prevChild.name === "row")) {
                     const id = prevChild.id;
                     const endId = `end-${id}`;
-                    const endRowMarker = <MergeTree.Marker>client.getMarkerFromId(endId);
+                    const endRowMarker = <Marker>client.getMarkerFromId(endId);
                     const endRowPos = client.getPosition(endRowMarker);
                     prevPos = endRowPos;
                 }
@@ -1651,7 +1678,7 @@ function findReplacePerf(filename: string) {
         cFetches++;
 
         const curSeg = curSegOff.segment;
-        const textSeg = <MergeTree.TextSegment>curSeg;
+        const textSeg = <TextSegment>curSeg;
         if (textSeg != null) {
             const text = textSeg.text;
             const i = text.indexOf("the");

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -80,7 +80,6 @@ export class TestClient extends Client {
     declare public mergeTree: MergeTree;
 
     public readonly checkQ: List<string> = ListMakeHead<string>();
-    // eslint-disable-next-line max-len
     protected readonly q: List<ISequencedDocumentMessage> = ListMakeHead<ISequencedDocumentMessage>();
 
     private readonly textHelper: MergeTreeTextHelper;

--- a/packages/dds/sequence/src/test/testFarm.ts
+++ b/packages/dds/sequence/src/test/testFarm.ts
@@ -1551,59 +1551,6 @@ export class DocumentTree {
     }
 }
 
-const docRanges = <MergeTree.IIntegerRange[]>[
-    { start: 0, end: 20 },
-    { start: 8, end: 12 },
-    { start: 8, end: 14 },
-    { start: 20, end: 24 },
-    { start: 11, end: 15 },
-    { start: 16, end: 33 },
-    { start: 19, end: 24 },
-    { start: 22, end: 80 },
-    { start: 25, end: 29 },
-    { start: 30, end: 32 },
-    { start: 41, end: 49 },
-    { start: 41, end: 49 },
-    { start: 41, end: 49 },
-    { start: 51, end: 69 },
-    { start: 55, end: 58 },
-    { start: 60, end: 71 },
-    { start: 81, end: 99 },
-    { start: 85, end: 105 },
-    { start: 9, end: 34 },
-];
-
-const testRanges = <MergeTree.IIntegerRange[]>[
-    { start: 9, end: 20 },
-    { start: 8, end: 10 },
-    { start: 82, end: 110 },
-    { start: 54, end: 56 },
-    { start: 57, end: 57 },
-    { start: 58, end: 58 },
-    { start: 22, end: 48 },
-    { start: 3, end: 11 },
-    { start: 43, end: 58 },
-    { start: 19, end: 31 },
-];
-
-function testRangeTree() {
-    const rangeTree = new MergeTree.IntegerRangeTree();
-    for (const docRange of docRanges) {
-        rangeTree.put(docRange);
-    }
-    console.log(rangeTree.toString());
-    function matchRange(r: MergeTree.IIntegerRange) {
-        console.log(`match range ${MergeTree.integerRangeToString(r)}`);
-        const results = rangeTree.match(r);
-        for (const result of results) {
-            console.log(MergeTree.integerRangeToString(result.key));
-        }
-    }
-    for (const testRange of testRanges) {
-        matchRange(testRange);
-    }
-}
-
 export function intervalTest() {
     const mt = random.engines.mt19937();
     mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
@@ -1679,7 +1626,6 @@ export function tstSimpleCmd() {
     }
 }
 
-const rangeTreeTest = false;
 const testPropCopy = false;
 const docTree = false;
 const chktst = false;
@@ -1699,10 +1645,6 @@ if (ivalTest) {
 
 if (tstTest) {
     tstSimpleCmd();
-}
-
-if (rangeTreeTest) {
-    testRangeTree();
 }
 
 if (chktst) {


### PR DESCRIPTION
This change reduces the public API surface exported from the merge-tree package.  Primarily for the purpose of reducing our potential maintenance obligations and simplifying our public documentation.

I tried to be fairly aggressive, but I'm also sure we could go further.