### PR TITLE
remove deprecated maxMessageSize properties

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -42,7 +42,7 @@ The `readOnly` and `readOnlyPermissions` properties from `Container` in `contain
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
 
 ### `maxMessageSize` removed from `IConnectionDetails` and `IDocumentDeltaConnection`
-The `maxMessageSize` property from `IConnectionDetails` and `IDocumentDeltaConnection` was deprecated in 0.51, and has now been removed. To replace its functionality, use `serviceConfiguration.maxMessageSize`.
+The `maxMessageSize` property from `IConnectionDetails` and `IDocumentDeltaConnection` was deprecated in 0.51, and has now been removed from the `container-definitions` and `driver-definitions` packages respectively. To replace its functionality, use `serviceConfiguration.maxMessageSize`.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,7 +14,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
 - [readOnly and readOnlyPermissions removed from Container](#readOnly-and-readOnlyPermissions-removed-from-container)
-- [maxMessageSize removed from driver-definitions and container-definitions](#maxMessageSize-removed-from-driver-definitions-and-container-definitions)
+- [maxMessageSize removed from IConnectionDetails and IDocumentDeltaConnection](#maxMessageSize-removed-from-IConnectionDetails-and-IDocumentDeltaConnection)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -37,8 +37,8 @@ Additionally, `codeDetails` which was already deprecated before is now marked as
 ### `readOnly` and `readOnlyPermissions` removed from `Container`
 The `readOnly` and `readOnlyPermissions` properties from `Container` in `container-loader` was deprecated in 0.35, and has now been removed. To replace its functionality, use `readOnlyInfo` by accessing `readOnlyInfo.readonly` and `readOnlyInfo.permissions` respectively.
 
-### `maxMessageSize` removed from `container-definitions` and `driver-definitions`
-The `maxMessageSize` property from `container-definitions` and `driver-definitions` was deprecated in 0.51, and has now been removed. To replace its functionality, use `serviceConfiguration.maxMessageSize`.
+### `maxMessageSize` removed from `IConnectionDetails` and `IDocumentDeltaConnection`
+The `maxMessageSize` property from `IConnectionDetails` and `IDocumentDeltaConnection` was deprecated in 0.51, and has now been removed. To replace its functionality, use `serviceConfiguration.maxMessageSize`.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,6 +14,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
 - [readOnly and readOnlyPermissions removed from Container](#readOnly-and-readOnlyPermissions-removed-from-container)
+- [maxMessageSize removed from driver-definitions and container-definitions](#maxMessageSize-removed-from-driver-definitions-and-container-definitions)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -35,6 +36,9 @@ Additionally, `codeDetails` which was already deprecated before is now marked as
 
 ### `readOnly` and `readOnlyPermissions` removed from `Container`
 The `readOnly` and `readOnlyPermissions` properties from `Container` in `container-loader` was deprecated in 0.35, and has now been removed. To replace its functionality, use `readOnlyInfo` by accessing `readOnlyInfo.readonly` and `readOnlyInfo.permissions` respectively.
+
+### `maxMessageSize` removed from `container-definitions` and `driver-definitions`
+The `maxMessageSize` property from `container-definitions` and `driver-definitions` was deprecated in 0.51, and has now been removed. To replace its functionality, use `serviceConfiguration.maxMessageSize`.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -112,8 +112,6 @@ export interface IConnectionDetails {
     existing: boolean;
     // (undocumented)
     initialClients: ISignalClient[];
-    // @deprecated (undocumented)
-    maxMessageSize: number;
     // (undocumented)
     mode: ConnectionMode;
     // (undocumented)

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -122,6 +122,12 @@
         },
         "InterfaceDeclaration_IThrottlingWarning": {
           "backCompat": false
+        },
+        "InterfaceDeclaration_IDeltaManager": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IConnectionDetails": {
+          "backCompat": false
         }
       },
       "0.40.0": {
@@ -156,6 +162,12 @@
         },
         "InterfaceDeclaration_IContainer": {
           "backCompat": false
+        },
+        "InterfaceDeclaration_IDeltaManager": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IConnectionDetails": {
+          "backCompat": false
         }
       },
       "0.41.0": {
@@ -179,6 +191,12 @@
         },
         "InterfaceDeclaration_ICodeLoader": {
           "backCompat": false
+        },
+        "InterfaceDeclaration_IDeltaManager": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IConnectionDetails": {
+          "backCompat": false
         }
       },
       "0.42.0": {
@@ -198,6 +216,12 @@
           "backCompat": false
         },
         "InterfaceDeclaration_IProvideLoader": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IDeltaManager": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IConnectionDetails": {
           "backCompat": false
         }
       }

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -25,10 +25,6 @@ export interface IConnectionDetails {
     mode: ConnectionMode;
     version: string;
     initialClients: ISignalClient[];
-    /**
-     * @deprecated - please use `serviceConfiguration.maxMessageSize`
-     */
-    maxMessageSize: number;
     serviceConfiguration: IClientConfiguration;
     /**
      * Last known sequence number to ordering service at the time of connection

--- a/common/lib/container-definitions/src/test/types/validate0.39.8.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.39.8.ts
@@ -202,6 +202,7 @@ declare function get_current_InterfaceDeclaration_IConnectionDetails():
 declare function use_old_InterfaceDeclaration_IConnectionDetails(
     use: old.IConnectionDetails);
 use_old_InterfaceDeclaration_IConnectionDetails(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnectionDetails());
 
 /*
@@ -374,6 +375,7 @@ declare function get_current_InterfaceDeclaration_IDeltaManager():
 declare function use_old_InterfaceDeclaration_IDeltaManager(
     use: old.IDeltaManager<any,any>);
 use_old_InterfaceDeclaration_IDeltaManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaManager());
 
 /*

--- a/common/lib/container-definitions/src/test/types/validate0.40.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.40.0.ts
@@ -201,6 +201,7 @@ declare function get_current_InterfaceDeclaration_IConnectionDetails():
 declare function use_old_InterfaceDeclaration_IConnectionDetails(
     use: old.IConnectionDetails);
 use_old_InterfaceDeclaration_IConnectionDetails(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnectionDetails());
 
 /*
@@ -372,6 +373,7 @@ declare function get_current_InterfaceDeclaration_IDeltaManager():
 declare function use_old_InterfaceDeclaration_IDeltaManager(
     use: old.IDeltaManager<any,any>);
 use_old_InterfaceDeclaration_IDeltaManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaManager());
 
 /*

--- a/common/lib/container-definitions/src/test/types/validate0.41.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.41.0.ts
@@ -200,6 +200,7 @@ declare function get_current_InterfaceDeclaration_IConnectionDetails():
 declare function use_old_InterfaceDeclaration_IConnectionDetails(
     use: old.IConnectionDetails);
 use_old_InterfaceDeclaration_IConnectionDetails(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnectionDetails());
 
 /*
@@ -370,6 +371,7 @@ declare function get_current_InterfaceDeclaration_IDeltaManager():
 declare function use_old_InterfaceDeclaration_IDeltaManager(
     use: old.IDeltaManager<any,any>);
 use_old_InterfaceDeclaration_IDeltaManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaManager());
 
 /*

--- a/common/lib/container-definitions/src/test/types/validate0.42.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.42.0.ts
@@ -199,6 +199,7 @@ declare function get_current_InterfaceDeclaration_IConnectionDetails():
 declare function use_old_InterfaceDeclaration_IConnectionDetails(
     use: old.IConnectionDetails);
 use_old_InterfaceDeclaration_IConnectionDetails(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnectionDetails());
 
 /*
@@ -369,6 +370,7 @@ declare function get_current_InterfaceDeclaration_IDeltaManager():
 declare function use_old_InterfaceDeclaration_IDeltaManager(
     use: old.IDeltaManager<any,any>);
 use_old_InterfaceDeclaration_IDeltaManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaManager());
 
 /*

--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -95,8 +95,6 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     initialClients: ISignalClient[];
     initialMessages: ISequencedDocumentMessage[];
     initialSignals: ISignalMessage[];
-    // @deprecated
-    maxMessageSize: number;
     mode: ConnectionMode;
     relayServiceAgent?: string;
     serviceConfiguration: IClientConfiguration;

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -130,6 +130,17 @@
         "get_current_InterfaceDeclaration_IDocumentDeltaConnection": {
           "backCompat": false
         }
+      },
+      "0.42.0": {
+        "InterfaceDeclaration_IDocumentDeltaConnection": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IDocumentService": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IDocumentServiceFactory": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -182,13 +182,6 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     existing: boolean;
 
     /**
-     * Maximum size of a message that can be sent to the server. Messages larger than this size must be chunked.
-     *
-     * @deprecated - please use `serviceConfiguration.maxMessageSize`
-     */
-    maxMessageSize: number;
-
-    /**
      * Protocol version being used with the service
      */
     version: string;

--- a/common/lib/driver-definitions/src/test/types/validate0.42.0.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.42.0.ts
@@ -199,6 +199,7 @@ declare function get_current_InterfaceDeclaration_IDocumentDeltaConnection():
 declare function use_old_InterfaceDeclaration_IDocumentDeltaConnection(
     use: old.IDocumentDeltaConnection);
 use_old_InterfaceDeclaration_IDocumentDeltaConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDocumentDeltaConnection());
 
 /*
@@ -271,6 +272,7 @@ declare function get_current_InterfaceDeclaration_IDocumentService():
 declare function use_old_InterfaceDeclaration_IDocumentService(
     use: old.IDocumentService);
 use_old_InterfaceDeclaration_IDocumentService(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDocumentService());
 
 /*
@@ -295,6 +297,7 @@ declare function get_current_InterfaceDeclaration_IDocumentServiceFactory():
 declare function use_old_InterfaceDeclaration_IDocumentServiceFactory(
     use: old.IDocumentServiceFactory);
 use_old_InterfaceDeclaration_IDocumentServiceFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDocumentServiceFactory());
 
 /*


### PR DESCRIPTION
Remove the `maxMessageSize` property from the following files:
1. `common\lib\container-definitions\src\deltas.ts`
2. `common\lib\driver-definitions\src\storage.ts`

To replace its functionality, use `serviceConfiguration.maxMessageSize`.

Issue: https://github.com/microsoft/FluidFramework/issues/8189