### PR TITLE
Remove sequenced message from map and dictionary events

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -19,6 +19,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [maxMessageSize removed from IConnectionDetails and IDocumentDeltaConnection](#maxMessageSize-removed-from-IConnectionDetails-and-IDocumentDeltaConnection)
 - [Remove `IntervalCollection.getView()` from sequence dds](#Remove-IntervalCollectiongetView-from-sequence-dds)
 - [Moved `ICodeDetailsLoader` and `IFluidModuleWithDetails` interface to `@fluidframework/container-definitions`](#Moved-ICodeDetailsLoader-and-IFluidModuleWithDetails-interface-to-fluidframeworkcontainer-definitions)
+- [ISequencedDocumentMessage arg removed from SharedMap and SharedDirectory events](#ISequencedDocumentMessage-arg-removed-from-SharedMap-and-SharedDirectory-events)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -77,6 +78,9 @@ The `IntervalCollection.getView()` was removed.  If you were calling this API, y
 
 ### Moved `ICodeDetailsLoader` and `IFluidModuleWithDetails` interface to `@fluidframework/container-definitions`
 The `ICodeDetailsLoader` and `IFluidModuleWithDetails` interface are deprecated in `@fluidframework/container-loader` and moved to `@fluidframework/container-definitions`. The `ICodeDetailsLoader` interface should be imported from `@fluidframework/container-definition` package. The `ICodeDetailsLoader` and `IFluidModuleWithDetails` from `@fluidframework/container-loader` will be removed from `@fluidframework/container-loader` in further releases.
+
+### `ISequencedDocumentMessage` arg removed from `SharedMap` and `SharedDirectory` events
+The `ISequencedDocumentMessage` argument in events emitted from `SharedMap` and `SharedDirectory` (the `"valueChanged"` and `"clear"` events) has been removed.  It is not recommended to access the protocol layer directly.  Note that if you were leveraging the `this` argument of these events, you will need to update your event listeners due to the arity change.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/api-report/map.api.md
+++ b/api-report/map.api.md
@@ -110,9 +110,9 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
 // @public
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     // (undocumented)
-    (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, op: ISequencedDocumentMessage | null, target: IEventThisPlaceHolder) => void): any;
+    (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     // (undocumented)
-    (event: "clear", listener: (local: boolean, op: ISequencedDocumentMessage | null, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
 // @public
@@ -125,9 +125,9 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
 // @public
 export interface ISharedMapEvents extends ISharedObjectEvents {
     // (undocumented)
-    (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, op: ISequencedDocumentMessage | null, target: IEventThisPlaceHolder) => void): any;
+    (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     // (undocumented)
-    (event: "clear", listener: (local: boolean, op: ISequencedDocumentMessage | null, target: IEventThisPlaceHolder) => void): any;
+    (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
 // @public

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 import { IEvent, IEventProvider, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
 
@@ -146,12 +145,10 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (
         changed: IDirectoryValueChanged,
         local: boolean,
-        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder,
     ) => void);
     (event: "clear", listener: (
         local: boolean,
-        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder,
     ) => void);
 }
@@ -249,11 +246,9 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (
         changed: IValueChanged,
         local: boolean,
-        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder) => void);
     (event: "clear", listener: (
         local: boolean,
-        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder
     ) => void);
 }

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -364,7 +364,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
      * @internal
      */
     protected applyStashedOp(content: any): unknown {
-        this.kernel.tryProcessMessage(content, false, undefined, undefined);
+        this.kernel.tryProcessMessage(content, false, undefined);
         return this.kernel.tryGetStashedOpLocalMetadata(content);
     }
 
@@ -374,7 +374,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
      */
     protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) {
         if (message.type === MessageType.Operation) {
-            this.kernel.tryProcessMessage(message.contents, local, message, localOpMetadata);
+            this.kernel.tryProcessMessage(message.contents, local, localOpMetadata);
         }
     }
 

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -4,7 +4,6 @@
  */
 
 import { IFluidHandle, IFluidSerializer } from "@fluidframework/core-interfaces";
-import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ValueType } from "@fluidframework/shared-object-base";
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
@@ -27,14 +26,12 @@ interface IMapMessageHandler {
      * Apply the given operation.
      * @param op - The map operation to apply
      * @param local - Whether the message originated from the local client
-     * @param message - The full message. Not provided for stashed ops.
      * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
      * For messages from a remote client, this will be undefined.
      */
     process(
         op: IMapOperation,
         local: boolean,
-        message: ISequencedDocumentMessage | undefined,
         localOpMetadata: unknown,
     ): void;
 
@@ -317,7 +314,6 @@ export class MapKernel {
             key,
             localValue,
             true,
-            undefined,
         );
 
         // If we are not attached, don't submit the op.
@@ -340,7 +336,7 @@ export class MapKernel {
      */
     public delete(key: string): boolean {
         // Delete the key locally first.
-        const successfullyRemoved = this.deleteCore(key, true, undefined);
+        const successfullyRemoved = this.deleteCore(key, true);
 
         // If we are not attached, don't submit the op.
         if (!this.isAttached()) {
@@ -361,7 +357,7 @@ export class MapKernel {
      */
     public clear(): void {
         // Clear the data locally first.
-        this.clearCore(true, undefined);
+        this.clearCore(true);
 
         // If we are not attached, don't submit the op.
         if (!this.isAttached()) {
@@ -456,14 +452,13 @@ export class MapKernel {
     public tryProcessMessage(
         op: IMapOperation,
         local: boolean,
-        message: ISequencedDocumentMessage | undefined,
         localOpMetadata: unknown,
     ): boolean {
         if (this.messageHandlers.has(op.type)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.messageHandlers
                 .get(op.type)!
-                .process(op, local, message, localOpMetadata);
+                .process(op, local, localOpMetadata);
             return true;
         }
         return false;
@@ -476,11 +471,11 @@ export class MapKernel {
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote set, or null if from a local set
      */
-    private setCore(key: string, value: ILocalValue, local: boolean, op: ISequencedDocumentMessage | undefined): void {
+    private setCore(key: string, value: ILocalValue, local: boolean): void {
         const previousValue = this.get(key);
         this.data.set(key, value);
         const event: IValueChanged = { key, previousValue };
-        this.eventEmitter.emit("valueChanged", event, local, op, this.eventEmitter);
+        this.eventEmitter.emit("valueChanged", event, local, this.eventEmitter);
     }
 
     /**
@@ -488,9 +483,9 @@ export class MapKernel {
      * @param local - Whether the message originated from the local client
      * @param op - The message if from a remote clear, or null if from a local clear
      */
-    private clearCore(local: boolean, op: ISequencedDocumentMessage | undefined): void {
+    private clearCore(local: boolean): void {
         this.data.clear();
-        this.eventEmitter.emit("clear", local, op, this.eventEmitter);
+        this.eventEmitter.emit("clear", local, this.eventEmitter);
     }
 
     /**
@@ -500,12 +495,12 @@ export class MapKernel {
      * @param op - The message if from a remote delete, or null if from a local delete
      * @returns True if the key existed and was deleted, false if it did not exist
      */
-    private deleteCore(key: string, local: boolean, op: ISequencedDocumentMessage | undefined): boolean {
+    private deleteCore(key: string, local: boolean): boolean {
         const previousValue = this.get(key);
         const successfullyRemoved = this.data.delete(key);
         if (successfullyRemoved) {
             const event: IValueChanged = { key, previousValue };
-            this.eventEmitter.emit("valueChanged", event, local, op, this.eventEmitter);
+            this.eventEmitter.emit("valueChanged", event, local, this.eventEmitter);
         }
         return successfullyRemoved;
     }
@@ -597,7 +592,7 @@ export class MapKernel {
         messageHandlers.set(
             "clear",
             {
-                process: (op: IMapClearOperation, local, message, localOpMetadata) => {
+                process: (op: IMapClearOperation, local, localOpMetadata) => {
                     if (local) {
                         assert(localOpMetadata !== undefined,
                             0x015 /* "pendingMessageId is missing from the local client's clear operation" */);
@@ -611,7 +606,7 @@ export class MapKernel {
                         this.clearExceptPendingKeys();
                         return;
                     }
-                    this.clearCore(local, message);
+                    this.clearCore(local);
                 },
                 submit: (op: IMapClearOperation, localOpMetadata: unknown) => {
                     // We don't reuse the metadata but send a new one on each submit.
@@ -625,11 +620,11 @@ export class MapKernel {
         messageHandlers.set(
             "delete",
             {
-                process: (op: IMapDeleteOperation, local, message, localOpMetadata) => {
+                process: (op: IMapDeleteOperation, local, localOpMetadata) => {
                     if (!this.needProcessKeyOperation(op, local, localOpMetadata)) {
                         return;
                     }
-                    this.deleteCore(op.key, local, message);
+                    this.deleteCore(op.key, local);
                 },
                 submit: (op: IMapDeleteOperation, localOpMetadata: unknown) => {
                     // We don't reuse the metadata but send a new one on each submit.
@@ -643,14 +638,14 @@ export class MapKernel {
         messageHandlers.set(
             "set",
             {
-                process: (op: IMapSetOperation, local, message, localOpMetadata) => {
+                process: (op: IMapSetOperation, local, localOpMetadata) => {
                     if (!this.needProcessKeyOperation(op, local, localOpMetadata)) {
                         return;
                     }
 
                     // needProcessKeyOperation should have returned false if local is true
                     const context = this.makeLocal(op.key, op.value);
-                    this.setCore(op.key, context, local, message);
+                    this.setCore(op.key, context, local);
                 },
                 submit: (op: IMapSetOperation, localOpMetadata: unknown) => {
                     // We don't reuse the metadata but send a new one on each submit.

--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -88,7 +88,7 @@ describe("Directory", () => {
                 directory.on("op", (arg1, arg2, arg3) => {
                     assert.fail("shouldn't receive an op event");
                 });
-                directory.on("valueChanged", (changed, local, op, target) => {
+                directory.on("valueChanged", (changed, local, target) => {
                     assert.equal(valueChangedExpected, true, "valueChange event not expected");
                     valueChangedExpected = false;
 
@@ -97,7 +97,6 @@ describe("Directory", () => {
                     assert.equal(changed.path, directory.absolutePath);
 
                     assert.equal(local, true, "local should be true for local action for valueChanged event");
-                    assert.equal(op, null, "op should be null for local actions for valueChanged event");
                     assert.equal(target, directory, "target should be the directory for valueChanged event");
                 });
                 directory.on("containedValueChanged", (changed, local, target) => {
@@ -111,12 +110,11 @@ describe("Directory", () => {
                     assert.equal(local, true, "local should be true for local action for containedValueChanged event");
                     assert.equal(target, directory, "target should be the directory for containedValueChanged event");
                 });
-                directory.on("clear", (local, op, target) => {
+                directory.on("clear", (local, target) => {
                     assert.equal(clearExpected, true, "clear event not expected");
                     clearExpected = false;
 
                     assert.equal(local, true, "local should be true for local action for clear event");
-                    assert.equal(op, null, "op should be null for local actions for clear event");
                     assert.equal(target, directory, "target should be the directory for clear event");
                 });
                 directory.on("error", (error) => {

--- a/packages/dds/map/src/test/map.spec.ts
+++ b/packages/dds/map/src/test/map.spec.ts
@@ -61,7 +61,7 @@ describe("Map", () => {
                 dummyMap.on("op", (arg1, arg2, arg3) => {
                     assert.fail("shouldn't receive an op event");
                 });
-                dummyMap.on("valueChanged", (changed, local, op, target) => {
+                dummyMap.on("valueChanged", (changed, local, target) => {
                     assert.equal(valueChangedExpected, true, "valueChange event not expected");
                     valueChangedExpected = false;
 
@@ -69,15 +69,13 @@ describe("Map", () => {
                     assert.equal(changed.previousValue, previousValue);
 
                     assert.equal(local, true, "local should be true for local action for valueChanged event");
-                    assert.equal(op, undefined, "op should be undefined for local actions for valueChanged event");
                     assert.equal(target, dummyMap, "target should be the map for valueChanged event");
                 });
-                dummyMap.on("clear", (local, op, target) => {
+                dummyMap.on("clear", (local, target) => {
                     assert.equal(clearExpected, true, "clear event not expected");
                     clearExpected = false;
 
                     assert.equal(local, true, "local should be true for local action  for clear event");
-                    assert.equal(op, undefined, "op should be undefined for local actions for clear event");
                     assert.equal(target, dummyMap, "target should be the map for clear event");
                 });
                 dummyMap.on("error", (error) => {

--- a/packages/dds/sequence/src/mapKernelInterfaces.ts
+++ b/packages/dds/sequence/src/mapKernelInterfaces.ts
@@ -118,11 +118,9 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (
         changed: IValueChanged,
         local: boolean,
-        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder) => void);
     (event: "clear", listener: (
         local: boolean,
-        op: ISequencedDocumentMessage | null,
         target: IEventThisPlaceHolder
     ) => void);
 }

--- a/packages/framework/undo-redo/src/mapHandler.ts
+++ b/packages/framework/undo-redo/src/mapHandler.ts
@@ -20,7 +20,7 @@ export class SharedMapUndoRedoHandler {
         map.off("valueChanged", this.mapDeltaHandler);
     }
 
-    private readonly mapDeltaHandler = (changed: IValueChanged, local: boolean, op, target: ISharedMap) => {
+    private readonly mapDeltaHandler = (changed: IValueChanged, local: boolean, target: ISharedMap) => {
         if (local) {
             this.stackManager.pushToCurrentOperation(new SharedMapRevertible(changed, target));
         }

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISharedDirectory, ISharedMap, SharedDirectory, SharedMap } from "@fluidframework/map";
-import { MessageType } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ITestObjectProvider,
@@ -150,31 +149,22 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
             let user1ValueChangedCount: number = 0;
             let user2ValueChangedCount: number = 0;
             let user3ValueChangedCount: number = 0;
-            sharedDirectory1.on("valueChanged", (changed, local, msg) => {
+            sharedDirectory1.on("valueChanged", (changed, local) => {
                 if (!local) {
-                    assert(msg);
-                    if (msg.type === MessageType.Operation) {
-                        assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 1");
-                        user1ValueChangedCount = user1ValueChangedCount + 1;
-                    }
+                    assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 1");
+                    user1ValueChangedCount = user1ValueChangedCount + 1;
                 }
             });
-            sharedDirectory2.on("valueChanged", (changed, local, msg) => {
+            sharedDirectory2.on("valueChanged", (changed, local) => {
                 if (!local) {
-                    assert(msg);
-                    if (msg.type === MessageType.Operation) {
-                        assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 2");
-                        user2ValueChangedCount = user2ValueChangedCount + 1;
-                    }
+                    assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 2");
+                    user2ValueChangedCount = user2ValueChangedCount + 1;
                 }
             });
-            sharedDirectory3.on("valueChanged", (changed, local, msg) => {
+            sharedDirectory3.on("valueChanged", (changed, local) => {
                 if (!local) {
-                    assert(msg);
-                    if (msg.type === MessageType.Operation) {
-                        assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 3");
-                        user3ValueChangedCount = user3ValueChangedCount + 1;
-                    }
+                    assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 3");
+                    user3ValueChangedCount = user3ValueChangedCount + 1;
                 }
             });
 
@@ -408,34 +398,25 @@ describeFullCompat("SharedDictionary", (getTestObjectProvider) => {
             let user1ValueChangedCount: number = 0;
             let user2ValueChangedCount: number = 0;
             let user3ValueChangedCount: number = 0;
-            sharedDirectory1.on("valueChanged", (changed, local, msg) => {
+            sharedDirectory1.on("valueChanged", (changed, local) => {
                 if (!local) {
-                    assert(msg);
-                    if (msg.type === MessageType.Operation) {
-                        assert.equal(changed.key, "testKey1", "Incorrect value for key in container 1");
-                        assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 1");
-                        user1ValueChangedCount = user1ValueChangedCount + 1;
-                    }
+                    assert.equal(changed.key, "testKey1", "Incorrect value for key in container 1");
+                    assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 1");
+                    user1ValueChangedCount = user1ValueChangedCount + 1;
                 }
             });
-            sharedDirectory2.on("valueChanged", (changed, local, msg) => {
+            sharedDirectory2.on("valueChanged", (changed, local) => {
                 if (!local) {
-                    assert(msg);
-                    if (msg.type === MessageType.Operation) {
-                        assert.equal(changed.key, "testKey1", "Incorrect value for key in container 2");
-                        assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 2");
-                        user2ValueChangedCount = user2ValueChangedCount + 1;
-                    }
+                    assert.equal(changed.key, "testKey1", "Incorrect value for key in container 2");
+                    assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 2");
+                    user2ValueChangedCount = user2ValueChangedCount + 1;
                 }
             });
-            sharedDirectory3.on("valueChanged", (changed, local, msg) => {
+            sharedDirectory3.on("valueChanged", (changed, local) => {
                 if (!local) {
-                    assert(msg);
-                    if (msg.type === MessageType.Operation) {
-                        assert.equal(changed.key, "testKey1", "Incorrect value for key in container 3");
-                        assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 3");
-                        user3ValueChangedCount = user3ValueChangedCount + 1;
-                    }
+                    assert.equal(changed.key, "testKey1", "Incorrect value for key in container 3");
+                    assert.equal(changed.path, "/testSubDir1", "Incorrect value for path in container 3");
+                    user3ValueChangedCount = user3ValueChangedCount + 1;
                 }
             });
 

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { Container } from "@fluidframework/container-loader";
 import { ISharedMap, SharedMap } from "@fluidframework/map";
-import { MessageType } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ITestObjectProvider,
@@ -125,31 +124,22 @@ describeFullCompat("SharedMap", (getTestObjectProvider) => {
         let user1ValueChangedCount: number = 0;
         let user2ValueChangedCount: number = 0;
         let user3ValueChangedCount: number = 0;
-        sharedMap1.on("valueChanged", (changed, local, msg) => {
+        sharedMap1.on("valueChanged", (changed, local) => {
             if (!local) {
-                assert(msg);
-                if (msg.type === MessageType.Operation) {
-                    assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 1");
-                    user1ValueChangedCount = user1ValueChangedCount + 1;
-                }
+                assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 1");
+                user1ValueChangedCount = user1ValueChangedCount + 1;
             }
         });
-        sharedMap2.on("valueChanged", (changed, local, msg) => {
+        sharedMap2.on("valueChanged", (changed, local) => {
             if (!local) {
-                assert(msg);
-                if (msg.type === MessageType.Operation) {
-                    assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 2");
-                    user2ValueChangedCount = user2ValueChangedCount + 1;
-                }
+                assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 2");
+                user2ValueChangedCount = user2ValueChangedCount + 1;
             }
         });
-        sharedMap3.on("valueChanged", (changed, local, msg) => {
+        sharedMap3.on("valueChanged", (changed, local) => {
             if (!local) {
-                assert(msg);
-                if (msg.type === MessageType.Operation) {
-                    assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 3");
-                    user3ValueChangedCount = user3ValueChangedCount + 1;
-                }
+                assert.equal(changed.key, "testKey1", "Incorrect value for testKey1 in container 3");
+                user3ValueChangedCount = user3ValueChangedCount + 1;
             }
         });
 


### PR DESCRIPTION
Resolves #8481 

Would also probably be good to remove from the map kernel in Sequence, but that requires a little more attention as it's grabbing the sequence number off the sequenced message to stamp on the interval properties.