### PR TITLE
Added logging when older snapshot format for data store snapshot is detected

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -704,7 +704,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
         if (typeof this.initSnapshotValue === "string") {
             const commit = (await this.storage.getVersions(this.initSnapshotValue, 1))[0];
             tree = await this.storage.getSnapshotTree(commit) ?? undefined;
-            this.logger.sendTelemetryEvent({ eventName: "LegacyDataStoreSnapshot", reason: "snapshotAsString" });
+            this.logger.sendErrorEvent({ eventName: "LegacyDataStoreSnapshot", reason: "snapshotAsString" });
         } else {
             tree = this.initSnapshotValue;
         }
@@ -713,7 +713,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
         if (tree) {
             const loadedSummary = await this.summarizerNode.loadBaseSummary(tree, localReadAndParse);
             if (loadedSummary.outstandingOps.length > 0) {
-                this.logger.sendTelemetryEvent({ eventName: "LegacyDataStoreSnapshot", reason: "outstandingOps" });
+                this.logger.sendErrorEvent({ eventName: "LegacyDataStoreSnapshot", reason: "outstandingOps" });
             }
             tree = loadedSummary.baseSummary;
             // Prepend outstanding ops to pending queue of ops to process.
@@ -731,7 +731,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
             // For snapshotFormatVersion = "0.1" (1) or above, pkg is jsonified, otherwise it is just a string.
             const formatVersion = getAttributesFormatVersion(attributes);
             if (formatVersion < 1) {
-                this.logger.sendTelemetryEvent({ eventName: "LegacyDataStoreSnapshot", reason: "formatVersion < 1" });
+                this.logger.sendErrorEvent({ eventName: "LegacyDataStoreSnapshot", reason: "formatVersion < 1" });
                 if (attributes.pkg.startsWith("[\"") && attributes.pkg.endsWith("\"]")) {
                     pkgFromSnapshot = JSON.parse(attributes.pkg) as string[];
                 } else {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { BlobCacheStorageService } from "@fluidframework/driver-utils";
@@ -27,7 +26,6 @@ import {
     CreateSummarizerNodeSource,
     channelsTreeName,
 } from "@fluidframework/runtime-definitions";
-import { MockLogger } from "@fluidframework/telemetry-utils";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { createRootSummarizerNodeWithGC, IRootSummarizerNodeWithGC } from "@fluidframework/runtime-utils";
 import { stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
@@ -297,7 +295,6 @@ describe("Data Store Context Tests", () => {
         const storage: Partial<IDocumentStorageService> = {};
         let scope: FluidObject;
         let summarizerNode: IRootSummarizerNodeWithGC;
-        const logger: ITelemetryLogger = new MockLogger();
 
         function mockContainerRuntime(disableIsolatedChannels = true): ContainerRuntime {
             const factory: { [key: string]: any } = {};
@@ -310,7 +307,7 @@ describe("Data Store Context Tests", () => {
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             return {
-                logger,
+                logger: new TelemetryNullLogger(),
                 disableIsolatedChannels,
                 IFluidDataStoreRegistry: registry,
                 on: (event, listener) => { },

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { BlobCacheStorageService } from "@fluidframework/driver-utils";
@@ -26,6 +27,7 @@ import {
     CreateSummarizerNodeSource,
     channelsTreeName,
 } from "@fluidframework/runtime-definitions";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { createRootSummarizerNodeWithGC, IRootSummarizerNodeWithGC } from "@fluidframework/runtime-utils";
 import { stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
@@ -295,6 +297,7 @@ describe("Data Store Context Tests", () => {
         const storage: Partial<IDocumentStorageService> = {};
         let scope: FluidObject;
         let summarizerNode: IRootSummarizerNodeWithGC;
+        const logger: ITelemetryLogger = new MockLogger();
 
         function mockContainerRuntime(disableIsolatedChannels = true): ContainerRuntime {
             const factory: { [key: string]: any } = {};
@@ -307,6 +310,7 @@ describe("Data Store Context Tests", () => {
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             return {
+                logger,
                 disableIsolatedChannels,
                 IFluidDataStoreRegistry: registry,
                 on: (event, listener) => { },


### PR DESCRIPTION
When a data store is loaded, it's initial snapshot is loaded to get the attributes blob. There is code to read older snapshot format and convert them to newer formats.
These older snapshot formats should not really exist today. However, adding telemetry to confirm this. This telemetry will be monitored for some time and then these code paths will be removed if we don't see these events - https://github.com/microsoft/FluidFramework/issues/8503