### PR TITLE
[Phase 1.5 of 3 `IContainer` Updates] Add all non-casting required changes to use `IContainer` in repo

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -213,7 +213,7 @@ export class RelativeLoader implements ILoader {
 }
 
 // @public
-export function waitContainerToCatchUp(container: Container): Promise<boolean>;
+export function waitContainerToCatchUp(container: IContainer): Promise<boolean>;
 
 
 // (No @packageDocumentation comment for this package)

--- a/api-report/fluid-static.api.md
+++ b/api-report/fluid-static.api.md
@@ -6,11 +6,11 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { BaseContainerRuntimeFactory } from '@fluidframework/aqueduct';
-import { Container } from '@fluidframework/container-loader';
 import { DataObject } from '@fluidframework/aqueduct';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IClient } from '@fluidframework/protocol-definitions';
+import { IContainer } from '@fluidframework/container-definitions';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
@@ -38,7 +38,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 
 // @public
 export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> implements IFluidContainer {
-    constructor(container: Container, rootDataObject: RootDataObject);
+    constructor(container: IContainer, rootDataObject: RootDataObject);
     attach(): Promise<string>;
     get attachState(): AttachState;
     get connected(): boolean;
@@ -127,11 +127,11 @@ export interface RootDataObjectProps {
 
 // @public
 export abstract class ServiceAudience<M extends IMember = IMember> extends TypedEventEmitter<IServiceAudienceEvents<M>> implements IServiceAudience<M> {
-    constructor(container: Container);
+    constructor(container: IContainer);
     // (undocumented)
     protected readonly audience: IAudience;
     // (undocumented)
-    protected readonly container: Container;
+    protected readonly container: IContainer;
     // (undocumented)
     protected abstract createServiceMember(audienceMember: IClient): M;
     getMembers(): Map<string, M>;

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.54.0",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-utils": "^0.54.0",

--- a/examples/hosts/hosts-sample/src/app.ts
+++ b/examples/hosts/hosts-sample/src/app.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import {
     IUser,
 } from "@fluidframework/protocol-definitions";
@@ -79,7 +80,7 @@ async function start() {
 
     // Request URL associated with the document.
     let url: string;
-    let container: Container;
+    let container: IContainer;
 
     // when the document ID is not provided, create a new one.
     const shouldCreateNew = location.hash.length === 0;
@@ -107,7 +108,8 @@ async function start() {
     }
 
     // Wait for connection so that proposals can be sent.
-    if (container !== undefined && !container.connected) {
+    // TODO: Remove null check after next release
+    if (container !== undefined && container.connected !== undefined && !container.connected) {
         await new Promise<void>((resolve, reject) => {
             // the promise resolves when the connected event fires.
             container.once("connected", () => resolve());

--- a/examples/hosts/hosts-sample/src/app.ts
+++ b/examples/hosts/hosts-sample/src/app.ts
@@ -108,7 +108,7 @@ async function start() {
     }
 
     // Wait for connection so that proposals can be sent.
-    // TODO: Remove null check after next release
+    // TODO: Remove null check after next release #8523
     if (container !== undefined && container.connected !== undefined && !container.connected) {
         await new Promise<void>((resolve, reject) => {
             // the promise resolves when the connected event fires.

--- a/examples/hosts/hosts-sample/src/codeDetailsView.ts
+++ b/examples/hosts/hosts-sample/src/codeDetailsView.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
-import { Container } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
 import { getCodeDetailsFromQuorum, parsePackageDetails } from "./utils";
 
 /**
@@ -11,7 +11,7 @@ import { getCodeDetailsFromQuorum, parsePackageDetails } from "./utils";
  *
  * @param container - Loaded Fluid container
  */
-export const setupUI = (container: Container) => {
+export const setupUI = (container: IContainer) => {
     // Observe container events to detect when it gets forcefully closed.
     container.once("closed", (error) => {
         if (

--- a/examples/hosts/hosts-sample/src/utils.ts
+++ b/examples/hosts/hosts-sample/src/utils.ts
@@ -4,7 +4,8 @@
  */
 
 import { IFluidCodeDetails, FluidObject, IFluidPackage } from "@fluidframework/core-interfaces";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import { extractPackageIdentifierDetails } from "@fluidframework/web-code-loader";
 
@@ -32,7 +33,7 @@ async function getFluidObjectAndRenderCore(loader: Loader, url: string, div: HTM
  * on the document it listens for the "contextChanged" event which fires when a new code value is quorumed on. In this
  * case it simply runs the attach method again.
  */
-export async function getFluidObjectAndRender(loader: Loader, container: Container, url: string, div: HTMLDivElement) {
+export async function getFluidObjectAndRender(loader: Loader, container: IContainer, url: string, div: HTMLDivElement) {
     container.on("contextChanged", (codeDetails) => {
         console.log("Context changed", codeDetails);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -53,7 +54,7 @@ export function parsePackageDetails(pkg: string | Readonly<IFluidPackage>) {
 }
 
 /** Retrieve the code proposal value from the container's quorum */
-export function getCodeDetailsFromQuorum(container: Container): IFluidCodeDetails {
+export function getCodeDetailsFromQuorum(container: IContainer): IFluidCodeDetails {
     const pkg = container.getQuorum().get("code");
     return pkg as IFluidCodeDetails;
 }

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -11,8 +11,9 @@ import {
     IRuntime,
     IProxyLoaderFactory,
     ILoaderOptions,
+    IContainer,
 } from "@fluidframework/container-definitions";
-import { Loader, Container } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { IRequest, IResponse, FluidObject } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
 import {
@@ -159,7 +160,7 @@ export class IFrameOuterHost {
      * provides only limited functionality.
      * @param request - The request to resolve on the internal loader
      */
-    public async loadContainer(request: IRequest): Promise<Container> {
+    public async loadContainer(request: IRequest): Promise<IContainer> {
         return this.loader.resolve(request);
     }
 }

--- a/examples/hosts/iframe-host/src/inner.ts
+++ b/examples/hosts/iframe-host/src/inner.ts
@@ -5,7 +5,9 @@
 
 import * as Comlink from "comlink";
 import { fluidExport as TodoContainer } from "@fluid-example/todo";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
+import { IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { FluidObject, IRequest } from "@fluidframework/core-interfaces";
 import {
     InnerDocumentServiceFactory,
@@ -15,9 +17,9 @@ import { HTMLViewAdapter } from "@fluidframework/view-adapters";
 import { IFrameInnerApi } from "./inframehost";
 
 let innerPort: MessagePort;
-const containers: Map<string, Container> = new Map();
+const containers: Map<string, IContainer> = new Map();
 
-async function getFluidObjectAndRender(container: Container, div: HTMLDivElement) {
+async function getFluidObjectAndRender(container: IContainer, div: HTMLDivElement) {
     const response = await container.request({ url: "/" });
     if (response.status !== 200 || response.mimeType !== "fluid/object") {
         return undefined;
@@ -31,7 +33,7 @@ async function getFluidObjectAndRender(container: Container, div: HTMLDivElement
 
 async function loadFluidObject(
     divId: string,
-    container: Container,
+    container: IContainer,
 ) {
     const componentDiv = document.getElementById(divId) as HTMLDivElement;
     await getFluidObjectAndRender(container, componentDiv).catch(() => { });
@@ -58,12 +60,12 @@ async function loadContainer(
         codeLoader,
     });
 
-    let container: Container;
+    let container: IContainer;
 
     // TODO: drive new/existing creation entirely from outer
     if (createNew) {
         // We're not actually using the code proposal (our code loader always loads the same module regardless of the
-        // proposal), but the Container will only give us a NullRuntime if there's no proposal.  So we'll use a fake
+        // proposal), but the IContainer will only give us a NullRuntime if there's no proposal.  So we'll use a fake
         // proposal.
         container = await loader.createDetachedContainer({ package: "no-dynamic-package", config: {} });
         // Caller is responsible for attaching the created container
@@ -73,9 +75,10 @@ async function loadContainer(
     }
 
     await loadFluidObject(divId, container);
-    containers.set(container.id, container);
+    const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+    containers.set(containerId, container);
 
-    return container.id;
+    return containerId;
 }
 
 async function attachContainer(

--- a/experimental/framework/get-container/src/getFluidRelayContainer.ts
+++ b/experimental/framework/get-container/src/getFluidRelayContainer.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import { IRuntimeFactory } from "@fluidframework/container-definitions";
-import { Container } from "@fluidframework/container-loader";
+import { IContainer, IRuntimeFactory } from "@fluidframework/container-definitions";
 import { DriverHeader } from "@fluidframework/driver-definitions";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { InsecureTinyliciousTokenProvider, InsecureTinyliciousUrlResolver } from "@fluidframework/tinylicious-driver";
@@ -31,14 +30,14 @@ export async function getFluidRelayContainer(
     documentId: string,
     containerRuntimeFactory: IRuntimeFactory,
     createNew: boolean,
-): Promise<[Container, string]> {
+): Promise<[IContainer, string]> {
     verifyEnvConfig();
 
     const tokenProvider = new InsecureTinyliciousTokenProvider();
     const documentServiceFactory = new RouterliciousDocumentServiceFactory(tokenProvider);
     const urlResolver = new InsecureTinyliciousUrlResolver();
 
-    let container: Container;
+    let container: IContainer;
     if (createNew) {
         container = await createContainer({
             documentServiceFactory,

--- a/experimental/framework/get-container/src/getSessionStorageContainer.ts
+++ b/experimental/framework/get-container/src/getSessionStorageContainer.ts
@@ -4,9 +4,10 @@
  */
 
 import {
+    IContainer,
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { LocalResolver, LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
 
@@ -24,7 +25,7 @@ export async function getSessionStorageContainer(
     documentId: string,
     containerRuntimeFactory: IRuntimeFactory,
     createNew: boolean,
-): Promise<Container> {
+): Promise<IContainer> {
     let deltaConnection = deltaConnectionMap.get(documentId);
     if (deltaConnection === undefined) {
         deltaConnection = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory(documentId));
@@ -45,11 +46,11 @@ export async function getSessionStorageContainer(
         codeLoader,
     });
 
-    let container: Container;
+    let container: IContainer;
 
     if (createNew) {
         // We're not actually using the code proposal (our code loader always loads the same module regardless of the
-        // proposal), but the Container will only give us a NullRuntime if there's no proposal.  So we'll use a fake
+        // proposal), but the IContainer will only give us a NullRuntime if there's no proposal.  So we'll use a fake
         // proposal.
         container = await loader.createDetachedContainer({ package: "", config: {} });
         await container.attach({ url });

--- a/experimental/framework/get-container/src/getTinyliciousContainer.ts
+++ b/experimental/framework/get-container/src/getTinyliciousContainer.ts
@@ -6,7 +6,6 @@ import {
     IContainer,
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
-import { Container } from "@fluidframework/container-loader";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import {
@@ -34,7 +33,7 @@ export async function getTinyliciousContainer(
     const tokenProvider = new InsecureTinyliciousTokenProvider();
     const urlResolver = new InsecureTinyliciousUrlResolver(tinyliciousPort);
     const documentServiceFactory = new RouterliciousDocumentServiceFactory(tokenProvider);
-    let container: Container;
+    let container: IContainer;
     if (createNew) {
         container = await createContainer({
             documentServiceFactory,

--- a/packages/framework/azure-client/src/AzureClient.ts
+++ b/packages/framework/azure-client/src/AzureClient.ts
@@ -2,12 +2,12 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import {
     IDocumentServiceFactory,
     IUrlResolver,
 } from "@fluidframework/driver-definitions";
-import { AttachState } from "@fluidframework/container-definitions";
+import { AttachState, IContainer } from "@fluidframework/container-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
@@ -128,7 +128,7 @@ export class AzureClient {
         return { container: fluidContainer, services };
     }
 
-    private getContainerServices(container: Container): AzureContainerServices {
+    private getContainerServices(container: IContainer): AzureContainerServices {
         return {
             audience: new AzureAudience(container),
         };

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { Container } from "@fluidframework/container-loader";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
-import { AttachState } from "@fluidframework/container-definitions";
+import { AttachState, IContainer } from "@fluidframework/container-definitions";
 import { LoadableObjectClass, LoadableObjectRecord } from "./types";
 import { RootDataObject } from "./rootDataObject";
 
@@ -143,7 +142,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
     private readonly dirtyHandler = () => this.emit("dirty");
 
     public constructor(
-        private readonly container: Container,
+        private readonly container: IContainer,
         private readonly rootDataObject: RootDataObject,
     ) {
         super();
@@ -179,7 +178,9 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
      * {@inheritDoc IFluidContainer.connected}
      */
     public get connected() {
-        return this.container.connected;
+        // TODO: Remove null check after next release #8523
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.container.connected!;
     }
 
     /**

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -4,8 +4,7 @@
  */
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { IAudience } from "@fluidframework/container-definitions";
-import { Container } from "@fluidframework/container-loader";
+import { IAudience, IContainer } from "@fluidframework/container-definitions";
 import { IClient } from "@fluidframework/protocol-definitions";
 import { IServiceAudience, IServiceAudienceEvents, IMember } from "./types";
 
@@ -34,10 +33,12 @@ export abstract class ServiceAudience<M extends IMember = IMember>
   protected lastMembers: Map<string, M> = new Map();
 
   constructor(
-      protected readonly container: Container,
+      protected readonly container: IContainer,
   ) {
     super();
-    this.audience = container.audience;
+    // TODO: Remove null check after next release #8523
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.audience = container.audience!;
 
     // getMembers will assign lastMembers so the removeMember event has what it needs
     // in case it would fire before getMembers otherwise gets called the first time

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -2,12 +2,12 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import {
     IDocumentServiceFactory,
     IUrlResolver,
 } from "@fluidframework/driver-definitions";
-import { AttachState } from "@fluidframework/container-definitions";
+import { AttachState, IContainer } from "@fluidframework/container-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import {
     createTinyliciousCreateNewRequest,
@@ -108,7 +108,7 @@ export class TinyliciousClient {
 
     // #region private
     private getContainerServices(
-        container: Container,
+        container: IContainer,
     ): TinyliciousContainerServices {
         return {
             audience: new TinyliciousAudience(container),

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -171,7 +171,7 @@ export enum ConnectionState {
  *          false: storage does not provide indication of how far the client is. Container processed
  *          all the ops known to it, but it maybe still behind.
  */
-export async function waitContainerToCatchUp(container: Container) {
+export async function waitContainerToCatchUp(container: IContainer) {
     // Make sure we stop waiting if container is closed.
     if (container.closed) {
         throw new Error("Container is closed");
@@ -218,7 +218,9 @@ export async function waitContainerToCatchUp(container: Container) {
         };
         container.on(connectedEventName, callback);
 
-        container.resume();
+        // TODO: Remove null check after next release #8523
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        container.resume!();
     });
 }
 

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -14,8 +14,9 @@ import {
     IResolvedFluidCodeDetails,
     isFluidBrowserPackage,
     IProvideRuntimeFactory,
+    IContainer,
 } from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { prefetchLatestSnapshot } from "@fluidframework/odsp-driver";
 import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { IUser } from "@fluidframework/protocol-definitions";
@@ -199,7 +200,7 @@ async function createWebLoader(
     });
 }
 
-const containers: Container[] = [];
+const containers: IContainer[] = [];
 // A function for testing to make sure the containers are not dirty and in sync (at the same seq num)
 export function isSynchronized() {
     if (containers.length === 0) { return true; }
@@ -248,7 +249,7 @@ export async function start(
         testOrderer,
         odspPersistantCache);
 
-    let container1: Container;
+    let container1: IContainer;
     if (autoAttach || manualAttach) {
         // For new documents, create a detached container which will be attached later.
         container1 = await loader1.createDetachedContainer(codeDetails);
@@ -331,7 +332,7 @@ export async function start(
     }
 }
 
-async function getFluidObjectAndRender(container: Container, url: string, div: HTMLDivElement) {
+async function getFluidObjectAndRender(container: IContainer, url: string, div: HTMLDivElement) {
     const response = await container.request({
         headers: {
             mountableView: true,
@@ -375,7 +376,7 @@ async function getFluidObjectAndRender(container: Container, url: string, div: H
  */
 async function attachContainer(
     loader: Loader,
-    container: Container,
+    container: IContainer,
     fluidObjectUrl: string,
     urlResolver: MultiUrlResolver,
     documentId: string,


### PR DESCRIPTION
This PR contains a portion of the changes from #8448

It has all of the updates required to use `IContainer` as the returned value from `Loader` that do not require any casting to `Container`. There is a counterpart PR #8525 to this that will include all the places where additional casting back to `Container` is required, largely for our internal tests.