### PR TITLE
[Draft WiP] Change loader container returns to IContainer

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -188,15 +188,15 @@ export interface ILoaderServices {
 export class Loader implements IHostLoader {
     constructor(loaderProps: ILoaderProps);
     // (undocumented)
-    createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<Container>;
+    createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<IContainer>;
     // (undocumented)
     get IFluidRouter(): IFluidRouter;
     // (undocumented)
-    rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<Container>;
+    rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer>;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
-    resolve(request: IRequest, pendingLocalState?: string): Promise<Container>;
+    resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
     // (undocumented)
     readonly services: ILoaderServices;
 }
@@ -213,7 +213,7 @@ export class RelativeLoader implements ILoader {
 }
 
 // @public
-export function waitContainerToCatchUp(container: Container): Promise<boolean>;
+export function waitContainerToCatchUp(container: IContainer): Promise<boolean>;
 
 
 // (No @packageDocumentation comment for this package)

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -6,11 +6,11 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { BaseContainerRuntimeFactory } from '@fluidframework/aqueduct';
-import { Container } from '@fluidframework/container-loader';
 import { DataObject } from '@fluidframework/aqueduct';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IClient } from '@fluidframework/protocol-definitions';
+import { IContainer } from '@fluidframework/container-definitions';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
@@ -38,7 +38,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
-    constructor(container: Container, rootDataObject: RootDataObject);
+    constructor(container: IContainer, rootDataObject: RootDataObject);
     attach(): Promise<string>;
     get attachState(): AttachState;
     get connected(): boolean;
@@ -125,11 +125,11 @@ export interface RootDataObjectProps {
 
 // @public
 export abstract class ServiceAudience<M extends IMember = IMember> extends TypedEventEmitter<IServiceAudienceEvents<M>> implements IServiceAudience<M> {
-    constructor(container: Container);
+    constructor(container: IContainer);
     // (undocumented)
     protected readonly audience: IAudience;
     // (undocumented)
-    protected readonly container: Container;
+    protected readonly container: IContainer;
     // (undocumented)
     protected abstract createServiceMember(audienceMember: IClient): M;
     getMembers(): Map<string, M>;

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { Container } from '@fluidframework/container-loader';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
@@ -252,10 +251,10 @@ export class TestObjectProvider {
     // (undocumented)
     ensureSynchronized(): Promise<void>;
     // (undocumented)
-    loadContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions, requestHeader?: IRequestHeader): Promise<Container>;
+    loadContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)
     readonly LoaderConstructor: typeof Loader;
-    loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<Container>;
+    loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>;
     // (undocumented)
     get logger(): ITelemetryBaseLogger;
     makeTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>;

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.53.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-utils": "^0.53.0",

--- a/examples/hosts/hosts-sample/src/app.ts
+++ b/examples/hosts/hosts-sample/src/app.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import {
     IUser,
 } from "@fluidframework/protocol-definitions";
@@ -79,7 +80,7 @@ async function start() {
 
     // Request URL associated with the document.
     let url: string;
-    let container: Container;
+    let container: IContainer;
 
     // when the document ID is not provided, create a new one.
     const shouldCreateNew = location.hash.length === 0;
@@ -107,7 +108,7 @@ async function start() {
     }
 
     // Wait for connection so that proposals can be sent.
-    if (container !== undefined && !container.connected) {
+    if (container !== undefined && container.connected !== undefined && !container.connected) {
         await new Promise<void>((resolve, reject) => {
             // the promise resolves when the connected event fires.
             container.once("connected", () => resolve());

--- a/examples/hosts/hosts-sample/src/codeDetailsView.ts
+++ b/examples/hosts/hosts-sample/src/codeDetailsView.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
-import { Container } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
 import { getCodeDetailsFromQuorum, parsePackageDetails } from "./utils";
 
 /**
@@ -11,7 +11,7 @@ import { getCodeDetailsFromQuorum, parsePackageDetails } from "./utils";
  *
  * @param container - Loaded Fluid container
  */
-export const setupUI = (container: Container) => {
+export const setupUI = (container: IContainer) => {
     // Observe container events to detect when it gets forcefully closed.
     container.once("closed", (error) => {
         if (

--- a/examples/hosts/hosts-sample/src/utils.ts
+++ b/examples/hosts/hosts-sample/src/utils.ts
@@ -4,7 +4,8 @@
  */
 
 import { IFluidCodeDetails, FluidObject, IFluidPackage } from "@fluidframework/core-interfaces";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import { extractPackageIdentifierDetails } from "@fluidframework/web-code-loader";
 
@@ -32,7 +33,7 @@ async function getFluidObjectAndRenderCore(loader: Loader, url: string, div: HTM
  * on the document it listens for the "contextChanged" event which fires when a new code value is quorumed on. In this
  * case it simply runs the attach method again.
  */
-export async function getFluidObjectAndRender(loader: Loader, container: Container, url: string, div: HTMLDivElement) {
+export async function getFluidObjectAndRender(loader: Loader, container: IContainer, url: string, div: HTMLDivElement) {
     container.on("contextChanged", (codeDetails) => {
         console.log("Context changed", codeDetails);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -53,7 +54,7 @@ export function parsePackageDetails(pkg: string | Readonly<IFluidPackage>) {
 }
 
 /** Retrieve the code proposal value from the container's quorum */
-export function getCodeDetailsFromQuorum(container: Container): IFluidCodeDetails {
+export function getCodeDetailsFromQuorum(container: IContainer): IFluidCodeDetails {
     const pkg = container.getQuorum().get("code");
     return pkg as IFluidCodeDetails;
 }

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -11,8 +11,9 @@ import {
     IRuntime,
     IProxyLoaderFactory,
     ILoaderOptions,
+    IContainer,
 } from "@fluidframework/container-definitions";
-import { Loader, Container } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { IRequest, IResponse, FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 import {
@@ -159,7 +160,7 @@ export class IFrameOuterHost {
      * provides only limited functionality.
      * @param request - The request to resolve on the internal loader
      */
-    public async loadContainer(request: IRequest): Promise<Container> {
+    public async loadContainer(request: IRequest): Promise<IContainer> {
         return this.loader.resolve(request);
     }
 }

--- a/examples/hosts/iframe-host/src/inner.ts
+++ b/examples/hosts/iframe-host/src/inner.ts
@@ -5,7 +5,9 @@
 
 import * as Comlink from "comlink";
 import { fluidExport as TodoContainer } from "@fluid-example/todo";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
+import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { FluidObject, IRequest } from "@fluidframework/core-interfaces";
 import {
     InnerDocumentServiceFactory,
@@ -13,11 +15,10 @@ import {
 } from "@fluidframework/iframe-driver";
 import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { IFrameInnerApi } from "./inframehost";
-
 let innerPort: MessagePort;
-const containers: Map<string, Container> = new Map();
+const containers: Map<string, IContainer> = new Map();
 
-async function getFluidObjectAndRender(container: Container, div: HTMLDivElement) {
+async function getFluidObjectAndRender(container: IContainer, div: HTMLDivElement) {
     const response = await container.request({ url: "/" });
     if (response.status !== 200 || response.mimeType !== "fluid/object") {
         return undefined;
@@ -31,7 +32,7 @@ async function getFluidObjectAndRender(container: Container, div: HTMLDivElement
 
 async function loadFluidObject(
     divId: string,
-    container: Container,
+    container: IContainer,
 ) {
     const componentDiv = document.getElementById(divId) as HTMLDivElement;
     await getFluidObjectAndRender(container, componentDiv).catch(() => { });
@@ -58,7 +59,7 @@ async function loadContainer(
         codeLoader,
     });
 
-    let container: Container;
+    let container: IContainer;
 
     // TODO: drive new/existing creation entirely from outer
     if (createNew) {
@@ -73,9 +74,10 @@ async function loadContainer(
     }
 
     await loadFluidObject(divId, container);
-    containers.set(container.id, container);
+    const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+    containers.set(containerId, container);
 
-    return container.id;
+    return containerId;
 }
 
 async function attachContainer(

--- a/experimental/framework/get-container/src/getContainer.ts
+++ b/experimental/framework/get-container/src/getContainer.ts
@@ -5,8 +5,9 @@
 
 import {
     IRuntimeFactory,
+    IContainer,
 } from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {
     IDocumentServiceFactory,
@@ -22,7 +23,7 @@ export interface IGetContainerParams {
 
 export async function createContainer(
     params: IGetContainerParams,
-): Promise<Container> {
+): Promise<IContainer> {
     const module = { fluidExport: params.containerRuntimeFactory };
     const codeLoader = { load: async () => module };
 
@@ -43,7 +44,7 @@ export async function createContainer(
 
 export async function getContainer(
     params: IGetContainerParams,
-): Promise<Container> {
+): Promise<IContainer> {
     const module = { fluidExport: params.containerRuntimeFactory };
     const codeLoader = { load: async () => module };
 

--- a/experimental/framework/get-container/src/getFluidRelayContainer.ts
+++ b/experimental/framework/get-container/src/getFluidRelayContainer.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import { IRuntimeFactory } from "@fluidframework/container-definitions";
-import { Container } from "@fluidframework/container-loader";
+import { IContainer, IRuntimeFactory } from "@fluidframework/container-definitions";
 import { DriverHeader } from "@fluidframework/driver-definitions";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { InsecureTinyliciousTokenProvider, InsecureTinyliciousUrlResolver } from "@fluidframework/tinylicious-driver";
@@ -31,14 +30,14 @@ export async function getFluidRelayContainer(
     documentId: string,
     containerRuntimeFactory: IRuntimeFactory,
     createNew: boolean,
-): Promise<[Container, string]> {
+): Promise<[IContainer, string]> {
     verifyEnvConfig();
 
     const tokenProvider = new InsecureTinyliciousTokenProvider();
     const documentServiceFactory = new RouterliciousDocumentServiceFactory(tokenProvider);
     const urlResolver = new InsecureTinyliciousUrlResolver();
 
-    let container: Container;
+    let container: IContainer;
     if (createNew) {
         container = await createContainer({
             documentServiceFactory,

--- a/experimental/framework/get-container/src/getSessionStorageContainer.ts
+++ b/experimental/framework/get-container/src/getSessionStorageContainer.ts
@@ -5,8 +5,9 @@
 
 import {
     IRuntimeFactory,
+    IContainer,
 } from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { LocalResolver, LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
 
@@ -24,7 +25,7 @@ export async function getSessionStorageContainer(
     documentId: string,
     containerRuntimeFactory: IRuntimeFactory,
     createNew: boolean,
-): Promise<Container> {
+): Promise<IContainer> {
     let deltaConnection = deltaConnectionMap.get(documentId);
     if (deltaConnection === undefined) {
         deltaConnection = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory(documentId));
@@ -45,7 +46,7 @@ export async function getSessionStorageContainer(
         codeLoader,
     });
 
-    let container: Container;
+    let container: IContainer;
 
     if (createNew) {
         // We're not actually using the code proposal (our code loader always loads the same module regardless of the

--- a/experimental/framework/get-container/src/getTinyliciousContainer.ts
+++ b/experimental/framework/get-container/src/getTinyliciousContainer.ts
@@ -6,7 +6,6 @@ import {
     IContainer,
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
-import { Container } from "@fluidframework/container-loader";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import {
@@ -34,7 +33,7 @@ export async function getTinyliciousContainer(
     const tokenProvider = new InsecureTinyliciousTokenProvider();
     const urlResolver = new InsecureTinyliciousUrlResolver(tinyliciousPort);
     const documentServiceFactory = new RouterliciousDocumentServiceFactory(tokenProvider);
-    let container: Container;
+    let container: IContainer;
     if (createNew) {
         container = await createContainer({
             documentServiceFactory,

--- a/packages/framework/azure-client/src/AzureClient.ts
+++ b/packages/framework/azure-client/src/AzureClient.ts
@@ -2,12 +2,12 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import {
     IDocumentServiceFactory,
     IUrlResolver,
 } from "@fluidframework/driver-definitions";
-import { AttachState } from "@fluidframework/container-definitions";
+import { AttachState, IContainer } from "@fluidframework/container-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
@@ -128,7 +128,7 @@ export class AzureClient {
         return { container: fluidContainer, services };
     }
 
-    private getContainerServices(container: Container): AzureContainerServices {
+    private getContainerServices(container: IContainer): AzureContainerServices {
         return {
             audience: new AzureAudience(container),
         };

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { Container } from "@fluidframework/container-loader";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
-import { AttachState } from "@fluidframework/container-definitions";
+import { AttachState, IContainer } from "@fluidframework/container-definitions";
 import { LoadableObjectClass, LoadableObjectRecord } from "./types";
 import { RootDataObject } from "./rootDataObject";
 
@@ -143,7 +142,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     private readonly dirtyHandler = () => this.emit("dirty");
 
     public constructor(
-        private readonly container: Container,
+        private readonly container: IContainer,
         private readonly rootDataObject: RootDataObject,
     ) {
         super();
@@ -179,7 +178,8 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
      * {@inheritDoc IFluidContainer.connected}
      */
     public get connected() {
-        return this.container.connected;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.container.connected!;
     }
 
     /**

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -4,8 +4,7 @@
  */
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { IAudience } from "@fluidframework/container-definitions";
-import { Container } from "@fluidframework/container-loader";
+import { IAudience, IContainer } from "@fluidframework/container-definitions";
 import { IClient } from "@fluidframework/protocol-definitions";
 import { IServiceAudience, IServiceAudienceEvents, IMember } from "./types";
 
@@ -34,10 +33,11 @@ export abstract class ServiceAudience<M extends IMember = IMember>
   protected lastMembers: Map<string, M> = new Map();
 
   constructor(
-      protected readonly container: Container,
+      protected readonly container: IContainer,
   ) {
     super();
-    this.audience = container.audience;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.audience = container.audience!;
 
     // getMembers will assign lastMembers so the removeMember event has what it needs
     // in case it would fire before getMembers otherwise gets called the first time

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -2,12 +2,12 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import {
     IDocumentServiceFactory,
     IUrlResolver,
 } from "@fluidframework/driver-definitions";
-import { AttachState } from "@fluidframework/container-definitions";
+import { AttachState, IContainer } from "@fluidframework/container-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import {
     createTinyliciousCreateNewRequest,
@@ -108,7 +108,7 @@ export class TinyliciousClient {
 
     // #region private
     private getContainerServices(
-        container: Container,
+        container: IContainer,
     ): TinyliciousContainerServices {
         return {
             audience: new TinyliciousAudience(container),

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -169,7 +169,7 @@ export enum ConnectionState {
  *          false: storage does not provide indication of how far the client is. Container processed
  *          all the ops known to it, but it maybe still behind.
  */
-export async function waitContainerToCatchUp(container: Container) {
+export async function waitContainerToCatchUp(container: IContainer) {
     // Make sure we stop waiting if container is closed.
     if (container.closed) {
         throw new Error("Container is closed");
@@ -216,7 +216,8 @@ export async function waitContainerToCatchUp(container: Container) {
         };
         container.on(connectedEventName, callback);
 
-        container.resume();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        container.resume!();
     });
 }
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -294,7 +294,7 @@ export class Loader implements IHostLoader {
 
     public get IFluidRouter(): IFluidRouter { return this; }
 
-    public async createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<Container> {
+    public async createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<IContainer> {
         const container = await Container.createDetached(
             this,
             codeDetails,
@@ -313,11 +313,11 @@ export class Loader implements IHostLoader {
         return container;
     }
 
-    public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<Container> {
+    public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer> {
         return Container.rehydrateDetachedFromSnapshot(this, snapshot);
     }
 
-    public async resolve(request: IRequest, pendingLocalState?: string): Promise<Container> {
+    public async resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer> {
         const eventName = pendingLocalState === undefined ? "Resolve" : "ResolveWithPendingState";
         return PerformanceEvent.timedExecAsync(this.logger, { eventName }, async () => {
             const resolved = await this.resolveCore(

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -56,6 +56,7 @@
     "@fluid-internal/replay-tool": "^0.53.0",
     "@fluidframework/cell": "^0.53.0",
     "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.53.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/counter": "^0.53.0",

--- a/packages/test/snapshots/src/validateSnapshots.ts
+++ b/packages/test/snapshots/src/validateSnapshots.ts
@@ -5,6 +5,7 @@
 
 import fs from "fs";
 import { assert } from "@fluidframework/common-utils";
+import { IContainer } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
 import { FileStorageDocumentName } from "@fluidframework/file-driver";
 import { ISequencedDocumentMessage, TreeEntry } from "@fluidframework/protocol-definitions";
@@ -63,7 +64,7 @@ export async function validateSnapshots(
         const snapshotFileName = file.name.split(".")[0];
         const srcContent = fs.readFileSync(`${srcDir}/${file.name}`, "utf-8");
         // eslint-disable-next-line prefer-const
-        let container: Container;
+        let container: IContainer;
         // This function will be called by the storage service when the container is snapshotted. When that happens,
         // validate that snapshot with the destination snapshot.
         const onSnapshotCb =
@@ -78,7 +79,7 @@ export async function validateSnapshots(
             new StaticStorageDocumentServiceFactory(storage),
             FileStorageDocumentName,
         );
-        await container.snapshot(file.name, true /* fullTree */);
+        await (container as Container).snapshot(file.name, true /* fullTree */);
     }
 
     if (errors.length !== 0) {

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -239,7 +239,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
             return service;
         };
         const container = await loadContainer({ documentServiceFactory: mockFactory });
-        container.on("error", () => {
+        container.on("closed", () => {
             assert.ok(false, "Error event should not be raised.");
         });
         assert.strictEqual(container.connectionState, ConnectionState.Connecting,

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -35,6 +35,7 @@ import {
     ISnapshotTreeWithBlobContents,
     // eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/container-loader/dist/utils";
+import { IContainer } from "@fluidframework/container-definitions";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -145,7 +146,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
     };
 
     const getSnapshotTreeFromSerializedSnapshot = (
-        container: Container,
+        container: IContainer,
     ) => {
         return getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
     };
@@ -359,7 +360,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
                 await createDetachedContainerAndGetRootDataStore();
 
             const snapshotTree = container.serialize();
-            assert(container.storage !== undefined, "Storage should be present in detached container");
+            assert((container as Container).storage !== undefined, "Storage should be present in detached container");
             const response = await container.request({ url: "/" });
             const defaultDataStore = response.value as TestFluidObject;
             assert(defaultDataStore.context.storage !== undefined,
@@ -369,7 +370,8 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             assert(success1 === false, "Snapshot fetch should not be allowed in detached data store");
 
             const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
-            assert(container2.storage !== undefined, "Storage should be present in rehydrated container");
+            assert((container2 as Container).storage !== undefined,
+                "Storage should be present in rehydrated container");
             const response2 = await container2.request({ url: "/" });
             const defaultDataStore2 = response2.value as TestFluidObject;
             assert(defaultDataStore2.context.storage !== undefined,

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { AttachState } from "@fluidframework/container-definitions";
-import { ConnectionState, Loader } from "@fluidframework/container-loader";
+import { ConnectionState, Container, Loader } from "@fluidframework/container-loader";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import {
     ITestContainerConfig,
@@ -32,7 +32,7 @@ import { DataStoreMessageType } from "@fluidframework/datastore";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeFullCompat, describeNoCompat } from "@fluidframework/test-version-utils";
-import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -84,7 +84,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
     });
 
     it("Create detached container", async () => {
-        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        const container = (await loader.createDetachedContainer(provider.defaultCodeDetails)) as Container;
         assert.strictEqual(container.attachState, AttachState.Detached, "Container should be detached");
         assert.strictEqual(container.closed, false, "Container should be open");
         assert.strictEqual(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
@@ -112,9 +112,10 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(container.attachState, AttachState.Attached, "Container should be attached");
         assert.strictEqual(container.closed, false, "Container should be open");
         assert.strictEqual(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
-        assert.ok(container.id, "No container ID");
+        const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+        assert.ok(container, "No container ID");
         if (provider.driver.type === "local") {
-            assert.strictEqual(container.id, provider.documentId, "Doc id is not matching!!");
+            assert.strictEqual(containerId, provider.documentId, "Doc id is not matching!!");
         }
     });
 
@@ -598,9 +599,10 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(container.attachState, AttachState.Attached, "Container should be attached");
         assert.strictEqual(container.closed, false, "Container should be open");
         assert.strictEqual(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
-        assert.ok(container.id, "No container ID");
+        const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+        assert.ok(containerId, "No container ID");
         if (provider.driver.type === "local") {
-            assert.strictEqual(container.id, provider.documentId, "Doc id is not matching!!");
+            assert.strictEqual(containerId, provider.documentId, "Doc id is not matching!!");
         }
         assert.strictEqual(retryTimes, 0, "Should not succeed at first time");
     }).timeout(5000);

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -5,13 +5,13 @@
 
 import commander from "commander";
 import { ITestDriver, TestDriverTypes } from "@fluidframework/test-driver-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import random from "random-js";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { IRequestHeader } from "@fluidframework/core-interfaces";
-import { LoaderHeader } from "@fluidframework/container-definitions";
-import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { ILoadTest, IRunConfig } from "./loadTestDataStore";
 import { createCodeLoader, createTestDriver, getProfile, loggerP, safeExit } from "./utils";
@@ -176,7 +176,8 @@ async function runnerProcess(
             });
 
             const container = await loader.resolve({ url, headers });
-            container.resume();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            container.resume!();
             const test = await requestFluidObject<ILoadTest>(container, "/");
 
             // Control fault injection period through config.
@@ -221,7 +222,7 @@ async function runnerProcess(
 
 function scheduleFaultInjection(
     ds: FaultInjectionDocumentServiceFactory,
-    container: Container,
+    container: IContainer,
     runConfig: IRunConfig,
     faultInjectionMinMs: number,
     faultInjectionMaxMs: number) {
@@ -229,7 +230,7 @@ function scheduleFaultInjection(
         const injectionTime = random.integer(faultInjectionMinMs, faultInjectionMaxMs)(runConfig.randEng);
         printStatus(runConfig, `fault injection in ${(injectionTime / 60000).toString().substring(0, 4)} min`);
         setTimeout(() => {
-            if (container.connected && container.resolvedUrl !== undefined) {
+            if (container.connected !== undefined && container.connected && container.resolvedUrl !== undefined) {
                 const deltaConn =
                     ds.documentServices.get(container.resolvedUrl)?.documentDeltaConnection;
                 if (deltaConn !== undefined) {
@@ -252,7 +253,7 @@ function scheduleFaultInjection(
                         case 3:
                         case 4:
                         default: {
-                            deltaConn.injectNack(container.id, canRetry);
+                            deltaConn.injectNack((container.resolvedUrl as IFluidResolvedUrl).id, canRetry);
                             printStatus(runConfig, `nack injected canRetry:${canRetry}`);
                             break;
                         }
@@ -268,17 +269,17 @@ function scheduleFaultInjection(
 }
 
 function scheduleContainerClose(
-    container: Container,
+    container: IContainer,
     runConfig: IRunConfig,
     faultInjectionMinMs: number,
     faultInjectionMaxMs: number) {
     new Promise<void>((res) => {
         // wait for the container to connect write
-        container.once("closed", res);
-        if (!container.connected && !container.closed) {
+        container.once("closed", () => res);
+        if (container.connected !== undefined && !container.connected && !container.closed) {
             container.once("connected", () => {
                 res();
-                container.off("closed", res);
+                container.off("closed", () => res);
             });
         }
     }).then(() => {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -138,7 +138,7 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
     });
 
     const container = await loader.createDetachedContainer(codeDetails);
-    container.on("error", (error) => {
+    container.on("closed", (error) => {
         console.log(error);
         process.exit(-1);
     });

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -138,7 +138,7 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
     });
 
     const container = await loader.createDetachedContainer(codeDetails);
-    (container as Container).on("closed", (error) => {
+    (container as Container).on("error", (error) => {
         console.log(error);
         process.exit(-1);
     });

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 import random from "random-js";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { assert, LazyPromise } from "@fluidframework/common-utils";
-import { IDetachedBlobStorage, Loader } from "@fluidframework/container-loader";
+import { Container, IDetachedBlobStorage, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { ICreateBlobResponse } from "@fluidframework/protocol-definitions";
@@ -138,7 +138,7 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
     });
 
     const container = await loader.createDetachedContainer(codeDetails);
-    container.on("closed", (error) => {
+    (container as Container).on("closed", (error) => {
         console.log(error);
         process.exit(-1);
     });

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -5,7 +5,7 @@
 
 import { IContainer, IHostLoader, ILoaderOptions } from "@fluidframework/container-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import { Container, IDetachedBlobStorage, Loader, waitContainerToCatchUp } from "@fluidframework/container-loader";
+import { IDetachedBlobStorage, Loader, waitContainerToCatchUp } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IFluidCodeDetails, IRequestHeader } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
@@ -288,7 +288,7 @@ export class TestObjectProvider {
      * Container loaded is automatically added to the OpProcessingController to manage op flow
      * @param testContainerConfig - optional configuring the test Container
      */
-    public async loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<Container> {
+    public async loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer> {
         const loader = this.makeTestLoader(testContainerConfig);
         const container = await loader.resolve({ url: await this.driver.createContainerUrl(this.documentId) });
         await waitContainerToCatchUp(container);

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -5,7 +5,8 @@
 
 import { strict } from "assert";
 import fs from "fs";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import {
     IDocumentServiceFactory,
@@ -71,7 +72,7 @@ export async function loadContainer(
     documentServiceFactory: IDocumentServiceFactory,
     documentName: string,
     logger?: TelemetryLogger,
-): Promise<Container> {
+): Promise<IContainer> {
     const resolved: IFluidResolvedUrl = {
         endpoints: {
             deltaStorageUrl: "example.com",

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -8,6 +8,7 @@ import child_process from "child_process";
 import fs from "fs";
 import { assert, Lazy } from "@fluidframework/common-utils";
 import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { IContainer } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
 import { ChildLogger, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import {
@@ -140,7 +141,7 @@ class Logger implements ITelemetryBaseLogger {
  * Helper class holding container and providing load / snapshot capabilities
  */
 class Document {
-    private container: Container;
+    private container: IContainer;
     private replayer: Replayer;
     private documentSeqNumber = 0;
     private from = -1;
@@ -230,7 +231,7 @@ class Document {
     }
 
     public async snapshot() {
-        return this.container.snapshot(
+        return (this.container as Container).snapshot(
             `ReplayTool Snapshot: op ${this.currentOp}, ${this.getFileName()}`,
             !this.args.incremental /* generateFullTreeNoOtimizations */);
     }

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -14,8 +14,9 @@ import {
     IResolvedFluidCodeDetails,
     isFluidBrowserPackage,
     IProvideRuntimeFactory,
+    IContainer,
 } from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { prefetchLatestSnapshot } from "@fluidframework/odsp-driver";
 import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
@@ -199,7 +200,7 @@ async function createWebLoader(
     });
 }
 
-const containers: Container[] = [];
+const containers: IContainer[] = [];
 // A function for testing to make sure the containers are not dirty and in sync (at the same seq num)
 export function isSynchronized() {
     if (containers.length === 0) { return true; }
@@ -248,7 +249,7 @@ export async function start(
         testOrderer,
         odspPersistantCache);
 
-    let container1: Container;
+    let container1: IContainer;
     if (autoAttach || manualAttach) {
         // For new documents, create a detached container which will be attached later.
         container1 = await loader1.createDetachedContainer(codeDetails);
@@ -331,7 +332,7 @@ export async function start(
     }
 }
 
-async function getFluidObjectAndRender(container: Container, url: string, div: HTMLDivElement) {
+async function getFluidObjectAndRender(container: IContainer, url: string, div: HTMLDivElement) {
     const response = await container.request({
         headers: {
             mountableView: true,
@@ -375,7 +376,7 @@ async function getFluidObjectAndRender(container: Container, url: string, div: H
  */
 async function attachContainer(
     loader: Loader,
-    container: Container,
+    container: IContainer,
     fluidObjectUrl: string,
     urlResolver: MultiUrlResolver,
     documentId: string,


### PR DESCRIPTION
Creating this draft PR to run our CI builds and tests on it, and as a preview of changes to come. This is not for check-in.

The code in this draft PR is going to be broken up into 3 separate PRs:
1) All non-breaking API changes that only require internal code refactoring to switch from Container -> IContainer
2) Any developer surface API changes or changes that require casting/logical changes
3) The actual changes on loader to return IContainer instead of Container

1 & 2 should go in for this release. 3 should be in the next release.