### PR TITLE
Rename telemetry prop and fix spelling error

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -166,7 +166,7 @@ export class EpochTracker implements IPersistedFileCache {
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;
         }).catch((error) => {
-            const fluidError = normalizeError(error, { props: { requestStatsHeader: clientCorrelationId}});
+            const fluidError = normalizeError(error, { props: { XRequestStatsHeader: clientCorrelationId }});
             throw fluidError;
         });
     }
@@ -207,7 +207,7 @@ export class EpochTracker implements IPersistedFileCache {
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;
         }).catch((error) => {
-            const fluidError = normalizeError(error, { props: { requestStatsHeader: clientCorrelationId }});
+            const fluidError = normalizeError(error, { props: { XRequestStatsHeader: clientCorrelationId }});
             throw fluidError;
         });
     }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -143,9 +143,9 @@ export class EpochTracker implements IPersistedFileCache {
         fetchType: FetchType,
         addInBody: boolean = false,
     ): Promise<IOdspResponse<T>> {
-        const clientCorelationId = this.formatClientCorelationId();
+        const clientCorrelationId = this.formatClientCorrelationId();
         // Add epoch in fetch request.
-        this.addEpochInRequest(fetchOptions, addInBody, clientCorelationId);
+        this.addEpochInRequest(fetchOptions, addInBody, clientCorrelationId);
         let epochFromResponse: string | undefined;
         return this.rateLimiter.schedule(
             async () => fetchAndParseAsJSONHelper<T>(url, fetchOptions),
@@ -154,7 +154,7 @@ export class EpochTracker implements IPersistedFileCache {
             this.validateEpochFromResponse(epochFromResponse, fetchType);
             response.commonSpoHeaders = {
                 ...response.commonSpoHeaders,
-                "X-RequestStats": clientCorelationId,
+                "X-RequestStats": clientCorrelationId,
             };
             return response;
         }).catch(async (error) => {
@@ -166,7 +166,7 @@ export class EpochTracker implements IPersistedFileCache {
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;
         }).catch((error) => {
-            const fluidError = normalizeError(error, {props: {"X-RequestStats": clientCorelationId}});
+            const fluidError = normalizeError(error, { props: { odspRequestStats: clientCorrelationId}});
             throw fluidError;
         });
     }
@@ -184,9 +184,9 @@ export class EpochTracker implements IPersistedFileCache {
         fetchType: FetchType,
         addInBody: boolean = false,
     ) {
-        const clientCorelationId = this.formatClientCorelationId();
+        const clientCorrelationId = this.formatClientCorrelationId();
         // Add epoch in fetch request.
-        this.addEpochInRequest(fetchOptions, addInBody, clientCorelationId);
+        this.addEpochInRequest(fetchOptions, addInBody, clientCorrelationId);
         let epochFromResponse: string | undefined;
         return this.rateLimiter.schedule(
             async () => fetchArray(url, fetchOptions),
@@ -195,7 +195,7 @@ export class EpochTracker implements IPersistedFileCache {
             this.validateEpochFromResponse(epochFromResponse, fetchType);
             response.commonSpoHeaders = {
                 ...response.commonSpoHeaders,
-                "X-RequestStats": clientCorelationId,
+                "X-RequestStats": clientCorrelationId,
             };
             return response;
         }).catch(async (error) => {
@@ -207,7 +207,7 @@ export class EpochTracker implements IPersistedFileCache {
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;
         }).catch((error) => {
-            const fluidError = normalizeError(error, {props: {"X-RequestStats": clientCorelationId}});
+            const fluidError = normalizeError(error, { props: { odspRequestStats: clientCorrelationId }});
             throw fluidError;
         });
     }
@@ -215,11 +215,11 @@ export class EpochTracker implements IPersistedFileCache {
     private addEpochInRequest(
         fetchOptions: RequestInit,
         addInBody: boolean,
-        clientCorelationId: string,
+        clientCorrelationId: string,
     ) {
         if (addInBody) {
             const headers: {[key: string]: string} = {};
-            headers["X-RequestStats"] = clientCorelationId;
+            headers["X-RequestStats"] = clientCorrelationId;
             if (this.fluidEpoch !== undefined) {
                 headers["x-fluid-epoch"] = this.fluidEpoch;
             }
@@ -232,7 +232,7 @@ export class EpochTracker implements IPersistedFileCache {
                 assert(fetchOptions.headers !== undefined, 0x282 /* "Headers should be present now" */);
                 fetchOptions.headers[key] = val;
             };
-            addHeader("X-RequestStats", clientCorelationId);
+            addHeader("X-RequestStats", clientCorrelationId);
             if (this.fluidEpoch !== undefined) {
                 addHeader("x-fluid-epoch", this.fluidEpoch);
             }
@@ -257,7 +257,7 @@ export class EpochTracker implements IPersistedFileCache {
         fetchOptions.body = formParams.join("\r\n");
     }
 
-    private formatClientCorelationId() {
+    private formatClientCorrelationId() {
         return `driverId=${this.driverId}, RequestNumber=${this.networkCallNumber++}`;
     }
 

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -166,7 +166,7 @@ export class EpochTracker implements IPersistedFileCache {
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;
         }).catch((error) => {
-            const fluidError = normalizeError(error, { props: { odspRequestStats: clientCorrelationId}});
+            const fluidError = normalizeError(error, { props: { requestStatsHeader: clientCorrelationId}});
             throw fluidError;
         });
     }
@@ -207,7 +207,7 @@ export class EpochTracker implements IPersistedFileCache {
             await this.checkForEpochError(error, epochFromResponse, fetchType);
             throw error;
         }).catch((error) => {
-            const fluidError = normalizeError(error, { props: { odspRequestStats: clientCorrelationId }});
+            const fluidError = normalizeError(error, { props: { requestStatsHeader: clientCorrelationId }});
             throw fluidError;
         });
     }

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -134,7 +134,7 @@ describe("Tests for Epoch Tracker", () => {
         assert.strictEqual(success, false, "Fetching should fail!!");
     });
 
-    it("Check client corelationID on error in unsuccessful fetch case", async () => {
+    it("Check client correlationID on error in unsuccessful fetch case", async () => {
         let success: boolean = true;
         const cacheEntry1: IEntry = {
             key:"key1",
@@ -151,12 +151,12 @@ describe("Tests for Epoch Tracker", () => {
                 { "x-fluid-epoch": "epoch2" });
         } catch (error) {
             success = false;
-            assert(error["X-RequestStats"] !== undefined, "CorelationId should be present");
+            assert(error["X-RequestStats"] !== undefined, "CorrelationId should be present");
         }
         assert.strictEqual(success, false, "Fetching should fail!!");
     });
 
-    it("Check client corelationID on spoCommonHeaders in successful fetch case", async () => {
+    it("Check client correlationID on spoCommonHeaders in successful fetch case", async () => {
         const cacheEntry1: IEntry = {
             key:"key1",
             type: "snapshot",
@@ -169,7 +169,7 @@ describe("Tests for Epoch Tracker", () => {
                 async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "test"),
                 {},
                 { "x-fluid-epoch": "epoch1" });
-        assert(response.commonSpoHeaders["X-RequestStats"] !== undefined, "CorelationId should be present");
+        assert(response.commonSpoHeaders["X-RequestStats"] !== undefined, "CorrelationId should be present");
     });
 
     it("Epoch error should not occur if response does not contain epoch", async () => {

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -151,7 +151,7 @@ describe("Tests for Epoch Tracker", () => {
                 { "x-fluid-epoch": "epoch2" });
         } catch (error) {
             success = false;
-            assert(error.requestStatsHeader !== undefined, "CorrelationId should be present");
+            assert(error.XRequestStatsHeader !== undefined, "CorrelationId should be present");
         }
         assert.strictEqual(success, false, "Fetching should fail!!");
     });

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -151,7 +151,7 @@ describe("Tests for Epoch Tracker", () => {
                 { "x-fluid-epoch": "epoch2" });
         } catch (error) {
             success = false;
-            assert(error["X-RequestStats"] !== undefined, "CorrelationId should be present");
+            assert(error.requestStatsHeader !== undefined, "CorrelationId should be present");
         }
         assert.strictEqual(success, false, "Fetching should fail!!");
     });


### PR DESCRIPTION
The office telemetry logging code doesn't like dashes in telemetry prop names.