### PR TITLE
DataObject: Reduce Generic Arguments and Improve Type inference

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -63,7 +63,7 @@ here are some examples:
 
 Above I've used DataObject, and DataObjectFactory however the same changes apply to PureDataObject and PureDataObjectFactory.
 
-To ease transition we've also added LegacyDataObject, LegacyPureDataObject, LegacyDataObjectFactory, and LegacyPureDataObjectFactory. These types have the same generic parameters as the types before this change, and can be used as a drop in replacement, but please move away from test types asap, as the will be removed in a following release.
+To ease transition we've also added LegacyDataObject, LegacyPureDataObject, LegacyDataObjectFactory, and LegacyPureDataObjectFactory. These types have the same generic parameters as the types before this change, and can be used as a drop in replacement, but please move away from these types asap, as they will be removed in a following release.
 
 ### Remove `loader` property from `MockFluidDataStoreContext` class
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -63,6 +63,8 @@ here are some examples:
 
 Above I've used DataObject, and DataObjectFactory however the same changes apply to PureDataObject and PureDataObjectFactory.
 
+To ease transition we've also added LegacyDataObject, LegacyPureDataObject, LegacyDataObjectFactory, and LegacyPureDataObjectFactory. These types have the same generic parameters as the types before this change, and can be used as a drop in replacement, but please move away from test types asap, as the will be removed in a following release.
+
 ### Remove `loader` property from `MockFluidDataStoreContext` class
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,6 +14,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
 - [readOnly and readOnlyPermissions removed from Container](#readOnly-and-readOnlyPermissions-removed-from-container)
+- [Generic Argument Changes to DataObjects and Factories](#Generic-Argument-Changes-to-DataObjects-and-Factories)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -35,6 +36,30 @@ Additionally, `codeDetails` which was already deprecated before is now marked as
 
 ### `readOnly` and `readOnlyPermissions` removed from `Container`
 The `readOnly` and `readOnlyPermissions` properties from `Container` in `container-loader` was deprecated in 0.35, and has now been removed. To replace its functionality, use `readOnlyInfo` by accessing `readOnlyInfo.readonly` and `readOnlyInfo.permissions` respectively.
+
+### Generic Argument Changes to DataObjects and Factories
+
+DataObject and PureDataObject used to take 3 generic type parameters. This has been collasped to a single generic argument. This new format takes the same types, but allows for easier exclusion or inclusion of specific types, while also being more readable.
+
+In general the existing data object generic parameters map to the new generic parameter as follow:
+`DataObject<O,S,E>` maps to `DataObject<{OptionalProviders: O, InitialState: S, Events: E}>`
+
+We would frequently see default values for generic paramaters, in order to set a following parameter. This is no longer necessary. If you see a generic parameter with a type of `{}`, `undefined`, `object`, `unknown`, `any`, `IEvent`, or `IFluidObject` is not needed, and can now be excluded.
+
+Here are some examples:
+ - `DataObject<{}, any, IEvent>` becomes `DataObject`
+ - `DataObject<IFluidUserInformation>` becomes `DataObject<{OptionalProviders: IFluidUserInformation}>`
+ - `DataObject<{}, RootDataObjectProps>` becomes `DataObject<{InitialState: RootDataObjectProps}>`
+ - `DataObject<object, undefined, IClickerEvents>` becomes `DataObject<{Events: IClickerEvents}>`
+
+Very similar changes have been made to DataObjectFactory and PureDataObjectFactory. Rather than 4 generic arguments it is reduced to 2. The first is still the same, and is the DataObject, the second is the same type the DataObject itself takes. However, this detail should not be important, as will this change has come improved type inference, so it should no longer be necessary to set any generic arguments on the factory.
+
+here are some examples:
+ - `new DataObjectFactory<SpacesStorage, undefined, undefined, IEvent>` becomes `new DataObjectFactory`
+ - `DataObjectFactory<MockComponentFooProvider, object, undefined>` becomes `DataObjectFactory<MockComponentFooProvider>`
+
+Above I've used DataObject, and DataObjectFactory however the same changes apply to PureDataObject and PureDataObjectFactory.
+
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -95,20 +95,21 @@ export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> ex
 
 // @public
 export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes> extends PureDataObjectFactory<TObj, I> {
-    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[] | undefined, optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime);
+    // Warning: (ae-incompatible-release-tags) The symbol "__constructor" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[] | undefined, optionalProviders: FluidObjectSymbolProvider<DataObjectType<I, "OptionalProviders">>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime);
 }
+
+// Warning: (ae-internal-missing-underscore) The name "DataObjectType" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export type DataObjectType<T extends DataObjectTypes, P extends keyof DataObjectTypes> = T[P] extends Required<DataObjectTypes>[P] ? T[P] : Required<DataObjectTypes>[P];
 
 // @public
 export interface DataObjectTypes {
     Events?: IEvent;
+    InitialState?: any;
     OptionalProviders?: FluidObject;
-    State?: any;
 }
-
-// @public (undocumented)
-export type Default<T extends DataObjectTypes> = {
-    [P in keyof Required<DataObjectTypes>]: T[P] extends Required<DataObjectTypes>[P] ? T[P] : Required<DataObjectTypes>[P];
-};
 
 // @public
 export function defaultFluidObjectRequestHandler(fluidObject: FluidObject, request: IRequest): IResponse;
@@ -132,10 +133,14 @@ export function getObjectWithIdFromContainer<T = IFluidObject & FluidObject>(id:
 export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
     // (undocumented)
     readonly context: IFluidDataStoreContext;
+    // Warning: (ae-incompatible-release-tags) The symbol "initProps" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    //
     // (undocumented)
-    readonly initProps?: Default<I>["State"];
+    readonly initProps?: DataObjectType<I, "InitialState">;
+    // Warning: (ae-incompatible-release-tags) The symbol "providers" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    //
     // (undocumented)
-    readonly providers: AsyncFluidObjectProvider<FluidObjectKey<Default<I>["OptionalProviders"]>, FluidObjectKey<object>>;
+    readonly providers: AsyncFluidObjectProvider<FluidObjectKey<DataObjectType<I, "OptionalProviders">>, FluidObjectKey<object>>;
     // (undocumented)
     readonly runtime: IFluidDataStoreRuntime;
 }
@@ -149,8 +154,10 @@ export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
 // @public
 export const mountableViewRequestHandler: (MountableViewClass: IFluidMountableViewClass, handlers: RuntimeRequestHandler[]) => (request: RequestParser, runtime: IContainerRuntime) => Promise<IResponse>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "PureDataObject" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+//
 // @public
-export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends EventForwarder<Default<I>["Events"]> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle, IFluidObject {
+export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends EventForwarder<DataObjectType<I, "Events">> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle, IFluidObject {
     constructor(props: IDataObjectProps<I>);
     protected readonly context: IFluidDataStoreContext;
     dispose(): void;
@@ -174,12 +181,12 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     initializeInternal(existing: boolean): Promise<void>;
     // (undocumented)
     protected initializeP: Promise<void> | undefined;
-    protected initializingFirstTime(props?: Default<I>["State"]): Promise<void>;
+    protected initializingFirstTime(props?: DataObjectType<I, "InitialState">): Promise<void>;
     protected initializingFromExisting(): Promise<void>;
     // (undocumented)
-    protected initProps?: Default<I>["State"];
+    protected initProps?: DataObjectType<I, "InitialState">;
     protected preInitialize(): Promise<void>;
-    protected readonly providers: AsyncFluidObjectProvider<FluidObjectKey<Default<I>["OptionalProviders"]>, FluidObjectKey<object>>;
+    protected readonly providers: AsyncFluidObjectProvider<FluidObjectKey<DataObjectType<I, "OptionalProviders">>, FluidObjectKey<object>>;
     request(req: IRequest): Promise<IResponse>;
     // @deprecated (undocumented)
     protected requestFluidObject_UNSAFE<T extends IFluidObject>(id: string): Promise<T>;
@@ -188,15 +195,24 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 
 // @public
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry>, IRootDataObjectFactory {
-    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
-    createChildInstance(parentContext: IFluidDataStoreContext, initialState?: Default<I>["State"]): Promise<TObj>;
-    createInstance(runtime: IContainerRuntimeBase, initialState?: Default<I>["State"]): Promise<TObj>;
+    // Warning: (ae-incompatible-release-tags) The symbol "__constructor" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<DataObjectType<I, "OptionalProviders">>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
+    // Warning: (ae-incompatible-release-tags) The symbol "createChildInstance" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    createChildInstance(parentContext: IFluidDataStoreContext, initialState?: DataObjectType<I, "InitialState">): Promise<TObj>;
+    // Warning: (ae-incompatible-release-tags) The symbol "createInstance" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    createInstance(runtime: IContainerRuntimeBase, initialState?: DataObjectType<I, "InitialState">): Promise<TObj>;
+    // Warning: (ae-incompatible-release-tags) The symbol "createInstanceCore" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    //
     // (undocumented)
-    protected createInstanceCore(context: IFluidDataStoreContextDetached, initialState?: Default<I>["State"]): Promise<TObj>;
+    protected createInstanceCore(context: IFluidDataStoreContextDetached, initialState?: DataObjectType<I, "InitialState">): Promise<TObj>;
+    // Warning: (ae-incompatible-release-tags) The symbol "createNonRootInstanceCore" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    //
     // (undocumented)
-    protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: Default<I>["State"]): Promise<TObj>;
-    createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: Default<I>["State"]): Promise<TObj>;
-    createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime, initialState?: Default<I>["State"]): Promise<TObj>;
+    protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: DataObjectType<I, "InitialState">): Promise<TObj>;
+    // Warning: (ae-incompatible-release-tags) The symbol "createPeerInstance" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: DataObjectType<I, "InitialState">): Promise<TObj>;
+    // Warning: (ae-incompatible-release-tags) The symbol "createRootInstance" is marked as @public, but its signature references "DataObjectType" which is marked as @internal
+    createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime, initialState?: DataObjectType<I, "InitialState">): Promise<TObj>;
     // (undocumented)
     get IFluidDataStoreFactory(): this;
     // (undocumented)

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -95,17 +95,14 @@ export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> ex
 
 // @public
 export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes> extends PureDataObjectFactory<TObj, I> {
-    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[] | undefined, optionalProviders: FluidObjectSymbolProvider<Default<I>["O"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime);
+    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[] | undefined, optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime);
 }
 
-// @public (undocumented)
+// @public
 export interface DataObjectTypes {
-    // (undocumented)
-    E?: IEvent;
-    // (undocumented)
-    O?: FluidObject;
-    // (undocumented)
-    S?: any;
+    Events?: IEvent;
+    OptionalProviders?: FluidObject;
+    State?: any;
 }
 
 // @public (undocumented)
@@ -136,9 +133,9 @@ export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
     // (undocumented)
     readonly context: IFluidDataStoreContext;
     // (undocumented)
-    readonly initProps?: Default<I>["S"];
+    readonly initProps?: Default<I>["State"];
     // (undocumented)
-    readonly providers: AsyncFluidObjectProvider<FluidObjectKey<Default<I>["O"]>, FluidObjectKey<object>>;
+    readonly providers: AsyncFluidObjectProvider<FluidObjectKey<Default<I>["OptionalProviders"]>, FluidObjectKey<object>>;
     // (undocumented)
     readonly runtime: IFluidDataStoreRuntime;
 }
@@ -153,7 +150,7 @@ export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
 export const mountableViewRequestHandler: (MountableViewClass: IFluidMountableViewClass, handlers: RuntimeRequestHandler[]) => (request: RequestParser, runtime: IContainerRuntime) => Promise<IResponse>;
 
 // @public
-export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends EventForwarder<Default<I>["E"]> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle, IFluidObject {
+export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends EventForwarder<Default<I>["Events"]> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle, IFluidObject {
     constructor(props: IDataObjectProps<I>);
     protected readonly context: IFluidDataStoreContext;
     dispose(): void;
@@ -177,12 +174,12 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     initializeInternal(existing: boolean): Promise<void>;
     // (undocumented)
     protected initializeP: Promise<void> | undefined;
-    protected initializingFirstTime(props?: Default<I>["S"]): Promise<void>;
+    protected initializingFirstTime(props?: Default<I>["State"]): Promise<void>;
     protected initializingFromExisting(): Promise<void>;
     // (undocumented)
-    protected initProps?: Default<I>["S"];
+    protected initProps?: Default<I>["State"];
     protected preInitialize(): Promise<void>;
-    protected readonly providers: AsyncFluidObjectProvider<FluidObjectKey<Default<I>["O"]>, FluidObjectKey<object>>;
+    protected readonly providers: AsyncFluidObjectProvider<FluidObjectKey<Default<I>["OptionalProviders"]>, FluidObjectKey<object>>;
     request(req: IRequest): Promise<IResponse>;
     // @deprecated (undocumented)
     protected requestFluidObject_UNSAFE<T extends IFluidObject>(id: string): Promise<T>;
@@ -191,15 +188,15 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 
 // @public
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry>, IRootDataObjectFactory {
-    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<Default<I>["O"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
-    createChildInstance(parentContext: IFluidDataStoreContext, initialState?: Default<I>["S"]): Promise<TObj>;
-    createInstance(runtime: IContainerRuntimeBase, initialState?: Default<I>["S"]): Promise<TObj>;
+    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
+    createChildInstance(parentContext: IFluidDataStoreContext, initialState?: Default<I>["State"]): Promise<TObj>;
+    createInstance(runtime: IContainerRuntimeBase, initialState?: Default<I>["State"]): Promise<TObj>;
     // (undocumented)
-    protected createInstanceCore(context: IFluidDataStoreContextDetached, initialState?: Default<I>["S"]): Promise<TObj>;
+    protected createInstanceCore(context: IFluidDataStoreContextDetached, initialState?: Default<I>["State"]): Promise<TObj>;
     // (undocumented)
-    protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: Default<I>["S"]): Promise<TObj>;
-    createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: Default<I>["S"]): Promise<TObj>;
-    createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime, initialState?: Default<I>["S"]): Promise<TObj>;
+    protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: Default<I>["State"]): Promise<TObj>;
+    createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: Default<I>["State"]): Promise<TObj>;
+    createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime, initialState?: Default<I>["State"]): Promise<TObj>;
     // (undocumented)
     get IFluidDataStoreFactory(): this;
     // (undocumented)

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -151,6 +151,38 @@ export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
     createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime): Promise<IFluidRouter>;
 }
 
+// @public @deprecated (undocumented)
+export abstract class LegacyDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent> extends DataObject<{
+    OptionalProviders: O;
+    InitialState: S;
+    Events: E;
+}> {
+}
+
+// @public @deprecated (undocumented)
+export class LegacyDataObjectFactory<TObj extends LegacyDataObject<O, S, E>, O, S, E extends IEvent = IEvent> extends DataObjectFactory<TObj, {
+    OptionalProviders: O;
+    InitialState: S;
+    Events: E;
+}> {
+}
+
+// @public @deprecated (undocumented)
+export abstract class LegacyPureDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent> extends PureDataObject<{
+    OptionalProviders: O;
+    InitialState: S;
+    Events: E;
+}> {
+}
+
+// @public @deprecated (undocumented)
+export class LegacyPureDataObjectFactory<TObj extends LegacyPureDataObject<O, S, E>, O, S, E extends IEvent = IEvent> extends PureDataObjectFactory<TObj, {
+    OptionalProviders: O;
+    InitialState: S;
+    Events: E;
+}> {
+}
+
 // @public
 export const mountableViewRequestHandler: (MountableViewClass: IFluidMountableViewClass, handlers: RuntimeRequestHandler[]) => (request: RequestParser, runtime: IContainerRuntime) => Promise<IResponse>;
 

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -107,7 +107,7 @@ export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
 // @public (undocumented)
 export class RootDataObject extends DataObject<{
-    State: RootDataObjectProps;
+    InitialState: RootDataObjectProps;
 }> {
     // (undocumented)
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -106,7 +106,9 @@ export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) 
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
 // @public (undocumented)
-export class RootDataObject extends DataObject<{}, RootDataObjectProps> {
+export class RootDataObject extends DataObject<{
+    S: RootDataObjectProps;
+}> {
     // (undocumented)
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
     // (undocumented)

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -107,7 +107,7 @@ export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
 // @public (undocumented)
 export class RootDataObject extends DataObject<{
-    S: RootDataObjectProps;
+    State: RootDataObjectProps;
 }> {
     // (undocumented)
     create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;

--- a/examples/apps/collaborative-textarea/src/fluid-object/index.tsx
+++ b/examples/apps/collaborative-textarea/src/fluid-object/index.tsx
@@ -4,7 +4,6 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedString } from "@fluidframework/sequence";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
@@ -25,7 +24,7 @@ export class CollaborativeText extends DataObject implements IFluidHTMLView {
     public static get Name() { return "@fluid-example/collaborative-textarea"; }
 
     private static readonly factory =
-        new DataObjectFactory<CollaborativeText, undefined, undefined, IEvent>(
+        new DataObjectFactory(
             CollaborativeText.Name,
             CollaborativeText,
             [

--- a/examples/apps/contact-collection/src/dataObject.ts
+++ b/examples/apps/contact-collection/src/dataObject.ts
@@ -5,7 +5,6 @@
 
 import { EventEmitter } from "events";
 import { v4 as uuid } from "uuid";
-import { IEvent } from "@fluidframework/common-definitions";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { RequestParser } from "@fluidframework/runtime-utils";
@@ -122,7 +121,7 @@ export class ContactCollection extends DataObject implements IContactCollection 
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
 export const ContactCollectionInstantiationFactory =
-    new DataObjectFactory<ContactCollection, undefined, undefined, IEvent>(
+    new DataObjectFactory(
         "contact-collection",
         ContactCollection,
         [],

--- a/examples/apps/likes-and-comments/src/fluidObject.ts
+++ b/examples/apps/likes-and-comments/src/fluidObject.ts
@@ -6,7 +6,6 @@
 import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     SyncedDataObject,
     setSyncedCounterConfig,
@@ -23,7 +22,7 @@ export class LikesAndComments extends SyncedDataObject {
     public static get Name() { return "LikesAndComments"; }
 
     public static readonly factory =
-        new DataObjectFactory<LikesAndComments, unknown, unknown, IEvent>(
+        new DataObjectFactory(
             LikesAndComments.name,
             LikesAndComments,
             [

--- a/examples/apps/spaces/src/fluid-object/storage/spacesStorage.ts
+++ b/examples/apps/spaces/src/fluid-object/storage/spacesStorage.ts
@@ -8,7 +8,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { Serializable } from "@fluidframework/datastore-definitions";
 import { Layout } from "react-grid-layout";
 import { v4 as uuid } from "uuid";
@@ -57,7 +56,7 @@ export class SpacesStorage extends DataObject implements ISpacesStorage<ISpacesI
     public static get ComponentName() { return "@fluid-example/spaces-storage"; }
 
     private static readonly factory =
-        new DataObjectFactory<SpacesStorage, undefined, undefined, IEvent>(
+        new DataObjectFactory(
             SpacesStorage.ComponentName,
             SpacesStorage,
             [],

--- a/examples/apps/view-framework-sampler/src/dataObject.ts
+++ b/examples/apps/view-framework-sampler/src/dataObject.ts
@@ -4,7 +4,6 @@
  */
 
 import { EventEmitter } from "events";
-import { IEvent } from "@fluidframework/common-definitions";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 
 /**
@@ -70,7 +69,7 @@ export class DiceRoller extends DataObject implements IDiceRoller {
  * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
-export const DiceRollerInstantiationFactory = new DataObjectFactory<DiceRoller, undefined, undefined, IEvent>
+export const DiceRollerInstantiationFactory = new DataObjectFactory
 (
     "dice-roller",
     DiceRoller,

--- a/examples/data-objects/badge/src/instantiationFactory.ts
+++ b/examples/data-objects/badge/src/instantiationFactory.ts
@@ -5,14 +5,13 @@
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { SharedCell } from "@fluidframework/cell";
-import { IEvent } from "@fluidframework/common-definitions";
 import { SharedMap } from "@fluidframework/map";
 import { SharedObjectSequence } from "@fluidframework/sequence";
 import { Badge } from "./BadgeModel";
 
 const BadgeName = "@fluid-example/badge";
 
-export const BadgeInstantiationFactory = new DataObjectFactory<Badge, undefined, undefined, IEvent>(
+export const BadgeInstantiationFactory = new DataObjectFactory(
     BadgeName,
     Badge,
     [

--- a/examples/data-objects/canvas/src/index.ts
+++ b/examples/data-objects/canvas/src/index.ts
@@ -7,14 +7,13 @@ import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { Ink } from "@fluidframework/ink";
 import React from "react";
 import { Canvas } from "./canvas";
 import { CanvasView } from "./view";
 
 export const CanvasInstantiationFactory =
-    new DataObjectFactory<Canvas, undefined, undefined, IEvent>(
+    new DataObjectFactory(
         "Canvas",
         Canvas,
         [

--- a/examples/data-objects/clicker-react/clicker-context/src/index.tsx
+++ b/examples/data-objects/clicker-react/clicker-context/src/index.tsx
@@ -7,7 +7,6 @@ import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     IViewState,
     createContextFluid,
@@ -98,7 +97,7 @@ export class ClickerContext extends SyncedDataObject {
 
 // ----- FACTORY SETUP -----
 export const ClickerContextInstantiationFactory =
-    new DataObjectFactory<ClickerContext, unknown, unknown, IEvent>(
+    new DataObjectFactory(
         "clicker-context",
         ClickerContext,
         [],

--- a/examples/data-objects/clicker-react/clicker-function/src/index.tsx
+++ b/examples/data-objects/clicker-react/clicker-function/src/index.tsx
@@ -7,7 +7,6 @@ import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     setSyncedObjectConfig,
     useSyncedObject,
@@ -59,7 +58,7 @@ export class ClickerFunction extends SyncedDataObject {
 
 // ----- FACTORY SETUP -----
 export const ClickerFunctionInstantiationFactory =
-    new DataObjectFactory<ClickerFunction, unknown, unknown, IEvent>(
+    new DataObjectFactory(
         "clicker-function",
         ClickerFunction,
         [],

--- a/examples/data-objects/clicker-react/clicker-react/src/index.tsx
+++ b/examples/data-objects/clicker-react/clicker-react/src/index.tsx
@@ -7,7 +7,6 @@ import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     FluidReactView,
     IFluidState,
@@ -76,7 +75,7 @@ class CounterReactView extends FluidReactView<CounterViewState, CounterFluidStat
 
 // ----- FACTORY SETUP -----
 export const ClickerInstantiationFactory =
-    new DataObjectFactory<Clicker, unknown, unknown, IEvent>(
+    new DataObjectFactory(
         "clicker",
         Clicker,
         [SharedCounter.getFactory()],

--- a/examples/data-objects/clicker-react/clicker-reducer/src/index.tsx
+++ b/examples/data-objects/clicker-react/clicker-reducer/src/index.tsx
@@ -7,7 +7,6 @@ import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     IFluidReducerProps,
     IViewState,
@@ -139,7 +138,7 @@ export class ClickerReducer extends SyncedDataObject {
 
 // ----- FACTORY SETUP -----
 export const ClickerReducerInstantiationFactory =
-    new DataObjectFactory<ClickerReducer, unknown, unknown, IEvent>(
+    new DataObjectFactory(
         "clicker-reducer",
         ClickerReducer,
         [SharedCounter.getFactory()],

--- a/examples/data-objects/clicker-react/clicker-with-hook/src/index.tsx
+++ b/examples/data-objects/clicker-react/clicker-with-hook/src/index.tsx
@@ -7,7 +7,6 @@ import { ContainerViewRuntimeFactory } from "@fluid-example/example-utils";
 import {
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     SyncedDataObject,
     setSyncedCounterConfig,
@@ -55,7 +54,7 @@ export class ClickerWithHook extends SyncedDataObject {
 
 // ----- FACTORY SETUP -----
 export const ClickerWithHookInstantiationFactory =
-    new DataObjectFactory<ClickerWithHook, unknown, unknown, IEvent>(
+    new DataObjectFactory(
         "clicker-with-hook",
         ClickerWithHook,
         [SharedCounter.getFactory()],

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -29,8 +29,7 @@ export interface IClickerEvents extends IEvent {
 /**
  * Basic Clicker example using new interfaces and stock component classes.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class Clicker extends DataObject<object, undefined, IClickerEvents> {
+export class Clicker extends DataObject<{E: IClickerEvents}> {
     private _counter: SharedCounter | undefined;
     private _taskManager: TaskManager | undefined;
 
@@ -137,8 +136,7 @@ export class ClickerReactView extends React.Component<ClickerProps, ClickerState
 
 // ----- FACTORY SETUP -----
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const ClickerInstantiationFactory = new DataObjectFactory<Clicker, object, undefined, IClickerEvents>(
+export const ClickerInstantiationFactory = new DataObjectFactory(
     ClickerName,
     Clicker,
     [SharedCounter.getFactory(), TaskManager.getFactory()],

--- a/examples/data-objects/clicker/src/index.tsx
+++ b/examples/data-objects/clicker/src/index.tsx
@@ -29,7 +29,7 @@ export interface IClickerEvents extends IEvent {
 /**
  * Basic Clicker example using new interfaces and stock component classes.
  */
-export class Clicker extends DataObject<{E: IClickerEvents}> {
+export class Clicker extends DataObject<{Events: IClickerEvents}> {
     private _counter: SharedCounter | undefined;
     private _taskManager: TaskManager | undefined;
 

--- a/examples/data-objects/diceroller/src/main.tsx
+++ b/examples/data-objects/diceroller/src/main.tsx
@@ -8,7 +8,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IValueChanged } from "@fluidframework/map";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
@@ -72,7 +71,7 @@ export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLVie
 
     public get IFluidHTMLView() { return this; }
 
-    public static readonly factory = new DataObjectFactory<DiceRoller, undefined, undefined, IEvent>
+    public static readonly factory = new DataObjectFactory
     (
         DiceRoller.Name,
         DiceRoller,

--- a/examples/data-objects/image-gallery/src/model.ts
+++ b/examples/data-objects/image-gallery/src/model.ts
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 
 const imageGalleryName = "@fluid-example/image-gallery";
 
@@ -67,7 +66,7 @@ export class ImageGalleryModel extends DataObject {
     }
 }
 
-export const ImageGalleryInstantiationFactory = new DataObjectFactory<ImageGalleryModel, undefined, undefined, IEvent>
+export const ImageGalleryInstantiationFactory = new DataObjectFactory
 (
     imageGalleryName,
     ImageGalleryModel,

--- a/examples/data-objects/multiview/constellation-model/src/model.ts
+++ b/examples/data-objects/multiview/constellation-model/src/model.ts
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IValueChanged } from "@fluidframework/map";
 
@@ -28,7 +27,7 @@ export class Constellation extends DataObject implements IConstellation {
         return Constellation.factory;
     }
 
-    private static readonly factory = new DataObjectFactory<Constellation, undefined, undefined, IEvent>(
+    private static readonly factory = new DataObjectFactory(
         Constellation.ComponentName,
         Constellation,
         [],

--- a/examples/data-objects/multiview/coordinate-model/src/model.ts
+++ b/examples/data-objects/multiview/coordinate-model/src/model.ts
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IValueChanged } from "@fluidframework/map";
 import { ICoordinate } from "@fluid-example/multiview-coordinate-interface";
 
@@ -24,7 +23,7 @@ export class Coordinate extends DataObject implements ICoordinate {
         return Coordinate.factory;
     }
 
-    private static readonly factory = new DataObjectFactory<Coordinate, undefined, undefined, IEvent>(
+    private static readonly factory = new DataObjectFactory(
         Coordinate.ComponentName,
         Coordinate,
         [],

--- a/examples/data-objects/musica/src/index.tsx
+++ b/examples/data-objects/musica/src/index.tsx
@@ -9,7 +9,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 
 // React
@@ -102,7 +101,7 @@ export class Musica extends DataObject implements IFluidHTMLView {
 }
 
 export const MusicaInstantiationFactory =
-    new DataObjectFactory<Musica, undefined, undefined, IEvent>(
+    new DataObjectFactory(
         musicaName,
         Musica,
         [],

--- a/examples/data-objects/pond/src/data-objects/clicker.tsx
+++ b/examples/data-objects/pond/src/data-objects/clicker.tsx
@@ -10,7 +10,6 @@ import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
 import ReactDOM from "react-dom";
-import { IEvent } from "@fluidframework/common-definitions";
 
 const storedMapKey = "storedMap";
 const counter1Key = "counter";
@@ -73,7 +72,7 @@ export class Clicker extends DataObject implements IFluidHTMLView {
 
     public static getFactory() { return Clicker.factory; }
 
-    private static readonly factory = new DataObjectFactory<Clicker, undefined, undefined, IEvent>(
+    private static readonly factory = new DataObjectFactory(
         Clicker.ComponentName,
         Clicker,
         [

--- a/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
+++ b/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
@@ -16,7 +16,7 @@ import { IFluidUserInformation } from "../interfaces";
  * Basic example that takes a container provider
  */
 export class ExampleUsingProviders
-    extends DataObject<{O: IFluidUserInformation}>
+    extends DataObject<{OptionalProviders: IFluidUserInformation}>
     implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 

--- a/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
+++ b/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
@@ -6,7 +6,6 @@
 import {
     DataObject,
     DataObjectFactory,
-    IDataObjectProps,
 } from "@fluidframework/aqueduct";
 import { SharedMap } from "@fluidframework/map";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
@@ -20,10 +19,6 @@ export class ExampleUsingProviders
     extends DataObject<{O: IFluidUserInformation}>
     implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
-
-    constructor(props: IDataObjectProps<{O: IFluidUserInformation}>) {
-        super(props);
-    }
 
     private userInformation: IFluidUserInformation | undefined;
 

--- a/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
+++ b/examples/data-objects/pond/src/data-objects/exampleUsingProviders.tsx
@@ -3,21 +3,27 @@
  * Licensed under the MIT License.
  */
 
-import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
+import {
+    DataObject,
+    DataObjectFactory,
+    IDataObjectProps,
+} from "@fluidframework/aqueduct";
 import { SharedMap } from "@fluidframework/map";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
 import ReactDOM from "react-dom";
 import { IFluidUserInformation } from "../interfaces";
-
 /**
  * Basic example that takes a container provider
  */
 export class ExampleUsingProviders
-    extends DataObject<IFluidUserInformation>
+    extends DataObject<{O: IFluidUserInformation}>
     implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
+
+    constructor(props: IDataObjectProps<{O: IFluidUserInformation}>) {
+        super(props);
+    }
 
     private userInformation: IFluidUserInformation | undefined;
 
@@ -49,7 +55,7 @@ export class ExampleUsingProviders
     public static getFactory() { return ExampleUsingProviders.factory; }
 
     private static readonly factory =
-        new DataObjectFactory<ExampleUsingProviders, IFluidUserInformation, undefined, IEvent>(
+        new DataObjectFactory(
             ExampleUsingProviders.ComponentName,
             ExampleUsingProviders,
             [SharedMap.getFactory()],

--- a/examples/data-objects/pond/src/index.tsx
+++ b/examples/data-objects/pond/src/index.tsx
@@ -8,7 +8,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedDirectory } from "@fluidframework/map";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
@@ -105,7 +104,7 @@ export class Pond extends DataObject implements IFluidHTMLView {
 
     public static getFactory() { return Pond.factory; }
 
-    private static readonly factory = new DataObjectFactory<Pond, undefined, undefined, IEvent>(
+    private static readonly factory = new DataObjectFactory(
         PondName,
         Pond,
         [SharedDirectory.getFactory()],

--- a/examples/data-objects/primitives/src/model.ts
+++ b/examples/data-objects/primitives/src/model.ts
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IDirectory, ISharedMap, SharedMap } from "@fluidframework/map";
 
@@ -73,7 +72,7 @@ export class DdsCollection extends DataObject {
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
  export const DdsCollectionFactory =
-    new DataObjectFactory<DdsCollection, undefined, undefined, IEvent> (
+    new DataObjectFactory (
         DdsCollectionName,
         DdsCollection,
         [

--- a/examples/data-objects/simple-fluidobject-embed/src/index.tsx
+++ b/examples/data-objects/simple-fluidobject-embed/src/index.tsx
@@ -8,7 +8,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { ClickerInstantiationFactory, Clicker, ClickerReactView } from "@fluid-example/clicker";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
@@ -54,8 +53,7 @@ export class SimpleFluidObjectEmbed extends DataObject implements IFluidHTMLView
 }
 
 export const SimpleFluidObjectEmbedInstantiationFactory =
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    new DataObjectFactory<SimpleFluidObjectEmbed, undefined, undefined, IEvent>(
+    new DataObjectFactory(
         simpleFluidObjectEmbedName,
         SimpleFluidObjectEmbed,
         [],

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -33,12 +33,10 @@ export interface ITableDocumentEvents extends IEvent {
  * @deprecated - TableDocument is an abandoned prototype.  Please use SharedMatrix with
  *               the IMatrixProducer/Consumer interfaces instead.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class TableDocument extends DataObject<{}, {}, ITableDocumentEvents> implements ITable {
+export class TableDocument extends DataObject<{E: ITableDocumentEvents}> implements ITable {
     public static getFactory() { return TableDocument.factory; }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    private static readonly factory = new DataObjectFactory<TableDocument, object, object, IEvent>(
+    private static readonly factory = new DataObjectFactory(
         TableDocumentType,
         TableDocument,
         [

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -33,7 +33,7 @@ export interface ITableDocumentEvents extends IEvent {
  * @deprecated - TableDocument is an abandoned prototype.  Please use SharedMatrix with
  *               the IMatrixProducer/Consumer interfaces instead.
  */
-export class TableDocument extends DataObject<{E: ITableDocumentEvents}> implements ITable {
+export class TableDocument extends DataObject<{Events: ITableDocumentEvents}> implements ITable {
     public static getFactory() { return TableDocument.factory; }
 
     private static readonly factory = new DataObjectFactory(

--- a/examples/data-objects/table-document/src/slice.ts
+++ b/examples/data-objects/table-document/src/slice.ts
@@ -21,7 +21,7 @@ export interface ITableSliceConfig {
     maxCol: number;
 }
 
-export class TableSlice extends DataObject<{State: ITableSliceConfig}> implements ITable {
+export class TableSlice extends DataObject<{InitialState: ITableSliceConfig}> implements ITable {
     public static getFactory() { return TableSlice.factory; }
 
     private static readonly factory = new DataObjectFactory(

--- a/examples/data-objects/table-document/src/slice.ts
+++ b/examples/data-objects/table-document/src/slice.ts
@@ -4,7 +4,6 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ICombiningOp, PropertySet } from "@fluidframework/merge-tree";
 import { CellRange } from "./cellrange";
@@ -22,12 +21,10 @@ export interface ITableSliceConfig {
     maxCol: number;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class TableSlice extends DataObject<{}, ITableSliceConfig> implements ITable {
+export class TableSlice extends DataObject<{S: ITableSliceConfig}> implements ITable {
     public static getFactory() { return TableSlice.factory; }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    private static readonly factory = new DataObjectFactory<TableSlice, object, ITableSliceConfig, IEvent>(
+    private static readonly factory = new DataObjectFactory(
         TableSliceType,
         TableSlice,
         [],

--- a/examples/data-objects/table-document/src/slice.ts
+++ b/examples/data-objects/table-document/src/slice.ts
@@ -21,7 +21,7 @@ export interface ITableSliceConfig {
     maxCol: number;
 }
 
-export class TableSlice extends DataObject<{S: ITableSliceConfig}> implements ITable {
+export class TableSlice extends DataObject<{State: ITableSliceConfig}> implements ITable {
     public static getFactory() { return TableSlice.factory; }
 
     private static readonly factory = new DataObjectFactory(

--- a/examples/data-objects/table-view/src/tableview.ts
+++ b/examples/data-objects/table-view/src/tableview.ts
@@ -6,7 +6,6 @@
 import { Template } from "@fluid-example/flow-util-lib";
 import { TableDocument, TableDocumentType } from "@fluid-example/table-document";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidHTMLOptions, IFluidHTMLView } from "@fluidframework/view-interfaces";
 import { GridView } from "./grid";
@@ -102,7 +101,7 @@ export class TableView extends DataObject implements IFluidHTMLView {
     }
 }
 
-const factory = new DataObjectFactory<TableView, undefined, undefined, IEvent>(
+const factory = new DataObjectFactory(
     tableViewType,
     TableView,
     [],

--- a/examples/data-objects/task-selection/src/oldestClientDiceRoller.ts
+++ b/examples/data-objects/task-selection/src/oldestClientDiceRoller.ts
@@ -5,7 +5,6 @@
 
 import { OldestClientObserver } from "@fluid-experimental/task-manager";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { assert } from "@fluidframework/common-utils";
 
 import { IDiceRoller } from "./interface";
@@ -107,7 +106,7 @@ export class OldestClientDiceRoller extends DataObject implements IDiceRoller {
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
 export const OldestClientDiceRollerInstantiationFactory =
-    new DataObjectFactory<OldestClientDiceRoller, undefined, undefined, IEvent>
+    new DataObjectFactory
 (
     "@fluid-example/oldest-client-dice-roller",
     OldestClientDiceRoller,

--- a/examples/data-objects/task-selection/src/taskManagerDiceRoller.ts
+++ b/examples/data-objects/task-selection/src/taskManagerDiceRoller.ts
@@ -5,7 +5,6 @@
 
 import { TaskManager } from "@fluid-experimental/task-manager";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 
@@ -119,7 +118,7 @@ export class TaskManagerDiceRoller extends DataObject implements IDiceRoller {
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
 export const TaskManagerDiceRollerInstantiationFactory =
-    new DataObjectFactory<TaskManagerDiceRoller, undefined, undefined, IEvent>
+    new DataObjectFactory
 (
     "@fluid-example/task-manager-dice-roller",
     TaskManagerDiceRoller,

--- a/examples/data-objects/todo/src/TextBox/TextBox.tsx
+++ b/examples/data-objects/todo/src/TextBox/TextBox.tsx
@@ -18,7 +18,7 @@ export const TextBoxName = `${pkg.name as string}-textbox`;
  * TextBox is a really simple component that uses the CollaborativeTextArea to provide a
  * collaborative textarea.
  */
-export class TextBox extends DataObject<{S: string}> implements IFluidHTMLView {
+export class TextBox extends DataObject<{State: string}> implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 
     private text: SharedString | undefined;

--- a/examples/data-objects/todo/src/TextBox/TextBox.tsx
+++ b/examples/data-objects/todo/src/TextBox/TextBox.tsx
@@ -18,8 +18,7 @@ export const TextBoxName = `${pkg.name as string}-textbox`;
  * TextBox is a really simple component that uses the CollaborativeTextArea to provide a
  * collaborative textarea.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class TextBox extends DataObject<{}, string> implements IFluidHTMLView {
+export class TextBox extends DataObject<{S: string}> implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 
     private text: SharedString | undefined;

--- a/examples/data-objects/todo/src/TextBox/TextBox.tsx
+++ b/examples/data-objects/todo/src/TextBox/TextBox.tsx
@@ -18,7 +18,7 @@ export const TextBoxName = `${pkg.name as string}-textbox`;
  * TextBox is a really simple component that uses the CollaborativeTextArea to provide a
  * collaborative textarea.
  */
-export class TextBox extends DataObject<{State: string}> implements IFluidHTMLView {
+export class TextBox extends DataObject<{InitialState: string}> implements IFluidHTMLView {
     public get IFluidHTMLView() { return this; }
 
     private text: SharedString | undefined;

--- a/examples/data-objects/todo/src/TextBox/textBoxInstantiationFactory.ts
+++ b/examples/data-objects/todo/src/TextBox/textBoxInstantiationFactory.ts
@@ -4,14 +4,12 @@
  */
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { TextBoxName } from "./TextBox";
 import { TextBox } from "./index";
 
 export const TextBoxInstantiationFactory =
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    new DataObjectFactory<TextBox, object, string, IEvent>(
+    new DataObjectFactory(
         TextBoxName,
         TextBox,
         [

--- a/examples/data-objects/todo/src/TextList/textListInstantiationFactory.ts
+++ b/examples/data-objects/todo/src/TextList/textListInstantiationFactory.ts
@@ -4,13 +4,12 @@
  */
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import { TextListName } from "./TextList";
 import { TextList } from "./index";
 
 export const TextListInstantiationFactory =
-    new DataObjectFactory<TextList, undefined, undefined, IEvent>(
+    new DataObjectFactory(
         TextListName,
         TextList,
         [

--- a/examples/data-objects/todo/src/Todo/todoInstantiationFactory.ts
+++ b/examples/data-objects/todo/src/Todo/todoInstantiationFactory.ts
@@ -4,7 +4,6 @@
  */
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { SharedCell } from "@fluidframework/cell";
 import { SharedMap } from "@fluidframework/map";
 import { SharedObjectSequence, SharedString } from "@fluidframework/sequence";
@@ -14,7 +13,7 @@ import { TodoName } from "./Todo";
 import { Todo } from "./index";
 
 export const TodoInstantiationFactory =
-    new DataObjectFactory<Todo, undefined, undefined, IEvent>(
+    new DataObjectFactory(
         TodoName,
         Todo,
         [

--- a/examples/data-objects/todo/src/TodoItem/TodoItem.tsx
+++ b/examples/data-objects/todo/src/TodoItem/TodoItem.tsx
@@ -6,7 +6,6 @@
 import { Clicker, ClickerInstantiationFactory } from "@fluid-example/clicker";
 import { DataObject, DataObjectFactory, waitForAttach } from "@fluidframework/aqueduct";
 import { ISharedCell, SharedCell } from "@fluidframework/cell";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { IValueChanged } from "@fluidframework/map";
 import { SharedString } from "@fluidframework/sequence";
@@ -38,8 +37,7 @@ const innerComponentKey = "innerId";
  * - Link to open component in separate tab
  * - Button to remove entry
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class TodoItem extends DataObject<{}, ITodoItemInitialState> implements IFluidHTMLView {
+export class TodoItem extends DataObject<{S: ITodoItemInitialState}> implements IFluidHTMLView {
     private text: SharedString;
     private innerIdCell: ISharedCell<{ type: TodoItemSupportedComponents, handle: IFluidHandle }>;
     private _absoluteUrl: string | undefined;
@@ -110,8 +108,7 @@ export class TodoItem extends DataObject<{}, ITodoItemInitialState> implements I
     public static getFactory() { return TodoItem.factory; }
 
     private static readonly factory =
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        new DataObjectFactory<TodoItem, object, ITodoItemInitialState, IEvent>(
+        new DataObjectFactory(
             TodoItemName,
             TodoItem,
             [

--- a/examples/data-objects/todo/src/TodoItem/TodoItem.tsx
+++ b/examples/data-objects/todo/src/TodoItem/TodoItem.tsx
@@ -37,7 +37,7 @@ const innerComponentKey = "innerId";
  * - Link to open component in separate tab
  * - Button to remove entry
  */
-export class TodoItem extends DataObject<{State: ITodoItemInitialState}> implements IFluidHTMLView {
+export class TodoItem extends DataObject<{InitialState: ITodoItemInitialState}> implements IFluidHTMLView {
     private text: SharedString;
     private innerIdCell: ISharedCell<{ type: TodoItemSupportedComponents, handle: IFluidHandle }>;
     private _absoluteUrl: string | undefined;

--- a/examples/data-objects/todo/src/TodoItem/TodoItem.tsx
+++ b/examples/data-objects/todo/src/TodoItem/TodoItem.tsx
@@ -37,7 +37,7 @@ const innerComponentKey = "innerId";
  * - Link to open component in separate tab
  * - Button to remove entry
  */
-export class TodoItem extends DataObject<{S: ITodoItemInitialState}> implements IFluidHTMLView {
+export class TodoItem extends DataObject<{State: ITodoItemInitialState}> implements IFluidHTMLView {
     private text: SharedString;
     private innerIdCell: ISharedCell<{ type: TodoItemSupportedComponents, handle: IFluidHandle }>;
     private _absoluteUrl: string | undefined;

--- a/examples/data-objects/vltava/src/fluidObjects/anchor/anchor.ts
+++ b/examples/data-objects/vltava/src/fluidObjects/anchor/anchor.ts
@@ -5,7 +5,6 @@
 
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     IFluidLastEditedTracker,
     IProvideFluidLastEditedTracker,
@@ -32,7 +31,7 @@ export class Anchor extends DataObject implements IProvideFluidHTMLView, IProvid
     }
 
     private static readonly factory =
-        new DataObjectFactory<Anchor, undefined, undefined, IEvent>(
+        new DataObjectFactory(
             "anchor",
             Anchor,
             [],

--- a/examples/data-objects/vltava/src/fluidObjects/tabs/tabs.tsx
+++ b/examples/data-objects/vltava/src/fluidObjects/tabs/tabs.tsx
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
@@ -27,7 +26,7 @@ export class TabsFluidObject extends DataObject implements IFluidHTMLView {
     private dataModelInternal: ITabsDataModel | undefined;
 
     private static readonly factory =
-    new DataObjectFactory<TabsFluidObject, undefined, undefined, IEvent>(TabsName, TabsFluidObject, [], {});
+    new DataObjectFactory(TabsName, TabsFluidObject, [], {});
 
     public static getFactory() {
         return TabsFluidObject.factory;

--- a/examples/data-objects/vltava/src/fluidObjects/vltava/vltava.tsx
+++ b/examples/data-objects/vltava/src/fluidObjects/vltava/vltava.tsx
@@ -4,7 +4,6 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
@@ -25,7 +24,7 @@ export class Vltava extends DataObject implements IFluidHTMLView {
     private dataModelInternal: IVltavaDataModel | undefined;
 
     private static readonly factory =
-        new DataObjectFactory<Vltava, undefined, undefined, IEvent>("vltava", Vltava, [], {});
+        new DataObjectFactory("vltava", Vltava, [], {});
 
     public static getFactory() {
         return Vltava.factory;

--- a/examples/hosts/app-integration/container-views/src/model.ts
+++ b/examples/hosts/app-integration/container-views/src/model.ts
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IValueChanged } from "@fluidframework/map";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 
@@ -70,8 +69,7 @@ export class DiceRoller extends DataObject implements IDiceRoller, IFluidHTMLVie
  * The DataObjectFactory declares the Fluid object and defines any additional distributed data structures.
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const DiceRollerInstantiationFactory = new DataObjectFactory<DiceRoller, undefined, undefined, IEvent>
+export const DiceRollerInstantiationFactory = new DataObjectFactory
 (
     DiceRoller.Name,
     DiceRoller,

--- a/examples/hosts/app-integration/external-views/src/dataObject.ts
+++ b/examples/hosts/app-integration/external-views/src/dataObject.ts
@@ -5,7 +5,6 @@
 
 import { EventEmitter } from "events";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 
 /**
  * IDiceRoller describes the public API surface for our dice roller data object.
@@ -70,7 +69,7 @@ export class DiceRoller extends DataObject implements IDiceRoller {
  * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
-export const DiceRollerInstantiationFactory = new DataObjectFactory<DiceRoller, undefined, undefined, IEvent>
+export const DiceRollerInstantiationFactory = new DataObjectFactory
 (
     "dice-roller",
     DiceRoller,

--- a/examples/hosts/hosts-sample/src/fauxComponent.ts
+++ b/examples/hosts/hosts-sample/src/fauxComponent.ts
@@ -17,7 +17,7 @@ class FauxComponent extends DataObject implements IFluidHTMLView {
     private _componentEl: HTMLElement | undefined;
     public static readonly Factory = new DataObjectFactory(
         "FauxComponent",
-        FauxComponent as any,
+        FauxComponent,
         [],
         {},
         [],

--- a/experimental/examples/bubblebench/baseline/src/main.tsx
+++ b/experimental/examples/bubblebench/baseline/src/main.tsx
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 
 import React from "react";
@@ -40,7 +39,7 @@ export class Bubblebench extends DataObject implements IFluidHTMLView {
  * The DataObjectFactory declares the Fluid object and defines any additional distributed data structures.
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
-export const BubblebenchInstantiationFactory = new DataObjectFactory<Bubblebench, undefined, undefined, IEvent>(
+export const BubblebenchInstantiationFactory = new DataObjectFactory(
     Bubblebench.Name,
     Bubblebench,
     [],

--- a/experimental/examples/bubblebench/sharedtree/src/main.tsx
+++ b/experimental/examples/bubblebench/sharedtree/src/main.tsx
@@ -7,7 +7,6 @@ import {
     DataObject,
     DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import { AppView, IArrayish, IClient } from "@fluid-experimental/bubblebench-common";
@@ -81,8 +80,7 @@ export class Bubblebench extends DataObject implements IFluidHTMLView {
  * The DataObjectFactory declares the Fluid object and defines any additional distributed data structures.
  * To add a SharedSequence, SharedMap, or any other structure, put it in the array below.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const BubblebenchInstantiationFactory = new DataObjectFactory<Bubblebench, object, undefined, IEvent>(
+export const BubblebenchInstantiationFactory = new DataObjectFactory(
     Bubblebench.Name,
     Bubblebench,
     [SharedTree.getFactory()],

--- a/experimental/framework/data-objects/src/kvpair/DataObject.ts
+++ b/experimental/framework/data-objects/src/kvpair/DataObject.ts
@@ -5,7 +5,6 @@
 
 import { EventEmitter } from "events";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IDirectoryValueChanged, IValueChanged } from "@fluidframework/map";
 
 /**
@@ -45,7 +44,7 @@ export interface IKeyValueDataObject extends EventEmitter {
 export class KeyValueDataObject
     extends DataObject
     implements IKeyValueDataObject {
-    public static readonly factory = new DataObjectFactory<KeyValueDataObject, undefined, undefined, IEvent>(
+    public static readonly factory = new DataObjectFactory(
         "keyvalue-dataobject",
         KeyValueDataObject,
         [],

--- a/experimental/framework/data-objects/src/signalManager/signalManager.ts
+++ b/experimental/framework/data-objects/src/signalManager/signalManager.ts
@@ -194,7 +194,7 @@ export class Signaler extends TypedEventEmitter<IErrorEvent> implements ISignale
  * users to get an ISignaler without a custom DO.  Where possible, consumers should instead
  * create a Signaler themselves instead of using the DO wrapper to avoid the DO overhead.
  */
-export class SignalManager extends DataObject<{E: IErrorEvent}> implements EventEmitter, ISignaler {
+export class SignalManager extends DataObject<{Events: IErrorEvent}> implements EventEmitter, ISignaler {
     private _manager: Signaler | undefined;
     private get manager(): Signaler {
         assert(this._manager !== undefined, 0x24b /* "internal signaler should be defined" */);

--- a/experimental/framework/data-objects/src/signalManager/signalManager.ts
+++ b/experimental/framework/data-objects/src/signalManager/signalManager.ts
@@ -194,8 +194,7 @@ export class Signaler extends TypedEventEmitter<IErrorEvent> implements ISignale
  * users to get an ISignaler without a custom DO.  Where possible, consumers should instead
  * create a Signaler themselves instead of using the DO wrapper to avoid the DO overhead.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class SignalManager extends DataObject<{}, undefined, IErrorEvent> implements EventEmitter, ISignaler {
+export class SignalManager extends DataObject<{E: IErrorEvent}> implements EventEmitter, ISignaler {
     private _manager: Signaler | undefined;
     private get manager(): Signaler {
         assert(this._manager !== undefined, 0x24b /* "internal signaler should be defined" */);
@@ -204,7 +203,7 @@ export class SignalManager extends DataObject<{}, undefined, IErrorEvent> implem
 
     public static get Name() { return "@fluid-example/signal-manager"; }
 
-    public static readonly factory = new DataObjectFactory<SignalManager, undefined, undefined, IErrorEvent>
+    public static readonly factory = new DataObjectFactory
     (
         SignalManager.Name,
         SignalManager,

--- a/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
+++ b/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
@@ -4,7 +4,6 @@
  */
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedSummaryBlock } from "@fluidframework/shared-summary-block";
 import { LastEditedTracker } from "./lastEditedTracker";
@@ -16,7 +15,7 @@ import { IProvideFluidLastEditedTracker } from "./interfaces";
 export class LastEditedTrackerDataObject extends DataObject
     implements IProvideFluidLastEditedTracker {
     private static readonly factory =
-        new DataObjectFactory<LastEditedTrackerDataObject, undefined, undefined, IEvent>(
+        new DataObjectFactory(
             "@fluid-experimental/last-edited",
             LastEditedTrackerDataObject,
             [SharedSummaryBlock.getFactory()],

--- a/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
+++ b/experimental/framework/last-edited/src/lastEditedTrackerDataObject.ts
@@ -14,7 +14,7 @@ import { IProvideFluidLastEditedTracker } from "./interfaces";
  */
 export class LastEditedTrackerDataObject extends DataObject
     implements IProvideFluidLastEditedTracker {
-    private static readonly factory =
+    private static readonly factory: DataObjectFactory<LastEditedTrackerDataObject> =
         new DataObjectFactory(
             "@fluid-experimental/last-edited",
             LastEditedTrackerDataObject,
@@ -23,7 +23,7 @@ export class LastEditedTrackerDataObject extends DataObject
             undefined,
         );
 
-    public static getFactory() {
+    public static getFactory(): DataObjectFactory<LastEditedTrackerDataObject> {
         return LastEditedTrackerDataObject.factory;
     }
 

--- a/experimental/framework/react/src/syncedDataObject.ts
+++ b/experimental/framework/react/src/syncedDataObject.ts
@@ -2,12 +2,10 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { DataObject } from "@fluidframework/aqueduct";
+import { DataObject, DataObjectTypes } from "@fluidframework/aqueduct";
 import {
-    FluidObject,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
-import { IEvent } from "@fluidframework/common-definitions";
 import { SharedMap, ISharedMap } from "@fluidframework/map";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 
@@ -31,11 +29,7 @@ import {
  * and assures that the syncedState will be initialized according the config by the time the view
  * is rendered.
  */
-export abstract class SyncedDataObject<
-    P extends FluidObject = FluidObject,
-    S = undefined,
-    E extends IEvent = IEvent
-    > extends DataObject<P, S, E> {
+export abstract class SyncedDataObject<I extends DataObjectTypes = DataObjectTypes> extends DataObject<I> {
     private readonly syncedStateConfig: SyncedStateConfig = new Map();
     private readonly fluidObjectMap: FluidObjectMap = new Map();
     private readonly syncedStateDirectoryId = "syncedState";
@@ -102,7 +96,6 @@ export abstract class SyncedDataObject<
      * @param key - The syncedStateId that maps to the view that will be using these definitions
      * @param value - The config value containing the syncedStateId and the fluidToView and viewToFluid maps
      */
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     public setConfig<S>(key: string, value: ISyncedStateConfig<S, S>) {
         this.syncedStateConfig.set(key, value);
     }

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -9,7 +9,6 @@ import {
     SharedDirectory,
     SharedMap,
 } from "@fluidframework/map";
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
@@ -17,7 +16,7 @@ import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { FluidObjectSymbolProvider } from "@fluidframework/synthesize";
 import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 
-import { DataObject, IDataObjectProps } from "../data-objects";
+import { DataObject, DataObjectTypes, Default, IDataObjectProps  } from "../data-objects";
 import { PureDataObjectFactory } from "./pureDataObjectFactory";
 
 /**
@@ -30,14 +29,14 @@ import { PureDataObjectFactory } from "./pureDataObjectFactory";
  * @typeParam S - the initial state type that the produced data object may take during creation
  * @typeParam E - represents events that will be available in the EventForwarder
  */
-export class DataObjectFactory<TObj extends DataObject<O, S, E>, O, S, E extends IEvent = IEvent>
-    extends PureDataObjectFactory<TObj, O, S, E>
+export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes>
+    extends PureDataObjectFactory<TObj, I>
 {
     constructor(
         type: string,
-        ctor: new (props: IDataObjectProps<O, S>) => TObj,
+        ctor: new (props: IDataObjectProps<I>) => TObj,
         sharedObjects: readonly IChannelFactory[] = [],
-        optionalProviders: FluidObjectSymbolProvider<O>,
+        optionalProviders: FluidObjectSymbolProvider<Default<I>["O"]>,
         registryEntries?: NamedFluidDataStoreRegistryEntries,
         runtimeFactory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
     ) {

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -16,7 +16,8 @@ import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { FluidObjectSymbolProvider } from "@fluidframework/synthesize";
 import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 
-import { DataObject, DataObjectTypes, DataObjectType, IDataObjectProps  } from "../data-objects";
+import { IEvent } from "@fluidframework/common-definitions";
+import { DataObject, DataObjectTypes, DataObjectType, IDataObjectProps, LegacyDataObject  } from "../data-objects";
 import { PureDataObjectFactory } from "./pureDataObjectFactory";
 
 /**
@@ -61,3 +62,19 @@ export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectT
         );
     }
 }
+
+/**
+ * @deprecated - This type is meant to ease the transition from the old PureDataObjectFactory type to the new.
+ * please migrate to PureDataObjectFactory.
+ *
+ * DataObjectFactory is the IFluidDataStoreFactory for use with DataObjects.
+ * It facilitates DataObject's features (such as its shared directory) by
+ * ensuring relevant shared objects etc are available to the factory.
+ *
+ * @typeParam TObj - DataObject (concrete type)
+ * @typeParam O - represents a type that will define optional providers that will be injected
+ * @typeParam S - the initial state type that the produced data object may take during creation
+ * @typeParam E - represents events that will be available in the EventForwarder
+ */
+ export class LegacyDataObjectFactory<TObj extends LegacyDataObject<O, S, E>, O, S, E extends IEvent = IEvent>
+ extends DataObjectFactory<TObj, {OptionalProviders: O, InitialState: S, Events: E}> {}

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -25,9 +25,7 @@ import { PureDataObjectFactory } from "./pureDataObjectFactory";
  * ensuring relevant shared objects etc are available to the factory.
  *
  * @typeParam TObj - DataObject (concrete type)
- * @typeParam O - represents a type that will define optional providers that will be injected
- * @typeParam S - the initial state type that the produced data object may take during creation
- * @typeParam E - represents events that will be available in the EventForwarder
+ * @typeParam I - The input types for the DataObject
  */
 export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes>
     extends PureDataObjectFactory<TObj, I>
@@ -36,7 +34,7 @@ export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectT
         type: string,
         ctor: new (props: IDataObjectProps<I>) => TObj,
         sharedObjects: readonly IChannelFactory[] = [],
-        optionalProviders: FluidObjectSymbolProvider<Default<I>["O"]>,
+        optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>,
         registryEntries?: NamedFluidDataStoreRegistryEntries,
         runtimeFactory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
     ) {

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -16,7 +16,7 @@ import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { FluidObjectSymbolProvider } from "@fluidframework/synthesize";
 import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 
-import { DataObject, DataObjectTypes, Default, IDataObjectProps  } from "../data-objects";
+import { DataObject, DataObjectTypes, DataObjectType, IDataObjectProps  } from "../data-objects";
 import { PureDataObjectFactory } from "./pureDataObjectFactory";
 
 /**
@@ -34,7 +34,7 @@ export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectT
         type: string,
         ctor: new (props: IDataObjectProps<I>) => TObj,
         sharedObjects: readonly IChannelFactory[] = [],
-        optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>,
+        optionalProviders: FluidObjectSymbolProvider<DataObjectType<I, "OptionalProviders">>,
         registryEntries?: NamedFluidDataStoreRegistryEntries,
         runtimeFactory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
     ) {

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -31,7 +31,7 @@ import {
 import {
     IDataObjectProps,
     PureDataObject,
-    Default,
+    DataObjectType,
     DataObjectTypes,
 } from "../data-objects";
 /*
@@ -51,10 +51,10 @@ async function createDataObject<TObj extends PureDataObject,I extends DataObject
     ctor: new (props: IDataObjectProps<I>) => TObj,
     context: IFluidDataStoreContext,
     sharedObjectRegistry: ISharedObjectRegistry,
-    optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>,
+    optionalProviders: FluidObjectSymbolProvider<DataObjectType<I, "OptionalProviders">>,
     runtimeClassArg: typeof FluidDataStoreRuntime,
     existing: boolean,
-    initProps?: Default<I>["State"])
+    initProps?: DataObjectType<I, "InitialState">)
 {
     // base
     let runtimeClass = runtimeClassArg;
@@ -80,7 +80,7 @@ async function createDataObject<TObj extends PureDataObject,I extends DataObject
     // In order to use object, we need to go through full initialization by calling finishInitialization().
     const scope: FluidObject<IFluidDependencySynthesizer> = context.scope;
     const dependencyContainer = new DependencyContainer(scope.IFluidDependencySynthesizer);
-    const providers = dependencyContainer.synthesize<Default<I>["OptionalProviders"]>(optionalProviders, {});
+    const providers = dependencyContainer.synthesize<DataObjectType<I, "OptionalProviders">>(optionalProviders, {});
     const instance = new ctor({ runtime, context, providers, initProps });
 
     // if it's a newly created object, we need to wait for it to finish initialization
@@ -117,7 +117,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
         public readonly type: string,
         private readonly ctor: new (props: IDataObjectProps<I>) => TObj,
         sharedObjects: readonly IChannelFactory[],
-        private readonly optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>,
+        private readonly optionalProviders: FluidObjectSymbolProvider<DataObjectType<I, "OptionalProviders">>,
         registryEntries?: NamedFluidDataStoreRegistryEntries,
         private readonly runtimeClass: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
     ) {
@@ -176,7 +176,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
      */
     public async createChildInstance(
         parentContext: IFluidDataStoreContext,
-        initialState?: Default<I>["State"],
+        initialState?: DataObjectType<I, "InitialState">,
     ): Promise<TObj> {
         return this.createNonRootInstanceCore(
             parentContext.containerRuntime,
@@ -196,7 +196,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
      */
     public async createPeerInstance(
         peerContext: IFluidDataStoreContext,
-        initialState?: Default<I>["State"],
+        initialState?: DataObjectType<I, "InitialState">,
     ): Promise<TObj> {
         return this.createNonRootInstanceCore(
             peerContext.containerRuntime,
@@ -216,7 +216,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
      */
     public async createInstance(
         runtime: IContainerRuntimeBase,
-        initialState?: Default<I>["State"],
+        initialState?: DataObjectType<I, "InitialState">,
     ): Promise<TObj> {
         return this.createNonRootInstanceCore(
             runtime,
@@ -237,7 +237,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     public async createRootInstance(
         rootDataStoreId: string,
         runtime: IContainerRuntime,
-        initialState?: Default<I>["State"],
+        initialState?: DataObjectType<I, "InitialState">,
     ): Promise<TObj> {
         const context = runtime.createDetachedRootDataStore([this.type], rootDataStoreId);
         return this.createInstanceCore(context, initialState);
@@ -246,7 +246,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     protected async createNonRootInstanceCore(
         containerRuntime: IContainerRuntimeBase,
         packagePath: Readonly<string[]>,
-        initialState?: Default<I>["State"],
+        initialState?: DataObjectType<I, "InitialState">,
     ): Promise<TObj> {
         const context = containerRuntime.createDetachedDataStore(packagePath);
         return this.createInstanceCore(context, initialState);
@@ -254,7 +254,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
 
     protected async createInstanceCore(
         context: IFluidDataStoreContextDetached,
-        initialState?: Default<I>["State"],
+        initialState?: DataObjectType<I, "InitialState">,
     ): Promise<TObj> {
         const { instance, runtime } = await createDataObject(
             this.ctor,

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -28,11 +28,13 @@ import {
     IFluidDependencySynthesizer,
 } from "@fluidframework/synthesize";
 
+import { IEvent } from "@fluidframework/common-definitions";
 import {
     IDataObjectProps,
     PureDataObject,
     DataObjectType,
     DataObjectTypes,
+    LegacyPureDataObject,
 } from "../data-objects";
 /*
  * Useful interface in places where it's useful to do type erasure for PureDataObject generic
@@ -270,3 +272,19 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
         return instance;
     }
 }
+
+/**
+ * @deprecated - This type is meant to ease the transition from the old PureDataObjectFactory type to the new.
+ * please migrate to PureDataObjectFactory.
+ *
+ * PureDataObjectFactory is a barebones IFluidDataStoreFactory for use with PureDataObject.
+ * Consumers should typically use DataObjectFactory instead unless creating
+ * another base data store factory.
+ *
+ * @typeParam TObj - DataObject (concrete type)
+ * @typeParam O - represents a type that will define optional providers that will be injected
+ * @typeParam S - the initial state type that the produced data object may take during creation
+ * @typeParam E - represents events that will be available in the EventForwarder
+ */
+ export class LegacyPureDataObjectFactory<TObj extends LegacyPureDataObject<O, S, E>, O, S, E extends IEvent = IEvent>
+ extends PureDataObjectFactory<TObj,{OptionalProviders: O, InitialState: S, Events: E}> {}

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -51,10 +51,10 @@ async function createDataObject<TObj extends PureDataObject,I extends DataObject
     ctor: new (props: IDataObjectProps<I>) => TObj,
     context: IFluidDataStoreContext,
     sharedObjectRegistry: ISharedObjectRegistry,
-    optionalProviders: FluidObjectSymbolProvider<Default<I>["O"]>,
+    optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>,
     runtimeClassArg: typeof FluidDataStoreRuntime,
     existing: boolean,
-    initProps?: Default<I>["S"])
+    initProps?: Default<I>["State"])
 {
     // base
     let runtimeClass = runtimeClassArg;
@@ -80,7 +80,7 @@ async function createDataObject<TObj extends PureDataObject,I extends DataObject
     // In order to use object, we need to go through full initialization by calling finishInitialization().
     const scope: FluidObject<IFluidDependencySynthesizer> = context.scope;
     const dependencyContainer = new DependencyContainer(scope.IFluidDependencySynthesizer);
-    const providers = dependencyContainer.synthesize<Default<I>["O"]>(optionalProviders, {});
+    const providers = dependencyContainer.synthesize<Default<I>["OptionalProviders"]>(optionalProviders, {});
     const instance = new ctor({ runtime, context, providers, initProps });
 
     // if it's a newly created object, we need to wait for it to finish initialization
@@ -105,9 +105,7 @@ async function createDataObject<TObj extends PureDataObject,I extends DataObject
  * another base data store factory.
  *
  * @typeParam TObj - DataObject (concrete type)
- * @typeParam O - represents a type that will define optional providers that will be injected
- * @typeParam S - the initial state type that the produced data object may take during creation
- * @typeParam E - represents events that will be available in the EventForwarder
+ * @typeParam I - The input types for the DataObject
  */
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes>
     implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry>, IRootDataObjectFactory
@@ -119,7 +117,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
         public readonly type: string,
         private readonly ctor: new (props: IDataObjectProps<I>) => TObj,
         sharedObjects: readonly IChannelFactory[],
-        private readonly optionalProviders: FluidObjectSymbolProvider<Default<I>["O"]>,
+        private readonly optionalProviders: FluidObjectSymbolProvider<Default<I>["OptionalProviders"]>,
         registryEntries?: NamedFluidDataStoreRegistryEntries,
         private readonly runtimeClass: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
     ) {
@@ -178,7 +176,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
      */
     public async createChildInstance(
         parentContext: IFluidDataStoreContext,
-        initialState?: Default<I>["S"],
+        initialState?: Default<I>["State"],
     ): Promise<TObj> {
         return this.createNonRootInstanceCore(
             parentContext.containerRuntime,
@@ -198,7 +196,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
      */
     public async createPeerInstance(
         peerContext: IFluidDataStoreContext,
-        initialState?: Default<I>["S"],
+        initialState?: Default<I>["State"],
     ): Promise<TObj> {
         return this.createNonRootInstanceCore(
             peerContext.containerRuntime,
@@ -218,7 +216,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
      */
     public async createInstance(
         runtime: IContainerRuntimeBase,
-        initialState?: Default<I>["S"],
+        initialState?: Default<I>["State"],
     ): Promise<TObj> {
         return this.createNonRootInstanceCore(
             runtime,
@@ -239,7 +237,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     public async createRootInstance(
         rootDataStoreId: string,
         runtime: IContainerRuntime,
-        initialState?: Default<I>["S"],
+        initialState?: Default<I>["State"],
     ): Promise<TObj> {
         const context = runtime.createDetachedRootDataStore([this.type], rootDataStoreId);
         return this.createInstanceCore(context, initialState);
@@ -248,7 +246,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     protected async createNonRootInstanceCore(
         containerRuntime: IContainerRuntimeBase,
         packagePath: Readonly<string[]>,
-        initialState?: Default<I>["S"],
+        initialState?: Default<I>["State"],
     ): Promise<TObj> {
         const context = containerRuntime.createDetachedDataStore(packagePath);
         return this.createInstanceCore(context, initialState);
@@ -256,7 +254,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
 
     protected async createInstanceCore(
         context: IFluidDataStoreContextDetached,
-        initialState?: Default<I>["S"],
+        initialState?: Default<I>["State"],
     ): Promise<TObj> {
         const { instance, runtime } = await createDataObject(
             this.ctor,

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -9,7 +9,8 @@ import {
 } from "@fluidframework/core-interfaces";
 import { ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/map";
 import { RequestParser, create404Response } from "@fluidframework/runtime-utils";
-import { PureDataObject, DataObjectTypes } from "./pureDataObject";
+import { PureDataObject } from "./pureDataObject";
+import { DataObjectTypes } from "./types";
 
 /**
  * DataObject is a base data store that is primed with a root directory. It
@@ -19,9 +20,7 @@ import { PureDataObject, DataObjectTypes } from "./pureDataObject";
  * and registering channels with the runtime any new DDS that is set on the root
  * will automatically be registered.
  *
- * @typeParam O - represents a type that will define optional providers that will be injected
- * @typeParam S - the initial state type that the produced data object may take during creation
- * @typeParam E - represents events that will be available in the EventForwarder
+ * @typeParam I - The optional input types used to strongly type the data object
  */
 export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> extends PureDataObject<I>
 {

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { IEvent } from "@fluidframework/common-definitions";
 import {
+    IFluidObject,
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
@@ -85,3 +87,24 @@ export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> ex
         return `${item} must be initialized before being accessed.`;
     }
 }
+
+/**
+ * @deprecated - This type is meant to ease the transition from the old DataObject type to the new.
+ * please migrate to DataObject.
+ *
+ * DataObject is a base data store that is primed with a root directory. It
+ * ensures that it is created and ready before you can access it.
+ *
+ * Having a single root directory allows for easier development. Instead of creating
+ * and registering channels with the runtime any new DDS that is set on the root
+ * will automatically be registered.
+ *
+ * @typeParam O - represents a type that will define optional providers that will be injected
+ * @typeParam S - the initial state type that the produced data object may take during creation
+ * @typeParam E - represents events that will be available in the EventForwarder
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export abstract class LegacyDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent>
+    extends DataObject<{OptionalProviders: O, InitialState: S, Events: E}> {
+
+    }

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -4,14 +4,12 @@
  */
 
 import {
-    IFluidObject,
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
 import { ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/map";
 import { RequestParser, create404Response } from "@fluidframework/runtime-utils";
-import { IEvent } from "@fluidframework/common-definitions";
-import { PureDataObject } from "./pureDataObject";
+import { PureDataObject, DataObjectTypes } from "./pureDataObject";
 
 /**
  * DataObject is a base data store that is primed with a root directory. It
@@ -25,9 +23,7 @@ import { PureDataObject } from "./pureDataObject";
  * @typeParam S - the initial state type that the produced data object may take during creation
  * @typeParam E - represents events that will be available in the EventForwarder
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export abstract class DataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent>
-    extends PureDataObject<O, S, E>
+export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> extends PureDataObject<I>
 {
     private internalRoot: ISharedDirectory | undefined;
     private readonly rootDirectoryId = "root";

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export { DataObject } from "./dataObject";
-export { PureDataObject } from "./pureDataObject";
+export { DataObject, LegacyDataObject } from "./dataObject";
+export { PureDataObject, LegacyPureDataObject } from "./pureDataObject";
 export { DataObjectTypes, DataObjectType, IDataObjectProps } from "./types";

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -7,4 +7,6 @@ export { DataObject } from "./dataObject";
 export {
     IDataObjectProps,
     PureDataObject,
+    Default,
+    DataObjectTypes,
 } from "./pureDataObject";

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -5,4 +5,4 @@
 
 export { DataObject } from "./dataObject";
 export { PureDataObject } from "./pureDataObject";
-export { DataObjectTypes, Default, IDataObjectProps } from "./types";
+export { DataObjectTypes, DataObjectType, IDataObjectProps } from "./types";

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -4,9 +4,5 @@
  */
 
 export { DataObject } from "./dataObject";
-export {
-    IDataObjectProps,
-    PureDataObject,
-    Default,
-    DataObjectTypes,
-} from "./pureDataObject";
+export { PureDataObject } from "./pureDataObject";
+export { DataObjectTypes, Default, IDataObjectProps } from "./types";

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -22,7 +22,7 @@ import { assert, EventForwarder } from "@fluidframework/common-utils";
 import { handleFromLegacyUri } from "@fluidframework/request-handler";
 import { serviceRoutePathRoot } from "../container-services";
 import { defaultFluidObjectRequestHandler } from "../request-handlers";
-import { DataObjectTypes, Default, IDataObjectProps } from "./types";
+import { DataObjectTypes, DataObjectType, IDataObjectProps } from "./types";
 
 /**
  * This is a bare-bones base class that does basic setup and enables for factory on an initialize call.
@@ -32,7 +32,7 @@ import { DataObjectTypes, Default, IDataObjectProps } from "./types";
  * @typeParam I - The optional input types used to strongly type the data object
  */
 export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes>
-    extends EventForwarder<Default<I>["Events"]>
+    extends EventForwarder<DataObjectType<I, "Events">>
     implements IFluidLoadable, IFluidRouter, IProvideFluidHandle, IFluidObject {
     private readonly innerHandle: IFluidHandle<this>;
     private _disposed = false;
@@ -56,9 +56,9 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
      */
     protected readonly providers:
         // eslint-disable-next-line @typescript-eslint/ban-types
-        AsyncFluidObjectProvider<FluidObjectKey<Default<I>["OptionalProviders"]>, FluidObjectKey<object>>;
+        AsyncFluidObjectProvider<FluidObjectKey<DataObjectType<I, "OptionalProviders">>, FluidObjectKey<object>>;
 
-    protected initProps?: Default<I>["State"];
+    protected initProps?: DataObjectType<I, "InitialState">;
 
     protected initializeP: Promise<void> | undefined;
 
@@ -151,7 +151,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
             await this.initializingFromExisting();
         } else {
             await this.initializingFirstTime(
-                this.context.createProps as Default<I>["State"] ?? this.initProps);
+                this.context.createProps as DataObjectType<I, "InitialState"> ?? this.initProps);
         }
         await this.hasInitialized();
     }
@@ -213,7 +213,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
      *
      * @param props - Optional props to be passed in on create
      */
-    protected async initializingFirstTime(props?: Default<I>["State"]): Promise<void> { }
+    protected async initializingFirstTime(props?: DataObjectType<I, "InitialState">): Promise<void> { }
 
     /**
      * Called every time but the first time the data store is initialized (creations

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -20,6 +20,7 @@ import { FluidObjectHandle } from "@fluidframework/datastore";
 import { IDirectory } from "@fluidframework/map";
 import { assert, EventForwarder } from "@fluidframework/common-utils";
 import { handleFromLegacyUri } from "@fluidframework/request-handler";
+import { IEvent } from "@fluidframework/common-definitions";
 import { serviceRoutePathRoot } from "../container-services";
 import { defaultFluidObjectRequestHandler } from "../request-handlers";
 import { DataObjectTypes, DataObjectType, IDataObjectProps } from "./types";
@@ -232,4 +233,22 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     public dispose(): void {
         super.dispose();
     }
+}
+
+/**
+ * @deprecated - This type is meant to ease the transition from the old PureDataObject type to the new.
+ * please migrate to PureDataObject.
+ *
+ * This is a bare-bones base class that does basic setup and enables for factory on an initialize call.
+ * You probably don't want to inherit from this data store directly unless
+ * you are creating another base data store class
+ *
+ * @typeParam O - represents a type that will define optional providers that will be injected
+ * @typeParam S - the initial state type that the produced data object may take during creation
+ * @typeParam E - represents events that will be available in the EventForwarder
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export abstract class LegacyPureDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent>
+extends PureDataObject<{OptionalProviders: O, InitialState: S, Events: E}> {
+
 }

--- a/packages/framework/aqueduct/src/data-objects/types.ts
+++ b/packages/framework/aqueduct/src/data-objects/types.ts
@@ -18,29 +18,29 @@ export interface DataObjectTypes {
     /**
      * represents a type that will define optional providers that will be injected
      */
-    OptionalProviders?: FluidObject,
+    OptionalProviders?: FluidObject;
     /**
      * the initial state type that the produced data object may take during creation
      */
-    State?: any,
+    InitialState?: any;
     /**
      * represents events that will be available in the EventForwarder
      */
-    Events?: IEvent
+    Events?: IEvent;
 }
 
-export type Default<T extends DataObjectTypes> = {
-    [P in keyof Required<DataObjectTypes>]:
-        T[P] extends Required<DataObjectTypes>[P]
-            ? T[P]
-            : Required<DataObjectTypes>[P]
-};
+/**
+ * @internal This utility type pulls a specific key's type off the T and returns that,
+ *  or the default value if TKey is not specified by T
+ */
+export type DataObjectType<T extends DataObjectTypes, P extends keyof DataObjectTypes> =
+    T[P] extends Required<DataObjectTypes>[P] ? T[P] : Required<DataObjectTypes>[P];
 
 export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
     readonly runtime: IFluidDataStoreRuntime;
     readonly context: IFluidDataStoreContext;
     readonly providers:
         // eslint-disable-next-line @typescript-eslint/ban-types
-        AsyncFluidObjectProvider<FluidObjectKey<Default<I>["OptionalProviders"]>, FluidObjectKey<object>>;
-    readonly initProps?: Default<I>["State"];
+        AsyncFluidObjectProvider<FluidObjectKey<DataObjectType<I, "OptionalProviders">>, FluidObjectKey<object>>;
+    readonly initProps?: DataObjectType<I, "InitialState">;
 }

--- a/packages/framework/aqueduct/src/data-objects/types.ts
+++ b/packages/framework/aqueduct/src/data-objects/types.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    FluidObject,
+} from "@fluidframework/core-interfaces";
+import { AsyncFluidObjectProvider, FluidObjectKey } from "@fluidframework/synthesize";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { IEvent } from "@fluidframework/common-definitions";
+
+/**
+ * This type is used as the base generic input to DataObject and PureDataObject.
+ */
+export interface DataObjectTypes {
+    /**
+     * represents a type that will define optional providers that will be injected
+     */
+    OptionalProviders?: FluidObject,
+    /**
+     * the initial state type that the produced data object may take during creation
+     */
+    State?: any,
+    /**
+     * represents events that will be available in the EventForwarder
+     */
+    Events?: IEvent
+}
+
+export type Default<T extends DataObjectTypes> = {
+    [P in keyof Required<DataObjectTypes>]:
+        T[P] extends Required<DataObjectTypes>[P]
+            ? T[P]
+            : Required<DataObjectTypes>[P]
+};
+
+export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
+    readonly runtime: IFluidDataStoreRuntime;
+    readonly context: IFluidDataStoreContext;
+    readonly providers:
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        AsyncFluidObjectProvider<FluidObjectKey<Default<I>["OptionalProviders"]>, FluidObjectKey<object>>;
+    readonly initProps?: Default<I>["State"];
+}

--- a/packages/framework/azure-client/src/test/TestDataObject.ts
+++ b/packages/framework/azure-client/src/test/TestDataObject.ts
@@ -4,12 +4,11 @@
  */
 
 import { DataObject, DataObjectFactory, IDataObjectProps } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 
 export class TestDataObject extends DataObject {
     public static get Name() { return "@fluid-example/test-data-object"; }
 
-    public static readonly factory = new DataObjectFactory<TestDataObject, undefined, undefined, IEvent>
+    public static readonly factory = new DataObjectFactory
     (
         TestDataObject.Name,
         TestDataObject,

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -25,7 +25,7 @@ export interface RootDataObjectProps {
     initialObjects: LoadableObjectClassRecord;
 }
 
-export class RootDataObject extends DataObject<{State: RootDataObjectProps}> {
+export class RootDataObject extends DataObject<{InitialState: RootDataObjectProps}> {
     private readonly initialObjectsDirKey = "initial-objects-key";
     private readonly _initialObjects: LoadableObjectRecord = {};
 

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -25,8 +25,7 @@ export interface RootDataObjectProps {
     initialObjects: LoadableObjectClassRecord;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export class RootDataObject extends DataObject<{}, RootDataObjectProps> {
+export class RootDataObject extends DataObject<{S: RootDataObjectProps}> {
     private readonly initialObjectsDirKey = "initial-objects-key";
     private readonly _initialObjects: LoadableObjectRecord = {};
 
@@ -114,8 +113,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
     constructor(schema: ContainerSchema) {
         const [registryEntries, sharedObjects] = parseDataObjectsFromSharedObjects(schema);
         const rootDataObjectFactory =
-            // eslint-disable-next-line @typescript-eslint/ban-types
-            new DataObjectFactory<RootDataObject, {}, RootDataObjectProps>(
+            new DataObjectFactory(
                 "rootDO",
                 RootDataObject,
                 sharedObjects,

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -25,7 +25,7 @@ export interface RootDataObjectProps {
     initialObjects: LoadableObjectClassRecord;
 }
 
-export class RootDataObject extends DataObject<{S: RootDataObjectProps}> {
+export class RootDataObject extends DataObject<{State: RootDataObjectProps}> {
     private readonly initialObjectsDirKey = "initial-objects-key";
     private readonly _initialObjects: LoadableObjectRecord = {};
 

--- a/packages/framework/tinylicious-client/src/test/TestDataObject.ts
+++ b/packages/framework/tinylicious-client/src/test/TestDataObject.ts
@@ -4,12 +4,11 @@
  */
 
 import { DataObject, DataObjectFactory, IDataObjectProps } from "@fluidframework/aqueduct";
-import { IEvent } from "@fluidframework/common-definitions";
 
 export class TestDataObject extends DataObject {
     public static get Name() { return "@fluid-example/test-data-object"; }
 
-    public static readonly factory = new DataObjectFactory<TestDataObject, undefined, undefined, IEvent>
+    public static readonly factory = new DataObjectFactory
     (
         TestDataObject.Name,
         TestDataObject,

--- a/packages/runtime/agent-scheduler/README.md
+++ b/packages/runtime/agent-scheduler/README.md
@@ -16,7 +16,7 @@ protected async initializingFirstTime() {
 }
 
 // When creating your DataObjectFactory
-export const MyDataObjectFactory = new DataObjectFactory<MyDataObject, undefined, undefined, IEvent>
+export const MyDataObjectFactory = new DataObjectFactory
 (
     "my-data-object",
     MyDataObject,

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -10,7 +10,7 @@ import random from "random-js";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { IRequestHeader } from "@fluidframework/core-interfaces";
-import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { LoaderHeader } from "@fluidframework/container-definitions";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { ILoadTest, IRunConfig } from "./loadTestDataStore";
@@ -268,13 +268,13 @@ function scheduleFaultInjection(
 }
 
 function scheduleContainerClose(
-    container: IContainer,
+    container: Container,
     runConfig: IRunConfig,
     faultInjectionMinMs: number,
     faultInjectionMaxMs: number) {
     new Promise<void>((res) => {
         // wait for the container to connect write
-        container.once("closed", ()=>res());
+        container.once("closed", res);
         if (!container.connected && !container.closed) {
             container.once("connected", () => {
                 res();

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -10,7 +10,7 @@ import random from "random-js";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { IRequestHeader } from "@fluidframework/core-interfaces";
-import { LoaderHeader } from "@fluidframework/container-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { ILoadTest, IRunConfig } from "./loadTestDataStore";
@@ -268,13 +268,13 @@ function scheduleFaultInjection(
 }
 
 function scheduleContainerClose(
-    container: Container,
+    container: IContainer,
     runConfig: IRunConfig,
     faultInjectionMinMs: number,
     faultInjectionMaxMs: number) {
     new Promise<void>((res) => {
         // wait for the container to connect write
-        container.once("closed", res);
+        container.once("closed", ()=>res());
         if (!container.connected && !container.closed) {
             container.once("connected", () => {
                 res();


### PR DESCRIPTION
- Collapse DataObject generic types to single mapped type. This increased the ergonomics of setting a single type, as default value don't need to be provided for other types
- Remove usage of banned type and a significant number of suppressions: `object`, `{}`
- Remove unnecessary default imports: `IEvent`
- Allows type inference on DataObject factories, so no generic types need to be supplied. This is much more extensible, as we can more easily add new types to the mapped typed. This will also make future breaking changes easier as we will only break explicit users, rather than those just passing things to get to the param they need

Want to get initial feedback before comments, testing, and breaking notes are added

related to #8074 