### PR TITLE
Address issues from earlier downgraded connection mode change

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1522,17 +1522,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
      * If it's not true, runtime is not in position to send ops.
      */
     private activeConnection() {
-        const active = this.connectionState === ConnectionState.Connected &&
+        return this.connectionState === ConnectionState.Connected &&
             this._deltaManager.connectionMode === "write";
-
-        // Check for presence of current client in quorum for "write" connections - inactive clients
-        // would get leave op after some long timeout (5 min) and that should automatically transition
-        // state to "read" mode.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        assert(!active || this.getQuorum().getMember(this.clientId!) !== undefined,
-            0x276 /* "active connection not present in quorum" */);
-
-        return active;
     }
 
     private createDeltaManager() {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -331,7 +331,7 @@ export class DeltaManager
     public get connectionMode(): ConnectionMode {
         assert(!this.downgradedConnection || this.connection?.mode === "write",
             0x277 /* "Did we forget to reset downgradedConnection on new connection?" */);
-        if (this.connection === undefined || this.downgradedConnection) {
+        if (this.connection === undefined) {
             return "read";
         }
         return this.connection.mode;
@@ -876,7 +876,7 @@ export class DeltaManager
         // Note that we also want nacks to be rare and be treated as catastrophic failures.
         // Be careful with reentrancy though - disconnected event should not be be raised in the
         // middle of the current workflow, but rather on clean stack!
-        if (this.connectionMode === "read") {
+        if (this.connectionMode === "read" || this.downgradedConnection) {
             if (!this.pendingReconnect) {
                 this.pendingReconnect = true;
                 Promise.resolve().then(async () => {
@@ -1575,8 +1575,6 @@ export class DeltaManager
                 // We have been kicked out from quorum
                 this.logger.sendPerformanceEvent({ eventName: "ReadConnectionTransition" });
                 this.downgradedConnection = true;
-                assert(this.connectionMode === "read",
-                    0x27c /* "effective connectionMode should be 'read' after downgrade" */);
             }
         }
 


### PR DESCRIPTION
Addressing Issue #8398 - New Prod error: assert(this.runtime.deltaManager.active, 0x25d /* "We should never connect as 'read'" */);
Partial undo of https://github.com/microsoft/FluidFramework/pull/7753 that causes assert above.

The core of the problem - relay service sends leave op for "write" connection after 5 minutes of inactivity.
This leaves connection in weird state - most of the system believes it's "write" connection, but you can't send ops on that connection. Above mentioned PR attempted (among other things) to remove this discrepancy for loader layer, but I missed that runtime layer does not expect change in properties of connection.

This change constraints visible changes to DM layer, making other layers believe that we still work with "write" connection (see items below for more details).

It's worth raising that we can go in various ways about it, roughly in priority order:
1. Best option IMHO - service disconnects "write" connection after 5 min of inactivity. Sending leave op and keeping connection alive is weird for client as some layers do not care about such op (DM itself for most part), while others expect properties of connection do not change over lifetime of connection.
2. Same as above, but client does it (and reconnects as "read") on own join
    - I favor this direction as longterm direction at the moment (i.e., I think we need to implement it, this change is more stop-gap solution).
    - It has rather big con for R11S stack that does not have (ODSP) socket reuse logic though
3. Same as above, but disconnect / reconnect is "virtual", i.e. we keep using same connection with same clientId, but expose it to other layers (runtime) as disconnect from "write" connection and reconnect to same connection (same clientId) but as "read".
   - I'm not sure I like it as it breaks fundamental gurantee that every new connection gets unique clientId.
3. This approach - client keeps connection as if it's "write" connection, but DM internally knows it's "read" connection and will go through reconnection logic if any op is sent by client.
    - The pro of this change over next - we never see weird nacks like "nonexciting client". The con - summarizer keeps going on such connection without realizing it.
4. Undo above mentioned PR altogether. Same con as above (plus weird nack/disconnect reasons).

