### PR TITLE
Update SimpleFluidError to extend LoggingError

### DIFF
--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -309,7 +309,5 @@ class SimpleFluidError extends LoggingError implements IFluidErrorBase {
         if (errorProps.stack !== undefined) {
             overwriteStack(this, errorProps.stack);
         }
-
-        this.addTelemetryProperties(errorProps);
     }
 }

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -78,42 +78,6 @@ export interface IFluidErrorAnnotations {
     props?: ITelemetryProperties;
 }
 
-/** Simplest possible implementation of IFluidErrorBase */
-class SimpleFluidError implements IFluidErrorBase {
-    private readonly telemetryProps: ITelemetryProperties = {};
-
-    readonly errorType: string;
-    readonly fluidErrorCode: string;
-    readonly message: string;
-    readonly stack?: string;
-    readonly name: string = "Error";
-    readonly errorInstanceId: string;
-
-    constructor(
-        errorProps: Omit<IFluidErrorBase,
-            | "getTelemetryProperties"
-            | "addTelemetryProperties"
-            | "errorInstanceId"
-            | "name">,
-    ) {
-        this.errorType = errorProps.errorType;
-        this.fluidErrorCode = errorProps.fluidErrorCode;
-        this.message = errorProps.message;
-        this.stack = errorProps.stack;
-        this.errorInstanceId = uuid();
-
-        this.addTelemetryProperties(errorProps);
-    }
-
-    getTelemetryProperties(): ITelemetryProperties {
-        return this.telemetryProps;
-    }
-
-    addTelemetryProperties(props: ITelemetryProperties) {
-        copyProps(this.telemetryProps, props);
-    }
-}
-
 /** For backwards compatibility with pre-fluidErrorCode valid errors */
 function patchWithErrorCode(
     legacyError: Omit<IFluidErrorBase, "fluidErrorCode">,
@@ -320,5 +284,41 @@ export class LoggingError extends Error implements ILoggingError, Pick<IFluidErr
             stack: this.stack,
             message: this.message,
         };
+    }
+}
+
+/** Simplest possible implementation of IFluidErrorBase */
+class SimpleFluidError implements IFluidErrorBase {
+    private readonly telemetryProps: ITelemetryProperties = {};
+
+    readonly errorType: string;
+    readonly fluidErrorCode: string;
+    readonly message: string;
+    readonly stack?: string;
+    readonly name: string = "Error";
+    readonly errorInstanceId: string;
+
+    constructor(
+        errorProps: Omit<IFluidErrorBase,
+            | "getTelemetryProperties"
+            | "addTelemetryProperties"
+            | "errorInstanceId"
+            | "name">,
+    ) {
+        this.errorType = errorProps.errorType;
+        this.fluidErrorCode = errorProps.fluidErrorCode;
+        this.message = errorProps.message;
+        this.stack = errorProps.stack;
+        this.errorInstanceId = uuid();
+
+        this.addTelemetryProperties(errorProps);
+    }
+
+    getTelemetryProperties(): ITelemetryProperties {
+        return this.telemetryProps;
+    }
+
+    addTelemetryProperties(props: ITelemetryProperties) {
+        copyProps(this.telemetryProps, props);
     }
 }


### PR DESCRIPTION
Fixes #8382.

In retrospect this should have always been this way - it was weird that sometimes our errors would have LoggingError semantics (telemetry props are read straight from the object) and others it would not (a dedicated property bag _on_ the error).  See #6485 for context on that debate.

This also removes the need for stack generation since it now extends `Error`.