### PR TITLE
include loaderVersion on loader logger not only container logger

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -576,7 +576,6 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             {
                 all: {
                     clientType, // Differentiating summarizer container from main container
-                    loaderVersion: pkgVersion,
                     containerId: uuid(),
                     docId: () => this.id,
                     containerAttachState: () => this._attachState,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -41,6 +41,7 @@ import {
 } from "@fluidframework/driver-utils";
 import { Container } from "./container";
 import { IParsedUrl, parseUrl } from "./utils";
+import { pkgVersion } from "./packageVersion";
 
 function canUseCache(request: IRequest): boolean {
     if (request.headers === undefined) {
@@ -279,13 +280,17 @@ export class Loader implements IHostLoader {
         if (loaderProps.options?.provideScopeLoader !== false) {
             scope.ILoader = this;
         }
+        const telemetryProps = {
+            loaderId: uuid(),
+            loaderVersion: pkgVersion,
+        };
         this.services = {
             urlResolver: createCachedResolver(MultiUrlResolver.create(loaderProps.urlResolver)),
             documentServiceFactory: MultiDocumentServiceFactory.create(loaderProps.documentServiceFactory),
             codeLoader: loaderProps.codeLoader,
             options: loaderProps.options ?? {},
             scope,
-            subLogger: DebugLogger.mixinDebugLogger("fluid:telemetry", loaderProps.logger, { all:{loaderId: uuid()} }),
+            subLogger: DebugLogger.mixinDebugLogger("fluid:telemetry", loaderProps.logger, { all: telemetryProps }),
             proxyLoaderFactories: loaderProps.proxyLoaderFactories ?? new Map<string, IProxyLoaderFactory>(),
             detachedBlobStorage: loaderProps.detachedBlobStorage,
         };


### PR DESCRIPTION
Fixes #7778

If we want other props from container's logger, we can consider something like #8346 but just doing the simple thing for now.

Also, as mentioned in the issue I've observed loaders loading multiple containers, so those scenarios would need careful consideration.