### PR TITLE
Remove unnecessary request pattern usages

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -490,7 +490,7 @@ export interface ISummarizeOptions {
 export const ISummarizer: keyof IProvideSummarizer;
 
 // @public (undocumented)
-export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable, Partial<IProvideSummarizer> {
+export interface ISummarizer extends IEventProvider<ISummarizerEvents>, IFluidLoadable, Partial<IProvideSummarizer> {
     enqueueSummarize(options: IEnqueueSummarizeOptions): EnqueueSummarizeResult;
     // (undocumented)
     run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;
@@ -682,11 +682,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
     // (undocumented)
     get IFluidLoadable(): this;
     // (undocumented)
-    get IFluidRouter(): this;
-    // (undocumented)
     get ISummarizer(): this;
-    // (undocumented)
-    request(request: IRequest): Promise<IResponse>;
     // (undocumented)
     run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;
     stop(reason: SummarizerStopReason): void;

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -5,11 +5,8 @@
 
 import {
     IFluidHandleContext,
-    IRequest,
-    IResponse,
 } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle } from "@fluidframework/datastore";
-import { create404Response } from "@fluidframework/runtime-utils";
 import { ISharedObject } from "./types";
 
 /**
@@ -49,14 +46,5 @@ export class SharedObjectHandle extends FluidObjectHandle<ISharedObject> {
     public attachGraph(): void {
         this.value.bindToContext();
         super.attachGraph();
-    }
-
-    /**
-     * Returns 404.
-     * @param request - The request to make
-     * @returns A 404 error
-     */
-    public async request(request: IRequest): Promise<IResponse> {
-        return create404Response(request);
     }
 }

--- a/packages/runtime/container-runtime/src/containerHandleContext.ts
+++ b/packages/runtime/container-runtime/src/containerHandleContext.ts
@@ -13,7 +13,6 @@ import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 import { ContainerRuntime } from "./containerRuntime";
 
 export class ContainerFluidHandleContext implements IFluidHandleContext {
-    public get IFluidRouter() { return this; }
     public get IFluidHandleContext() { return this; }
     public readonly absolutePath: string;
 

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -8,7 +8,6 @@ import { Deferred } from "@fluidframework/common-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ChildLogger, IFluidErrorBase, LoggingError, wrapErrorAndLog } from "@fluidframework/telemetry-utils";
 import {
-
     IFluidHandleContext,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -8,8 +8,7 @@ import { Deferred } from "@fluidframework/common-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ChildLogger, IFluidErrorBase, LoggingError, wrapErrorAndLog } from "@fluidframework/telemetry-utils";
 import {
-    IRequest,
-    IResponse,
+
     IFluidHandleContext,
     IFluidHandle,
 } from "@fluidframework/core-interfaces";
@@ -17,7 +16,6 @@ import {
     ISequencedDocumentMessage,
     ISummaryConfiguration,
 } from "@fluidframework/protocol-definitions";
-import { create404Response } from "@fluidframework/runtime-utils";
 import { ICancellableSummarizerController } from "./runWhileConnectedCoordinator";
 import { SummaryCollection } from "./summaryCollection";
 import { SummarizerHandle } from "./summarizerHandle";
@@ -63,7 +61,6 @@ export const createSummarizingWarning =
  */
 export class Summarizer extends EventEmitter implements ISummarizer {
     public get IFluidLoadable() { return this; }
-    public get IFluidRouter() { return this; }
     public get ISummarizer() { return this; }
 
     private readonly logger: ITelemetryLogger;
@@ -119,17 +116,6 @@ export class Summarizer extends EventEmitter implements ISummarizer {
      */
     public stop(reason: SummarizerStopReason) {
         this.stopDeferred.resolve(reason);
-    }
-
-    public async request(request: IRequest): Promise<IResponse> {
-        if (request.url === "/" || request.url === "") {
-            return {
-                mimeType: "fluid/object",
-                status: 200,
-                value: this,
-            };
-        }
-        return create404Response(request);
     }
 
     private async runCore(

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -9,7 +9,6 @@ import {
     ITelemetryLogger,
 } from "@fluidframework/common-definitions";
 import {
-    IFluidRouter,
     IFluidLoadable,
 } from "@fluidframework/core-interfaces";
 import { ContainerWarning, IDeltaManager } from "@fluidframework/container-definitions";
@@ -296,7 +295,7 @@ export interface ISummarizerEvents extends IEvent {
 }
 
 export interface ISummarizer extends
-    IEventProvider<ISummarizerEvents>, IFluidRouter, IFluidLoadable, Partial<IProvideSummarizer>{
+    IEventProvider<ISummarizerEvents>, IFluidLoadable, Partial<IProvideSummarizer>{
     stop(reason: SummarizerStopReason): void;
     run(onBehalfOf: string, options?: Readonly<Partial<ISummarizerOptions>>): Promise<SummarizerStopReason>;
 

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import sinon from "sinon";
 import { Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
-import { IFluidHandle, IFluidLoadable, IFluidRouter } from "@fluidframework/core-interfaces";
+import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import {
     IConnectedEvents,
@@ -100,9 +100,7 @@ describe("Summary Manager", () => {
 
         public readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"] = () => this.notImplemented();
         public readonly enqueueSummarize: ISummarizer["enqueueSummarize"] = () => this.notImplemented();
-        public readonly request: ISummarizer["request"] = () => this.notImplemented();
         public get IFluidLoadable(): IFluidLoadable { return this.notImplemented(); }
-        public get IFluidRouter(): IFluidRouter { return this.notImplemented(); }
         public get handle(): IFluidHandle { return this.notImplemented(); }
     }
 


### PR DESCRIPTION
We used to require IFluidHandles to also be IFluidRouters. This was changed long ago, but it looks like some remanent were missed. 