### PR TITLE
Port: Type Validation: Handle type names with periods 

### DIFF
--- a/tools/build-tools/src/typeValidator/testGeneration.ts
+++ b/tools/build-tools/src/typeValidator/testGeneration.ts
@@ -85,8 +85,8 @@ interface TestCaseTypeData extends TypeData{
 }
 
 function buildTestCase(getAsType:TestCaseTypeData, useType:TestCaseTypeData, isCompatible: boolean){
-    const getSig =`get_${getAsType.prefix}_${getFullTypeName(getAsType)}`;
-    const useSig =`use_${useType.prefix}_${getFullTypeName(useType)}`;
+    const getSig =`get_${getAsType.prefix}_${getFullTypeName(getAsType).replace(".","_")}`;
+    const useSig =`use_${useType.prefix}_${getFullTypeName(useType).replace(".","_")}`;
     const testString: string[] =[];
     testString.push(`declare function ${getSig}():\n    ${toTypeString(getAsType.prefix, getAsType)};`);
     testString.push(`declare function ${useSig}(\n    use: ${toTypeString(useType.prefix, useType)});`);


### PR DESCRIPTION
The latest version of protocol def uses namespaces, which leads to type names with periods . in them. There is a bug in the test generation that keeps these periods in the function names, which is not valid syntax. This change simple replaces ' with _ in the function names.

Once this is in, I'll release the build tools, bump the version, and re-add generation in protocol defs

related to #8373