### PR TITLE
Changed performance.now() to Date.now() for unix timestamps

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -924,7 +924,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         } else {
             this.createContainerMetadata = {
                 createContainerRuntimeVersion: pkgVersion,
-                createContainerTimestamp: performance.now(),
+                createContainerTimestamp: Date.now(),
             };
         }
 
@@ -947,7 +947,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
          * of this client's connection - https://github.com/microsoft/FluidFramework/issues/8375.
          */
         const getCurrentTimestamp = () => {
-            return this.deltaManager.lastMessage?.timestamp ?? performance.now();
+            return this.deltaManager.lastMessage?.timestamp ?? Date.now();
         };
         this.garbageCollector = GarbageCollector.create(
             this,


### PR DESCRIPTION
Updated the timestamps for `unreferencedTimestamp` and `createContainerTimestamp` to use Date.now() instead of performance.now().
peformance.now() returns a time relative to the document load and is not an absolute timestamp. So, it cannot be used to compare time across documents. We need to use Date.now() which gives a number that is the number of milliseconds since the unix epoch.
We could use something like `performance.timing.navigationStart + performance.now()` to get a comparable timestamp but performance.timing is deprecated so using Date.now() is better.