### PR TITLE
Update repo to use the new 0.43 container-definitions package with updated IContainer

### DIFF
--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-example/search-menu": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/ink": "^0.53.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.53.0",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluid-example/client-ui-lib": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/merge-tree": "^0.53.0",
     "@fluidframework/runtime-definitions": "^0.53.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-example/host-service-interfaces": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/cell": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -41,7 +41,7 @@
     "@fluid-example/table-document": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/runtime-utils": "^0.53.0",
     "@fluidframework/sequence": "^0.53.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/request-handler": "^0.53.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -35,7 +35,7 @@
     "@fluid-experimental/get-container": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/map": "^0.53.0",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0"
   },
   "devDependencies": {

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-example/todo": "^0.53.0",
     "@fluid-experimental/get-container": "^0.53.0",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@fluid-example/key-value-cache": "^0.53.0",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -34,7 +34,7 @@
     "@fluid-experimental/property-changeset": "^0.53.0",
     "@fluid-experimental/property-properties": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/bubblebench-common": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/map": "^0.53.0",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/map": "^0.53.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/sharejs-json1": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/map": "^0.53.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/tree": "^0.53.0",
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/map": "^0.53.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2004,12 +2004,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.42.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.42.0.tgz",
-			"integrity": "sha512-xSGoZMJ6dFF9Y+oiuG2Vi9N/7VR1pHNYMSkumVmhX9hGp7cLqqYKA+stugEpb14g4GL3jTz5mx0taXEMUo1LSw==",
+			"version": "0.43.0-45414",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.43.0-45414.tgz",
+			"integrity": "sha512-0JEO3YdjpfTOaC7stCcaDg82m5eTTcKMBbag4BwKssmDPmda8vOn9MjsphaMSzXw5WYM6i24OBC43mTiyFN3Ng==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.41.0",
+				"@fluidframework/driver-definitions": "^0.43.0-0",
 				"@fluidframework/protocol-definitions": "^0.1026.0"
 			}
 		},
@@ -2077,6 +2078,17 @@
 				"@types/node": "^12.19.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.42.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.42.0.tgz",
+					"integrity": "sha512-xSGoZMJ6dFF9Y+oiuG2Vi9N/7VR1pHNYMSkumVmhX9hGp7cLqqYKA+stugEpb14g4GL3jTz5mx0taXEMUo1LSw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/driver-definitions": "^0.42.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.42.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -2088,9 +2100,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.52.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.52.0.tgz",
-					"integrity": "sha512-UW6w7SCqEulqASF8iNPHIEe/ws3WXwh/KY93QyXYEe/qndAjCE0lh0bmJxfpHxstQW49FbfRc6sfiDcMBlGSQg==",
+					"version": "0.52.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.52.1.tgz",
+					"integrity": "sha512-faQLxWWzrbjhv3X3pDFSRgB5nTXTElnFDTfF/KpC1+OH6WixToIAli41IbIsrNoitrD3GzrrtOruEhPsew/xTw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2172,6 +2184,17 @@
 				"@types/node": "^12.19.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.42.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.42.0.tgz",
+					"integrity": "sha512-xSGoZMJ6dFF9Y+oiuG2Vi9N/7VR1pHNYMSkumVmhX9hGp7cLqqYKA+stugEpb14g4GL3jTz5mx0taXEMUo1LSw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/driver-definitions": "^0.42.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.42.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -2183,9 +2206,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.52.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.52.0.tgz",
-					"integrity": "sha512-UW6w7SCqEulqASF8iNPHIEe/ws3WXwh/KY93QyXYEe/qndAjCE0lh0bmJxfpHxstQW49FbfRc6sfiDcMBlGSQg==",
+					"version": "0.52.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.52.1.tgz",
+					"integrity": "sha512-faQLxWWzrbjhv3X3pDFSRgB5nTXTElnFDTfF/KpC1+OH6WixToIAli41IbIsrNoitrD3GzrrtOruEhPsew/xTw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2251,9 +2274,9 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "0.51.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.51.2.tgz",
-			"integrity": "sha512-sj3SEhEkRbMBtoJJaKR3neka52IJrGGk0mJqgLsHlWPXoLaDZlSrEziakApkpi+IWMSvdh98oWzV5+merUyu7Q==",
+			"version": "0.51.3",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.51.3.tgz",
+			"integrity": "sha512-f//lYnlhc+3ZtzPkiFyGA8jvP3ipKInHTC4yXwcbuRGNk18MMzfu7d0ZuLWy2n4cZa9EymzGc5v1e7RvPKqIYA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.1",
@@ -2364,6 +2387,17 @@
 				"@types/node": "^12.19.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.42.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.42.0.tgz",
+					"integrity": "sha512-xSGoZMJ6dFF9Y+oiuG2Vi9N/7VR1pHNYMSkumVmhX9hGp7cLqqYKA+stugEpb14g4GL3jTz5mx0taXEMUo1LSw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/driver-definitions": "^0.42.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.42.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",
     "@fluidframework/datastore-definitions": "^0.53.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/fluid-static": "^0.53.0",
     "@fluidframework/map": "^0.53.0",
     "@fluidframework/sequence": "^0.53.0"

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",
     "@fluidframework/driver-utils": "^0.53.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-utils": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/telemetry-utils": "^0.53.0"
   },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.53.0",
     "@fluidframework/datastore-definitions": "^0.53.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
@@ -63,6 +63,18 @@
   },
   "typeValidation": {
     "version": "0.53.0",
-    "broken": {}
+    "broken": {
+      "0.51.1": {
+        "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IProvideContainerRuntime": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": false
+        }
+      }
+    }
   }
 }

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.51.1.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.51.1.ts
@@ -55,6 +55,7 @@ declare function get_current_InterfaceDeclaration_IContainerRuntime():
 declare function use_old_InterfaceDeclaration_IContainerRuntime(
     use: old.IContainerRuntime);
 use_old_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -79,6 +80,7 @@ declare function get_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombi
 declare function use_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: old.IContainerRuntimeBaseWithCombinedEvents);
 use_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -127,4 +129,5 @@ declare function get_current_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_old_InterfaceDeclaration_IProvideContainerRuntime(
     use: old.IProvideContainerRuntime);
 use_old_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideContainerRuntime());

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",
     "@fluidframework/container-utils": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.53.0",
@@ -63,6 +63,18 @@
   },
   "typeValidation": {
     "version": "0.53.0",
-    "broken": {}
+    "broken": {
+      "0.51.1": {
+        "InterfaceDeclaration_IChannel": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IChannelFactory": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRuntime": {
+          "backCompat": false
+        }
+      }
+    }
   }
 }

--- a/packages/runtime/datastore-definitions/src/test/types/validate0.51.1.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validate0.51.1.ts
@@ -31,6 +31,7 @@ declare function get_current_InterfaceDeclaration_IChannel():
 declare function use_old_InterfaceDeclaration_IChannel(
     use: old.IChannel);
 use_old_InterfaceDeclaration_IChannel(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IChannel());
 
 /*
@@ -79,6 +80,7 @@ declare function get_current_InterfaceDeclaration_IChannelFactory():
 declare function use_old_InterfaceDeclaration_IChannelFactory(
     use: old.IChannelFactory);
 use_old_InterfaceDeclaration_IChannelFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IChannelFactory());
 
 /*
@@ -199,6 +201,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: old.IFluidDataStoreRuntime);
 use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-utils": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
@@ -63,6 +63,27 @@
   },
   "typeValidation": {
     "version": "0.53.0",
-    "broken": {}
+    "broken": {
+      "0.51.1": {
+        "InterfaceDeclaration_IFluidDataStoreContextDetached": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContext": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntimeBase": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IChannelFactory": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRuntime": {
+          "backCompat": false
+        }
+      }
+    }
   }
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.51.1.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.51.1.ts
@@ -223,6 +223,7 @@ declare function get_current_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_old_InterfaceDeclaration_IContainerRuntimeBase(
     use: old.IContainerRuntimeBase);
 use_old_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -319,6 +320,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContext(
     use: old.IFluidDataStoreContext);
 use_old_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -343,6 +345,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContextDetached
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: old.IFluidDataStoreContextDetached);
 use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.53.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/cell": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/container-runtime-definitions": "^0.53.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/cell": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/cell": "^0.53.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/container-runtime": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.42.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0-0",


### PR DESCRIPTION
- Update all `package.json`'s consuming `"@fluidframework/container-definitions"` to use the pre-release 0.43.0-0
- Updated back-compat tests to pass with the new breaking changes introduced in the updated `IContainer`

The follow-up to this will be updating the returns of `Loader` to be `IContainer` instead of `Container` but that will require many other changes in the places `Loader` is used so I'd like to keep the PRs separate