### PR TITLE
remove deprecated containerPath property from DriverPreCheckInfo interface

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
 - [readOnly and readOnlyPermissions removed from Container](#readOnly-and-readOnlyPermissions-removed-from-container)
 - [Remove `loader` property from `MockFluidDataStoreContext` class](#Remove-loader-property-from-MockFluidDataStoreContext-class)
+- [Remove `containerPath` property from `DriverPreCheckInfo` interface](#Remove-containerPath-property-from-DriverPreCheckInfo-interface)]
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -39,6 +40,9 @@ The `readOnly` and `readOnlyPermissions` properties from `Container` in `contain
 
 ### Remove `loader` property from `MockFluidDataStoreContext` class
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
+
+### Remove `containerPath` property from `DriverPreCheckInfo` interface
+The `containerPath` property from the `DriverPreCheckInfo` interface was deprecated in release 0.32 and is now removed. To replace its functionality, use `Loader.request().url`.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -58,8 +58,6 @@ export enum DriverHeader {
 // @public
 export interface DriverPreCheckInfo {
     codeDetailsHint?: string;
-    // @deprecated (undocumented)
-    containerPath: string;
     criticalBootDomains?: string[];
 }
 

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -143,9 +143,7 @@
       "0.42.0": {
         "InterfaceDeclaration_DriverPreCheckInfo": {
           "backCompat": false
-        }
-      },
-      "0.42.0": {
+        },
         "InterfaceDeclaration_IDocumentDeltaConnection": {
           "backCompat": false
         },

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -101,6 +101,9 @@
         },
         "get_current_InterfaceDeclaration_IDocumentDeltaConnection": {
           "backCompat": false
+        },
+        "InterfaceDeclaration_DriverPreCheckInfo": {
+          "backCompat": false
         }
       },
       "0.40.0": {
@@ -115,6 +118,9 @@
         },
         "get_current_InterfaceDeclaration_IDocumentDeltaConnection": {
           "backCompat": false
+        },
+        "InterfaceDeclaration_DriverPreCheckInfo": {
+          "backCompat": false
         }
       },
       "0.41.0": {
@@ -128,6 +134,14 @@
           "backCompat": false
         },
         "get_current_InterfaceDeclaration_IDocumentDeltaConnection": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_DriverPreCheckInfo": {
+          "backCompat": false
+        }
+      },
+      "0.42.0": {
+        "InterfaceDeclaration_DriverPreCheckInfo": {
           "backCompat": false
         }
       }

--- a/common/lib/driver-definitions/src/test/types/validate0.39.8.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.39.8.ts
@@ -105,6 +105,7 @@ declare function get_current_InterfaceDeclaration_DriverPreCheckInfo():
 declare function use_old_InterfaceDeclaration_DriverPreCheckInfo(
     use: old.DriverPreCheckInfo);
 use_old_InterfaceDeclaration_DriverPreCheckInfo(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_DriverPreCheckInfo());
 
 /*

--- a/common/lib/driver-definitions/src/test/types/validate0.40.0.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.40.0.ts
@@ -103,6 +103,7 @@ declare function get_current_InterfaceDeclaration_DriverPreCheckInfo():
 declare function use_old_InterfaceDeclaration_DriverPreCheckInfo(
     use: old.DriverPreCheckInfo);
 use_old_InterfaceDeclaration_DriverPreCheckInfo(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_DriverPreCheckInfo());
 
 /*

--- a/common/lib/driver-definitions/src/test/types/validate0.41.0.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.41.0.ts
@@ -103,6 +103,7 @@ declare function get_current_InterfaceDeclaration_DriverPreCheckInfo():
 declare function use_old_InterfaceDeclaration_DriverPreCheckInfo(
     use: old.DriverPreCheckInfo);
 use_old_InterfaceDeclaration_DriverPreCheckInfo(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_DriverPreCheckInfo());
 
 /*

--- a/common/lib/driver-definitions/src/test/types/validate0.42.0.ts
+++ b/common/lib/driver-definitions/src/test/types/validate0.42.0.ts
@@ -103,6 +103,7 @@ declare function get_current_InterfaceDeclaration_DriverPreCheckInfo():
 declare function use_old_InterfaceDeclaration_DriverPreCheckInfo(
     use: old.DriverPreCheckInfo);
 use_old_InterfaceDeclaration_DriverPreCheckInfo(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_DriverPreCheckInfo());
 
 /*

--- a/common/lib/driver-definitions/src/urlResolver.ts
+++ b/common/lib/driver-definitions/src/urlResolver.ts
@@ -48,12 +48,6 @@ export interface IUrlResolver {
 */
 export interface DriverPreCheckInfo {
     /**
-     * @deprecated - only needed as long as long as Loader.request() does not work as intended. When
-     * Loader.request() caches and resolves pathing properly, this can be removed. #4489, #4491
-     */
-    containerPath: string;
-
-    /**
      * A code details hint that can potentially be used to prefetch container code prior to having a snapshot.
      */
     codeDetailsHint?: string;


### PR DESCRIPTION
Remove the `containerPath` property from the `DriverPreCheckInfo` interface in the following file: `common/lib/driver-definitions/src/urlResolver.ts`.

To replace its functionality, use `Loader.request().url`.

Issue: https://github.com/microsoft/FluidFramework/issues/8510