### PR TITLE
Deprecate codeDetailsProposed on IContainerRuntimeEvents and remove implementation

### DIFF
--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -67,7 +67,7 @@ export type IContainerRuntimeBaseWithCombinedEvents = IContainerRuntimeBase & IE
 
 // @public (undocumented)
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
-    // (undocumented)
+    // @deprecated (undocumented)
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void): any;
     // (undocumented)
     (event: "dirty" | "disconnected" | "dispose" | "saved" | "attached", listener: () => void): any;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -60,6 +60,7 @@ export interface IProvideContainerRuntime {
 }
 
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
+    /** @deprecated codeDetailsProposed no longer fires on the container runtime. */
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
     (
         event: "dirty" | "disconnected" | "dispose" | "saved" | "attached",

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1002,12 +1002,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.clearPartialChunks(clientId);
         });
 
-        this.context.quorum.on("addProposal", (proposal) => {
-            if (proposal.key === "code" || proposal.key === "code2") {
-                this.emit("codeDetailsProposed", proposal.value, proposal);
-            }
-        });
-
         this.summaryCollection = new SummaryCollection(this.deltaManager, this.logger);
 
         // Only create a SummaryManager if summaries are enabled and we are not the summarizer client


### PR DESCRIPTION
As part of removing access to the quorum proposals, the container runtime should stop accessing them as well (everything below `Container` will only have an `IQuorumClients`).  This event doesn't appear used (which makes sense, because firing on proposal add is not particularly useful without knowing whether the proposal is accepted/rejected, and rejecting the proposal is not a scenario we are really targeting at the moment), so going ahead with removal and marking the interface deprecated.

I hit some issues making the version compat tests work (I think there are some issues currently maybe?) so will double-back to change the interface later.