### PR TITLE
Reduce parallelism by removing splitTestVariants

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -89,15 +89,15 @@ stages:
         timeoutInMinutes: 360
         continueOnError: true
         testCommand: test:realsvc:frs:report
-        splitTestVariants:
-          - name: Non-compat
-            flags: --compatVersion=0
-          - name: N-1
-            flags: --compatVersion=-1
-          - name: N-2
-            flags: --compatVersion=-2
-          - name: LTS
-            flags: --compatVersion=LTS
+        # splitTestVariants:
+        #   - name: Non-compat
+        #     flags: --compatVersion=0
+        #   - name: N-1
+        #     flags: --compatVersion=-1
+        #   - name: N-2
+        #     flags: --compatVersion=-2
+        #   - name: LTS
+        #     flags: --compatVersion=LTS
         env:
           fluid__test__driver__frs: $(automation-fluid-test-driver-frs)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
FRS is supposed to handle this level of load, but we currently have some scalability issues. We wanted to serialize the test runs temporarily to have a pass rate not skewed by these known issues while we’re addressing them.