### PR TITLE
[r11s] Enabling restart flag to be set by RdKafka depending on the error code

### DIFF
--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -5,61 +5,40 @@ services:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
-            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
-            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
-            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     deli:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
-            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
-            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
-            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     scriptorium:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
-            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
-            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
-            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     copier:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
-            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
-            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
-            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     scribe:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
-            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
-            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
-            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     foreman:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
-            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
-            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
-            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     riddler:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
-            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
-            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
-            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/

--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -5,40 +5,61 @@ services:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
+            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
+            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
+            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     deli:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
+            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
+            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
+            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     scriptorium:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
+            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
+            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
+            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     copier:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
+            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
+            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
+            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     scribe:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
+            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
+            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
+            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     foreman:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
+            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
+            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
+            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
     riddler:
         volumes:
             - .:/usr/src/server
             - /usr/src/server/node_modules/zookeeper
             - /usr/src/server/node_modules/node-rdkafka
+            - ./node_modules/node-rdkafka/lib/client.js:/usr/src/server/node_modules/node-rdkafka/lib/client.js
+            - ./node_modules/node-rdkafka/lib/error.js:/usr/src/server/node_modules/node-rdkafka/lib/error.js
+            - ./node_modules/node-rdkafka/lib/admin.js:/usr/src/server/node_modules/node-rdkafka/lib/admin.js
             - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -106,6 +106,7 @@ export abstract class RdkafkaBase extends EventEmitter {
         return new Promise<void>((resolve, reject) => {
             adminClient.createTopic(newTopic, 10000, (err) => {
                 adminClient.disconnect();
+
                 if (err && err.code !== this.kafka.CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS) {
                     reject(err);
                 } else {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -74,17 +74,17 @@ export abstract class RdkafkaBase extends EventEmitter {
             ${JSON.stringify(this.defaultRestartOnKafkaErrorCodes)}`);
 
         setTimeout(() => void this.initialize(), 1);
-
-        console.log(
-            `[DEBUG RdKafkaBase] defaultRestartOnKafkaErrorCodes 2:
-            ${JSON.stringify(this.defaultRestartOnKafkaErrorCodes)}`);
     }
 
     protected abstract connect(): void;
 
     private async initialize() {
+        console.log(
+            `[DEBUG RdKafkaBase] defaultRestartOnKafkaErrorCodes inside initialize:
+            ${JSON.stringify(this.defaultRestartOnKafkaErrorCodes)}`);
         try {
             await this.ensureTopics();
+            this.connect();
         } catch (ex) {
             console.log(`[DEBUG DEBUG] Ensure topics throwing error, will emit: ${JSON.stringify(ex)}`);
             this.error(ex);
@@ -94,8 +94,6 @@ export abstract class RdkafkaBase extends EventEmitter {
 
             return;
         }
-
-        this.connect();
     }
 
     protected async ensureTopics() {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -12,7 +12,7 @@ export interface IKafkaBaseOptions {
     numberOfPartitions: number;
     replicationFactor: number;
     sslCACertFilePath?: string;
-    restartOnKafkaErrorCodes?: number[]
+    restartOnKafkaErrorCodes?: number[];
 }
 
 export interface IKafkaEndpoints {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -126,6 +126,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		consumer.on("connection.failure", async (error) => {
 			await this.close(true);
+
 			this.error(error);
 
 			this.connect();

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -42,6 +42,15 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		options?: Partial<IKafkaConsumerOptions>) {
 		super(endpoints, clientId, topic, options);
 
+        this.defaultRestartOnKafkaErrorCodes = [
+            this.kafka.CODES.ERRORS.ERR__TRANSPORT,
+            this.kafka.CODES.ERRORS.ERR__MSG_TIMED_OUT,
+            this.kafka.CODES.ERRORS.ERR__ALL_BROKERS_DOWN,
+            this.kafka.CODES.ERRORS.ERR__TIMED_OUT,
+            this.kafka.CODES.ERRORS.ERR__SSL,
+            this.kafka.CODES.ERRORS.ERR_COORDINATOR_LOAD_IN_PROGRESS,
+        ];
+
 		this.consumerOptions = {
 			...options,
 			consumeTimeout: options?.consumeTimeout ?? 1000,
@@ -51,6 +60,8 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			automaticConsume: options?.automaticConsume ?? true,
 			maxConsumerCommitRetries: options?.maxConsumerCommitRetries ?? 10,
 		};
+
+        console.log(`[DEBUG] RdKafkaBase consumerOptions: ${JSON.stringify(this.consumerOptions)}`);
 	}
 
 	/**
@@ -117,7 +128,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		consumer.on("connection.failure", async (error) => {
 			await this.close(true);
-
+            console.log(`[DEBUG DEBUG] connection.failure error info: ${JSON.stringify(error)}`);
 			this.error(error);
 
 			this.connect();
@@ -236,10 +247,12 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		});
 
 		consumer.on("rebalance.error", (error) => {
+            console.log(`[DEBUG DEBUG] rebalance.error error info: ${JSON.stringify(error)}`);
 			this.error(error);
 		});
 
 		consumer.on("event.error", (error) => {
+            console.log(`[DEBUG DEBUG] event.error error info: ${JSON.stringify(error)}`);
 			this.error(error);
 		});
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -60,8 +60,6 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			automaticConsume: options?.automaticConsume ?? true,
 			maxConsumerCommitRetries: options?.maxConsumerCommitRetries ?? 10,
 		};
-
-        console.log(`[DEBUG] RdKafkaBase consumerOptions: ${JSON.stringify(this.consumerOptions)}`);
 	}
 
 	/**
@@ -128,7 +126,6 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		consumer.on("connection.failure", async (error) => {
 			await this.close(true);
-            console.log(`[DEBUG DEBUG] connection.failure error info: ${JSON.stringify(error)}`);
 			this.error(error);
 
 			this.connect();
@@ -247,12 +244,10 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		});
 
 		consumer.on("rebalance.error", (error) => {
-            console.log(`[DEBUG DEBUG] rebalance.error error info: ${JSON.stringify(error)}`);
 			this.error(error);
 		});
 
 		consumer.on("event.error", (error) => {
-            console.log(`[DEBUG DEBUG] event.error error info: ${JSON.stringify(error)}`);
 			this.error(error);
 		});
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -295,9 +295,10 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	 * Handles an error that requires a reconnect to Kafka
 	 */
 	private async handleError(error: any) {
-        await this.close(true);
+		await this.close(true);
 
 		this.error(error);
+
 		this.connect();
 	}
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -55,8 +55,6 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			enableIdempotence: options?.enableIdempotence ?? false,
 			pollIntervalMs: options?.pollIntervalMs ?? 10,
 		};
-
-        console.log(`[DEBUG] RdKafkaBase producerOptions: ${JSON.stringify(this.producerOptions)}`);
 	}
 
 	/**
@@ -110,13 +108,11 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 		});
 
 		producer.on("connection.failure", (error) => {
-            console.log(`[DEBUG PRODUCER] connection.failure error info: ${JSON.stringify(error)}`);
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			this.handleError(error);
 		});
 
 		producer.on("event.error", (error) => {
-            console.log(`[DEBUG PRODUCER] event.error error info: ${JSON.stringify(error)}`);
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			this.handleError(error);
 		});
@@ -299,11 +295,9 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	 * Handles an error that requires a reconnect to Kafka
 	 */
 	private async handleError(error: any) {
-		console.log(`[DEBUG PRODUCER] error info: ${JSON.stringify(error)}`);
         await this.close(true);
 
 		this.error(error);
-        console.log(`[DEBUG PRODUCER] finished calling base error(). error info: ${JSON.stringify(error)}`);
 		this.connect();
 	}
 }


### PR DESCRIPTION
librdkafka errors have [specific error codes](https://docs.confluent.io/5.5.1/clients/librdkafka/rdkafka_8h.html) for each type of error (and node-rdkafka defines all of them [here](https://github.com/Blizzard/node-rdkafka/blob/f092160b3624d9d9e6ae13947fd1dff1acaadfc9/lib/error.js#L31)). We've noticed that the Fluid service can end up in a bad state ("frozen" or "dead" state) inn certain occasions, for example when the Kafka server restarts/shuts down Kafka brokers. Therefore, this PR adds the capability for our service to automatically restart when those Kafka errors happen.