### PR TITLE
fluid:telemetry:Container:connectedStateRejected are incorrectly issues when container is closed

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -691,6 +691,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
                 this._protocolHandler?.close();
 
+                this.connectionStateHandler.dispose();
+
                 this._context?.dispose(error !== undefined ? new Error(error.message) : undefined);
 
                 assert(this.connectionState === ConnectionState.Disconnected,


### PR DESCRIPTION
See issue #8235: Too many fluid:telemetry:Container:connectedStateRejected events with source = timeout
This generates a lot of errors in telemetry (I recently made it an error to see the impact on related areas - client not processing join op soon after connection, and overall high latencies in op processing)
