### PR TITLE
Remove `readAndParseFromBlobs` from `driver-utils`

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -22,6 +22,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Removed `errorMessage` property from `ISummaryNack` interface](#Removed-errorMessage-property-from-ISummaryNack-interface)
 - [ISequencedDocumentMessage arg removed from SharedMap and SharedDirectory events](#ISequencedDocumentMessage-arg-removed-from-SharedMap-and-SharedDirectory-events)
 - [Moved `@fluidframework/core-interface#fluidPackage.ts` to `@fluidframework/container-definition#fluidPackage.ts`](#Moved-fluidframeworkcore-interfacefluidPackagets-to-fluidframeworkcontainer-definitionfluidPackagets)
+- [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -100,6 +101,9 @@ Moved the following interfaces and const from `@fluidframework/core-interface` t
 - `IFluidCodeDetailsComparer`
 
 They are deprecated from `@fluidframework/core-interface` and would be removed in future release. Please import them from `@fluidframework/container-definitions`.
+
+### Removed `readAndParseFromBlobs` from `driver-utils`
+The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -10,6 +10,12 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
+## 0.54 Breaking changes
+- [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)
+
+### Removed `readAndParseFromBlobs` from `driver-utils`
+The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
+
 ## 0.53 Breaking changes
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)
 - [Remove `getLegacyInterval()` and `delete()` from sequence dds](#Remove-getLegacyInterval-and-delete-from-sequence-dds)
@@ -23,7 +29,6 @@ There are a few steps you can take to write a good change note and avoid needing
 - [ISequencedDocumentMessage arg removed from SharedMap and SharedDirectory events](#ISequencedDocumentMessage-arg-removed-from-SharedMap-and-SharedDirectory-events)
 - [Moved `@fluidframework/core-interface#fluidPackage.ts` to `@fluidframework/container-definition#fluidPackage.ts`](#Moved-fluidframeworkcore-interfacefluidPackagets-to-fluidframeworkcontainer-definitionfluidPackagets)
 - [Deprecated `IFluidSerializer` in `IFluidDataStoreRuntime`](#Deprecated-IFluidSerializer-in-IFluidDataStoreRuntime)
-- [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)
 
 ### `IContainer` interface updated to expose actively used `Container` public APIs
 In order to have the `IContainer` interface be the active developer surface that is used when interacting with a `Container` instance, it has been updated to expose the APIs that are necessary for currently used behavior. The motivation here is to move away from using the `Container` class when only its type is required, and to use the `IContainer` interface instead.
@@ -105,9 +110,6 @@ They are deprecated from `@fluidframework/core-interface` and would be removed i
 
 ### Deprecated `IFluidSerializer` in `IFluidDataStoreRuntime`
 `IFluidSerializer` should only be used by DDSs to serialize data and they should use the one created by `SharedObject`.
-
-### Removed `readAndParseFromBlobs` from `driver-utils`
-The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
 
 ## 0.52 Breaking changes
 - [chaincodePackage removed from Container](#chaincodePackage-removed-from-Container)

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -326,11 +326,6 @@ export class RateLimiter {
 // @public
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
 
-// @public @deprecated (undocumented)
-export function readAndParseFromBlobs<T>(blobs: {
-    [index: string]: string;
-}, id: string): T;
-
 // @public (undocumented)
 export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLogger, signal?: AbortSignal, fetchReason?: string): IStream<ISequencedDocumentMessage[]>;
 

--- a/packages/loader/driver-utils/src/readAndParse.ts
+++ b/packages/loader/driver-utils/src/readAndParse.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { bufferToString, fromBase64ToUtf8 } from "@fluidframework/common-utils";
+import { bufferToString } from "@fluidframework/common-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 
 /**
@@ -16,19 +16,5 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 export async function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T> {
     const blob = await storage.readBlob(id);
     const decoded = bufferToString(blob, "utf8");
-    return JSON.parse(decoded) as T;
-}
-
-/**
- * @deprecated - Older Runtime needs to use this api.
- * Read a blob from map, decode it (from "base64") and JSON.parse it into object of type T
- *
- * @param blobs - the blob map to read from
- * @param id - the id of the blob to read and parse
- * @returns the object that we decoded and JSON.parse
- */
- export function readAndParseFromBlobs<T>(blobs: {[index: string]: string}, id: string): T {
-    const encoded = blobs[id];
-    const decoded = fromBase64ToUtf8(encoded);
     return JSON.parse(decoded) as T;
 }


### PR DESCRIPTION
Remove the `readAndParseFromBlobs` function from `packages\loader\driver-utils\src\readAndParse.ts`.

All previous uses of the funciton have been removed in https://github.com/microsoft/FluidFramework/pull/6816. 