### PR TITLE
remove readOnly and readOnlyPermissions from container-loader

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -10,6 +10,12 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
+## 0.53 Breaking changes
+- [readOnly and readOnlyPermissions removed from container-loader](#readOnly-and-readOnlyPermissions-removed-from-container-loader)
+
+### `readOnly` and `readOnlyPermissions` removed from `container-loader`
+The `readOnly` and `readOnlyPermissions` properties on `container-loader` was deprecated in 0.35, and has now been removed. To replace its functionality, use `readOnlyInfo` by accessing `readOnlyInfo.readonly` and `readOnlyInfo.permissions` respectively.
+
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)
 - [`OdspDocumentInfo` type replaced with `OdspFluidDataStoreLocator` interface](#OdspDocumentInfo-type-replaced-with-OdspFluidDataStoreLocator-interface)
@@ -17,7 +23,6 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Remove `IOdspResolvedUrl.sharingLinkToRedeem` and use `IOdspResolvedUrl.shareLinkInfo` instead](#Remove-IOdspResolvedUrl.sharingLinkToRedeem-and-use-IOdspResolvedUrl.shareLinkInfo-instead)
 - [Replace `createCreateNewRequest` function with `createOdspCreateContainerRequest` function](#Replace-createCreateNewRequest-function-with-createOdspCreateContainerRequest-function)
 - [Deprecate IFluidObject and introduce FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject)
-- [readOnly and readOnlyPermissions removed from container-loader](#readOnly-and-readOnlyPermissions-removed-from-container-loader)
 
 ### `chaincodePackage` removed from `Container`
 The `chaincodePackage` property on `Container` was deprecated in 0.28, and has now been removed.  Two new APIs have been added to replace its functionality, `getSpecifiedCodeDetails()` and `getLoadedCodeDetails()`.  Use `getSpecifiedCodeDetails()` to get the code details currently specified for the `Container`, or `getLoadedCodeDetails()` to get the code details that were used to load the `Container`.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -17,6 +17,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Remove `IOdspResolvedUrl.sharingLinkToRedeem` and use `IOdspResolvedUrl.shareLinkInfo` instead](#Remove-IOdspResolvedUrl.sharingLinkToRedeem-and-use-IOdspResolvedUrl.shareLinkInfo-instead)
 - [Replace `createCreateNewRequest` function with `createOdspCreateContainerRequest` function](#Replace-createCreateNewRequest-function-with-createOdspCreateContainerRequest-function)
 - [Deprecate IFluidObject and introduce FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject)
+- [readOnly and readOnlyPermissions removed from container-loader](#readOnly-and-readOnlyPermissions-removed-from-container-loader)
 
 ### `chaincodePackage` removed from `Container`
 The `chaincodePackage` property on `Container` was deprecated in 0.28, and has now been removed.  Two new APIs have been added to replace its functionality, `getSpecifiedCodeDetails()` and `getLoadedCodeDetails()`.  Use `getSpecifiedCodeDetails()` to get the code details currently specified for the `Container`, or `getLoadedCodeDetails()` to get the code details that were used to load the `Container`.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -11,10 +11,10 @@ There are a few steps you can take to write a good change note and avoid needing
 - Consider providing code examples as part of guidance for non-trivial changes.
 
 ## 0.53 Breaking changes
-- [readOnly and readOnlyPermissions removed from container-loader](#readOnly-and-readOnlyPermissions-removed-from-container-loader)
+- [readOnly and readOnlyPermissions removed from Container](#readOnly-and-readOnlyPermissions-removed-from-container)
 
-### `readOnly` and `readOnlyPermissions` removed from `container-loader`
-The `readOnly` and `readOnlyPermissions` properties on `container-loader` was deprecated in 0.35, and has now been removed. To replace its functionality, use `readOnlyInfo` by accessing `readOnlyInfo.readonly` and `readOnlyInfo.permissions` respectively.
+### `readOnly` and `readOnlyPermissions` removed from `Container`
+The `readOnly` and `readOnlyPermissions` properties from `Container` in `container-loader` was deprecated in 0.35, and has now been removed. To replace its functionality, use `readOnlyInfo` by accessing `readOnlyInfo.readonly` and `readOnlyInfo.permissions` respectively.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -93,12 +93,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     // (undocumented)
     proposeCodeDetails(codeDetails: IFluidCodeDetails): Promise<boolean>;
     raiseContainerWarning(warning: ContainerWarning): void;
-    // @deprecated
-    get readonly(): boolean | undefined;
     // (undocumented)
     get readOnlyInfo(): ReadOnlyInfo;
-    // @deprecated
-    get readonlyPermissions(): boolean | undefined;
     static rehydrateDetachedFromSnapshot(loader: Loader, snapshot: string): Promise<Container>;
     // (undocumented)
     request(path: IRequest): Promise<IResponse>;

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -94,10 +94,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     proposeCodeDetails(codeDetails: IFluidCodeDetails): Promise<boolean>;
     raiseContainerWarning(warning: ContainerWarning): void;
     // (undocumented)
-    /**
-      * Object defining the current readonly state of the Container.
-      * If the Container is readonly it also provides additional properties describing how it got to that state.
-     **/
     get readOnlyInfo(): ReadOnlyInfo;
     static rehydrateDetachedFromSnapshot(loader: Loader, snapshot: string): Promise<Container>;
     // (undocumented)

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -94,6 +94,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     proposeCodeDetails(codeDetails: IFluidCodeDetails): Promise<boolean>;
     raiseContainerWarning(warning: ContainerWarning): void;
     // (undocumented)
+    /**
+      * Object defining the current readonly state of the Container.
+      * If the Container is readonly it also provides additional properties describing how it got to that state.
+     **/
     get readOnlyInfo(): ReadOnlyInfo;
     static rehydrateDetachedFromSnapshot(loader: Loader, snapshot: string): Promise<Container>;
     // (undocumented)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -412,33 +412,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return this._loadedFromVersion;
     }
 
-    /**
-     * Tells if container is in read-only mode.
-     * Data stores should listen for "readonly" notifications and disallow user making changes to data stores.
-     * Readonly state can be because of no storage write permission,
-     * or due to host forcing readonly mode for container.
-     *
-     * We do not differentiate here between no write access to storage vs. host disallowing changes to container -
-     * in all cases container runtime and data stores should respect readonly state and not allow local changes.
-     *
-     * It is undefined if we have not yet established websocket connection
-     * and do not know if user has write access to a file.
-     * @deprecated - use readOnlyInfo
-     */
-    public get readonly() {
-        return this._deltaManager.readonly;
-    }
-
-    /**
-     * Tells if user has no write permissions for file in storage
-     * It is undefined if we have not yet established websocket connection
-     * and do not know if user has write access to a file.
-     * @deprecated - use readOnlyInfo
-     */
-    public get readonlyPermissions() {
-        return this._deltaManager.readonlyPermissions;
-    }
-
     public get readOnlyInfo(): ReadOnlyInfo {
         return this._deltaManager.readOnlyInfo;
     }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -337,6 +337,23 @@ export class DeltaManager
         return this.connection.mode;
     }
 
+    /**
+     * Tells if container is in read-only mode.
+     * Data stores should listen for "readonly" notifications and disallow user
+     * making changes to data stores.
+     * Readonly state can be because of no storage write permission,
+     * or due to host forcing readonly mode for container.
+     * It is undefined if we have not yet established websocket connection
+     * and do not know if user has write access to a file.
+     * @deprecated - use readOnlyInfo
+     */
+     public get readonly() {
+        if (this._forceReadonly) {
+            return true;
+        }
+        return this._readonlyPermissions;
+    }
+
     public get readOnlyInfo(): ReadOnlyInfo {
         const storageOnly = this.connection !== undefined && this.connection instanceof NoDeltaStream;
         if (storageOnly || this._forceReadonly || this._readonlyPermissions === true) {

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -129,10 +129,6 @@ export class DeltaManagerProxy
         return this.deltaManager.active;
     }
 
-    public get readonly(): boolean | undefined {
-        return this.deltaManager.readonly;
-    }
-
     public get readOnlyInfo(): ReadOnlyInfo {
         return this.deltaManager.readOnlyInfo;
     }

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -129,6 +129,10 @@ export class DeltaManagerProxy
         return this.deltaManager.active;
     }
 
+    public get readonly(): boolean | undefined {
+        return this.deltaManager.readonly;
+    }
+
     public get readOnlyInfo(): ReadOnlyInfo {
         return this.deltaManager.readOnlyInfo;
     }

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -234,13 +234,13 @@ describe("Loader", () => {
                 it("Should override readonly", async () => {
                     await startDeltaManager();
 
-                    assert.strictEqual(deltaManager.readonly, false);
+                    assert.strictEqual(deltaManager.readOnlyInfo.readonly, false);
 
                     deltaManager.forceReadonly(true);
-                    assert.strictEqual(deltaManager.readonly, true);
+                    assert.strictEqual(deltaManager.readOnlyInfo.readonly, true);
 
                     deltaManager.forceReadonly(false);
-                    assert.strictEqual(deltaManager.readonly, false);
+                    assert.strictEqual(deltaManager.readOnlyInfo.readonly, false);
                 });
 
                 it("Should raise readonly event when container was not readonly", async () => {
@@ -261,7 +261,7 @@ describe("Loader", () => {
 
                     // Closing underlying connection makes container readonly
                     deltaConnection.dispose();
-                    assert.strictEqual(deltaManager.readonly, true);
+                    assert.strictEqual(deltaManager.readOnlyInfo.readonly, true);
 
                     deltaManager.on("readonly", () => {
                         assert.fail("Shouldn't be called");

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1135,7 +1135,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.deltaManager.on("readonly", (readonly: boolean) => {
             // we accumulate ops while being in read-only state.
             // once user gets write permissions and we have active connection, flush all pending ops.
-            assert(readonly === this.deltaManager.readonly, 0x124 /* "inconsistent readonly property/event state" */);
+            // eslint-disable-next-line max-len
+            assert(readonly === this.deltaManager.readOnlyInfo.readonly, 0x124 /* "inconsistent readonly property/event state" */);
 
             // We need to be very careful with when we (re)send pending ops, to ensure that we only send ops
             // when we either never send an op, or attempted to send it but we know for sure it was not

--- a/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
@@ -92,7 +92,7 @@ describe("No Delta Stream", () => {
         const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
 
         assert.strictEqual(container.deltaManager.active, false, "active");
-        assert.strictEqual(container.deltaManager.readonly, false, "readonly");
+        assert.strictEqual(container.deltaManager.readOnlyInfo.readonly, false, "readonly");
 
         assert.strictEqual(dataObject.runtime.connected, true, "connected");
         assert.notStrictEqual(dataObject.runtime.clientId, undefined, "clientId");
@@ -111,13 +111,11 @@ describe("No Delta Stream", () => {
 
         assert.strictEqual(container.connected, true, "container.connected");
         assert.strictEqual(container.clientId, "storage-only client", "container.clientId");
-        assert.strictEqual(container.readonly, true, "container.readonly");
-        assert.strictEqual(container.readonlyPermissions, true, "container.readonlyPermissions");
+        assert.strictEqual(container.readOnlyInfo.readonly, true, "container.readOnlyInfo.readonly");
         assert.ok(container.readOnlyInfo.readonly, "container.storageOnly");
 
         const deltaManager = container.deltaManager;
         assert.strictEqual(deltaManager.active, false, "deltaManager.active");
-        assert.strictEqual(deltaManager.readonly, true, "deltaManager.readonly");
         assert.ok(deltaManager.readOnlyInfo.readonly, "deltaManager.readOnlyInfo.readonly");
         assert.ok(deltaManager.readOnlyInfo.permissions, "deltaManager.readOnlyInfo.permissions");
         assert.ok(deltaManager.readOnlyInfo.storageOnly, "deltaManager.readOnlyInfo.storageOnly");
@@ -164,13 +162,11 @@ describe("No Delta Stream", () => {
 
         assert.strictEqual(container.connected, true, "container.connected");
         assert.strictEqual(container.clientId, "storage-only client", "container.clientId");
-        assert.strictEqual(container.readonly, true, "container.readonly");
-        assert.strictEqual(container.readonlyPermissions, true, "container.readonlyPermissions");
+        assert.strictEqual(container.readOnlyInfo.readonly, true, "container.readOnlyInfo.readonly");
         assert.ok(container.readOnlyInfo.readonly, "container.storageOnly");
 
         const deltaManager = container.deltaManager;
         assert.strictEqual(deltaManager.active, false, "deltaManager.active");
-        assert.strictEqual(deltaManager.readonly, true, "deltaManager.readonly");
         assert.ok(deltaManager.readOnlyInfo.readonly, "deltaManager.readOnlyInfo.readonly");
         assert.ok(deltaManager.readOnlyInfo.permissions, "deltaManager.readOnlyInfo.permissions");
         assert.ok(deltaManager.readOnlyInfo.storageOnly, "deltaManager.readOnlyInfo.storageOnly");

--- a/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
@@ -112,7 +112,6 @@ describe("No Delta Stream", () => {
         assert.strictEqual(container.connected, true, "container.connected");
         assert.strictEqual(container.clientId, "storage-only client", "container.clientId");
         assert.strictEqual(container.readOnlyInfo.readonly, true, "container.readOnlyInfo.readonly");
-        assert.ok(container.readOnlyInfo.readonly, "container.storageOnly");
 
         const deltaManager = container.deltaManager;
         assert.strictEqual(deltaManager.active, false, "deltaManager.active");

--- a/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
@@ -150,7 +150,6 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
                 storageOnlyContainer.resume();
                 const deltaManager = storageOnlyContainer.deltaManager;
                 assert.strictEqual(deltaManager.active, false, "deltaManager.active");
-                assert.strictEqual(deltaManager.readonly, true, "deltaManager.readonly");
                 assert.ok(deltaManager.readOnlyInfo.readonly, "deltaManager.readOnlyInfo.readonly");
                 assert.ok(deltaManager.readOnlyInfo.permissions, "deltaManager.readOnlyInfo.permissions");
                 assert.ok(deltaManager.readOnlyInfo.storageOnly, "deltaManager.readOnlyInfo.storageOnly");


### PR DESCRIPTION
This PR removes the `readOnly` and `readOnlyPermissions` properties from `container-loader`.

Issue: https://github.com/microsoft/FluidFramework/issues/8190