### PR TITLE
r11s-driver: optional telemetry aggregation

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -18,6 +18,8 @@ import { ITokenProvider } from "./tokens";
 import { RouterliciousOrdererRestWrapper, RouterliciousStorageRestWrapper } from "./restWrapper";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ICache } from "./cache";
+import { AggregatePerformanceEvent } from "./telemetry";
+import { RouterliciousDriverPerformanceEventName } from ".";
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
@@ -36,6 +38,8 @@ export class DocumentService implements api.IDocumentService {
         private readonly driverPolicies: IRouterliciousDriverPolicies,
         private readonly blobCache: ICache<ArrayBufferLike>,
         private readonly snapshotTreeCache: ICache<ISnapshotTree>,
+        private readonly aggregatePerformanceEvents:
+            Partial<Record<RouterliciousDriverPerformanceEventName, AggregatePerformanceEvent>>,
     ) {
     }
 
@@ -87,7 +91,8 @@ export class DocumentService implements api.IDocumentService {
             documentStorageServicePolicies,
             this.driverPolicies,
             this.blobCache,
-            this.snapshotTreeCache);
+            this.snapshotTreeCache,
+            this.aggregatePerformanceEvents);
         return this.documentStorageService;
     }
 

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -17,10 +17,11 @@ import {
     GitManager,
 } from "@fluidframework/server-services-client";
 import { DocumentStorageServiceProxy, PrefetchDocumentStorageService } from "@fluidframework/driver-utils";
-import { IRouterliciousDriverPolicies } from "./policies";
+import { IRouterliciousDriverPolicies, RouterliciousDriverPerformanceEventName } from "./policies";
 import { ICache } from "./cache";
 import { WholeSummaryDocumentStorageService } from "./wholeSummaryDocumentStorageService";
 import { ShreddedSummaryDocumentStorageService } from "./shreddedSummaryDocumentStorageService";
+import { AggregatePerformanceEvent } from "./telemetry";
 
 export class DocumentStorageService extends DocumentStorageServiceProxy {
     private _logTailSha: string | undefined = undefined;
@@ -36,7 +37,10 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
         policies: IDocumentStorageServicePolicies,
         driverPolicies?: IRouterliciousDriverPolicies,
         blobCache?: ICache<ArrayBufferLike>,
-        snapshotTreeCache?: ICache<ISnapshotTree>): IDocumentStorageService {
+        snapshotTreeCache?: ICache<ISnapshotTree>,
+        aggregatePerformancEvents?:
+            Partial<Record<RouterliciousDriverPerformanceEventName, AggregatePerformanceEvent>>,
+    ): IDocumentStorageService {
         const storageService = driverPolicies?.enableWholeSummaryUpload ?
             new WholeSummaryDocumentStorageService(
                 id,
@@ -54,6 +58,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
                 driverPolicies,
                 blobCache,
                 snapshotTreeCache,
+                aggregatePerformancEvents,
             );
         // TODO: worth prefetching latest summary making version + snapshot call with WholeSummary storage?
         if (!driverPolicies?.enableWholeSummaryUpload && policies.caching === LoaderCachingPolicy.Prefetch) {
@@ -69,7 +74,9 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
         policies: IDocumentStorageServicePolicies = {},
         driverPolicies?: IRouterliciousDriverPolicies,
         blobCache?: ICache<ArrayBufferLike>,
-        snapshotTreeCache?: ICache<ISnapshotTree>) {
+        snapshotTreeCache?: ICache<ISnapshotTree>,
+        aggregatePerformancEvents?:
+            Partial<Record<RouterliciousDriverPerformanceEventName, AggregatePerformanceEvent>>) {
         super(DocumentStorageService.loadInternalDocumentStorageService(
             id,
             manager,
@@ -78,6 +85,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
             driverPolicies,
             blobCache,
             snapshotTreeCache,
+            aggregatePerformancEvents,
         ));
     }
 

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -3,6 +3,24 @@
  * Licensed under the MIT License.
  */
 
+export enum RouterliciousDriverPerformanceEventName {
+    getVersions = "getVersions",
+    readBlob = "readBlob",
+    // Shredded summaries
+    getSnapshotTree = "getSnapshotTree",
+    // Whole summaries
+    getWholeFlatSummaryTree = "getWholeFlatSummaryTree",
+}
+/**
+ * Number of [eventName] performance events to aggregate into 1 event.
+ * Setting as undefined will disable aggregation for [eventName] events.
+ * Example: { readBlob: 100 } will aggregate every 100 readBlob events into 1 event and log it.
+ */
+type ITelemetryAggregationPolicy = Partial<Record<RouterliciousDriverPerformanceEventName, number | undefined>>;
+
+/**
+ * Policies configurable by Routerlicious Driver consumer.
+ */
 export interface IRouterliciousDriverPolicies {
     /**
      * Enable prefetching entire snapshot tree into memory before it is loaded by the runtime.
@@ -37,4 +55,11 @@ export interface IRouterliciousDriverPolicies {
      * Default: false
      */
     enableRestLess: boolean;
+    /**
+     * Configure if/how performance telemetry events are aggregated. Useful for reducing telemetry noise.
+     * Do not use if per-event data examination is needed.
+     * Aggregated will be logged as total sums along with a total count.
+     * Default: undefined
+     */
+    telemetryAggregation: ITelemetryAggregationPolicy | undefined;
 }

--- a/packages/drivers/routerlicious-driver/src/telemetry.ts
+++ b/packages/drivers/routerlicious-driver/src/telemetry.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryGenericEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
+
+/**
+ * Helper class to reduce telemetry noise by aggregating performance events.
+ * Aggregate data will be logged, on flush, as sums along with the total count.
+ * Optionally, takes a threshold param and will flush each time the threshold is reached.
+ */
+export class AggregatePerformanceEvent {
+    private data: Record<string, number> = {};
+    private count: number = 0;
+
+    constructor(
+        private readonly event: ITelemetryGenericEvent,
+        private readonly threshold?: number,
+    ) {
+    }
+
+    public push(logger: ITelemetryLogger, data: Record<string, number>) {
+        this.count++;
+        Object.entries(data).forEach(([key, value]) => {
+            this.data[key] = (this.data[key] ?? 0) + value;
+        });
+        if (this.threshold !== undefined && this.count >= this.threshold) {
+            this.flush(logger);
+        }
+    }
+
+    public flush(logger: ITelemetryLogger) {
+        logger.sendPerformanceEvent({
+            ...this.event,
+            ...this.data,
+            count: this.count });
+        this.data = {};
+        this.count = 0;
+    }
+}


### PR DESCRIPTION
#8300 was an initial attempt at resolving #7061 by using a logger in the r11s driver to sample all performance telemetry from the driver. This PR attempts to follow the suggestions from @vladsud and @anthony-murphy regarding lowering the level, aggregation instead of sampling and making sure local debugging stays in-tact.

I am leaving the default as verbose for now to make sure debugging stays in place, but will revisit if needed.

One thing that is unsolved is how to consistently flush aggregated events, but for the current use-case in the FF E2E test pipeline, this should be fine.

Note: I hoisted the AggregatePerformanceEvents to the DocumentServiceFactory level because otherwise aggregation for `getSnapshotTree` and `getVersion` wouldn't really do anything to reduce telemetry noise in e2e tests.