### PR TITLE
Cleanup usage of createOdspNetworkError/throwOdspNetworkError and mark SPO errors to easily identify them

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -59,7 +59,7 @@ export async function createNewFluidFile(
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
         throw new NonRetryableError(
-            "CreateNewInvalidFilename", "Invalid filename", OdspErrorType.invalidFileNameError);
+            "createNewInvalidFilename", "Invalid filename", OdspErrorType.invalidFileNameError);
     }
 
     let itemId: string;
@@ -121,7 +121,7 @@ export async function createNewEmptyFluidFile(
 
         return PerformanceEvent.timedExecAsync(
             logger,
-            { eventName: "CreateNewEmptyFile" },
+            { eventName: "createNewEmptyFile" },
             async (event) => {
                 const { url, headers } = getUrlAndHeadersWithAuth(initialUrl, storageToken);
                 headers["Content-Type"] = "application/json";
@@ -179,7 +179,7 @@ export async function createNewFluidFileFromSummary(
 
         return PerformanceEvent.timedExecAsync(
             logger,
-            { eventName: "CreateNewFile" },
+            { eventName: "createNewFile" },
             async (event) => {
                 const { url, headers } = getUrlAndHeadersWithAuth(initialUrl, storageToken);
                 headers["Content-Type"] = "application/json";

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -143,7 +143,7 @@ export async function createNewEmptyFluidFile(
                 const content = fetchResponse.content;
                 if (!content || !content.id) {
                     throw new NonRetryableError(
-                        "CreateEmptyFileNoItemId",
+                        "createEmptyFileNoItemId",
                         "ODSP CreateFile call returned no item ID",
                         DriverErrorType.incorrectServerResponse);
                 }

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -201,7 +201,7 @@ export async function createNewFluidFileFromSummary(
                 const content = fetchResponse.content;
                 if (!content || !content.itemId) {
                     throw new NonRetryableError(
-                        "CreateFileNoItemId",
+                        "createFileNoItemId",
                         "ODSP CreateFile call returned no item ID",
                         DriverErrorType.incorrectServerResponse);
                 }

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -4,12 +4,7 @@
  */
 
 import { assert, Uint8ArrayToString } from "@fluidframework/common-utils";
-import { getDocAttributesFromProtocolSummary } from "@fluidframework/driver-utils";
-import {
-    fetchIncorrectResponse,
-    invalidFileNameStatusCode,
-    throwOdspNetworkError,
-} from "@fluidframework/odsp-doclib-utils";
+import { getDocAttributesFromProtocolSummary, NonRetryableError } from "@fluidframework/driver-utils";
 import { getGitType } from "@fluidframework/protocol-base";
 import { SummaryType, ISummaryTree, ISummaryBlob } from "@fluidframework/protocol-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -18,7 +13,9 @@ import {
     IFileEntry,
     InstrumentedStorageTokenFetcher,
     IOdspResolvedUrl,
+    OdspErrorType,
 } from "@fluidframework/odsp-driver-definitions";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
 import {
     IOdspSummaryTree,
     OdspSummaryTreeValue,
@@ -61,7 +58,8 @@ export async function createNewFluidFile(
 ): Promise<IOdspResolvedUrl> {
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
-        throwOdspNetworkError("invalidFilename", invalidFileNameStatusCode);
+        throw new NonRetryableError(
+            "CreateNewInvalidFilename", "Invalid filename", OdspErrorType.invalidFileNameError);
     }
 
     let itemId: string;
@@ -123,7 +121,7 @@ export async function createNewEmptyFluidFile(
 
         return PerformanceEvent.timedExecAsync(
             logger,
-            { eventName: "createNewEmptyFile" },
+            { eventName: "CreateNewEmptyFile" },
             async (event) => {
                 const { url, headers } = getUrlAndHeadersWithAuth(initialUrl, storageToken);
                 headers["Content-Type"] = "application/json";
@@ -144,7 +142,10 @@ export async function createNewEmptyFluidFile(
 
                 const content = fetchResponse.content;
                 if (!content || !content.id) {
-                    throwOdspNetworkError("couldNotParseItemFromVroomResponse", fetchIncorrectResponse);
+                    throw new NonRetryableError(
+                        "CreateEmptyFileNoItemId",
+                        "ODSP CreateFile call returned no item ID",
+                        DriverErrorType.incorrectServerResponse);
                 }
                 event.end({
                     headers: Object.keys(headers).length !== 0 ? true : undefined,
@@ -178,7 +179,7 @@ export async function createNewFluidFileFromSummary(
 
         return PerformanceEvent.timedExecAsync(
             logger,
-            { eventName: "createNewFile" },
+            { eventName: "CreateNewFile" },
             async (event) => {
                 const { url, headers } = getUrlAndHeadersWithAuth(initialUrl, storageToken);
                 headers["Content-Type"] = "application/json";
@@ -199,7 +200,10 @@ export async function createNewFluidFileFromSummary(
 
                 const content = fetchResponse.content;
                 if (!content || !content.itemId) {
-                    throwOdspNetworkError("couldNotParseItemFromVroomResponse", fetchIncorrectResponse);
+                    throw new NonRetryableError(
+                        "CreateFileNoItemId",
+                        "ODSP CreateFile call returned no item ID",
+                        DriverErrorType.incorrectServerResponse);
                 }
                 event.end({
                     headers: Object.keys(headers).length !== 0 ? true : undefined,

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -5,9 +5,9 @@
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, delay } from "@fluidframework/common-utils";
-import { canRetryOnError, getRetryDelayFromError } from "@fluidframework/driver-utils";
+import { canRetryOnError, getRetryDelayFromError, NonRetryableError } from "@fluidframework/driver-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { fetchIncorrectResponse, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
 import {
     IOdspUrlParts,
     OdspResourceTokenFetchOptions,
@@ -120,7 +120,10 @@ async function getFileLinkCore(
                 const directUrl = sharingInfo?.d?.directUrl;
                 if (typeof directUrl !== "string") {
                     // This will retry once in getWithRetryForTokenRefresh
-                    throwOdspNetworkError("malformedGetSharingInformationResponse", fetchIncorrectResponse);
+                    throw new NonRetryableError(
+                        "getFileLinkCoreMalformedResponse",
+                        "Malformed GetSharingInformation response",
+                        DriverErrorType.incorrectServerResponse);
                 }
                 return directUrl;
             });
@@ -171,7 +174,10 @@ async function getFileItemLite(
                 const responseJson = await response.content.json();
                 if (!isFileItemLite(responseJson)) {
                     // This will retry once in getWithRetryForTokenRefresh
-                    throwOdspNetworkError("malformedGetFileItemLiteResponse", fetchIncorrectResponse);
+                    throw new NonRetryableError(
+                        "malformedGetFileItemLiteResponse",
+                        "Malformed getFileItemLite response",
+                        DriverErrorType.incorrectServerResponse);
                 }
                 return responseJson;
             });

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -175,7 +175,7 @@ async function getFileItemLite(
                 if (!isFileItemLite(responseJson)) {
                     // This will retry once in getWithRetryForTokenRefresh
                     throw new NonRetryableError(
-                        "malformedGetFileItemLiteResponse",
+                        "getFileItemLiteMalformedResponse",
                         "Malformed getFileItemLite response",
                         DriverErrorType.incorrectServerResponse);
                 }

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -14,8 +14,8 @@ import {
     IDocumentStorageService,
     IDocumentServicePolicies,
 } from "@fluidframework/driver-definitions";
-import { DeltaStreamConnectionForbiddenError } from "@fluidframework/driver-utils";
-import { fetchTokenErrorCode, IFacetCodes, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
+import { DeltaStreamConnectionForbiddenError, NonRetryableError } from "@fluidframework/driver-utils";
+import { IFacetCodes } from "@fluidframework/odsp-doclib-utils";
 import {
     IClient,
     ISequencedDocumentMessage,
@@ -26,6 +26,7 @@ import {
     IEntry,
     HostStoragePolicy,
     InstrumentedStorageTokenFetcher,
+    OdspErrorType,
 } from "@fluidframework/odsp-driver-definitions";
 import { HostStoragePolicyInternal, ISocketStorageDiscovery } from "./contracts";
 import { IOdspCache } from "./odspCache";
@@ -270,7 +271,10 @@ export class OdspDocumentService implements IDocumentService {
 
             const finalWebsocketToken = websocketToken ?? (websocketEndpoint.socketToken || null);
             if (finalWebsocketToken === null) {
-                throwOdspNetworkError("pushTokenIsNull", fetchTokenErrorCode);
+                throw new NonRetryableError(
+                    "pushTokenIsNull",
+                    "Websocket token is null",
+                    OdspErrorType.fetchTokenError);
             }
             try {
                 const connection = await this.connectToDeltaStreamWithRetry(

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -17,9 +17,9 @@ import {
     ISummaryContext,
     IDocumentStorageService,
     LoaderCachingPolicy,
+    DriverErrorType,
 } from "@fluidframework/driver-definitions";
-import { RateLimiter } from "@fluidframework/driver-utils";
-import { throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
+import { RateLimiter, NonRetryableError } from "@fluidframework/driver-utils";
 import {
     IOdspResolvedUrl,
     ISnapshotOptions,
@@ -508,10 +508,16 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             );
             const versionsResponse = response.content;
             if (!versionsResponse) {
-                throwOdspNetworkError("getVersionsReturnedNoResponse", 400);
+                throw new NonRetryableError(
+                    "getVersionsReturnedNoResponse",
+                    "No response from getVersions()",
+                    DriverErrorType.genericNetworkError);
             }
             if (!Array.isArray(versionsResponse.value)) {
-                throwOdspNetworkError("getVersionsReturnedNonArrayResponse", 400);
+                throw new NonRetryableError(
+                    "getVersionsReturnedNonArrayResponse",
+                    "Incorrect response from getVersions()",
+                    DriverErrorType.genericNetworkError);
             }
             return versionsResponse.value.map((version) => {
                 // Parse the date from the message
@@ -683,19 +689,28 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
 
     private checkSnapshotUrl() {
         if (!this.snapshotUrl) {
-            throwOdspNetworkError("methodNotSupportedBecauseNoSnapshotUrlWasProvided", 400);
+            throw new NonRetryableError(
+                "noSnapshotUrlProvided",
+                "Method failed because no snapshot url was available",
+                DriverErrorType.genericError);
         }
     }
 
     private checkAttachmentPOSTUrl() {
         if (!this.attachmentPOSTUrl) {
-            throwOdspNetworkError("methodNotSupportedBecauseNoAttachmentPOSTUrlWasProvided", 400);
+            throw new NonRetryableError(
+                "noAttachmentPOSTUrlProvided",
+                "Method failed because no attachment POST url was available",
+                DriverErrorType.genericError);
         }
     }
 
     private checkAttachmentGETUrl() {
         if (!this.attachmentGETUrl) {
-            throwOdspNetworkError("methodNotSupportedBecauseNoAttachmentGETUrlWasProvided", 400);
+            throw new NonRetryableError(
+                "noAttachmentGETUrlWasProvided",
+                "Method failed because no attachment GET url was available",
+                DriverErrorType.genericError);
         }
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -510,7 +510,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             if (!versionsResponse) {
                 throw new NonRetryableError(
                     "getVersionsReturnedNoResponse",
-                    "No response from getVersions()",
+                    "No response from /versions endpoint",
                     DriverErrorType.genericNetworkError);
             }
             if (!Array.isArray(versionsResponse.value)) {

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -516,7 +516,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
             if (!Array.isArray(versionsResponse.value)) {
                 throw new NonRetryableError(
                     "getVersionsReturnedNonArrayResponse",
-                    "Incorrect response from getVersions()",
+                    "Incorrect response from /versions endpoint",
                     DriverErrorType.genericNetworkError);
             }
             return versionsResponse.value.map((version) => {

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -7,7 +7,7 @@ import { PromiseCache } from "@fluidframework/common-utils";
 import { IFluidCodeDetails, IRequest, isFluidPackage } from "@fluidframework/core-interfaces";
 import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
-import { fetchTokenErrorCode, throwOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
+import { NonRetryableError } from "@fluidframework/driver-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
     IOdspResolvedUrl,
@@ -15,6 +15,7 @@ import {
     isTokenFromCache,
     OdspResourceTokenFetchOptions,
     TokenFetcher,
+    OdspErrorType,
 } from "@fluidframework/odsp-driver-definitions";
 import {
     getLocatorFromOdspUrl,
@@ -162,7 +163,10 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
                 { eventName: "GetSharingLinkToken" },
                 async (event) => tokenFetcher(options).then((tokenResponse) => {
                     if (tokenResponse === null) {
-                        throwOdspNetworkError("shareLinkTokenIsNull", fetchTokenErrorCode);
+                        throw new NonRetryableError(
+                            "shareLinkTokenIsNull",
+                            "Token is null",
+                            OdspErrorType.fetchTokenError);
                     }
                     event.end({ fromCache: isTokenFromCache(tokenResponse) });
                     return tokenResponse;

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -165,7 +165,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
                     if (tokenResponse === null) {
                         throw new NonRetryableError(
                             "shareLinkTokenIsNull",
-                            "Token is null",
+                            "Token callback returned null",
                             OdspErrorType.fetchTokenError);
                     }
                     event.end({ fromCache: isTokenFromCache(tokenResponse) });

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -17,7 +17,7 @@ export function errorObjectFromSocketError(socketError: IOdspSocketError, handle
         socketError.code,
         socketError.retryAfter);
 
-    error.addTelemetryProperties({ odspError: true, odspRelayServiceError: true });
+    error.addTelemetryProperties({ odspError: true, relayServiceError: true });
 
     return error;
 }

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -11,9 +11,13 @@ import { IOdspSocketError } from "./contracts";
  */
 export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string) {
     const message = `OdspSocketError (${handler}): ${socketError.message}`;
-    return createOdspNetworkError(
+    const error = createOdspNetworkError(
         `odspSocketError [${handler}]`,
         message,
         socketError.code,
         socketError.retryAfter);
+
+    error.addTelemetryProperties({ odspError: true, odspRelayServiceError: true });
+
+    return error;
 }

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -135,7 +135,7 @@ describe("Odsp Create Container Test", () => {
             assert.strictEqual(error.statusCode, undefined, "Wrong error code");
             assert.strictEqual(error.errorType, DriverErrorType.incorrectServerResponse,
                 "Error type should be correct");
-            assert.strictEqual(error.fluidErrorCode, "CreateFileNoItemId", "fluidErrorCode should be correct");
+            assert.strictEqual(error.fluidErrorCode, "createFileNoItemId", "fluidErrorCode should be correct");
             assert.strictEqual(error.message, "ODSP CreateFile call returned no item ID", "Message should be correct");
         }
     });

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -135,7 +135,8 @@ describe("Odsp Create Container Test", () => {
             assert.strictEqual(error.statusCode, undefined, "Wrong error code");
             assert.strictEqual(error.errorType, DriverErrorType.incorrectServerResponse,
                 "Error type should be correct");
-            assert.strictEqual(error.message, "couldNotParseItemFromVroomResponse", "Message should be correct");
+            assert.strictEqual(error.fluidErrorCode, "CreateFileNoItemId", "fluidErrorCode should be correct");
+            assert.strictEqual(error.message, "ODSP CreateFile call returned no item ID", "Message should be correct");
         }
     });
 });

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -9,10 +9,9 @@ import { strict as assert } from "assert";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import {
     createOdspNetworkError,
-    fetchIncorrectResponse,
-    invalidFileNameStatusCode,
     throwOdspNetworkError,
 } from "@fluidframework/odsp-doclib-utils";
+import { NonRetryableError } from "@fluidframework/driver-utils";
 import { OdspError } from "@fluidframework/odsp-driver-definitions";
 import { IOdspSocketError } from "../contracts";
 import { getWithRetryForTokenRefresh } from "../odspUtils";
@@ -126,21 +125,10 @@ describe("Odsp Error", () => {
             if (options.refresh) {
                 return 1;
             } else {
-                throwOdspNetworkError("some error", 401);
+                throwOdspNetworkError("some error", 401, testResponse);
             }
         });
         assert.equal(res, 1, "did not successfully retried with new token");
-    });
-
-    it("invalid file name - no retry", async () => {
-        const res = getWithRetryForTokenRefresh(async (options) => {
-            if (options.refresh) {
-                return 1;
-            } else {
-                throwOdspNetworkError("some error", invalidFileNameStatusCode);
-            }
-        });
-        await assert.rejects(res, "Invalid file name should not result in retry!");
     });
 
     it("fetch incorrect response retries", async () => {
@@ -148,7 +136,10 @@ describe("Odsp Error", () => {
             if (options.refresh) {
                 return 1;
             } else {
-                throwOdspNetworkError("some error", fetchIncorrectResponse);
+                throw new NonRetryableError(
+                    "code",
+                    "some message",
+                    DriverErrorType.incorrectServerResponse);
             }
         });
         assert.equal(res, 1, "did not successfully retried with new token");
@@ -159,7 +150,7 @@ describe("Odsp Error", () => {
             if (options.refresh) {
                 return 1;
             } else {
-                throwOdspNetworkError("some error", invalidFileNameStatusCode);
+                throwOdspNetworkError("some error", 404, testResponse);
             }
         });
         await assert.rejects(res, "Other errors should not result in retries!");

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -145,7 +145,7 @@ describe("Odsp Error", () => {
         assert.equal(res, 1, "did not successfully retried with new token");
     });
 
-    it("Other errors - no retries", async () => {
+    it("404 errors - no retries", async () => {
         const res = getWithRetryForTokenRefresh(async (options) => {
             if (options.refresh) {
                 return 1;

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -9,7 +9,8 @@
 */
 
 import { assert, IsoBuffer, Uint8ArrayToArrayBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
-import { createOdspNetworkError, fetchIncorrectResponse } from "@fluidframework/odsp-doclib-utils";
+import { NonRetryableError } from "@fluidframework/driver-utils";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { ReadBuffer } from "./ReadBufferUtils";
 
 // eslint-disable-next-line max-len
@@ -477,18 +478,14 @@ function throwBufferParseException(
     expectedNodeType: NodeType,
     message: string,
 ): never {
-    const error = createOdspNetworkError(
+    throw new NonRetryableError(
         "bufferParsingException",
         message,
-        fetchIncorrectResponse,
-        undefined,
-        undefined,
-        undefined,
+        DriverErrorType.incorrectServerResponse,
         {
             nodeType: getNodeType(node),
             expectedNodeType,
         });
-    throw error;
 }
 
 function getNodeType(value: NodeTypes): NodeType {

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -101,7 +101,7 @@ export async function fetchTokens(
     const refreshToken = tokens.refresh_token;
 
     if (accessToken === undefined || refreshToken === undefined) {
-        throwOdspNetworkError("unableToGetAccessToken", tokens.error === "invalid_grant" ? 401 : result.status);
+        throwOdspNetworkError("unableToGetAccessToken", tokens.error === "invalid_grant" ? 401 : result.status, result);
     }
     return { accessToken, refreshToken };
 }

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -248,7 +248,7 @@ export function throwOdspNetworkError(
         responseText,
         props);
 
-    networkError.addTelemetryProperties({ odspError: true, spoError: true });
+    networkError.addTelemetryProperties({ odspError: true, storageServiceError: true });
 
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw networkError;

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -9,7 +9,6 @@ import { IFluidErrorBase, TelemetryLogger } from "@fluidframework/telemetry-util
 import {
     AuthorizationError,
     createGenericNetworkError,
-    GenericNetworkError,
     isOnline,
     RetryableError,
     NonRetryableError,
@@ -19,19 +18,8 @@ import { OdspErrorType, OdspError, IOdspError } from "@fluidframework/odsp-drive
 import { parseAuthErrorClaims } from "./parseAuthErrorClaims";
 import { parseAuthErrorTenant } from "./parseAuthErrorTenant";
 
-// Status code for invalid file name error in odsp driver.
-export const invalidFileNameStatusCode: number = 711;
 // no response, or can't parse response
 export const fetchIncorrectResponse = 712;
-// Fetch request took more time then limit.
-export const fetchTimeoutStatusCode = 713;
-// This status code is sent by the server when the client and server epoch mismatches.
-// The client sets its epoch version in the calls it makes to the server and if that mismatches
-// with the server epoch version, the server throws this error code.
-// This indicates that the file/container has been modified externally.
-export const fluidEpochMismatchError = 409;
-// Error code for when the fetched token is null.
-export const fetchTokenErrorCode = 724;
 // Error code for when the server state is read only and client tries to write. This code is set by the server
 // and is not likely to change.
 export const OdspServiceReadOnlyErrorCode = "serviceReadOnly";
@@ -141,7 +129,8 @@ export function createOdspNetworkError(
     }
     switch (statusCode) {
         case 400:
-            error = new GenericNetworkError(fluidErrorCode, errorMessage, false, { statusCode });
+            error = new NonRetryableError(
+                fluidErrorCode, errorMessage, DriverErrorType.genericNetworkError, { statusCode });
             break;
         case 401:
         case 403:
@@ -170,7 +159,11 @@ export function createOdspNetworkError(
         case 410:
             error = new NonRetryableError(fluidErrorCode, errorMessage, OdspErrorType.cannotCatchUp, { statusCode });
             break;
-        case fluidEpochMismatchError:
+        case 409:
+            // This status code is sent by the server when the client and server epoch mismatches.
+            // The client sets its epoch version in the calls it makes to the server and if that mismatches
+            // with the server epoch version, the server throws this error code.
+            // This indicates that the file/container has been modified externally.
             error = new NonRetryableError(
                 fluidErrorCode, errorMessage, DriverErrorType.fileOverwrittenInStorage, { statusCode });
             break;
@@ -184,12 +177,12 @@ export function createOdspNetworkError(
             error = new NonRetryableError(fluidErrorCode, errorMessage, OdspErrorType.snapshotTooBig, { statusCode });
             break;
         case 414:
-        case invalidFileNameStatusCode:
             error = new NonRetryableError(
                 fluidErrorCode, errorMessage, OdspErrorType.invalidFileNameError, { statusCode });
             break;
         case 500:
-            error = new GenericNetworkError(fluidErrorCode, errorMessage, true, { statusCode });
+            error = new RetryableError(
+                fluidErrorCode, errorMessage, DriverErrorType.genericNetworkError, { statusCode });
             break;
         case 501:
             error = new NonRetryableError(fluidErrorCode, errorMessage, OdspErrorType.fluidNotEnabled, { statusCode });
@@ -201,12 +194,6 @@ export function createOdspNetworkError(
         case fetchIncorrectResponse:
             // Note that getWithRetryForTokenRefresh will retry it once, then it becomes non-retryable error
             error = new NonRetryableError(fluidErrorCode, errorMessage, DriverErrorType.incorrectServerResponse);
-            break;
-        case fetchTimeoutStatusCode:
-            error = new RetryableError(fluidErrorCode, errorMessage, OdspErrorType.fetchTimeout);
-            break;
-        case fetchTokenErrorCode:
-            error = new NonRetryableError(fluidErrorCode, errorMessage, OdspErrorType.fetchTokenError);
             break;
         default:
             const retryAfterMs = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : undefined;
@@ -248,18 +235,20 @@ export function enrichOdspError(
 export function throwOdspNetworkError(
     fluidErrorCode: string,
     statusCode: number,
-    response?: Response,
+    response: Response,
     responseText?: string,
     props?: ITelemetryProperties,
 ): never {
     const networkError = createOdspNetworkError(
         fluidErrorCode,
-        response && response.statusText !== "" ? `${fluidErrorCode} (${response.statusText})` : fluidErrorCode,
+        response.statusText !== "" ? `${fluidErrorCode} (${response.statusText})` : fluidErrorCode,
         statusCode,
-        response ? numberFromHeader(response.headers.get("retry-after")) : undefined, /* retryAfterSeconds */
+        numberFromHeader(response.headers.get("retry-after")), /* retryAfterSeconds */
         response,
         responseText,
         props);
+
+    networkError.addTelemetryProperties({ odspError: true, spoError: true });
 
     // eslint-disable-next-line @typescript-eslint/no-throw-literal
     throw networkError;

--- a/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
@@ -10,7 +10,7 @@ import { DriverErrorType, IThrottlingWarning } from "@fluidframework/driver-defi
 import { createWriteError, GenericNetworkError } from "@fluidframework/driver-utils";
 import { OdspErrorType, OdspError, IOdspError } from "@fluidframework/odsp-driver-definitions";
 import { isILoggingError } from "@fluidframework/telemetry-utils";
-import { createOdspNetworkError, invalidFileNameStatusCode, enrichOdspError } from "../odspErrorUtils";
+import { createOdspNetworkError, enrichOdspError } from "../odspErrorUtils";
 
 describe("OdspErrorUtils", () => {
     function assertCustomPropertySupport(err: any) {
@@ -94,16 +94,6 @@ describe("OdspErrorUtils", () => {
                 "testErrorCode",
                 "Test Message",
                 414 /* statusCode */);
-            assert(networkError.errorType === OdspErrorType.invalidFileNameError,
-                "Error should be an InvalidFileNameError");
-            assertCustomPropertySupport(networkError);
-        });
-
-        it("InvalidFileNameError Test", () => {
-            const networkError = createOdspNetworkError(
-                "testErrorCode",
-                "Test Message",
-                invalidFileNameStatusCode /* statusCode */);
             assert(networkError.errorType === OdspErrorType.invalidFileNameError,
                 "Error should be an InvalidFileNameError");
             assertCustomPropertySupport(networkError);


### PR DESCRIPTION
Issue #8258: Cleanup usage of createOdspNetworkError/throwOdspNetworkError

The only not real code I've left there is fetchIncorrectResponse