### PR TITLE
Remove intervalcollection.getView from sequence dds

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -42,7 +42,7 @@ The `readOnly` and `readOnlyPermissions` properties from `Container` in `contain
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
 
 ### Remove `IntervalCollection.getView()` from sequence dds
-The `IntervalCollection.getView()` was deprecated and no longer reference anywhere.
+The `IntervalCollection.getView()` was removed.  If you were calling this API, you should instead refer to the `IntervalCollection` itself directly in places where you were using the view.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -42,7 +42,7 @@ The `readOnly` and `readOnlyPermissions` properties from `Container` in `contain
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
 
 ### Remove `IntervalCollection.getView()` from sequence dds
-The `IntervalCollection.getView()` was deprecated and no longer reference anywhere. IntervalCollectionView has been removed, refer to IntervalCollection directly.
+The `IntervalCollection.getView()` was deprecated and no longer reference anywhere.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
 - [readOnly and readOnlyPermissions removed from Container](#readOnly-and-readOnlyPermissions-removed-from-container)
 - [Remove `loader` property from `MockFluidDataStoreContext` class](#Remove-loader-property-from-MockFluidDataStoreContext-class)
+- [Remove `IntervalCollection.getView()` from sequence dds](#Remove-IntervalCollection-getView-from-sequence-dds)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -39,6 +40,9 @@ The `readOnly` and `readOnlyPermissions` properties from `Container` in `contain
 
 ### Remove `loader` property from `MockFluidDataStoreContext` class
 The `loader` property from `MockFluidDataStoreContext` class was deprecated in release 0.37 and is now removed. Refer the following deprecation warning: [Loader in data stores deprecated](#Loader-in-data-stores-deprecated)
+
+### Remove `IntervalCollection.getView()` from sequence dds
+The `IntervalCollection.getView()` was deprecated and no longer reference anywhere. IntervalCollectionView has been removed, refer to IntervalCollection directly.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -160,8 +160,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     gatherIterationResults(results: TInterval[], iteratesForward: boolean, start?: number, end?: number): void;
     // (undocumented)
     getIntervalById(id: string): TInterval;
-    // @deprecated (undocumented)
-    getView(onDeserialize?: DeserializeCallback): Promise<IntervalCollection<TInterval>>;
     // (undocumented)
     map(fn: (interval: TInterval) => void): void;
     // (undocumented)

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1152,22 +1152,6 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
         });
     }
 
-    /**
-     * @deprecated IntervalCollectionView has been removed. Refer to IntervalCollection directly.
-     */
-    public async getView(onDeserialize?: DeserializeCallback): Promise<IntervalCollection<TInterval>> {
-        if (!this.attached) {
-            return Promise.reject(new Error("attachSequence must be called prior to retrieving the view"));
-        }
-
-        // Attach custom deserializers if specified
-        if (onDeserialize) {
-            this.attachDeserializer(onDeserialize);
-        }
-
-        return this;
-    }
-
     public addInternal(
         serializedInterval: ISerializedInterval,
         local: boolean,


### PR DESCRIPTION
The `IntervalCollection.getView()` function part of the sequence dds is no longer reference anywhere. 

The files affected: 
1. packages\dds\sequence\src\intervalCollection.ts

Resolves: https://github.com/microsoft/FluidFramework/issues/8281