### PR TITLE
Revert #8269 - Removed bindToContext from IFluidDataStoreChannel

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,7 +14,6 @@ There are a few steps you can take to write a good change note and avoid needing
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)
 - [`OdspDocumentInfo` type replaced with `OdspFluidDataStoreLocator` interface](#OdspDocumentInfo-type-replaced-with-OdspFluidDataStoreLocator-interface)
 - [close() removed from IDocumentDeltaConnection](#close-removed-from-IDocumentDeltaConnection)
-- [Removed bindToContext from IFluidDataStoreChannel](#Removed-bindToContext-from-IFluidDataStoreChannel)
 - [Remove `IOdspResolvedUrl.sharingLinkToRedeem` and use `IOdspResolvedUrl.shareLinkInfo` instead](#Remove-IOdspResolvedUrl.sharingLinkToRedeem-and-use-IOdspResolvedUrl.shareLinkInfo-instead)
 - [Replace `createCreateNewRequest` function with `createOdspCreateContainerRequest` function](#Replace-createCreateNewRequest-function-with-createOdspCreateContainerRequest-function)
 
@@ -23,9 +22,6 @@ The `chaincodePackage` property on `Container` was deprecated in 0.28, and has n
 
 ### `OdspDocumentInfo` type replaced with `OdspFluidDataStoreLocator` interface
 The `OdspDocumentInfo` type is removed from `odsp-driver` package. It is removed from `packages\drivers\odsp-driver\src\contractsPublic.ts` and replaced with `OdspFluidDataStoreLocator` interface as parameter in `OdspDriverUrlResolverForShareLink.createDocumentUrl()`. If there are any instances of `OdspDocumentInfo` type used, it can be simply replaced with `OdspFluidDataStoreLocator` interface.
-
-### Removed bindToContext from IFluidDataStoreChannel
-bindToContext in IFluidDataStoreChannel was deprecated in [0.50](#Deprecated-bindToContext-in-IFluidDataStoreChannel). This has now been removed.
 
 ### Remove `IOdspResolvedUrl.sharingLinkToRedeem` and use `IOdspResolvedUrl.shareLinkInfo` instead
 The `sharingLinkToRedeem` property is removed from the `IOdspResolvedUrl` interface. The property can be accesed from `IOdspResolvedUrl.shareLinkInfo` instead.

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -53,6 +53,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     bind(handle: IFluidHandle): void;
     bindChannel(channel: IChannel): void;
+    bindToContext(): void;
     // (undocumented)
     get channelsRoutingContext(): this;
     // (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -120,6 +120,8 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     applyStashedOp(content: any): Promise<unknown>;
     attachGraph(): void;
     readonly attachState: AttachState;
+    // @deprecated (undocumented)
+    bindToContext(): void;
     getAttachSummary(): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     // (undocumented)

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -353,6 +353,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     bindChannel(channel: IChannel): void;
     // (undocumented)
+    bindToContext(): void;
+    // (undocumented)
     get channelsRoutingContext(): IFluidHandleContext;
     // (undocumented)
     clientId: string | undefined;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -14,6 +14,7 @@ import {
     IAudience,
     IDeltaManager,
     ContainerWarning,
+    BindState,
     AttachState,
     ILoaderOptions,
 } from "@fluidframework/container-definitions";
@@ -159,6 +160,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private readonly contextsDeferred = new Map<string, Deferred<IChannelContext>>();
     private readonly pendingAttach = new Map<string, IAttachMessage>();
 
+    private bindState: BindState;
     // For new data stores, this is used to break the recursion while attaching the graph. The graph must be attached
     // before the data store can move to Attached state (see _attachState) and become live.
     // For existing data stores, the graph is always attached.
@@ -286,8 +288,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         }
 
         this.attachListener();
-        // If exists on storage or loaded from a snapshot, its graph should be already be attached.
-        this.graphAttachState = existing ? AttachState.Attached : AttachState.Detached;
+        // If exists on storage or loaded from a snapshot, it should already be binded.
+        this.bindState = existing ? BindState.Bound : BindState.NotBound;
         this._attachState = dataStoreContext.attachState;
 
         // If it's existing we know it has been attached.
@@ -430,8 +432,23 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         });
 
         this.localChannelContextQueue.clear();
-        this.dataStoreContext.bindToContext();
+        this.bindToContext();
         this.graphAttachState = AttachState.Attached;
+    }
+
+    /**
+     * Binds this runtime to the container
+     * This includes the following:
+     * 1. Sending an Attach op that includes all existing state
+     * 2. Attaching the graph if the data store becomes attached.
+     */
+     public bindToContext() {
+        if (this.bindState !== BindState.NotBound) {
+            return;
+        }
+        this.bindState = BindState.Binding;
+        this.dataStoreContext.bindToContext();
+        this.bindState = BindState.Bound;
     }
 
     public bind(handle: IFluidHandle): void {
@@ -696,6 +713,11 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public getAttachSummary(): ISummaryTreeWithStats {
+        // back-compat 0.50: attachGraph() will be called when creating a root data store or when adding the handle
+        // of a non-root data store to an already bound DDS.
+        // To be removed when N >= 0.52
+        this.attachGraph();
+
         const summaryBuilder = new SummaryTreeBuilder();
 
         // Craft the .attributes file for each shared object
@@ -760,9 +782,9 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         channel.handle.attachGraph();
 
         assert(this.isAttached, 0x182 /* "Data store should be attached to attach the channel." */);
-        // Get the object snapshot only if its graph is attached too, because if the graph is attaching,
-        // then it would get included in the data store snapshot.
-        if (this.graphAttachState === AttachState.Attached) {
+        // Get the object snapshot only if the data store is Bound and its graph is attached too,
+        // because if the graph is attaching, then it would get included in the data store snapshot.
+        if (this.bindState === BindState.Bound && this.graphAttachState === AttachState.Attached) {
             const summarizeResult = summarizeChannel(channel, true /* fullTree */, false /* trackState */);
             // Attach message needs the summary in ITree format. Convert the ISummaryTree into an ITree.
             const snapshot = convertSummaryTreeToITree(summarizeResult.summary);
@@ -855,20 +877,16 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private attachListener() {
         this.setMaxListeners(Number.MAX_SAFE_INTEGER);
         this.dataStoreContext.once("attaching", () => {
-            assert(
-                this.graphAttachState !== AttachState.Detached,
-                "Data store attaching should not occur if its graph is detached",
-            );
+            assert(this.bindState !== BindState.NotBound,
+                0x186 /* "Data store attaching should not occur if it is not bound" */);
             this._attachState = AttachState.Attaching;
             // This promise resolution will be moved to attached event once we fix the scheduler.
             this.deferredAttached.resolve();
             this.emit("attaching");
         });
         this.dataStoreContext.once("attached", () => {
-            assert(
-                this.graphAttachState === AttachState.Attached,
-                "Data store should only be attached after its graph is attached",
-            );
+            assert(this.bindState === BindState.Bound,
+                0x187 /* "Data store should only be attached after it is bound" */);
             this._attachState = AttachState.Attached;
             this.emit("attached");
         });

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -159,6 +159,13 @@ export interface IFluidDataStoreChannel extends
     readonly attachState: AttachState;
 
     /**
+     * @deprecated - This is an internal method that should not be exposed.
+     * Called to bind the runtime to the container.
+     * If the container is not attached to storage, then this would also be unknown to other clients.
+     */
+     bindToContext(): void;
+
+    /**
      * Runs through the graph and attaches the bound handles. Then binds this runtime to the container.
      */
     attachGraph(): void;

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -438,6 +438,10 @@ export class MockFluidDataStoreRuntime extends EventEmitter
         return;
     }
 
+    public bindToContext(): void {
+        return;
+    }
+
     public bind(handle: IFluidHandle): void {
         return;
     }


### PR DESCRIPTION
We cannot remove bindToContext yet because of this bug - https://github.com/microsoft/FluidFramework/issues/8305