### PR TITLE
Remove zookeeper dependency in rdkafka package

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -58,6 +58,7 @@
     "@fluidframework/server-services-core": "^0.1035.0",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1035.0",
     "@fluidframework/server-services-ordering-rdkafka": "^0.1035.0",
+    "@fluidframework/server-services-ordering-zookeeper": "^0.1035.0",
     "@fluidframework/server-services-telemetry": "^0.1035.0",
     "@fluidframework/server-services-utils": "^0.1035.0",
     "@types/node": "^12.19.0",

--- a/server/routerlicious/packages/routerlicious-base/src/ordering/resourcesFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/ordering/resourcesFactory.ts
@@ -5,6 +5,7 @@
 
 import { KafkaResources, KafkaResourcesFactory } from "@fluidframework/server-services-ordering-kafkanode";
 import { RdkafkaResourcesFactory } from "@fluidframework/server-services-ordering-rdkafka";
+import { ZookeeperClient } from "@fluidframework/server-services-ordering-zookeeper";
 import { IResourcesFactory } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 
@@ -25,7 +26,7 @@ export class OrderingResourcesFactory implements IResourcesFactory<KafkaResource
                 break;
 
             case "rdkafka":
-                resourcesFactory = new RdkafkaResourcesFactory(this.name, this.lambdaModule);
+                resourcesFactory = new RdkafkaResourcesFactory(this.name, this.lambdaModule, ZookeeperClient);
                 break;
 
             default:

--- a/server/routerlicious/packages/services-core/src/zookeeper.ts
+++ b/server/routerlicious/packages/services-core/src/zookeeper.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+export type ZookeeperClientConstructor = new (url: string) => IZookeeperClient;
+
 /**
  * Interface for a Zookeeper Client
  */

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/server-services-core": "^0.1035.0",
-    "@fluidframework/server-services-ordering-zookeeper": "^0.1035.0",
     "moniker": "^0.1.2",
     "nconf": "^0.11.0",
     "node-rdkafka": "^2.11.0"

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -6,8 +6,14 @@
 import type * as kafkaTypes from "node-rdkafka";
 
 import { Deferred } from "@fluidframework/common-utils";
-import { IConsumer, IPartition, IPartitionWithEpoch, IQueuedMessage } from "@fluidframework/server-services-core";
-import { ZookeeperClient } from "@fluidframework/server-services-ordering-zookeeper";
+import {
+	IConsumer,
+	IPartition,
+	IPartitionWithEpoch,
+	IQueuedMessage,
+	IZookeeperClient,
+	ZookeeperClientConstructor,
+} from "@fluidframework/server-services-core";
 import { IKafkaBaseOptions, IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
 
 export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
@@ -18,6 +24,7 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
 	automaticConsume: boolean;
 	maxConsumerCommitRetries: number;
 	additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
+	zooKeeperClientConstructor?: ZookeeperClientConstructor;
 }
 
 /**
@@ -26,7 +33,7 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
 export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 	private readonly consumerOptions: IKafkaConsumerOptions;
 	private consumer?: kafkaTypes.KafkaConsumer;
-	private zooKeeperClient?: ZookeeperClient;
+	private zooKeeperClient?: IZookeeperClient;
 	private closed = false;
 	private isRebalancing = true;
 	private assignedPartitions: Set<number> = new Set();
@@ -73,9 +80,9 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		}
 
 		const zookeeperEndpoints = this.endpoints.zooKeeper;
-		if (zookeeperEndpoints && zookeeperEndpoints.length > 0) {
+		if (zookeeperEndpoints && zookeeperEndpoints.length > 0 && this.consumerOptions.zooKeeperClientConstructor) {
 			const zooKeeperEndpoint = zookeeperEndpoints[Math.floor(Math.random() % zookeeperEndpoints.length)];
-			this.zooKeeperClient = new ZookeeperClient(zooKeeperEndpoint);
+			this.zooKeeperClient = new this.consumerOptions.zooKeeperClientConstructor(zooKeeperEndpoint);
 		}
 
 		const options: kafkaTypes.ConsumerGlobalConfig = {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -8,6 +8,7 @@ import {
     IPartitionLambdaFactory,
     IResources,
     IResourcesFactory,
+    ZookeeperClientConstructor,
 } from "@fluidframework/server-services-core";
 import * as moniker from "moniker";
 import { Provider } from "nconf";
@@ -35,7 +36,10 @@ export class RdkafkaResources implements IRdkafkaResources {
 }
 
 export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResources> {
-    constructor(private readonly name: string, private readonly lambdaModule: string) {
+    constructor(
+        private readonly name: string,
+        private readonly lambdaModule: string,
+        private readonly zookeeperClientConstructor: ZookeeperClientConstructor) {
     }
 
     public async create(config: Provider): Promise<RdkafkaResources> {
@@ -65,7 +69,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const endpoints = {
             kafka: kafkaEndpoint ? kafkaEndpoint.split(",") : [],
             zooKeeper: zookeeperEndpoint ? zookeeperEndpoint.split(",") : [],
-         };
+        };
 
         const consumer = new RdkafkaConsumer(
             endpoints,
@@ -80,6 +84,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
                 consumeTimeout,
                 maxConsumerCommitRetries,
                 sslCACertFilePath,
+                zooKeeperClientConstructor: this.zookeeperClientConstructor,
             },
         );
 


### PR DESCRIPTION
`@fluidframework/server-services-ordering-zookeeper` is currently required by `@fluidframework/server-services-ordering-rdkafka`. That means the [zookeeper](https://github.com/yfinkelstein/node-zookeeper) package is required when pulling in `rdkafka`. 

`zookeeper` is a native addon that sometimes builds when installing and it's been causing trouble on my team. We recently moved to node 16 and the package is not building correctly for us on windows. Here's an example error during `npm install`:

```
> zookeeper@4.10.0 build C:\Git\FluidFramework\server\routerlicious\node_modules\zookeeper
> node-gyp-build

Building the projects in this solution one at a time. To enable parallel build, please add the "-m" switch.
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(241,5): warning MSB8017: A circular dependency has been detected while executing custom build commands for item ".". This may cause incremental build to work incorrectly. [C:\Git\FluidFramework\server\routerlicious\node_modules\zookeeper\build\libzk.vcxproj]
  build_zk_client_lib
  'cmake' is not recognized as an internal or external command,
  operable program or batch file.
  C:\Git\FluidFramework\server\routerlicious\node_modules\shelljs\src\common.js:401
        if (config.fatal) throw e;
                          ^

CUSTOMBUILD : error : exec: 'cmake' is not recognized as an internal or external command, [C:\Git\FluidFramework\server\routerlicious\node_modules\zookeeper\build\libzk.vcxproj]

  operable program or batch file.
```

It's possible that a zookeeper package update will be released with an included node 16 prebuild to fix this issue. 

However it's important to note that `@fluidframework/server-services-ordering-rdkafka` can run without zookeeper and that is the mode PushChannel runs in. So we do not need this package to be included in our dependency tree.

This change refactors rdkafka so you can pass in the `IZookeeperClient` class when constructing the rdkafka consumer. This removes the hard dependency on the zookeeper package.