### PR TITLE
[r11s and historian] Updating k8s configmaps to use json morganFormat

### DIFF
--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -13,7 +13,7 @@ data:
     {
         "logger": {
             "colorize": false,
-            "morganFormat": "short",
+            "morganFormat": "json",
             "json": false,
             "level": "verbose",
             "timestamp": false

--- a/server/historian/packages/historian-base/src/test/routes.spec.ts
+++ b/server/historian/packages/historian-base/src/test/routes.spec.ts
@@ -26,7 +26,7 @@ const defaultProvider = new nconf.Provider({}).defaults({
         enableTokenExpiration: true,
     },
     logger: {
-        morganFormat: "dev",
+        morganFormat: "json",
     },
 });
 const defaultTenantService = new TestTenantService();

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -13,7 +13,7 @@ data:
     {
         "logger": {
             "colorize": false,
-            "morganFormat": "short",
+            "morganFormat": "json",
             "json": true,
             "level": "info",
             "timestamp": false,

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -29,7 +29,7 @@ const defaultProvider = new nconf.Provider({}).defaults({
         enableTokenExpiration: true
     },
     logger: {
-        morganFormat: "dev",
+        morganFormat: "json",
     },
     mongo: {
         collectionNames: {


### PR DESCRIPTION
Following up on #8456  and #8469, updating k8s configmaps for Routerlicious and Historian to use the `json` `morganFormat` option. Also updating the Routerlicious and Historian unit tests to use JSON and therefore match k8s configMaps and config.json.