### PR TITLE
Disable deno in the VSCode workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,7 @@
         "tools/pipelines/*.yml": "azure-pipelines"
     },
     "[azure-pipelines].customSchemaFile": "",
-    "deno.enable": true,
-    "deno.lint": true,
-    "deno.unstable": true,
+    "deno.enable": false,
+    "deno.lint": false,
+    "deno.unstable": false,
 }


### PR DESCRIPTION
The deno-related settings were committed accidentally. This PR disables the deno extension if it is installed locally, so it doesn't interfere with our typical settings.