### PR TITLE
Add expiry at epochTracker layer

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -419,16 +419,6 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                     // Record the cache age
                                     // eslint-disable-next-line @typescript-eslint/dot-notation
                                     props["cacheEntryAge"] = age;
-
-                                    // TODO: Refactor this logic (maybe move to a separate function)
-                                    // TODO: Currently there is a max of two days. Potentially remove this logic once proactive expiry exists.
-                                    // Set the max age to 2 days, a network call to retrieve the snapshot will be made if undefined is returned.
-                                    const maxCacheAge = defaultCacheExpiryTimeoutMs;
-                                    if (age > maxCacheAge) {
-                                        await this.epochTracker.removeEntries();
-                                        this.logger.sendTelemetryEvent({ eventName: "odspVersionsCacheExpired", duration: age, maxCacheAge });
-                                        return undefined;
-                                    }
                                 }
 
                                 return snapshotCachedEntry;

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -151,8 +151,6 @@ class BlobCache {
     }
 }
 
-export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
-
 export class OdspDocumentStorageService implements IDocumentStorageService {
     readonly policies = {
         // By default, ODSP tells the container not to prefetch/cache.

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -50,18 +50,20 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
             file: { docId: hashedDocumentId, resolvedUrl } };
         const cacheEntry2: ICacheEntry = { ... cacheEntry1, key: "key2" };
+        const cacheValue1 = { val: "val1", cacheEntryTime: Date.now() };
+        const cacheValue2 = { val: "val2", cacheEntryTime: Date.now() };
         const value1: IVersionedValueWithEpoch =
-            {value: "val1", fluidEpoch: "epoch1", version: persistedCacheValueVersion };
+            {value: cacheValue1, fluidEpoch: "epoch1", version: persistedCacheValueVersion };
         const value2 =
-            {value: "val2", fluidEpoch: "epoch1", version: "non-existing version" };
+            {value: cacheValue2, fluidEpoch: "epoch1", version: "non-existing version" };
         await localCache.put(cacheEntry1, value1);
         await localCache.put(cacheEntry2, value2);
         // This will set the initial epoch value in epoch tracker.
-        assert(await epochTracker.get(cacheEntry1) === "val1", "Entry 1 should continue to exist");
+        assert(await epochTracker.get(cacheEntry1) === cacheValue1, "Entry 1 should continue to exist");
         // This should not fail, just return nothing!
         await epochTracker.get(cacheEntry2);
         // Make sure nothing changed as result of reading data.
-        assert(await epochTracker.get(cacheEntry1) === "val1", "Entry 1 should continue to exist");
+        assert(await epochTracker.get(cacheEntry1) === cacheValue1, "Entry 1 should continue to exist");
         assert(await epochTracker.get(cacheEntry2) === undefined, "Entry 2 should not exist");
     });
 
@@ -71,18 +73,20 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
             file: { docId: hashedDocumentId, resolvedUrl } };
         const cacheEntry2: ICacheEntry = { ... cacheEntry1, key: "key2" };
+        const cacheValue1 = { val: "val1", cacheEntryTime: Date.now() };
+        const cacheValue2 = { val: "val2", cacheEntryTime: Date.now() };
         const value1: IVersionedValueWithEpoch =
-            {value: "val1", fluidEpoch: "epoch1", version: persistedCacheValueVersion };
+            {value: cacheValue1, fluidEpoch: "epoch1", version: persistedCacheValueVersion };
         const value2: IVersionedValueWithEpoch =
-            {value: "val2", fluidEpoch: "epoch2", version: persistedCacheValueVersion };
+            {value: cacheValue2, fluidEpoch: "epoch2", version: persistedCacheValueVersion };
         await localCache.put(cacheEntry1, value1);
         await localCache.put(cacheEntry2, value2);
         // This will set the initial epoch value in epoch tracker.
-        assert(await epochTracker.get(cacheEntry1) === "val1", "Entry 1 should continue to exist");
+        assert(await epochTracker.get(cacheEntry1) === cacheValue1, "Entry 1 should continue to exist");
         // This should not fail, just return nothing!
         await epochTracker.get(cacheEntry2);
         // Make sure nothing changed as result of reading data.
-        assert(await epochTracker.get(cacheEntry1) === "val1", "Entry 1 should continue to exist");
+        assert(await epochTracker.get(cacheEntry1) === cacheValue1, "Entry 1 should continue to exist");
         assert(await epochTracker.get(cacheEntry2) === undefined, "Entry 2 should not exist");
     });
 
@@ -93,7 +97,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
         // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         try {
@@ -117,7 +121,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
             // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         try {
@@ -141,7 +145,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
         // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         try {
@@ -162,7 +166,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
         // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         const response = await mockFetchOk(
@@ -179,7 +183,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
         // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         try {
@@ -189,7 +193,7 @@ describe("Tests for Epoch Tracker", () => {
         }
         assert.strictEqual(success, true, "Fetching should succeed!!");
         assert.strictEqual(
-            await epochTracker.get(cacheEntry1),
+            (await epochTracker.get(cacheEntry1)).val,
             "val1",
             "Entry in cache should be present");
     });
@@ -201,7 +205,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
         // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         try {
@@ -214,7 +218,7 @@ describe("Tests for Epoch Tracker", () => {
         }
         assert.strictEqual(success, true, "Fetching should succeed!!");
         assert.strictEqual(
-            await epochTracker.get(cacheEntry1),
+            (await epochTracker.get(cacheEntry1)).val,
             "val1", "Entry in cache should be present");
     });
 
@@ -225,7 +229,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
         // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         try {
@@ -238,7 +242,7 @@ describe("Tests for Epoch Tracker", () => {
         }
         assert.strictEqual(success, false, "Fetching should not succeed!!");
         assert.strictEqual(
-            await epochTracker.get(cacheEntry1),
+            (await epochTracker.get(cacheEntry1)).val,
             "val1",
             "Entry in cache should be present because it was not epoch 409");
     });
@@ -250,7 +254,7 @@ describe("Tests for Epoch Tracker", () => {
             type: "snapshot",
         };
         epochTracker.setEpoch("epoch1", true, "test");
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
         // This will set the initial epoch value in epoch tracker.
         await epochTracker.get(cacheEntry1);
         try {

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -65,7 +65,7 @@ describe("Tests for Epoch Tracker With Redemption", () => {
             type: snapshotKey,
             key:"key1",
         };
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
 
         // We will trigger a successful call to return the value set in the cache after the failed joinSession call
         epochCallback.setCallback(async () => epochTracker.get(cacheEntry1));
@@ -83,7 +83,7 @@ describe("Tests for Epoch Tracker With Redemption", () => {
             type: snapshotKey,
             key:"key1",
         };
-        await epochTracker.put(cacheEntry1, "val1");
+        await epochTracker.put(cacheEntry1, { val: "val1" });
 
         // We will trigger a successful call to return the value set in the cache after the failed joinSession call
         epochCallback.setCallback(async () => {

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -9,7 +9,7 @@ import {
     IOdspResolvedUrl,
     ICacheEntry,
 } from "@fluidframework/odsp-driver-definitions";
-import { EpochTracker } from "../epochTracker";
+import { EpochTracker, defaultCacheExpiryTimeoutMs } from "../epochTracker";
 import {
     IOdspSnapshot,
     HostStoragePolicyInternal,
@@ -21,7 +21,7 @@ import { INewFileInfo, ISnapshotContents } from "../odspUtils";
 import { createOdspUrl } from "../createOdspUrl";
 import { getHashedDocumentId } from "../odspPublicUtils";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
-import { defaultCacheExpiryTimeoutMs, OdspDocumentStorageService } from "../odspDocumentStorageManager";
+import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 import { mockFetchSingle, notFound, createResponse } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache(2000);


### PR DESCRIPTION
Resolves #8412 

Expires the cache at the epochTracker layer so that in the future any snapshot cache calls will be encapsulated safely so that they will always be expired.

Old snapshot caches will be immediately expired. All new snapshot caches will have the field `cacheEntryTime`.