### PR TITLE
r11s-driver: remove duplicate cache put code

### DIFF
--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -210,13 +210,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
             ));
         }
 
-        await Promise.all([
-            this.snapshotTreeCache.put(
-                snapshotId,
-                normalizedWholeSummary.snapshotTree,
-            ),
-            this.initBlobCache(normalizedWholeSummary.blobs),
-        ]);
+        await Promise.all(cachePs);
 
         return { id: snapshotId, snapshotTree: normalizedWholeSummary.snapshotTree};
     }


### PR DESCRIPTION
The cache.put code when caching a summary is duplicated. This probably has no effect other than some extra unnecessary operations, and not waiting for the "latest" id to be cached before continuing. Only impact would be on performance.