### PR TITLE
Git WholeSummary fix: use versionId not sha

### DIFF
--- a/server/routerlicious/packages/services-shared/src/wholeSummaryReadGitManager.ts
+++ b/server/routerlicious/packages/services-shared/src/wholeSummaryReadGitManager.ts
@@ -31,7 +31,7 @@ export class WholeSummaryReadGitManager {
         if (versionId === "latest") {
             versionId = await this.getLatestVersion();
         }
-        const rawTree = await this.readTreeRecursive(sha);
+        const rawTree = await this.readTreeRecursive(versionId);
         const wholeFlatSummaryTreeEntries: IWholeFlatSummaryTreeEntry[] = [];
         const wholeFlatSummaryBlobPs: Promise<IWholeFlatSummaryBlob>[] = [];
         rawTree.tree.forEach((treeEntry) => {


### PR DESCRIPTION
While trying to use the abstracted whole summary logic from #8184 I came across this bug. This has 0 impact at the moment because the code is not yet used by anything.