### PR TITLE
Improving handling of Data processing errors and unknown errors

### DIFF
--- a/api-report/container-utils.api.md
+++ b/api-report/container-utils.api.md
@@ -14,29 +14,17 @@ import { IThrottlingWarning } from '@fluidframework/container-definitions';
 import { LoggingError } from '@fluidframework/telemetry-utils';
 
 // @public
-export const CreateProcessingError: typeof DataProcessingError.wrapIfUnrecognized;
+export function CreateProcessingError(originalError: any, fluidErrorCode: string, message?: ISequencedDocumentMessage): IFluidErrorBase;
 
 // @public (undocumented)
 export class DataCorruptionError extends LoggingError implements IErrorBase, IFluidErrorBase {
-    constructor(fluidErrorCode: string, props: ITelemetryProperties);
+    constructor(fluidErrorCode: string, message: string, props: ITelemetryProperties);
     // (undocumented)
     readonly canRetry = false;
     // (undocumented)
     readonly errorType = ContainerErrorType.dataCorruptionError;
     // (undocumented)
     readonly fluidErrorCode: string;
-}
-
-// @public (undocumented)
-export class DataProcessingError extends LoggingError implements IErrorBase, IFluidErrorBase {
-    constructor(errorMessage: string, fluidErrorCode: string, props?: ITelemetryProperties);
-    // (undocumented)
-    readonly canRetry = false;
-    // (undocumented)
-    readonly errorType = ContainerErrorType.dataProcessingError;
-    // (undocumented)
-    readonly fluidErrorCode: string;
-    static wrapIfUnrecognized(originalError: any, dataProcessingCodepath: string, message?: ISequencedDocumentMessage): IFluidErrorBase;
 }
 
 // @public (undocumented)

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -154,7 +154,7 @@ export class MultiSinkLogger extends TelemetryLogger {
 }
 
 // @public
-export function normalizeError(error: unknown, annotations?: IFluidErrorAnnotations): IFluidErrorBase;
+export function normalizeError(error: unknown, annotations?: IFluidErrorAnnotations, fluidErrorCode?: string): IFluidErrorBase;
 
 // @public
 export class PerformanceEvent {

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -252,7 +252,7 @@ export class ThresholdCounter {
     }
 
 // @public
-export function wrapError<T extends IFluidErrorBase>(innerError: unknown, newErrorFn: (message: string) => T): T;
+export function wrapError<T extends IFluidErrorBase>(innerError: any, newErrorFn: (message: string) => T): T;
 
 // @public
 export function wrapErrorAndLog<T extends IFluidErrorBase>(innerError: unknown, newErrorFn: (message: string) => T, logger: ITelemetryLogger): T;

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -157,6 +157,9 @@ export class MultiSinkLogger extends TelemetryLogger {
 export function normalizeError(error: unknown, annotations?: IFluidErrorAnnotations, fluidErrorCode?: string): IFluidErrorBase;
 
 // @public
+export const normalizeErrorType = "<unknown>";
+
+// @public
 export class PerformanceEvent {
     protected constructor(logger: ITelemetryLogger, event: ITelemetryGenericEvent, markers?: IPerformanceEventMarkers);
     // (undocumented)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1740,6 +1740,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             if (errorCode !== undefined) {
                 const error = new DataCorruptionError(
                     errorCode,
+                    "Message from client not in quorum",
                     extractSafePropertiesFromMessage(message));
                 this.close(normalizeError(error));
             }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1594,19 +1594,17 @@ export class DeltaManager
 
         // Watch the minimum sequence number and be ready to update as needed
         if (this.minSequenceNumber > message.minimumSequenceNumber) {
-            throw new DataCorruptionError("msnMovesBackwards", {
-                ...extractLogSafeMessageProperties(message),
-                clientId: this.connection?.clientId,
-            });
+            throw new DataCorruptionError(
+                "msnMovesBackwards",
+                "Protocol error: MSN moved backward",
+                {
+                    ...extractLogSafeMessageProperties(message),
+                    clientId: this.connection?.clientId,
+                });
         }
         this.minSequenceNumber = message.minimumSequenceNumber;
 
-        if (message.sequenceNumber !== this.lastProcessedSequenceNumber + 1) {
-            throw new DataCorruptionError("nonSequentialSequenceNumber", {
-                ...extractLogSafeMessageProperties(message),
-                clientId: this.connection?.clientId,
-            });
-        }
+        assert(message.sequenceNumber === this.lastProcessedSequenceNumber + 1, "non sequential sequence numbers");
         this.lastProcessedSequenceNumber = message.sequenceNumber;
 
         // a bunch of code assumes that this is true

--- a/packages/loader/container-utils/src/test/error.spec.ts
+++ b/packages/loader/container-utils/src/test/error.spec.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "assert";
 import { ContainerErrorType } from "@fluidframework/container-definitions";
 import { isILoggingError, LoggingError, normalizeError } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { CreateProcessingError, DataProcessingError, GenericError } from "../error";
+import { CreateProcessingError, GenericError } from "../error";
 
 // NOTE about this (temporary) alias:
 // CreateContainerError has been removed, with most call sites now using normalizeError.
@@ -108,7 +108,7 @@ describe("Errors", () => {
             const coercedError = CreateProcessingError(originalError, "someCodepath", undefined);
 
             assert(coercedError as any === originalError);
-            assert(coercedError.errorType === "genericError");
+            assert(coercedError.errorType === "<unknown>");
             assert(coercedError.fluidErrorCode === "");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
         });
@@ -133,7 +133,7 @@ describe("Errors", () => {
             const coercedError = CreateProcessingError(originalError, "someCodepath", undefined);
 
             assert(coercedError as any !== originalError);
-            assert(coercedError instanceof DataProcessingError);
+            assert((coercedError as any).dataProcessingError === 1);
             assert(coercedError.errorType === ContainerErrorType.dataProcessingError);
             assert(coercedError.fluidErrorCode === "");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
@@ -149,7 +149,7 @@ describe("Errors", () => {
             const coercedError = CreateProcessingError(originalError, "someCodepath", undefined);
 
             assert(coercedError as any !== originalError);
-            assert(coercedError instanceof DataProcessingError);
+            assert((coercedError as any).dataProcessingError === 1);
             assert(coercedError.errorType === ContainerErrorType.dataProcessingError);
             assert(coercedError.fluidErrorCode === "");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);

--- a/packages/loader/container-utils/src/test/error.spec.ts
+++ b/packages/loader/container-utils/src/test/error.spec.ts
@@ -6,7 +6,7 @@
 /* eslint-disable max-len */
 
 import { strict as assert } from "assert";
-import { isILoggingError, LoggingError, normalizeError } from "@fluidframework/telemetry-utils";
+import { isILoggingError, LoggingError, normalizeError, normalizeErrorType } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { CreateProcessingError, GenericError } from "../error";
 
@@ -22,7 +22,7 @@ describe("Errors", () => {
             const originalError: any = { hello: "world" };
             const testError = CreateContainerErrorViaNormalize(originalError, { foo: "bar" });
 
-            assert(testError.errorType === "<unknown>");
+            assert(testError.errorType === normalizeErrorType);
             assert(testError !== originalError);
             assert((testError as any).hello === undefined);
             assert(isILoggingError(testError));
@@ -32,7 +32,7 @@ describe("Errors", () => {
             const originalError = "womp womp";
             const testError = CreateContainerErrorViaNormalize(originalError, { foo: "bar" });
 
-            assert(testError.errorType === "<unknown>");
+            assert(testError.errorType === normalizeErrorType);
             assert(testError.message === "womp womp");
             assert(isILoggingError(testError));
             assert(testError.getTelemetryProperties().foo === "bar");
@@ -42,14 +42,14 @@ describe("Errors", () => {
             const originalError = { errorType: "someErrorType" }; // missing message and telemetry prop functions
             const testError = CreateContainerErrorViaNormalize(originalError);
 
-            assert(testError.errorType === "<unknown>");
+            assert(testError.errorType === normalizeErrorType);
             assert(testError !== originalError);
         });
         it("Should ignore non-string errorType", () => {
             const originalError = { errorType: 3 };
             const testError = CreateContainerErrorViaNormalize(originalError);
 
-            assert(testError.errorType === "<unknown>");
+            assert(testError.errorType === normalizeErrorType);
         });
         it("Should not expose original error props for telemetry besides message", () => {
             const originalError: any = { hello: "world", message: "super important" };
@@ -69,7 +69,7 @@ describe("Errors", () => {
             const loggingError = new LoggingError("hello", { foo: "bar" });
             const testError = CreateContainerErrorViaNormalize(loggingError);
 
-            assert(testError.errorType === "<unknown>");
+            assert(testError.errorType === normalizeErrorType);
             assert(isILoggingError(testError));
             assert(testError.getTelemetryProperties().foo === undefined, "telemetryProps shouldn't be copied when wrapping");
             assert(testError as any !== loggingError);
@@ -107,7 +107,7 @@ describe("Errors", () => {
             const coercedError = CreateProcessingError(originalError, "someCodepath", undefined);
 
             assert(coercedError as any === originalError);
-            assert(coercedError.errorType === "<unknown>");
+            assert(coercedError.errorType === normalizeErrorType);
             assert(coercedError.fluidErrorCode === "");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
         });
@@ -133,7 +133,7 @@ describe("Errors", () => {
 
             assert(coercedError as any !== originalError);
             assert((coercedError as any).dataProcessingError === 1);
-            assert(coercedError.errorType === "<unknown>");
+            assert(coercedError.errorType === normalizeErrorType);
             assert(coercedError.fluidErrorCode === "someCodepath");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
             assert(coercedError.getTelemetryProperties().fluidErrorCode === "someCodepath");
@@ -149,7 +149,7 @@ describe("Errors", () => {
 
             assert(coercedError as any !== originalError);
             assert((coercedError as any).dataProcessingError === 1);
-            assert(coercedError.errorType === "<unknown>");
+            assert(coercedError.errorType === normalizeErrorType);
             assert(coercedError.fluidErrorCode === "someCodepath");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
             assert(coercedError.getTelemetryProperties().fluidErrorCode === "someCodepath");
@@ -179,7 +179,7 @@ describe("Errors", () => {
                     (error) =>
                         typeof error.message === "string" &&
                         error.fluidErrorCode === "someCodepath" &&
-                        error.errorType === "<unknown>" &&
+                        error.errorType === normalizeErrorType &&
                         error.getTelemetryProperties().dataProcessingError === 1 &&
                         error.getTelemetryProperties().fluidErrorCode === "someCodepath" &&
                         error.getTelemetryProperties().untrustedOrigin === 1),
@@ -201,7 +201,7 @@ describe("Errors", () => {
             const coercedError = CreateProcessingError(originalMessage, "someCodepath", undefined);
 
             assert(coercedError.message === originalMessage);
-            assert(coercedError.errorType === "<unknown>");
+            assert(coercedError.errorType === normalizeErrorType);
             assert(coercedError.fluidErrorCode === "someCodepath");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
             assert(coercedError.getTelemetryProperties().fluidErrorCode === "someCodepath");
@@ -214,7 +214,7 @@ describe("Errors", () => {
             const coercedError = CreateProcessingError(originalError, "someCodepath", undefined);
 
             assert(coercedError.message === originalError.message);
-            assert(coercedError.errorType === "<unknown>");
+            assert(coercedError.errorType === normalizeErrorType);
             assert(coercedError.fluidErrorCode === "someCodepath");
             assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
             assert(coercedError.getTelemetryProperties().fluidErrorCode === "someCodepath");

--- a/packages/loader/container-utils/src/test/errorTypeLoggingTest.spec.ts
+++ b/packages/loader/container-utils/src/test/errorTypeLoggingTest.spec.ts
@@ -72,9 +72,9 @@ describe("Check if the errorType field matches after sending/receiving via Conta
             assert(mockLogger.matchEvents([{
                 eventName: "A",
                 category: "error",
-                message: "dataCorruptionError",
+                message: "message",
                 errorType: ContainerErrorType.dataCorruptionError,
-                error: "dataCorruptionError",
+                error: "message",
                 clientId: "clientId",
                 sequenceNumber: 0,
                 message1: "message1",

--- a/packages/loader/container-utils/src/test/errorTypeLoggingTest.spec.ts
+++ b/packages/loader/container-utils/src/test/errorTypeLoggingTest.spec.ts
@@ -59,6 +59,7 @@ describe("Check if the errorType field matches after sending/receiving via Conta
         it("Send and receive a DataCorruptionError.", () => {
             const testError = new DataCorruptionError(
                 "dataCorruptionError",
+                "message",
                 {
                     clientId: "clientId",
                     sequenceNumber: 0,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -464,6 +464,7 @@ class ScheduleManagerCore {
                 // "Batch not closed, yet message from another client!"
                 throw new DataCorruptionError(
                     "OpBatchIncomplete",
+                    "Protocol error: different client IDs in a batch!",
                     {
                         batchClientId: this.currentBatchClientId,
                         ...extractSafePropertiesFromMessage(message),
@@ -711,6 +712,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 // "Load from summary, runtime metadata sequenceNumber !== initialSequenceNumber"
                 const error = new DataCorruptionError(
                     "SummaryMetadataMismatch",
+                    "Summary reference sequence number does not match summary metadata information",
                     { runtimeSequenceNumber, protocolSequenceNumber },
                 );
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -150,6 +150,7 @@ export class DataStores implements IDisposable {
             // TODO: dataStoreId may require a different tag from PackageData #7488
             const error = new DataCorruptionError(
                 "duplicateDataStoreCreatedWithExistingId",
+                "Race condition: Duplicate data store IDs",
                 {
                     ...extractSafePropertiesFromMessage(message),
                     dataStoreId: {

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -5,7 +5,7 @@
 
 import { IDisposable } from "@fluidframework/common-definitions";
 import { assert, Lazy } from "@fluidframework/common-utils";
-import { DataProcessingError } from "@fluidframework/container-utils";
+import { DataCorruptionError } from "@fluidframework/container-utils";
 import {
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
@@ -339,9 +339,9 @@ export class PendingStateManager implements IDisposable {
         // The clientSequenceNumber of the incoming message must match that of the pending message.
         if (pendingState.clientSequenceNumber !== message.clientSequenceNumber) {
             // Close the container because this could indicate data corruption.
-            const error = new DataProcessingError(
+            const error = new DataCorruptionError(
                 "unexpectedAckReceived",
-                "unexpectedAckReceived",
+                "clientSequenceNumber mismatch",
                 {
                     clientId: message.clientId,
                     sequenceNumber: message.sequenceNumber,

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -167,42 +167,51 @@ export class RemoteChannelContext implements IChannelContext {
         if (attributes === undefined) {
             if (this.attachMessageType === undefined) {
                 // TODO: dataStoreId may require a different tag from PackageData #7488
-                throw new DataCorruptionError("channelTypeNotAvailable", {
-                    channelId: this.id,
-                    dataStoreId: {
-                        value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData,
-                    },
-                    dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-                });
+                throw new DataCorruptionError(
+                    "channelTypeNotAvailable",
+                    "There is no DDS type info in channel snapshot",
+                    {
+                        channelId: this.id,
+                        dataStoreId: {
+                            value: this.dataStoreContext.id,
+                            tag: TelemetryDataTag.PackageData,
+                        },
+                        dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                    });
             }
             factory = this.registry.get(this.attachMessageType);
             if (factory === undefined) {
                 // TODO: dataStoreId may require a different tag from PackageData #7488
-                throw new DataCorruptionError("channelFactoryNotRegisteredForAttachMessageType", {
-                    channelId: this.id,
-                    dataStoreId: {
-                        value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData,
-                    },
-                    dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-                    channelFactoryType: this.attachMessageType,
-                });
+                throw new DataCorruptionError(
+                    "channelFactoryNotRegisteredForAttachMessageType",
+                    "DDS factory type not registered",
+                    {
+                        channelId: this.id,
+                        dataStoreId: {
+                            value: this.dataStoreContext.id,
+                            tag: TelemetryDataTag.PackageData,
+                        },
+                        dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                        channelFactoryType: this.attachMessageType,
+                    });
             }
             attributes = factory.attributes;
         } else {
             factory = this.registry.get(attributes.type);
             if (factory === undefined) {
                 // TODO: dataStoreId may require a different tag from PackageData #7488
-                throw new DataCorruptionError("channelFactoryNotRegisteredForGivenType", {
-                    channelId: this.id,
-                    dataStoreId: {
-                        value: this.dataStoreContext.id,
-                        tag: TelemetryDataTag.PackageData,
-                    },
-                    dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-                    channelFactoryType: attributes.type,
-                });
+                throw new DataCorruptionError(
+                    "channelFactoryNotRegisteredForGivenType",
+                    "DDS factory type not registered",
+                    {
+                        channelId: this.id,
+                        dataStoreId: {
+                            value: this.dataStoreContext.id,
+                            tag: TelemetryDataTag.PackageData,
+                        },
+                        dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+                        channelFactoryType: attributes.type,
+                    });
             }
         }
 

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -8,7 +8,6 @@ import { IFluidCodeDetails, IRequest } from "@fluidframework/core-interfaces";
 import {
     IGenericError,
     IPendingLocalState,
-    ContainerErrorType,
     LoaderHeader,
 } from "@fluidframework/container-definitions";
 import {
@@ -39,6 +38,7 @@ import {
     TestDataObjectType,
     describeNoCompat,
 } from "@fluidframework/test-version-utils";
+import { normalizeErrorType } from "@fluidframework/telemetry-utils";
 
 const id = "fluid-test://localhost/containerTest";
 const testRequest: IRequest = { url: id };
@@ -119,7 +119,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
             await loadContainer({ documentServiceFactory: mockFactory });
             assert.fail("Error expected");
         } catch (error) {
-            assert.strictEqual(error.errorType, ContainerErrorType.genericError, "Error should be a general error");
+            assert.strictEqual(error.errorType, normalizeErrorType, "Error should be a general error");
             const genericError = error as IGenericError;
             assert.equal(genericError.message, "expectedFailure", "Expected the injected error message");
             success = false;
@@ -143,7 +143,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
             await waitContainerToCatchUp(container2);
             assert.fail("Error expected");
         } catch (error) {
-            assert.strictEqual(error.errorType, ContainerErrorType.genericError, "Error should be a general error");
+            assert.strictEqual(error.errorType, normalizeErrorType, "Error should be a general error");
             const genericError = error as IGenericError;
             assert.equal(genericError.message, "expectedFailure", "Expected the injected error message");
             success = false;

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -5,11 +5,10 @@
 
 import { strict as assert } from "assert";
 import { v4 as uuid } from "uuid";
-import { ContainerErrorType } from "@fluidframework/container-definitions";
 import { Container, ILoaderProps, Loader } from "@fluidframework/container-loader";
-import { IDocumentServiceFactory, DriverErrorType } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils";
-import { isILoggingError, normalizeError } from "@fluidframework/telemetry-utils";
+import { isILoggingError, normalizeError, normalizeErrorType } from "@fluidframework/telemetry-utils";
 import {
     LocalCodeLoader,
     LoaderContainerTracker,
@@ -83,10 +82,8 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
             await loadContainer({ documentServiceFactory: mockFactory });
             assert.fail("Error expected");
         } catch (error) {
-            assert(
-                [DriverErrorType.genericNetworkError, ContainerErrorType.genericError].includes(error.errorType),
-                `${error.errorType} should be genericError or genericNetworkError`,
-            );
+            assert(error.errorType === normalizeErrorType,
+                `${error.errorType} should be normalized error type`);
         }
     });
 

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -17,6 +17,11 @@ import {
     isValidLegacyError,
 } from "./fluidErrorBase";
 
+/**
+ * errorType used by normalizeError() for unknown errors
+ */
+export const normalizeErrorType = "<unknown>";
+
 /** @returns true if value is an object but neither null nor an array */
 const isRegularObject = (value: any): boolean => {
     return value !== null && !Array.isArray(value) && typeof value === "object";
@@ -113,7 +118,7 @@ export function normalizeError(
     // We have to construct a new Fluid Error, copying safe properties over
     const { message, stack } = extractLogSafeErrorProperties(error, false /* sanitizeStack */);
     const fluidError: IFluidErrorBase = new SimpleFluidError({
-        errorType: "<unknown>",
+        errorType: normalizeErrorType,
         fluidErrorCode,
         message,
         stack,

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -10,7 +10,15 @@ import sinon from "sinon";
 import { v4 as uuid } from "uuid";
 import { ITelemetryBaseEvent, ITelemetryProperties } from "@fluidframework/common-definitions";
 import { TelemetryDataTag, TelemetryLogger, TaggedLoggerAdapter } from "../logger";
-import { LoggingError, isTaggedTelemetryPropertyValue, normalizeError, IFluidErrorAnnotations, wrapError, wrapErrorAndLog } from "../errorLogging";
+import {
+    LoggingError,
+    isTaggedTelemetryPropertyValue,
+    normalizeError,
+    IFluidErrorAnnotations,
+    wrapError,
+    wrapErrorAndLog,
+    normalizeErrorType,
+} from "../errorLogging";
 import { IFluidErrorBase } from "../fluidErrorBase";
 import { MockLogger } from "../mockLogger";
 
@@ -448,7 +456,7 @@ describe("normalizeError", () => {
             stack: "cool stack trace",
         });
         const typicalOutput = (message: string, stackHint: "<<natural stack>>" | "<<stack from input>>") => new TestFluidError({
-            errorType: "<unknown>",
+            errorType: normalizeErrorType,
             fluidErrorCode: "fluidErrorCodeNormalize",
             message,
             stack: stackHint,


### PR DESCRIPTION
Issue #8262
1. DataProcessingError: Use fluidErrorCode instead of dataProcessingCodepath
2. Add user-friendly message to DataCorruptionError() errors - developers should have a chance to read it in plain English.
   - Opened bugs for all other cases like that (see #8474, #8473)
3. Moved {untrustedOrigin: 1} property to more generic layer to ensure that all wrapped errors that come from outside of our repo are marked correctly.
4. normilizeError() path: unknown errors will have errorType = "<unknown>" instead of "generic".
5. Remove ContainerErrorType.dataProcessingError. Instead use same workflow as we use in the rest of repo RE handling of errors, i.e. choosing among two paths:
   - wrapError() path: errorType is overwritten
   - normilizeError() path: preserves errorType, otherwise "<unknown>" is used.
