### PR TITLE
Removed IFluidSerializer from container runtime and deprecated it in IFluidDataStoreRuntime

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -22,6 +22,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Removed `errorMessage` property from `ISummaryNack` interface](#Removed-errorMessage-property-from-ISummaryNack-interface)
 - [ISequencedDocumentMessage arg removed from SharedMap and SharedDirectory events](#ISequencedDocumentMessage-arg-removed-from-SharedMap-and-SharedDirectory-events)
 - [Moved `@fluidframework/core-interface#fluidPackage.ts` to `@fluidframework/container-definition#fluidPackage.ts`](#Moved-fluidframeworkcore-interfacefluidPackagets-to-fluidframeworkcontainer-definitionfluidPackagets)
+- [Deprecated `IFluidSerializer` in `IFluidDataStoreRuntime`](#Deprecated-IFluidSerializer-in-IFluidDataStoreRuntime)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -100,6 +101,9 @@ Moved the following interfaces and const from `@fluidframework/core-interface` t
 - `IFluidCodeDetailsComparer`
 
 They are deprecated from `@fluidframework/core-interface` and would be removed in future release. Please import them from `@fluidframework/container-definitions`.
+
+### Deprecated `IFluidSerializer` in `IFluidDataStoreRuntime`
+`IFluidSerializer` should only be used by DDSs to serialize data and they should use the one created by `SharedObject`.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -31,7 +31,6 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
-import { IFluidSerializer } from '@fluidframework/core-interfaces';
 import { IFluidTokenProvider } from '@fluidframework/container-definitions';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
@@ -138,8 +137,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     readonly IFluidHandleContext: IFluidHandleContext;
     // (undocumented)
     get IFluidRouter(): this;
-    // (undocumented)
-    readonly IFluidSerializer: IFluidSerializer;
     // (undocumented)
     get IFluidTokenProvider(): IFluidTokenProvider | undefined;
     get isDirty(): boolean;

--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -107,7 +107,7 @@ export interface IFluidDataStoreRuntime extends IFluidRouter, IEventProvider<IFl
     readonly id: string;
     // (undocumented)
     readonly IFluidHandleContext: IFluidHandleContext;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly IFluidSerializer: IFluidSerializer;
     // (undocumented)
     readonly logger: ITelemetryLogger;

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -462,8 +462,7 @@ export class SharedPropertyTree extends SharedObject {
 		const handleTableChunk = await storage.readBlob("properties");
 		const utf8 = bufferToString(handleTableChunk, "utf8");
 
-		const serializer = runtime.IFluidSerializer;
-		const snapshot: ISnapshot = serializer !== undefined ? serializer.parse(utf8) : JSON.parse(utf8);
+		const snapshot: ISnapshot = this.serializer.parse(utf8);
 		this.useMH = snapshot.useMH;
 
 		try {

--- a/experimental/dds/ot/ot/src/ot.ts
+++ b/experimental/dds/ot/ot/src/ot.ts
@@ -100,7 +100,7 @@ export abstract class SharedOT<TState, TOp> extends SharedObject {
     protected async loadCore(storage: IChannelStorageService): Promise<void> {
         const blob = await storage.readBlob("header");
         const rawContent = bufferToString(blob, "utf8");
-        this.global = this.local = this.runtime.IFluidSerializer.parse(rawContent);
+        this.global = this.local = this.serializer.parse(rawContent);
     }
 
     protected registerCore() {}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -12,7 +12,6 @@ import {
     IFluidHandleContext,
     IFluidObject,
     IFluidRouter,
-    IFluidSerializer,
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
@@ -86,7 +85,6 @@ import {
     addTreeToSummary,
     convertToSummaryTree,
     createRootSummarizerNodeWithGC,
-    FluidSerializer,
     IRootSummarizerNodeWithGC,
     RequestParser,
     create404Response,
@@ -816,9 +814,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         return this.context.attachState;
     }
 
-    // Back compat: 0.28, can be removed in 0.29
-    public readonly IFluidSerializer: IFluidSerializer;
-
     public readonly IFluidHandleContext: IFluidHandleContext;
 
     // internal logger for ContainerRuntime. Use this.logger for stores, summaries, etc.
@@ -945,7 +940,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.chunkMap = new Map<string, string[]>(chunks);
 
         this.IFluidHandleContext = new ContainerFluidHandleContext("", this);
-        this.IFluidSerializer = new FluidSerializer(this.IFluidHandleContext);
 
         this._logger = ChildLogger.create(this.logger, "ContainerRuntime");
 

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -47,6 +47,9 @@ export interface IFluidDataStoreRuntime extends
 
     readonly id: string;
 
+    /**
+     * @deprecated - FluidSerializer is not required as DDSs are the only ones that serialize data.
+     */
     readonly IFluidSerializer: IFluidSerializer;
 
     readonly IFluidHandleContext: IFluidHandleContext;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -145,6 +145,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     private readonly serializer = new FluidSerializer(this.IFluidHandleContext);
+    // Back compat: deprecated in 0.53, can be removed in versions >= 0.55.
     public get IFluidSerializer() { return this.serializer; }
 
     public get IFluidHandleContext() { return this; }


### PR DESCRIPTION
Partly fixes https://github.com/microsoft/FluidFramework/issues/8467.

- Removed `IFluidSerializer` from container runtime.
- Deprecated `IFluidSerializer` in `IFluidDataStoreRuntime`.
- Updated properyDDS and OT to use the serializer in SharedObject. 