### PR TITLE
Add fetch reason in fetch ops call in delta manager

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -332,7 +332,7 @@ export function readAndParseFromBlobs<T>(blobs: {
 }, id: string): T;
 
 // @public (undocumented)
-export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal): IStream<ISequencedDocumentMessage[]>;
+export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal, fetchReason?: string): IStream<ISequencedDocumentMessage[]>;
 
 // @public (undocumented)
 export class RetryableError<T extends string> extends NetworkErrorBasic<T> {

--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -49,7 +49,7 @@ export class DeltaStorageService implements IDeltaStorageService {
 export class DocumentDeltaStorageService implements IDocumentDeltaStorageService {
     constructor(tenantId: string, id: string, storageService: IDeltaStorageService, documentStorageService: DocumentStorageService);
     // (undocumented)
-    fetchMessages(from: number, to: number | undefined, abortSignal?: AbortSignal, cachedOnly?: boolean): IStream<ISequencedDocumentMessage[]>;
+    fetchMessages(from: number, to: number | undefined, abortSignal?: AbortSignal, cachedOnly?: boolean, fetchReason?: string): IStream<ISequencedDocumentMessage[]>;
     }
 
 // @public

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -226,6 +226,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
             this.batchSize,
             this.logger,
             abortSignal,
+            fetchReason,
         );
 
         return streamObserver(stream, (result) => {

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -41,6 +41,7 @@ export class OdspDeltaStorageService {
         from: number,
         to: number,
         telemetryProps: ITelemetryProperties,
+        fetchReason?: string,
     ): Promise<IDeltasFetchResult> {
         return getWithRetryForTokenRefresh(async (options) => {
             // Note - this call ends up in getSocketStorageDiscovery() and can refresh token
@@ -52,6 +53,9 @@ export class OdspDeltaStorageService {
             let postBody = `--${formBoundary}\r\n`;
             postBody += `Authorization: Bearer ${storageToken}\r\n`;
             postBody += `X-HTTP-Method-Override: GET\r\n`;
+            if (fetchReason !== undefined) {
+                postBody += `fetchReason: ${fetchReason}\r\n`;
+            }
 
             postBody += `_post: 1\r\n`;
             postBody += `\r\n--${formBoundary}--`;
@@ -123,7 +127,8 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
         private readonly getFromStorage: (
             from: number,
             to: number,
-            telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>,
+            telemetryProps: ITelemetryProperties,
+            fetchReason?: string) => Promise<IDeltasFetchResult>,
         private readonly getCached: (from: number, to: number) => Promise<ISequencedDocumentMessage[]>,
         private readonly requestFromSocket: (from: number, to: number) => void,
         private readonly opsReceived: (ops: ISequencedDocumentMessage[]) => void,
@@ -151,7 +156,8 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
         fromTotal: number,
         toTotal: number | undefined,
         abortSignal?: AbortSignal,
-        cachedOnly?: boolean)
+        cachedOnly?: boolean,
+        fetchReason?: string)
     {
         // We do not control what's in the cache. Current API assumes that fetchMessages() keeps banging on
         // storage / cache until it gets ops it needs. This would result in deadlock if fixed range is asked from
@@ -198,7 +204,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
                 return { messages: [], partialResult: false };
             }
 
-            const ops = await this.getFromStorage(from, to, telemetryProps);
+            const ops = await this.getFromStorage(from, to, telemetryProps, fetchReason);
             this.validateMessages("storage", ops.messages, from);
             opsFromStorage += ops.messages.length;
             this.opsReceived(ops.messages);

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -211,7 +211,7 @@ export class OdspDocumentService implements IDocumentService {
             this.logger,
             batchSize,
             concurrency,
-            async (from, to, telemetryProps) => service.get(from, to, telemetryProps),
+            async (from, to, telemetryProps, fetchReason) => service.get(from, to, telemetryProps, fetchReason),
             async (from, to) => {
                 const res = await this.opsCache?.get(from, to);
                 return res as ISequencedDocumentMessage[] ?? [];

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -36,6 +36,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
         to: number | undefined,
         abortSignal?: AbortSignal,
         cachedOnly?: boolean,
+        fetchReason?: string,
     ): IStream<ISequencedDocumentMessage[]>
     {
         if (cachedOnly) {
@@ -51,6 +52,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
             MaxBatchDeltas,
             new TelemetryNullLogger(),
             abortSignal,
+            fetchReason,
         );
     }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1025,7 +1025,8 @@ export class DeltaManager
                 from, // inclusive
                 to, // exclusive
                 controller.signal,
-                cacheOnly);
+                cacheOnly,
+                this.fetchReason);
 
             // eslint-disable-next-line no-constant-condition
             while (true) {

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -360,7 +360,8 @@ async function getSingleOpBatch(
     props: ITelemetryProperties,
     strongTo: boolean,
     logger: ITelemetryLogger,
-    signal?: AbortSignal):
+    signal?: AbortSignal,
+    fetchReason?: string):
         Promise<{ partial: boolean, cancel: boolean, payload: ISequencedDocumentMessage[] }>
 {
     let lastSuccessTime: number | undefined;
@@ -424,6 +425,7 @@ async function getSingleOpBatch(
                     retry,
                     duration: performance.now() - startTime,
                     retryAfter,
+                    fetchReason,
                 },
                 error);
 
@@ -451,6 +453,7 @@ export function requestOps(
     payloadSize: number,
     logger: ITelemetryLogger,
     signal?: AbortSignal,
+    fetchReason?: string,
 ): IStream<ISequencedDocumentMessage[]> {
     let requests = 0;
     let lastFetch: number | undefined;
@@ -465,6 +468,7 @@ export function requestOps(
     const telemetryEvent = PerformanceEvent.start(logger, {
         eventName: "GetDeltas",
         ...propsTotal,
+        fetchReason,
     });
 
     const manager = new ParallelRequests<ISequencedDocumentMessage>(
@@ -480,6 +484,7 @@ export function requestOps(
                 strongTo,
                 logger,
                 signal,
+                fetchReason,
             );
         },
         (deltas: ISequencedDocumentMessage[]) => {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/6483
Add fetch reason in fetch ops call in delta manager, so that server can log that in telemetry and help in debugging issues by getting to know the scenario in which the ops are fetched.