### PR TITLE
Quick fix for the current issue with updating snapshots

### DIFF
--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -24,10 +24,10 @@
     "lint:fix": "npm run eslint:fix",
     "test": "npm run test:mocha",
     "test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
-    "test:mocha": "mocha --experimental-worker --recursive dist/test --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
+    "test:mocha": "mocha --experimental-worker dist/test --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
     "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-    "test:new": "node --experimental-worker dist/generateNewSnapshotFiles.js",
-    "test:update": "node --experimental-worker dist/updateSnapshotFiles.js",
+    "test:new": "mocha --experimental-worker dist/test/generate/new.spec.js --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
+    "test:update": "mocha --experimental-worker dist/test/generate/update.spec.js --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace"

--- a/packages/test/snapshots/src/generateNewSnapshotFiles.ts
+++ b/packages/test/snapshots/src/generateNewSnapshotFiles.ts
@@ -1,9 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-import { Mode, processContent } from "./replayMultipleFiles";
-
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-processContent(Mode.NewSnapshots);

--- a/packages/test/snapshots/src/test/generate/new.spec.ts
+++ b/packages/test/snapshots/src/test/generate/new.spec.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Mode, processContent } from "../../replayMultipleFiles";
+
+describe("Create snapshots", function() {
+    this.timeout(300000);
+
+    it("Create snapshots", async () => {
+        await processContent(Mode.NewSnapshots);
+    });
+});

--- a/packages/test/snapshots/src/test/generate/update.spec.ts
+++ b/packages/test/snapshots/src/test/generate/update.spec.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Mode, processContent } from "../../replayMultipleFiles";
+
+describe("Update snapshots", function() {
+    this.timeout(300000);
+
+    it("Update snapshots", async () => {
+        await processContent(Mode.UpdateSnapshots);
+    });
+});

--- a/packages/test/snapshots/src/updateSnapshotFiles.ts
+++ b/packages/test/snapshots/src/updateSnapshotFiles.ts
@@ -1,9 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-import { Mode, processContent } from "./replayMultipleFiles";
-
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-processContent(Mode.UpdateSnapshots);


### PR DESCRIPTION
Currently, generating snapshots hangs. However, the mocha test harness does not. 

I still believe there is value in investigating exactly why the tool is failing (https://github.com/microsoft/FluidFramework/issues/8335) as it may uncover a more serious issue with either the present tool or the replay tool or the container lifecycle itself. But at the same time, it would be great to incorporate this process in the test pipeline to at least have it running more often - not included in this PR.