### PR TITLE
Revert #7917 - Used attachGraph instead of bindToContext to bind and attach data store runtime

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1575,7 +1575,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
     public async createRootDataStore(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter> {
         const fluidDataStore = await this._createDataStore(pkg, true /* isRoot */, rootDataStoreId);
-        fluidDataStore.attachGraph();
+        fluidDataStore.bindToContext();
         return fluidDataStore;
     }
 
@@ -1599,7 +1599,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const fluidDataStore = await this.dataStores._createFluidDataStoreContext(
             Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
         if (isRoot) {
-            fluidDataStore.attachGraph();
+            fluidDataStore.bindToContext();
         }
         return fluidDataStore;
     }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -993,7 +993,7 @@ export class LocalDetachedFluidDataStoreContext
         super.bindRuntime(dataStoreRuntime);
 
         if (this.isRootDataStore) {
-            dataStoreRuntime.attachGraph();
+            dataStoreRuntime.bindToContext();
         }
     }
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -713,9 +713,6 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public getAttachSummary(): ISummaryTreeWithStats {
-        // back-compat 0.50: attachGraph() will be called when creating a root data store or when adding the handle
-        // of a non-root data store to an already bound DDS.
-        // To be removed when N >= 0.52
         this.attachGraph();
 
         const summaryBuilder = new SummaryTreeBuilder();

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -108,7 +108,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
         const channel = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
         assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
-        dataStore2RuntimeChannel.attachGraph();
+        dataStore2RuntimeChannel.bindToContext();
 
         assert(dataStore2.runtime.attachState !== AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", true));
@@ -135,7 +135,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
 
         // Now register the channel
         (await channel.handle.get() as SharedObject).bindToContext();
-        dataStore2RuntimeChannel.attachGraph();
+        dataStore2RuntimeChannel.bindToContext();
 
         assert(dataStore2.runtime.attachState !== AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", true));
@@ -186,7 +186,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
         const channel = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
         assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
-        dataStore2RuntimeChannel.attachGraph();
+        dataStore2RuntimeChannel.bindToContext();
 
         const rootOfDataStore2 = await dataStore2.runtime.getChannel("root") as SharedMap;
         const testChannelOfDataStore2 = await dataStore2.runtime.getChannel("test1");
@@ -218,7 +218,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
         const channel = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
         assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
-        dataStore2RuntimeChannel.attachGraph();
+        dataStore2RuntimeChannel.bindToContext();
 
         (await channel.handle.get() as SharedObject).bindToContext();
         assert.strictEqual(channel.handle.isAttached, true,
@@ -279,7 +279,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
             testChannel2OfDataStore2.set("test1handle", channel1.handle);
 
             // Now attach the dataStore2. Currently this will end up in infinite loop.
-            dataStore2RuntimeChannel.attachGraph();
+            dataStore2RuntimeChannel.bindToContext();
             assert.strictEqual(testChannel1OfDataStore2.handle.isAttached, true,
                 createTestStatementForAttachedDetached("Test Channel 1", true));
             assert.strictEqual(testChannel2OfDataStore2.handle.isAttached, true,
@@ -550,7 +550,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
             await createDetachedContainerAndGetRootDataStore();
         const peerDataStore1 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore1 = peerDataStore1.peerDataStore as TestFluidObject;
-        peerDataStore1.peerDataStoreRuntimeChannel.attachGraph();
+        peerDataStore1.peerDataStoreRuntimeChannel.bindToContext();
 
         const peerDataStore2 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore2.peerDataStore as TestFluidObject;
@@ -591,7 +591,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
             await createDetachedContainerAndGetRootDataStore();
         const peerDataStore1 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore1 = peerDataStore1.peerDataStore as TestFluidObject;
-        peerDataStore1.peerDataStoreRuntimeChannel.attachGraph();
+        peerDataStore1.peerDataStoreRuntimeChannel.bindToContext();
 
         const peerDataStore2 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore2.peerDataStore as TestFluidObject;

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -491,7 +491,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             // Create another dataStore
             const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore.peerDataStore as TestFluidObject;
-            peerDataStore.peerDataStoreRuntimeChannel.attachGraph();
+            peerDataStore.peerDataStoreRuntimeChannel.bindToContext();
             const sharedMap1 = await dataStore2.getSharedObject<SharedMap>(sharedMapId);
             sharedMap1.set("0", "A");
             const snapshotTree = container.serialize();
@@ -536,7 +536,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             // Create another dataStore
             const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore.peerDataStore as TestFluidObject;
-            peerDataStore.peerDataStoreRuntimeChannel.attachGraph();
+            peerDataStore.peerDataStoreRuntimeChannel.bindToContext();
             const sharedMap1 = await dataStore2.getSharedObject<SharedMap>(sharedMapId);
             sharedMap1.set("0", "A");
             const snapshotTree = container.serialize();

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -304,7 +304,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
             assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
             (await channel.handle.get() as SharedObject).bindToContext();
-            dataStore.channel.attachGraph();
+            dataStore.channel.bindToContext();
             (channel as SharedMap).set(testKey, testValue);
         });
 
@@ -331,7 +331,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
             assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
             (await channel.handle.get() as SharedObject).bindToContext();
-            dataStore.channel.attachGraph();
+            dataStore.channel.bindToContext();
             (channel as SharedMap).set(testKey, testValue);
         });
 


### PR DESCRIPTION
Cherry-picked from release/0.50 - #8327

#7917 regressed the attach behavior for the container - #8305.
Reverting this change to unblock the release. Will work on the original issue separately.