### PR TITLE
Moved GC unreferenced timer logic from data stores layer to container runtime

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -194,7 +194,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
     get summarizerClientId(): string | undefined;
-    updateUsedRoutes(usedRoutes: string[]): IUsedStateStats;
+    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
     }
@@ -337,7 +337,7 @@ export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
 // @public
 export interface IGarbageCollectionRuntime {
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    updateUsedRoutes(usedRoutes: string[]): IUsedStateStats;
+    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
 }
 
 // @public (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -299,7 +299,6 @@ export interface ISummarizerNodeConfig {
 // @public (undocumented)
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
     readonly gcDisabled?: boolean;
-    readonly maxUnreferencedDurationMs?: number;
 }
 
 // @public

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -923,7 +923,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
          * time when a node becomes unreferenced.
          * For now, we use the timestamp of the last op for gcTimestamp. However, there can be cases where
          * we don't have an op (on demand summaries for instance). In those cases, we will use the timestamp
-         * of this client's connection - https://github.com/microsoft/FluidFramework/issues/7152.
+         * of this client's connection - https://github.com/microsoft/FluidFramework/issues/8375.
          */
         const getCurrentTimestamp = () => {
             return this.deltaManager.lastMessage?.timestamp ?? performance.now();

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -75,6 +75,7 @@ export class DataStores implements IDisposable {
             (id: string, createParam: CreateChildSummarizerNodeParam)  => CreateChildSummarizerNodeFn,
         private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
+        private readonly dataStoreChanged: (id: string) => void,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
         this.logger = ChildLogger.create(baseLogger);
@@ -281,6 +282,9 @@ export class DataStores implements IDisposable {
         const context = this.contexts.get(envelope.address);
         assert(!!context, 0x162 /* "There should be a store context for the op" */);
         context.process(transformed, local, localMessageMetadata);
+
+        // Notify that a data store changed. This is used to detect if a deleted data store is being used.
+        this.dataStoreChanged(envelope.address);
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<FluidDataStoreContext> {
@@ -473,8 +477,10 @@ export class DataStores implements IDisposable {
      * @returns the statistics of the used state of the data stores.
      */
     public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats {
+        // Remove this node's route ("/") and update data stores' used routes.
+        const dsUsedRoutes = usedRoutes.filter((id: string) => { return id !== "/"; });
         // Get a map of data store ids to routes used in it.
-        const usedDataStoreRoutes = getChildNodesUsedRoutes(usedRoutes);
+        const usedDataStoreRoutes = getChildNodesUsedRoutes(dsUsedRoutes);
 
         // Verify that the used routes are correct.
         for (const [id] of usedDataStoreRoutes) {

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -4,15 +4,21 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { runGarbageCollection } from "@fluidframework/garbage-collector";
+import { assert, LazyPromise } from "@fluidframework/common-utils";
+import { IGCResult, runGarbageCollection } from "@fluidframework/garbage-collector";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
+import {
+    IGarbageCollectionData,
+    IGarbageCollectionSummaryDetails,
+} from "@fluidframework/runtime-definitions";
 import { ReadAndParseBlob, RefreshSummaryResult } from "@fluidframework/runtime-utils";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
 
 import { IGCRuntimeOptions } from "./containerRuntime";
+import { getSummaryForDatastores } from "./dataStores";
 import { getLocalStorageFeatureGate } from "./localStorageFeatureGates";
 import {
+    gcBlobName,
     getGCVersion,
     GCVersion,
     IContainerRuntimeMetadata,
@@ -28,6 +34,8 @@ const runGCKey = "FluidRunGC";
 const gcTestModeKey = "FluidGCTestMode";
 // Local storage key to turn GC sweep on / off.
 const runSweepKey = "FluidRunSweep";
+
+const defaultDeleteTimeoutMs = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /** The used state statistics of a node. */
 export interface IUsedStateStats {
@@ -48,7 +56,7 @@ export interface IGarbageCollectionRuntime {
     /** Returns the garbage collection data of the runtime. */
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     /** After GC has run, called to notify the runtime of routes that are used in it. */
-    updateUsedRoutes(usedRoutes: string[]): IUsedStateStats;
+    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
 }
 
 /** Defines the contract for the garbage collector. */
@@ -69,6 +77,64 @@ export interface IGarbageCollector {
     ): Promise<IGCStats>;
     /** Called when the latest summary of the system has been refreshed. */
     latestSummaryStateRefreshed(result: RefreshSummaryResult, readAndParseBlob: ReadAndParseBlob): Promise<void>;
+    /** Called when a node is changed. Used to detect and log when an inactive node is changed. */
+    nodeChanged(id: string): void;
+}
+
+/** The garbage collection data of each node in the reference graph. */
+interface IGCNodeData {
+    /** The set of routes to other nodes in the graph. */
+    outboundRoutes: string[];
+    /** If the node is unreferenced, the timestamp of when it was marked unreferenced. */
+    unreferencedTimestampMs?: number;
+}
+
+/**
+ * The garbage collection state of the reference graph. It contains a list of all the nodes in the graph and their
+ * GC data.
+ */
+interface IGCState {
+    gcNodes: { [ id: string ]: IGCNodeData };
+}
+
+/**
+ * Helper class that tracks the state of an unreferenced node such as the time it was unreferenced. It also sets
+ * the node's state to inactive if it remains unreferenced for a given amount of time (inactiveTimeoutMs).
+ */
+class UnreferencedStateTracker {
+    private inactive: boolean = false;
+    // Keeps track of all inactive events that are logged. This is used to limit the log generation for each event to 1
+    // so that it is not noisy.
+    private readonly inactiveEventsLogged: Set<string> = new Set();
+
+    constructor(
+        public readonly unrefencedTimestampMs: number,
+        inactiveTimeoutMs: number,
+    ) {
+        // If the timeout has already expired, i.e., inactiveTimeoutMs < 0, the node should become inactive immediately.
+        setTimeout(() => {
+            this.inactive = true;
+        }, Math.max(inactiveTimeoutMs, 0));
+    }
+
+    /** Logs an error with the given properties if the node  is inactive. */
+    public logIfInactive(
+        logger: ITelemetryLogger,
+        eventName: string,
+        currentTimestampMs: number,
+        deleteTimeoutMs: number,
+        inactiveNodeId: string,
+    ) {
+        if (this.inactive && !this.inactiveEventsLogged.has(eventName)) {
+            logger.sendErrorEvent({
+                eventName,
+                unreferencedDuratonMs: currentTimestampMs - this.unrefencedTimestampMs,
+                deleteTimeoutMs,
+                inactiveNodeId,
+            });
+            this.inactiveEventsLogged.add(eventName);
+        }
+    }
 }
 
 /**
@@ -80,11 +146,24 @@ export class GarbageCollector implements IGarbageCollector {
         provider: IGarbageCollectionRuntime,
         gcOptions: IGCRuntimeOptions,
         deleteUnusedRoutes: (unusedRoutes: string[]) => void,
+        getCurrentTimestampMs: () => number,
+        baseSnapshot: ISnapshotTree | undefined,
+        readAndParseBlob: ReadAndParseBlob,
         baseLogger: ITelemetryLogger,
         existing: boolean,
         metadata?: IContainerRuntimeMetadata,
     ): IGarbageCollector {
-        return new GarbageCollector(provider, gcOptions, deleteUnusedRoutes, baseLogger, existing, metadata);
+        return new GarbageCollector(
+            provider,
+            gcOptions,
+            deleteUnusedRoutes,
+            getCurrentTimestampMs,
+            baseSnapshot,
+            readAndParseBlob,
+            baseLogger,
+            existing,
+            metadata,
+        );
     }
 
     /**
@@ -125,19 +204,32 @@ export class GarbageCollector implements IGarbageCollector {
     // This is the version of GC data in the latest summary being tracked.
     private latestSummaryGCVersion: GCVersion;
 
+    // The current state - each node's GC data and unreferenced timestamp.
+    private currentGCState: IGCState | undefined;
+
+    // Promise when resolved initializes the base state of the nodes from the base summary state.
+    private readonly initializeBaseStateP: Promise<void>;
+    // The time after which an unreferenced node can be deleted. Currently, we only set the node's state to expired.
+    private readonly deleteTimeoutMs: number;
+    // Map of node ids to their unreferenced state tracker.
+    private readonly unreferencedNodesState: Map<string, UnreferencedStateTracker> = new Map();
+
     protected constructor(
         private readonly provider: IGarbageCollectionRuntime,
         private readonly gcOptions: IGCRuntimeOptions,
-        /**
-         * After GC has run, called to delete objects in the runtime whose routes are unused. This is not part of the
-         * provider because its specific to this garbage collector implementation and is not part of the contract.
-         */
+        /** After GC has run, called to delete objects in the runtime whose routes are unused. */
         private readonly deleteUnusedRoutes: (unusedRoutes: string[]) => void,
+        /** Returns the current timestamp to be assigned to nodes that become unreferenced. */
+        private readonly getCurrentTimestampMs: () => number,
+        baseSnapshot: ISnapshotTree | undefined,
+        readAndParseBlob: ReadAndParseBlob,
         baseLogger: ITelemetryLogger,
         existing: boolean,
         metadata?: IContainerRuntimeMetadata,
     ) {
         this.logger = ChildLogger.create(baseLogger, "GarbageCollector");
+
+        this.deleteTimeoutMs = this.gcOptions.deleteTimeoutMs ?? defaultDeleteTimeoutMs;
 
         let prevSummaryGCVersion: number | undefined;
         // GC can only be enabled during creation. After that, it can never be enabled again. So, for existing
@@ -170,6 +262,73 @@ export class GarbageCollector implements IGarbageCollector {
 
         // Whether we are running in test mode. In this mode, unreferenced nodes are immediately deleted.
         this.testMode = getLocalStorageFeatureGate(gcTestModeKey) ?? gcOptions.runGCInTestMode === true;
+
+        // Get the GC state from the GC blob in the base snapshot. Use LazyPromise because we only want to do
+        // this once since it involves fetching blobs from storage which is expensive.
+        const baseSummaryStateP = new LazyPromise<IGCState>(async () => {
+            const gcState: IGCState = { gcNodes: {} };
+            if (baseSnapshot === undefined) {
+                return gcState;
+            }
+
+            // Get GC blobs from each data store's summary tree. Get them and consolidate into IGCState format.
+            const dataStoreSnaphotTree = getSummaryForDatastores(baseSnapshot, metadata);
+            assert(dataStoreSnaphotTree !== undefined, "Expected data store snapshot tree in base snapshot");
+            for (const [dsId, dsSnapshotTree] of Object.entries(dataStoreSnaphotTree.trees)) {
+                const blobId = dsSnapshotTree.blobs[gcBlobName];
+                if (blobId === undefined) {
+                    continue;
+                }
+
+                const gcSummaryDetails = await readAndParseBlob<IGarbageCollectionSummaryDetails>(blobId);
+                if (gcSummaryDetails.gcData === undefined) {
+                    continue;
+                }
+                const dsRootId = `/${dsId}`;
+                for (const [id, outboundRoutes] of Object.entries(gcSummaryDetails.gcData.gcNodes)) {
+                    // Prefix the data store id to the GC node ids to make them relative to the root from being
+                    // relative to the data store. Similar to how its done in DataStore::getGCData.
+                    const rootId = id === "/" ? dsRootId : `${dsRootId}${id}`;
+                    gcState.gcNodes[rootId] = { outboundRoutes: Array.from(outboundRoutes) };
+                }
+                gcState.gcNodes[dsRootId].unreferencedTimestampMs = gcSummaryDetails.unrefTimestamp;
+            }
+            return gcState;
+        });
+
+        // Set up the initializer which initializes the base GC state from the base snapshot. Use lazy promise because
+        // we only do this once - the very first time we run GC.
+        this.initializeBaseStateP = new LazyPromise<void>(async () => {
+            const gcNodes: { [ id: string ]: IGCNodeData } = {};
+            const baseState = await baseSummaryStateP;
+            if (baseState === undefined) {
+                this.currentGCState = { gcNodes };
+                return;
+            }
+
+            // Set up tracking for the nodes in the base summary state and add them to GC nodes.
+            for (const [nodeId, nodeData] of Object.entries(baseState.gcNodes)) {
+                const unreferencedTimestampMs = nodeData.unreferencedTimestampMs;
+                if (unreferencedTimestampMs !== undefined) {
+                    // Get how long it has been since the node was unreferenced. Start a timeout for the remaining time
+                    // left for it to be eligible for deletion.
+                    const unreferencedDurationMs = this.getCurrentTimestampMs() - unreferencedTimestampMs;
+                    this.unreferencedNodesState.set(
+                        nodeId,
+                        new UnreferencedStateTracker(
+                            unreferencedTimestampMs,
+                            this.deleteTimeoutMs - unreferencedDurationMs,
+                        ),
+                    );
+                }
+
+                gcNodes[nodeId] = {
+                    outboundRoutes: Array.from(nodeData.outboundRoutes),
+                    unreferencedTimestampMs,
+                };
+            }
+            this.currentGCState = { gcNodes };
+        });
     }
 
     /**
@@ -193,6 +352,8 @@ export class GarbageCollector implements IGarbageCollector {
         } = options;
 
         return PerformanceEvent.timedExecAsync(logger, { eventName: "GarbageCollection" }, async (event) => {
+            await this.initializeBaseStateP;
+
             const gcStats: {
                 deletedNodes?: number,
                 totalNodes?: number,
@@ -202,30 +363,33 @@ export class GarbageCollector implements IGarbageCollector {
 
             // Get the runtime's GC data and run GC on the reference graph in it.
             const gcData = await this.provider.getGCData(fullGC);
-            const { referencedNodeIds, deletedNodeIds } = runGarbageCollection(
+            const gcResult = runGarbageCollection(
                 gcData.gcNodes,
                 [ "/" ],
                 logger,
             );
 
-            // Remove this node's route ("/") and notify data stores of routes that are used in it.
-            const usedRoutes = referencedNodeIds.filter((id: string) => { return id !== "/"; });
-            const dataStoreUsedStateStats = this.provider.updateUsedRoutes(usedRoutes);
+            const currentTimestampMs = this.getCurrentTimestampMs();
+            // Update the current state of the system based on the GC run.
+            this.updateCurrentState(gcData, gcResult, currentTimestampMs);
+
+            const dataStoreUsedStateStats =
+                this.provider.updateUsedRoutes(gcResult.referencedNodeIds, currentTimestampMs);
 
             if (runSweep) {
                 // Placeholder for running sweep logic.
             }
 
             // Update stats to be reported in the peformance event.
-            gcStats.deletedNodes = deletedNodeIds.length;
-            gcStats.totalNodes = referencedNodeIds.length + deletedNodeIds.length;
+            gcStats.deletedNodes = gcResult.deletedNodeIds.length;
+            gcStats.totalNodes = gcResult.referencedNodeIds.length + gcResult.deletedNodeIds.length;
             gcStats.deletedDataStores = dataStoreUsedStateStats.unusedNodeCount;
             gcStats.totalDataStores = dataStoreUsedStateStats.totalNodeCount;
 
             // If we are running in GC test mode, delete objects for unused routes. This enables testing scenarios
             // involving access to deleted data.
             if (this.testMode) {
-                this.deleteUnusedRoutes(deletedNodeIds);
+                this.deleteUnusedRoutes(gcResult.deletedNodeIds);
             }
             event.end(gcStats);
             return gcStats as IGCStats;
@@ -257,6 +421,21 @@ export class GarbageCollector implements IGarbageCollector {
     }
 
     /**
+     * Called when a node with the given id is changed. If the node is inactive, log an error.
+     */
+    public nodeChanged(id: string) {
+        // Prefix "/" if needed to make it relative to the root.
+        const nodeId = id.startsWith("/") ? id : `/${id}`;
+        this.unreferencedNodesState.get(nodeId)?.logIfInactive(
+            this.logger,
+            "inactiveObjectChanged",
+            this.getCurrentTimestampMs(),
+            this.deleteTimeoutMs,
+            nodeId,
+        );
+    }
+
+    /**
      * Update the latest summary GC version from the metadata blob in the given snapshot.
      */
     private async updateSummaryGCVersionFromSnapshot(snapshot: ISnapshotTree, readAndParseBlob: ReadAndParseBlob) {
@@ -264,6 +443,59 @@ export class GarbageCollector implements IGarbageCollector {
         if (metadataBlobId) {
             const metadata = await readAndParseBlob<IContainerRuntimeMetadata>(metadataBlobId);
             this.latestSummaryGCVersion = getGCVersion(metadata);
+        }
+    }
+
+    /**
+     * Updates the state of the system as per the current GC run. It does the following:
+     * 1. Sets up the current GC state as per the gcData.
+     * 2. Starts tracking for nodes that have become unreferenced in this run.
+     * 3. Clears tracking for nodes that were unreferenced but became referenced in this run.
+     * @param gcData - The data representing the reference graph on which GC is run.
+     * @param gcResult - The result of the GC run on the gcData.
+     * @param currentTimestampMs - The current timestamp to be used for unreferenced nodes' timestamp.
+     */
+    private updateCurrentState(gcData: IGarbageCollectionData, gcResult: IGCResult, currentTimestampMs: number) {
+        this.currentGCState = { gcNodes: {} };
+        for (const [id, outboundRoutes] of Object.entries(gcData.gcNodes)) {
+            this.currentGCState.gcNodes[id] = { outboundRoutes: Array.from(outboundRoutes) };
+        }
+
+        // Iterate through the deleted nodes and start tracking if they became unreferenced in this run.
+        for (const nodeId of gcResult.deletedNodeIds) {
+            assert(this.currentGCState.gcNodes[nodeId] !== undefined, "Unexpected node when running GC");
+
+            // The time when the node became unreferenced. This is added to the current GC state.
+            let unreferencedTimestampMs: number = currentTimestampMs;
+            const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
+            if (nodeStateTracker !== undefined) {
+                unreferencedTimestampMs = nodeStateTracker.unrefencedTimestampMs;
+            } else {
+                // Start tracking this node as it became unreferenced in this run.
+                this.unreferencedNodesState.set(
+                    nodeId,
+                    new UnreferencedStateTracker(unreferencedTimestampMs, this.deleteTimeoutMs),
+                );
+            }
+            this.currentGCState.gcNodes[nodeId].unreferencedTimestampMs = unreferencedTimestampMs;
+        }
+
+        // Iterate through the referenced nodes and stop tracking if they were unreferenced before.
+        for (const nodeId of gcResult.referencedNodeIds) {
+            assert(this.currentGCState.gcNodes[nodeId] !== undefined, "Unexpected node when running GC");
+            const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
+            if (nodeStateTracker !== undefined) {
+                // If this node has been unreferenced for longer than deleteTimeoutMs and is being referenced,
+                // log an error as this may mean the deleteTimeoutMs is not long enough.
+                nodeStateTracker.logIfInactive(
+                    this.logger,
+                    "inactiveObjectRevived",
+                    currentTimestampMs,
+                    this.deleteTimeoutMs,
+                    nodeId,
+                );
+                this.unreferencedNodesState.delete(nodeId);
+            }
         }
     }
 }

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -130,6 +130,7 @@ export const metadataBlobName = ".metadata";
 export const chunksBlobName = ".chunks";
 export const electedSummarizerBlobName = ".electedSummarizer";
 export const blobsTreeName = ".blobs";
+export const gcBlobName = "gc";
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function rootHasIsolatedChannels(metadata?: IContainerRuntimeMetadata): boolean {

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1,0 +1,246 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import {
+    IGarbageCollectionData,
+    IGarbageCollectionSummaryDetails,
+} from "@fluidframework/runtime-definitions";
+import { MockLogger } from "@fluidframework/telemetry-utils";
+import { GarbageCollector, IGarbageCollectionRuntime, IGarbageCollector } from "../garbageCollection";
+import { gcBlobName } from "../summaryFormat";
+
+describe("Garabge Collection Tests", () => {
+    // Nodes in the reference graph.
+    const nodes: string[] = [
+        "/node1",
+        "/node2",
+        "/node3",
+        "/node4",
+    ];
+
+    let mockLogger: MockLogger;
+
+    // Time after which unreferenced nodes can be deleted.
+    const deleteTimeoutMs = 500;
+    const inactiveObjectRevivedEvent = "GarbageCollector:inactiveObjectRevived";
+    const inactiveObjectChangedEvent = "GarbageCollector:inactiveObjectChanged";
+
+    // The GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
+    const gcData: IGarbageCollectionData = { gcNodes: {} };
+    const getGCData = async (fullGC?: boolean) => gcData;
+    const updateUsedRoutes = (usedRoutes: string[]) => {
+        return { totalNodeCount: 0, unusedNodeCount: 0 };
+    };
+    // The runtime to be passed to the garbage collector.
+    const gcRuntime: IGarbageCollectionRuntime = {
+        getGCData,
+        updateUsedRoutes,
+    };
+
+    // Waits for > deleteTimeoutMs. To be called to make sure that any unreferenced nodes have been deleted.
+    async function waitForDeleteTimeout(): Promise<void> {
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, deleteTimeoutMs + 100);
+        });
+    }
+
+    // Validates that no inactive event has been fired.
+    function validateNoInactiveEvents() {
+        assert(
+            !mockLogger.matchAnyEvent([
+                { eventName: inactiveObjectRevivedEvent },
+                { eventName: inactiveObjectChangedEvent },
+            ]),
+            "inactive object events should not have been logged",
+        );
+    }
+
+    // Simulates node changed activity for all the nodes in the graph.
+    function changeAllNodes(garbageCollector: IGarbageCollector) {
+        nodes.forEach((nodeId) => {
+            garbageCollector.nodeChanged(nodeId);
+        });
+    }
+
+    // Returns a dummy snapshot tree to be built upon.
+    const getDummySnapshotTree = (): ISnapshotTree => {
+        return {
+            id: "dummy",
+            blobs: {},
+            commits: {},
+            trees: {},
+        };
+    };
+
+    // The GC details in the summary blob of a node. This is used by the garbage collector to initialize GC state.
+    // Update this for individual node to update the initial GC state of that node.
+    const emptyGCDetails: IGarbageCollectionSummaryDetails = {};
+
+    const createGarbageCollector = (
+        baseSnapshot: ISnapshotTree | undefined = undefined,
+        getNodeGCDetails: (id: string) => IGarbageCollectionSummaryDetails = () => emptyGCDetails,
+    ) => {
+        return GarbageCollector.create(
+            gcRuntime,
+            { deleteTimeoutMs },
+            (unusedRoutes: string[]) => {},
+            () => Date.now(),
+            baseSnapshot,
+            async <T>(id: string) => getNodeGCDetails(id) as T,
+            mockLogger,
+            false /* existing */,
+        );
+    };
+
+    beforeEach(async () => {
+        mockLogger = new MockLogger();
+
+        // Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
+        gcData.gcNodes["/"] = [ nodes[0] ];
+        gcData.gcNodes[nodes[0]] = [ nodes[1] ];
+        gcData.gcNodes[nodes[1]] = [ nodes[0], nodes[2] ];
+        gcData.gcNodes[nodes[2]] = [ nodes[3] ];
+        gcData.gcNodes[nodes[3]] = [ nodes[0] ];
+    });
+
+    it("doesn't generate inactive events for referenced nodes", async () => {
+        const garbageCollector = createGarbageCollector();
+
+        // Run garbage collection on the default GC data where everything is referenced.
+        await garbageCollector.collectGarbage({ runGC: true });
+
+        // Change all nodes.
+        changeAllNodes(garbageCollector);
+
+        // Validate that no inactive events are generated yet.
+        validateNoInactiveEvents();
+
+        // Wait for unreferenced timer (if any) to expire.
+        await waitForDeleteTimeout();
+
+        // Change all nodes again.
+        changeAllNodes(garbageCollector);
+
+        // Validate that no inactive events are generated since everything is referenced.
+        validateNoInactiveEvents();
+    });
+
+    it("generates inactive events when inactive node is changed or revived", async () => {
+        const garbageCollector = createGarbageCollector();
+
+        // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+        gcData.gcNodes[nodes[1]] = [];
+
+        await garbageCollector.collectGarbage({ runGC: true });
+
+        // Change all nodes.
+        changeAllNodes(garbageCollector);
+
+        // Validate that no inactive events are generated yet.
+        validateNoInactiveEvents();
+
+        // Wait for unreferenced timer (if any) to expire.
+        await waitForDeleteTimeout();
+
+        // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
+        // are inactive.
+        changeAllNodes(garbageCollector);
+        assert(
+            mockLogger.matchEvents([
+                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[2] },
+                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+            ]),
+            "inactiveObjectChanged event not generated as expected",
+        );
+
+        // Add reference to node 3 from node 1.
+        gcData.gcNodes[nodes[1]] = [ nodes[3] ];
+
+        // Run GC and validate that we get inactiveObjectRevived for node 3.
+        await garbageCollector.collectGarbage({ runGC: true });
+        assert(
+            mockLogger.matchEvents([
+                { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+            ]),
+            "inactiveObjectRevived event not generated as expected",
+        );
+    });
+
+    it("generates inactive events once per node", async () => {
+        const garbageCollector = createGarbageCollector();
+
+        // Remove node 3's reference from node 2.
+        gcData.gcNodes[nodes[2]] = [];
+
+        await garbageCollector.collectGarbage({ runGC: true });
+
+        await waitForDeleteTimeout();
+
+        // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
+        // are inactive.
+        changeAllNodes(garbageCollector);
+        assert(
+            mockLogger.matchEvents([
+                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+            ]),
+            "inactiveObjectChanged event not generated as expected",
+        );
+
+        // Change all nodes. There shouldn't be any more inactive events since for each node the event is only
+        // once.
+        changeAllNodes(garbageCollector);
+        validateNoInactiveEvents();
+    });
+
+    it("generates inactive events for nodes that are inactive on load", async () => {
+        // Create GC details for node 3's GC blob whose unreferenced time was > deleteTimeoutMs ago.
+        // This means this node should become inactive as soon as its data is loaded.
+        const node3GCDetails: IGarbageCollectionSummaryDetails = {
+            gcData: { gcNodes: { "/": [] } },
+            unrefTimestamp: Date.now() - (deleteTimeoutMs + 100),
+        };
+        const node3Snapshot = getDummySnapshotTree();
+        node3Snapshot.blobs[gcBlobName] = "node3GCDetails";
+
+        // Create a base snapshot that contains snapshot tree of node 3.
+        const baseSnapshot = getDummySnapshotTree();
+        baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
+
+        // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
+        const getNodeGCDetails = (blobId: string) => {
+            if (blobId === "node3GCDetails") {
+                return node3GCDetails;
+            }
+            return {};
+        };
+        const garbageCollector = createGarbageCollector(baseSnapshot, getNodeGCDetails);
+
+        // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base summary
+        // are not loaded until the first time GC is run, so do that immediately.
+        gcData.gcNodes[nodes[2]] = [];
+        await garbageCollector.collectGarbage({ runGC: true });
+
+        // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
+        garbageCollector.nodeChanged(nodes[3]);
+        assert(
+            mockLogger.matchEvents([
+                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+            ]),
+            "inactiveObjectChanged event not generated as expected",
+        );
+
+        // Add a reference to node 3 from node 2. Run GC and validate that we get inactiveObjectRevived for node 3.
+        gcData.gcNodes[nodes[2]] = [ nodes[3] ];
+        await garbageCollector.collectGarbage({ runGC: true });
+        assert(
+            mockLogger.matchEvents([
+                { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+            ]),
+            "inactiveObjectRevived event not generated as expected",
+        );
+    });
+});

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -62,8 +62,6 @@ export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
      * This is propagated to all child nodes.
      */
     readonly gcDisabled?: boolean;
-    /** The max duration for which a node can be unreferenced before it is eligible for deletion. */
-    readonly maxUnreferencedDurationMs?: number;
 }
 
 export enum CreateSummarizerNodeSource {

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -4,9 +4,9 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { assert, LazyPromise, Timer } from "@fluidframework/common-utils";
+import { assert, LazyPromise } from "@fluidframework/common-utils";
 import { cloneGCData } from "@fluidframework/garbage-collector";
-import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
     CreateChildSummarizerNodeParam,
     gcBlobKey,
@@ -26,8 +26,6 @@ import {
     ISummarizerNodeRootContract,
     SummaryNode,
 } from "./summarizerNodeUtils";
-
-const defaultMaxUnreferencedDurationMs = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export interface IRootSummarizerNodeWithGC extends ISummarizerNodeWithGC, ISummarizerNodeRootContract {}
 
@@ -75,21 +73,8 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
     // If this node is marked as unreferenced, the time when it marked as such.
     private unreferencedTimestampMs: number | undefined;
 
-    // The max duration for which this node can be unreferenced before it is eligible for deletion.
-    private readonly maxUnreferencedDurationMs: number;
-
-    // The timer that runs when the node is marked unreferenced.
-    private readonly unreferencedTimer: Timer;
-
-    // Tracks whether this node is inactive after being unreferenced for maxUnreferencedDurationMs.
-    private inactive: boolean = false;
-
     // True if GC is disabled for this node. If so, do not track GC specific state for a summary.
     private readonly gcDisabled: boolean;
-
-    // Keeps track of whether we logged an use-after-free error. This is temporary since the error is too noisy.
-    // To be removed once this item is completed - https://github.com/microsoft/FluidFramework/issues/7895.
-    private useAfterFreeErrorLogged: boolean = false;
 
     /**
      * Do not call constructor directly.
@@ -118,15 +103,10 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         );
 
         this.gcDisabled = config.gcDisabled === true;
-        this.maxUnreferencedDurationMs = config.maxUnreferencedDurationMs ?? defaultMaxUnreferencedDurationMs;
 
         this.gcDetailsInInitialSummaryP = new LazyPromise(async () => {
             const gcSummaryDetails = await getInitialGCSummaryDetailsFn?.();
             return gcSummaryDetails ?? { usedRoutes: [] };
-        });
-
-        this.unreferencedTimer = new Timer(this.maxUnreferencedDurationMs, () => {
-            this.inactive = true;
         });
     }
 
@@ -334,7 +314,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
                 ...config,
                 // Propagate our gcDisabled state to the child if its not explicity specified in child's config.
                 gcDisabled: config.gcDisabled ?? this.gcDisabled,
-                maxUnreferencedDurationMs: config.maxUnreferencedDurationMs ?? this.maxUnreferencedDurationMs,
             },
             createDetails.changeSequenceNumber,
             createDetails.latestSummary,
@@ -382,82 +361,14 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         }
 
         if (this.isReferenced()) {
-            // If this node has been unreferenced for longer than maxUnreferencedDurationMs and is being referenced,
-            // log an error as this may mean the maxUnreferencedDurationMs is not long enough.
-            this.logErrorIfInactive("inactiveObjectRevived", gcTimestamp);
-
-            // Clear unreferenced / inactive state, if any.
-            this.inactive = false;
             this.unreferencedTimestampMs = undefined;
-            this.unreferencedTimer.clear();
             return;
         }
 
-        // This node is unreferenced. We need to check if this node is inative or if we need to start the unreferenced
-        // timer which would mark the node as inactive.
-
-        // If there is no timestamp when GC was run, we don't have enough information to determine whether this content
-        // should become inactive.
-        if (gcTimestamp === undefined) {
-            return;
-        }
-
-        // If unreferencedTimestampMs is not present, this node just became unreferenced. Update unreferencedTimestampMs
-        // and start the unreferenced timer.
-        // Note that it's possible this node has been unreferenced before but the unreferencedTimestampMs was not added.
-        // For example, older versions where this concept did not exist or if gcTimestamp wasn't available. In such
-        // cases, we track them as if the content just became unreferenced.
+        // If this node just became unreferenced, update its unreferencedTimestampMs.
         if (this.unreferencedTimestampMs === undefined) {
             this.unreferencedTimestampMs = gcTimestamp;
-            this.unreferencedTimer.start();
-            return;
         }
-
-        // If we are here, this node was unreferenced earlier.
-
-        // If it is already inactive or has an unreferenced timer running, there is no more work to be done.
-        if (this.inactive || this.unreferencedTimer.hasTimer) {
-            return;
-        }
-
-        // If it has been unreferenced longer than maxUnreferencedDurationMs, mark it as inactive. Otherwise, start the
-        // unreferenced timer for the duration left for it to reach maxUnreferencedDurationMs.
-        const currentUnreferencedDurationMs = gcTimestamp - this.unreferencedTimestampMs;
-        if (currentUnreferencedDurationMs >= this.maxUnreferencedDurationMs) {
-            this.inactive = true;
-        } else {
-            this.unreferencedTimer.start(this.maxUnreferencedDurationMs - currentUnreferencedDurationMs);
-        }
-    }
-
-    public recordChange(op: ISequencedDocumentMessage): void {
-        // If the node is changed after it is inactive, log an error as this may mean use-after-delete.
-        // Currently, we only log this error once per node per session as it's too noisy.
-        if (!this.useAfterFreeErrorLogged && this.logErrorIfInactive("inactiveObjectChanged")) {
-            this.useAfterFreeErrorLogged = true;
-        }
-        super.recordChange(op);
-    }
-
-    /**
-     * Logs an error event if the node is inactive. This is used to identify cases where an inactive object is used.
-     * @param eventName - The name of the event to log.
-     * @param currentTimestampMs - The current time stamp. Used to report how long the object has been inactive.
-     * @returns true if we logged an error, false otherwise.
-     */
-    private logErrorIfInactive(eventName: string, currentTimestampMs?: number): boolean {
-        if (this.inactive) {
-            assert(
-                this.unreferencedTimestampMs !== undefined,
-                0x271 /* "Node should not become inactive without setting unreferencedTimestampMs first" */);
-            this.defaultLogger.sendErrorEvent({
-                eventName,
-                unreferencedDuratonMs: (currentTimestampMs ?? Date.now()) - this.unreferencedTimestampMs,
-                maxUnreferencedDurationMs: this.maxUnreferencedDurationMs,
-            });
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { cloneGCData } from "@fluidframework/garbage-collector";
-import { ISequencedDocumentMessage, SummaryType } from "@fluidframework/protocol-definitions";
+import { SummaryType } from "@fluidframework/protocol-definitions";
 import {
     CreateSummarizerNodeSource,
     IGarbageCollectionData,
@@ -27,8 +27,6 @@ describe("SummarizerNodeWithGC Tests", () => {
     const subNode1Id = "/gcNode1/subNode";
     const subNode2Id = "/gcNode2/subNode";
 
-    const maxUnreferencedDurationMs = 1000;
-
     let internalGCData: IGarbageCollectionData;
     let initialGCSummaryDetails: IGarbageCollectionSummaryDetails;
     let rootSummarizerNode: IRootSummarizerNodeWithGC;
@@ -48,7 +46,7 @@ describe("SummarizerNodeWithGC Tests", () => {
             summarizeInternal,
             summarizerNodeId,
             { type: CreateSummarizerNodeSource.FromSummary },
-            { maxUnreferencedDurationMs },
+            undefined,
             getInternalGCData,
             getinitialGCSummaryDetails,
         );
@@ -197,80 +195,6 @@ describe("SummarizerNodeWithGC Tests", () => {
                 summarizerNode.summarize(true /* fullTree */),
                 "summarize should not have thrown an error since GC was run",
             );
-        });
-    });
-
-    describe("Unreferenced timeout expiry", () => {
-        const inactiveObjectRevivedEvent = "inactiveObjectRevived";
-        const inactiveObjectChangedEvent = "inactiveObjectChanged";
-
-        async function waitForTimeout(timeout: number): Promise<void> {
-            await new Promise<void>((resolve) => {
-                setTimeout(resolve, timeout);
-            });
-        }
-
-        function validateNoInactiveEvents() {
-            assert(
-                !mockLogger.matchAnyEvent([
-                    { eventName: inactiveObjectRevivedEvent },
-                    { eventName: inactiveObjectChangedEvent },
-                ]),
-                "inactive object events should not have been logged",
-            );
-        }
-
-        it("generates inactive events when inactive node is changed or revived", async () => {
-            // Mark node as unreferenced by updating it with empty used routes.
-            summarizerNode.updateUsedRoutes([], Date.now());
-
-            // Validate that no inactive events are generated yet.
-            validateNoInactiveEvents();
-
-            // The configured maxUnrefencedTime is 1000 ms. Wait for 1100 ms so that the unreferenced timer expires.
-            await waitForTimeout(1100);
-
-            // Record a new op. This should result in an inactiveObjectChanged event since the object inactive.
-            const op: Partial<ISequencedDocumentMessage> = { sequenceNumber: 1 };
-            summarizerNode.recordChange(op as ISequencedDocumentMessage);
-            assert(
-                mockLogger.matchEvents([{ eventName: inactiveObjectChangedEvent, maxUnreferencedDurationMs }]),
-                "inactiveObjectChanged event not generated as expected",
-            );
-
-            // Mark node as referenced by updating it with self route (""). This should result in an
-            // inactiveObjectRevived event since the object inactive.
-            summarizerNode.updateUsedRoutes([""], Date.now());
-            assert(
-                mockLogger.matchEvents([{ eventName: inactiveObjectRevivedEvent, maxUnreferencedDurationMs }]),
-                "inactiveObjectRevived event not generated as expected",
-            );
-
-            // Record a new op. There shouldn't be any more inactive events since the object is referenced now.
-            const op2: Partial<ISequencedDocumentMessage> = { sequenceNumber: 2 };
-            summarizerNode.recordChange(op2 as ISequencedDocumentMessage);
-            validateNoInactiveEvents();
-        });
-
-        it("does not generate inactive events while node is active", async () => {
-            // Mark node as unreferenced by updating it with empty used routes.
-            summarizerNode.updateUsedRoutes([], Date.now());
-
-            // Validate that no inactive events are generated yet.
-            validateNoInactiveEvents();
-
-            // The configured maxUnrefencedTime is 1000 ms. Wait for 500 ms so the unreferenced timer does not expire.
-            await waitForTimeout(500);
-
-            // Record a new op. This should not result in any inactive events since the object has not inactive.
-            const op: Partial<ISequencedDocumentMessage> = { sequenceNumber: 1 };
-            summarizerNode.recordChange(op as ISequencedDocumentMessage);
-            validateNoInactiveEvents();
-
-            // Mark node as referenced by updating it with self route (""). This should not result in any inactive
-            // events since the object has not inactive.
-            summarizerNode.updateUsedRoutes([""], Date.now());
-            validateNoInactiveEvents();
         });
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -14,23 +14,23 @@ import { Container } from "@fluidframework/container-loader";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluidframework/test-version-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { TestDataObject } from "./mockSummarizerClient";
 
 /**
  * Validates this scenario: When a data store becomes inactive (has been unreferenced for a given amount of time),
  * using that data store results in an error telemetry.
  */
-describeFullCompat("GC inactive data store tests", (getTestObjectProvider) => {
+describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
     const dataObjectFactory = new DataObjectFactory(
         "TestDataObject",
         TestDataObject,
         [],
         []);
-    const maxUnreferencedDurationMs = 2000;
+    const deleteTimeoutMs = 2000;
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: { disableSummaries: true },
-        gcOptions: { gcAllowed: true, maxUnreferencedDurationMs },
+        gcOptions: { gcAllowed: true, deleteTimeoutMs },
     };
     const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
         dataObjectFactory,
@@ -42,8 +42,8 @@ describeFullCompat("GC inactive data store tests", (getTestObjectProvider) => {
         runtimeOptions,
     );
     const summaryLogger = new TelemetryNullLogger();
-    const inactiveObjectRevivedEvent = "fluid:telemetry:SummarizerNode:inactiveObjectRevived";
-    const inactiveObjectChangedEvent = "fluid:telemetry:SummarizerNode:inactiveObjectChanged";
+    const inactiveObjectRevivedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObjectRevived";
+    const inactiveObjectChangedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObjectChanged";
 
     let provider: ITestObjectProvider;
     let containerRuntime: ContainerRuntime;
@@ -86,7 +86,7 @@ describeFullCompat("GC inactive data store tests", (getTestObjectProvider) => {
         containerRuntime = defaultDataStore.containerRuntime;
     });
 
-    it("can generate events when unreferenced data store is accessed after it's inactive", async () => {
+    it.only("can generate events when unreferenced data store is accessed after it's inactive", async () => {
         const dataStore1 = await dataObjectFactory.createInstance(containerRuntime);
         defaultDataStore._root.set("dataStore1", dataStore1.handle);
 
@@ -119,9 +119,21 @@ describeFullCompat("GC inactive data store tests", (getTestObjectProvider) => {
         dataStore1._root.set("key", "value");
         await provider.ensureSynchronized();
         assert(
-            mockLogger.matchEvents([{ eventName: inactiveObjectChangedEvent, maxUnreferencedDurationMs }]),
+            mockLogger.matchEvents([
+                {
+                    eventName: inactiveObjectChangedEvent,
+                    deleteTimeoutMs,
+                    inactiveNodeId: `/${dataStore1.id}`,
+                },
+            ]),
             "inactiveObjectChanged event not generated as expected",
         );
+
+        // Make a change again and validate that we don't get another inactiveObjectChanged event as we only log it
+        // once per data store per session.
+        dataStore1._root.set("key2", "value2");
+        await provider.ensureSynchronized();
+        validateNoInactiveEvents();
 
         // Revive the inactive data store and validate that we get the inactiveObjectRevivedEvent event.
         defaultDataStore._root.set("dataStore1", dataStore1.handle);
@@ -133,7 +145,13 @@ describeFullCompat("GC inactive data store tests", (getTestObjectProvider) => {
             summaryLogger,
         });
         assert(
-            mockLogger.matchEvents([{ eventName: inactiveObjectRevivedEvent, maxUnreferencedDurationMs }]),
+            mockLogger.matchEvents([
+                {
+                    eventName: inactiveObjectRevivedEvent,
+                    deleteTimeoutMs,
+                    inactiveNodeId: `/${dataStore1.id}`,
+                },
+            ]),
             "inactiveObjectRevived event not generated as expected",
         );
     }).timeout(10000);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -86,7 +86,7 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
         containerRuntime = defaultDataStore.containerRuntime;
     });
 
-    it.only("can generate events when unreferenced data store is accessed after it's inactive", async () => {
+    it("can generate events when unreferenced data store is accessed after it's inactive", async () => {
         const dataStore1 = await dataObjectFactory.createInstance(containerRuntime);
         defaultDataStore._root.set("dataStore1", dataStore1.handle);
 


### PR DESCRIPTION
Part 1 of fix for #8157.

- Moved unreferenced timestamp tracking from each node into container runtime's garbage collector. It tracks the unreferenced timestamp of each node in the GC reference graph. It also starts timer for each unreferenced node and expires them when the timer expires.
- Garbage collector gets the initial unreferenced timestamp of each data store by reading it from the data store's summary tree in the base summary.

Part 2 will move storing the GC blobs from data store's summary tree into container runtime. Draft PR for that (which also includes the changes in this PR) - https://github.com/microsoft/FluidFramework/pull/8325