### PR TITLE
Update Azure Function token provider to make container ID optional + audience fixes

### DIFF
--- a/api-report/azure-service-utils.api.md
+++ b/api-report/azure-service-utils.api.md
@@ -8,7 +8,7 @@ import { IUser } from '@fluidframework/protocol-definitions';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 
 // @public
-export function generateToken(tenantId: string, documentId: string, key: string, scopes: ScopeType[], user?: IUser, lifetime?: number, ver?: string): string;
+export function generateToken(tenantId: string, key: string, scopes: ScopeType[], documentId?: string, user?: IUser, lifetime?: number, ver?: string): string;
 
 export { ScopeType }
 

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -69,9 +69,9 @@ export interface IMockContainerRuntimePendingMessage {
 export class InsecureTokenProvider implements ITokenProvider {
     constructor(tenantKey: string, user: IUser);
     // (undocumented)
-    fetchOrdererToken(tenantId: string, documentId: string): Promise<ITokenResponse>;
+    fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)
-    fetchStorageToken(tenantId: string, documentId: string): Promise<ITokenResponse>;
+    fetchStorageToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     }
 
 // @public

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -71,7 +71,7 @@ export class InsecureTokenProvider implements ITokenProvider {
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)
-    fetchStorageToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
+    fetchStorageToken(tenantId: string, documentId: string): Promise<ITokenResponse>;
     }
 
 // @public

--- a/docs/content/docs/build/tokenproviders.md
+++ b/docs/content/docs/build/tokenproviders.md
@@ -90,44 +90,56 @@ import { generateToken } from "@fluidframework/azure-service-utils";
 //Replace "myTenantKey" with your key here.
 const key = "myTenantKey";
 
-const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
-    // tenantId, userId and userName are required parameters. documentId is only required for fetching existing containers
-    const tenantId = (req.query.tenantId || (req.body && req.body.tenantId)) as string;
-    const documentId = (req.query.documentId || (req.body && req.body.documentId)) as string;
-    const userId = (req.query.userId || (req.body && req.body.userId)) as string;
-    const userName = (req.query.userName || (req.body && req.body.userName)) as string;
-    const additionalDetails = (req.query.additionalDetails || (req.body && req.body.additionalDetails));
-    const scopes = (req.query.scopes || (req.body && req.body.scopes)) as ScopeType[];
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  // tenantId, userId and userName are required parameters. documentId is only required for fetching existing containers
+  const tenantId = (req.query.tenantId ||
+    (req.body && req.body.tenantId)) as string;
+  const documentId = (req.query.documentId ||
+    (req.body && req.body.documentId)) as string;
+  const userId = (req.query.userId || (req.body && req.body.userId)) as string;
+  const userName = (req.query.userName ||
+    (req.body && req.body.userName)) as string;
+  const additionalDetails =
+    req.query.additionalDetails || (req.body && req.body.additionalDetails);
+  const scopes = (req.query.scopes ||
+    (req.body && req.body.scopes)) as ScopeType[];
 
-    if (!tenantId) {
-        context.res = {
-            status: 400,
-            body: "No tenantId provided in query params",
-        };
-    }
-
-    if (!key) {
-        context.res = {
-            status: 404,
-            body: `No key found for the provided tenantId: ${tenantId}`,
-        };
-    }
-
-    let user = { name: userName, id: userId, additionalDetails: JSON.parse(additionalDetails) };
-
-    // Will generate the token and returned by an ITokenProvider implementation to use with the AzureClient.
-    const token = generateToken(
-        tenantId,
-        documentId,
-        key,
-        scopes ?? [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
-        user
-    );
-
+  if (!tenantId) {
     context.res = {
-        status: 200,
-        body: token
+      status: 400,
+      body: "No tenantId provided in query params",
     };
+  }
+
+  if (!key) {
+    context.res = {
+      status: 404,
+      body: `No key found for the provided tenantId: ${tenantId}`,
+    };
+  }
+
+  let user = {
+    name: userName,
+    id: userId,
+    additionalDetails: additionalDetails ? JSON.parse(additionalDetails) : {},
+  };
+
+  // Will generate the token and returned by an ITokenProvider implementation to use with the AzureClient.
+  const token = generateToken(
+    tenantId,
+    documentId,
+    key,
+    scopes ?? [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+    user
+  );
+
+  context.res = {
+    status: 200,
+    body: token,
+  };
 };
 
 export default httpTrigger;

--- a/docs/content/docs/build/tokenproviders.md
+++ b/docs/content/docs/build/tokenproviders.md
@@ -91,55 +91,55 @@ import { generateToken } from "@fluidframework/azure-service-utils";
 const key = "myTenantKey";
 
 const httpTrigger: AzureFunction = async function (
-  context: Context,
-  req: HttpRequest
+    context: Context,
+    req: HttpRequest
 ): Promise<void> {
-  // tenantId, userId and userName are required parameters. documentId is only required for fetching existing containers
-  const tenantId = (req.query.tenantId ||
-    (req.body && req.body.tenantId)) as string;
-  const documentId = (req.query.documentId ||
-    (req.body && req.body.documentId)) as string;
-  const userId = (req.query.userId || (req.body && req.body.userId)) as string;
-  const userName = (req.query.userName ||
-    (req.body && req.body.userName)) as string;
-  const additionalDetails =
-    req.query.additionalDetails || (req.body && req.body.additionalDetails);
-  const scopes = (req.query.scopes ||
-    (req.body && req.body.scopes)) as ScopeType[];
+    // tenantId, userId and userName are required parameters. documentId is only required for fetching existing containers
+    const tenantId = (req.query.tenantId ||
+        (req.body && req.body.tenantId)) as string;
+    const documentId = (req.query.documentId ||
+        (req.body && req.body.documentId)) as string;
+    const userId = (req.query.userId || (req.body && req.body.userId)) as string;
+    const userName = (req.query.userName ||
+        (req.body && req.body.userName)) as string;
+    const additionalDetails =
+        req.query.additionalDetails || (req.body && req.body.additionalDetails);
+    const scopes = (req.query.scopes ||
+        (req.body && req.body.scopes)) as ScopeType[];
 
-  if (!tenantId) {
-    context.res = {
-      status: 400,
-      body: "No tenantId provided in query params",
+    if (!tenantId) {
+        context.res = {
+            status: 400,
+            body: "No tenantId provided in query params",
+        };
+    }
+
+    if (!key) {
+        context.res = {
+            status: 404,
+            body: `No key found for the provided tenantId: ${tenantId}`,
+        };
+    }
+
+    let user = {
+        name: userName,
+        id: userId,
+        additionalDetails: additionalDetails ? JSON.parse(additionalDetails) : {},
     };
-  }
 
-  if (!key) {
+    // Will generate the token and returned by an ITokenProvider implementation to use with the AzureClient.
+    const token = generateToken(
+        tenantId,
+        documentId,
+        key,
+        scopes ?? [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+        user
+    );
+
     context.res = {
-      status: 404,
-      body: `No key found for the provided tenantId: ${tenantId}`,
+        status: 200,
+        body: token,
     };
-  }
-
-  let user = {
-    name: userName,
-    id: userId,
-    additionalDetails: additionalDetails ? JSON.parse(additionalDetails) : {},
-  };
-
-  // Will generate the token and returned by an ITokenProvider implementation to use with the AzureClient.
-  const token = generateToken(
-    tenantId,
-    documentId,
-    key,
-    scopes ?? [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
-    user
-  );
-
-  context.res = {
-    status: 200,
-    body: token,
-  };
 };
 
 export default httpTrigger;

--- a/docs/content/docs/build/tokenproviders.md
+++ b/docs/content/docs/build/tokenproviders.md
@@ -91,11 +91,12 @@ import { generateToken } from "@fluidframework/azure-service-utils";
 const key = "myTenantKey";
 
 const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
-    // tenantId, documentId, userId and userName are required parameters
+    // tenantId, userId and userName are required parameters. documentId is only required for fetching existing containers
     const tenantId = (req.query.tenantId || (req.body && req.body.tenantId)) as string;
     const documentId = (req.query.documentId || (req.body && req.body.documentId)) as string;
     const userId = (req.query.userId || (req.body && req.body.userId)) as string;
     const userName = (req.query.userName || (req.body && req.body.userName)) as string;
+    const additionalDetails = (req.query.additionalDetails || (req.body && req.body.additionalDetails));
     const scopes = (req.query.scopes || (req.body && req.body.scopes)) as ScopeType[];
 
     if (!tenantId) {
@@ -112,14 +113,7 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
         };
     }
 
-    if (!documentId) {
-        context.res = {
-            status: 400,
-            body: "No documentId provided in query params"
-        };
-    }
-
-    let user = { name: userName, id: userId };
+    let user = { name: userName, id: userId, additionalDetails: JSON.parse(additionalDetails) };
 
     // Will generate the token and returned by an ITokenProvider implementation to use with the AzureClient.
     const token = generateToken(

--- a/docs/content/docs/recipes/teams.md
+++ b/docs/content/docs/recipes/teams.md
@@ -267,7 +267,7 @@ Now follow the [instructions to upload the application to a Teams Tab](https://d
 
 {{< callout warning >}}
 
-Hostnames with `ngrok`'s free tunnels are not preserved. Each run will generate a different URL. This means that anytime a new `ngrok` tunnel is created, the older container will no longer be accessible. For production scenarios, please visit [the section below](#using-azureClient-with-azure-fluid-relay)
+Hostnames with `ngrok`'s free tunnels are not preserved. Each run will generate a different URL. This means that anytime a new `ngrok` tunnel is created, the older container will no longer be accessible. For production scenarios, please visit [the section below](#using-azureclient-with-azure-fluid-relay)
 
 {{< /callout >}}
 

--- a/packages/framework/azure-client/src/AzureFunctionTokenProvider.ts
+++ b/packages/framework/azure-client/src/AzureFunctionTokenProvider.ts
@@ -34,7 +34,7 @@ export class AzureFunctionTokenProvider implements ITokenProvider {
         };
     }
 
-    private async getToken(tenantId: string, documentId: string | undefined): Promise<string> {
+    private async getToken(tenantId: string, documentId?: string): Promise<string> {
         const response = await axios.get(this.azFunctionUrl, {
             params: {
                 tenantId,

--- a/packages/framework/azure-service-utils/src/generateToken.ts
+++ b/packages/framework/azure-service-utils/src/generateToken.ts
@@ -16,9 +16,9 @@ import { v4 as uuid } from "uuid";
  */
 export function generateToken(
     tenantId: string,
-    documentId: string,
     key: string,
     scopes: ScopeType[],
+    documentId?: string,
     user?: IUser,
     lifetime: number = 60 * 60,
     ver: string = "1.0"): string {

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -57,6 +57,8 @@ export abstract class ServiceAudience<M extends IMember = IMember>
         this.emit("membersChanged");
       }
     });
+
+    this.container.on("connected", () => this.emit("membersChanged"));
   }
 
   protected abstract createServiceMember(audienceMember: IClient): M;

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -19,35 +19,35 @@ export class InsecureTokenProvider implements ITokenProvider {
 
     }
 
-    public async fetchOrdererToken(tenantId: string, documentId: string): Promise<ITokenResponse> {
+    public async fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
         return {
             fromCache: true,
             jwt:  generateToken(
                 tenantId,
-                documentId,
                 this.tenantKey,
                 [
                     ScopeType.DocRead,
                     ScopeType.DocWrite,
                     ScopeType.SummaryWrite,
                 ],
+                documentId,
                 this.user,
             ),
         };
     }
 
-    public async fetchStorageToken(tenantId: string, documentId: string): Promise<ITokenResponse> {
+    public async fetchStorageToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
         return {
             fromCache: true,
             jwt: generateToken(
                 tenantId,
-                documentId,
                 this.tenantKey,
                 [
                     ScopeType.DocRead,
                     ScopeType.DocWrite,
                     ScopeType.SummaryWrite,
                 ],
+                documentId,
                 this.user,
             ),
         };

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -36,7 +36,7 @@ export class InsecureTokenProvider implements ITokenProvider {
         };
     }
 
-    public async fetchStorageToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
+    public async fetchStorageToken(tenantId: string, documentId: string): Promise<ITokenResponse> {
         return {
             fromCache: true,
             jwt: generateToken(


### PR DESCRIPTION
This PR aims to update our Azure Function sample code to make the container ID optional. This is required as, during the container creation process, FRS no longer allows for the client to specify container ID. It is instead ordained by the service. Subsequent calls to fetch the container however will need a token generated with the container ID. Fixes #8326 

Changes in this PR:
- Update Azure Function sample code with optional container ID
- Update the `AzureFunctionTokenProvider` and `InsecureTokenProvider` to match `ITokenProvider` interface and make container ID optional for `generateToken`
- Add support for `additionalDetails` parsing in the Azure Function sample code. This was missing before and is required for sending additional audience data
- Add a listener for the `audience` to emit `membersChanged` when the container connects as `getSelf` will return undefined until a client ID is set when connection is established