### PR TITLE
Remove loader property from test-runtime-utils

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -13,6 +13,7 @@ There are a few steps you can take to write a good change note and avoid needing
 ## 0.53 Breaking changes
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
+- [readOnly and readOnlyPermissions removed from Container](#readOnly-and-readOnlyPermissions-removed-from-container)
 - [Remove `loader` property from `MockFluidDataStoreContext` class](#Remove-loader-property-from-MockFluidDataStoreContext-class)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
@@ -32,6 +33,9 @@ Additionally, `codeDetails` which was already deprecated before is now marked as
 
 ### Remove `getLegacyInterval()` and `delete()` from sequence dds
 `getLegacyInterval()` was only being used by the deprecated `IntervalCollection.delete()`. The alternative to `IntervalCollection.delete()` is `IntervalCollection.removeIntervalById()`.
+
+### `readOnly` and `readOnlyPermissions` removed from `Container`
+The `readOnly` and `readOnlyPermissions` properties from `Container` in `container-loader` was deprecated in 0.35, and has now been removed. To replace its functionality, use `readOnlyInfo` by accessing `readOnlyInfo.readonly` and `readOnlyInfo.permissions` respectively.
 
 ### Remove `loader` property from `MockFluidDataStoreContext` class
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -13,6 +13,7 @@ There are a few steps you can take to write a good change note and avoid needing
 ## 0.53 Breaking changes
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
+- [Remove `loader` property from `MockFluidDataStoreContext` class](#Remove-loader-property-from-MockFluidDataStoreContext-class)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -31,6 +32,9 @@ Additionally, `codeDetails` which was already deprecated before is now marked as
 
 ### Remove `getLegacyInterval()` and `delete()` from sequence dds
 `getLegacyInterval()` was only being used by the deprecated `IntervalCollection.delete()`. The alternative to `IntervalCollection.delete()` is `IntervalCollection.removeIntervalById()`.
+
+### Remove `loader` property from `MockFluidDataStoreContext` class
+The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -308,8 +308,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     IFluidHandleContext: IFluidHandleContext;
     // (undocumented)
     isLocalDataStore: boolean;
-    // @deprecated (undocumented)
-    loader: ILoader;
     // (undocumented)
     readonly logger: ITelemetryLogger;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -13,7 +13,6 @@ import {
     IAudience,
     IDeltaManager,
     ContainerWarning,
-    ILoader,
     AttachState,
     ILoaderOptions,
 } from "@fluidframework/container-definitions";
@@ -52,11 +51,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     public IFluidDataStoreRegistry: IFluidDataStoreRegistry;
     public IFluidHandleContext: IFluidHandleContext;
 
-    /**
-     * @deprecated 0.37 Containers created using a loader will make automatically it
-     * available through scope instead
-     */
-    public loader: ILoader;
     /**
      * Indicates the attachment state of the data store to a host service.
      */


### PR DESCRIPTION
This PR aims to remove one of the deprecated property `loader` from `test-runtime-utils` package. 

Resolves: https://github.com/microsoft/FluidFramework/issues/8289