### PR TITLE
[r11s and Historian] Logging path category on morgan for http requests

### DIFF
--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -56,6 +56,7 @@ export function create(
             const tenantId = getTenantIdFromRequest(req.params);
             const messageMetaData = {
                 method: tokens.method(req, res),
+                pathCategory: `${req.baseUrl}${req.route ? req.route.path : "PATH_UNAVAILABLE"}`,
                 url: tokens.url(req, res),
                 status: tokens.status(req, res),
                 contentLength: tokens.res(req, res, "content-length"),

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -77,6 +77,7 @@ export function create(
         app.use(morgan((tokens, req, res) => {
             const messageMetaData = {
                 method: tokens.method(req, res),
+                pathCategory: `${req.baseUrl}${req.route ? req.route.path : "PATH_UNAVAILABLE"}`,
                 url: tokens.url(req, res),
                 status: tokens.status(req, res),
                 contentLength: tokens.res(req, res, "content-length"),

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -45,6 +45,7 @@ export function create(
         app.use(morgan((tokens, req, res) => {
             const messageMetaData = {
                 method: tokens.method(req, res),
+                pathCategory: `${req.baseUrl}${req.route ? req.route.path : "PATH_UNAVAILABLE"}`,
                 url: tokens.url(req, res),
                 status: tokens.status(req, res),
                 contentLength: tokens.res(req, res, "content-length"),

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -1,7 +1,7 @@
 {
     "logger": {
         "colorize": true,
-        "morganFormat": "dev",
+        "morganFormat": "json",
         "json": false,
         "level": "info",
         "timestamp": true,


### PR DESCRIPTION
Currently, when logging HTTP request information with `morgan`, we cannot aggregate logs based on the route category. The `url` field resolves to something like `/deltas/fluid/86c805c8-63ef-461d-8722-2057aaf3951b?from=0&to=2001`. However, we would like to have information about the express route that was matched for the request: in other words, something like `/deltas/:tenantId/:id`. That would allow to filter logs per route category. This PR accomplishes that by logging a new property, `pathCategory`, which leverages the request's `baseUrl` and `route.path` to form the path category.

Also, enabling the `json` `morganFormat` for logging in config.json as it provides interesting information when running r11s locally.