### PR TITLE
update node version to slim-stretch

### DIFF
--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.22.7-slim AS base
+FROM node:12.22.7-stretch-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:12.22.7-slim AS base
+FROM node:12.22.7-stretch-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
12.22.7-stretch-slim resolve a vulnerability in tar 1.29b-1.1. Gitrest doesn't get updated since it is not using node slim flavor.
Details: https://security-tracker.debian.org/tracker/CVE-2018-20482