### PR TITLE
[Phase 1.5 of 3 `IContainer` Updates] Add all casting required changes to use `IContainer` in repo

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { Container } from '@fluidframework/container-loader';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
@@ -252,10 +251,10 @@ export class TestObjectProvider {
     // (undocumented)
     ensureSynchronized(): Promise<void>;
     // (undocumented)
-    loadContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions, requestHeader?: IRequestHeader): Promise<Container>;
+    loadContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)
     readonly LoaderConstructor: typeof Loader;
-    loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<Container>;
+    loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>;
     // (undocumented)
     get logger(): ITelemetryBaseLogger;
     makeTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>;

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -56,6 +56,7 @@
     "@fluid-internal/replay-tool": "^0.54.0",
     "@fluidframework/cell": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
+    "@fluidframework/container-definitions": "^0.43.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/counter": "^0.54.0",

--- a/packages/test/snapshots/src/validateSnapshots.ts
+++ b/packages/test/snapshots/src/validateSnapshots.ts
@@ -5,6 +5,7 @@
 
 import fs from "fs";
 import { assert } from "@fluidframework/common-utils";
+import { IContainer } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
 import { FileStorageDocumentName } from "@fluidframework/file-driver";
 import { ISequencedDocumentMessage, TreeEntry } from "@fluidframework/protocol-definitions";
@@ -63,7 +64,7 @@ export async function validateSnapshots(
         const snapshotFileName = file.name.split(".")[0];
         const srcContent = fs.readFileSync(`${srcDir}/${file.name}`, "utf-8");
         // eslint-disable-next-line prefer-const
-        let container: Container;
+        let container: IContainer;
         // This function will be called by the storage service when the container is snapshotted. When that happens,
         // validate that snapshot with the destination snapshot.
         const onSnapshotCb =
@@ -78,7 +79,7 @@ export async function validateSnapshots(
             new StaticStorageDocumentServiceFactory(storage),
             FileStorageDocumentName,
         );
-        await container.snapshot(file.name, true /* fullTree */);
+        await (container as Container).snapshot(file.name, true /* fullTree */);
     }
 
     if (errors.length !== 0) {

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import { compare } from "semver";
 import { bufferToString } from "@fluidframework/common-utils";
+import { IContainer } from "@fluidframework/container-definitions";
 import { Container, Loader } from "@fluidframework/container-loader";
 import {
     LocalCodeLoader,
@@ -96,7 +97,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
     const loaderContainerTracker = new LoaderContainerTracker();
 
     async function createDetachedContainerAndGetRootDataStore() {
-        const container = await loader.createDetachedContainer(codeDetails);
+        const container: IContainer = await loader.createDetachedContainer(codeDetails);
         // Get the root dataStore from the detached container.
         const response = await container.request({ url: "/" });
         const defaultDataStore = response.value as TestFluidObject;
@@ -145,7 +146,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
     };
 
     const getSnapshotTreeFromSerializedSnapshot = (
-        container: Container,
+        container: IContainer,
     ) => {
         return getSnapshotTreeFromSerializedContainer(JSON.parse(container.serialize()));
     };
@@ -359,7 +360,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
                 await createDetachedContainerAndGetRootDataStore();
 
             const snapshotTree = container.serialize();
-            assert(container.storage !== undefined, "Storage should be present in detached container");
+            assert((container as Container).storage !== undefined, "Storage should be present in detached container");
             const response = await container.request({ url: "/" });
             const defaultDataStore = response.value as TestFluidObject;
             assert(defaultDataStore.context.storage !== undefined,
@@ -368,8 +369,11 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             await defaultDataStore.context.storage.getSnapshotTree(undefined).catch((err) => success1 = false);
             assert(success1 === false, "Snapshot fetch should not be allowed in detached data store");
 
-            const container2 = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
-            assert(container2.storage !== undefined, "Storage should be present in rehydrated container");
+            const container2: IContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
+            assert(
+                (container2 as Container).storage !== undefined,
+                "Storage should be present in rehydrated container",
+            );
             const response2 = await container2.request({ url: "/" });
             const defaultDataStore2 = response2.value as TestFluidObject;
             assert(defaultDataStore2.context.storage !== undefined,

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "assert";
 import { IRequest } from "@fluidframework/core-interfaces";
-import { AttachState } from "@fluidframework/container-definitions";
-import { ConnectionState, Loader } from "@fluidframework/container-loader";
+import { AttachState, IContainer } from "@fluidframework/container-definitions";
+import { ConnectionState, Container, Loader } from "@fluidframework/container-loader";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import {
     ITestContainerConfig,
@@ -32,7 +32,7 @@ import { DataStoreMessageType } from "@fluidframework/datastore";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeFullCompat, describeNoCompat } from "@fluidframework/test-version-utils";
-import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -84,7 +84,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
     });
 
     it("Create detached container", async () => {
-        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        const container: IContainer = (await loader.createDetachedContainer(provider.defaultCodeDetails));
         assert.strictEqual(container.attachState, AttachState.Detached, "Container should be detached");
         assert.strictEqual(container.closed, false, "Container should be open");
         assert.strictEqual(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
@@ -101,8 +101,12 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
             assert.strictEqual(container.getLoadedCodeDetails()?.package, provider.defaultCodeDetails.package,
             "Loaded package should be same as provided");
         }
-        assert.strictEqual(container.id, "", "Detached container's id should be empty string");
-        assert.strictEqual(container.clientDetails.capabilities.interactive, true,
+        assert.strictEqual(
+            (container.resolvedUrl as IFluidResolvedUrl).id,
+            "",
+            "Detached container's id should be empty string",
+        );
+        assert.strictEqual((container as Container).clientDetails.capabilities.interactive, true,
             "Client details should be set with interactive as true");
     });
 
@@ -112,9 +116,10 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(container.attachState, AttachState.Attached, "Container should be attached");
         assert.strictEqual(container.closed, false, "Container should be open");
         assert.strictEqual(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
-        assert.ok(container.id, "No container ID");
+        const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+        assert.ok(container, "No container ID");
         if (provider.driver.type === "local") {
-            assert.strictEqual(container.id, provider.documentId, "Doc id is not matching!!");
+            assert.strictEqual(containerId, provider.documentId, "Doc id is not matching!!");
         }
     });
 
@@ -598,9 +603,10 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(container.attachState, AttachState.Attached, "Container should be attached");
         assert.strictEqual(container.closed, false, "Container should be open");
         assert.strictEqual(container.deltaManager.inbound.length, 0, "Inbound queue should be empty");
-        assert.ok(container.id, "No container ID");
+        const containerId = (container.resolvedUrl as IFluidResolvedUrl).id;
+        assert.ok(containerId, "No container ID");
         if (provider.driver.type === "local") {
-            assert.strictEqual(container.id, provider.documentId, "Doc id is not matching!!");
+            assert.strictEqual(containerId, provider.documentId, "Doc id is not matching!!");
         }
         assert.strictEqual(retryTimes, 0, "Should not succeed at first time");
     }).timeout(5000);

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -102,7 +102,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
             "Loaded package should be same as provided");
         }
         assert.strictEqual(
-            (container.resolvedUrl as IFluidResolvedUrl).id,
+            (container as Container).id,
             "",
             "Detached container's id should be empty string",
         );

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -5,13 +5,13 @@
 
 import commander from "commander";
 import { ITestDriver, TestDriverTypes } from "@fluidframework/test-driver-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import random from "random-js";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { IRequestHeader } from "@fluidframework/core-interfaces";
-import { LoaderHeader } from "@fluidframework/container-definitions";
-import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { IDocumentServiceFactory, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { ILoadTest, IRunConfig } from "./loadTestDataStore";
 import { createCodeLoader, createTestDriver, getProfile, loggerP, safeExit } from "./utils";
@@ -175,8 +175,10 @@ async function runnerProcess(
                 options: loaderOptions[runConfig.runId % containerOptions.length],
             });
 
-            const container = await loader.resolve({ url, headers });
-            container.resume();
+            const container: IContainer = await loader.resolve({ url, headers });
+            // TODO: Remove null check after next release #8523
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            container.resume!();
             const test = await requestFluidObject<ILoadTest>(container, "/");
 
             // Control fault injection period through config.
@@ -221,7 +223,7 @@ async function runnerProcess(
 
 function scheduleFaultInjection(
     ds: FaultInjectionDocumentServiceFactory,
-    container: Container,
+    container: IContainer,
     runConfig: IRunConfig,
     faultInjectionMinMs: number,
     faultInjectionMaxMs: number) {
@@ -229,7 +231,8 @@ function scheduleFaultInjection(
         const injectionTime = random.integer(faultInjectionMinMs, faultInjectionMaxMs)(runConfig.randEng);
         printStatus(runConfig, `fault injection in ${(injectionTime / 60000).toString().substring(0, 4)} min`);
         setTimeout(() => {
-            if (container.connected && container.resolvedUrl !== undefined) {
+            // TODO: Remove null check after next release #8523
+            if (container.connected !== undefined && container.connected && container.resolvedUrl !== undefined) {
                 const deltaConn =
                     ds.documentServices.get(container.resolvedUrl)?.documentDeltaConnection;
                 if (deltaConn !== undefined) {
@@ -252,7 +255,7 @@ function scheduleFaultInjection(
                         case 3:
                         case 4:
                         default: {
-                            deltaConn.injectNack(container.id, canRetry);
+                            deltaConn.injectNack((container.resolvedUrl as IFluidResolvedUrl).id, canRetry);
                             printStatus(runConfig, `nack injected canRetry:${canRetry}`);
                             break;
                         }
@@ -268,17 +271,18 @@ function scheduleFaultInjection(
 }
 
 function scheduleContainerClose(
-    container: Container,
+    container: IContainer,
     runConfig: IRunConfig,
     faultInjectionMinMs: number,
     faultInjectionMaxMs: number) {
     new Promise<void>((res) => {
         // wait for the container to connect write
-        container.once("closed", res);
-        if (!container.connected && !container.closed) {
+        container.once("closed", () => res);
+        // TODO: Remove null check after next release #8523
+        if (container.connected !== undefined && !container.connected && !container.closed) {
             container.once("connected", () => {
                 res();
-                container.off("closed", res);
+                container.off("closed", () => res);
             });
         }
     }).then(() => {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -8,7 +8,8 @@ import fs from "fs";
 import random from "random-js";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { assert, LazyPromise } from "@fluidframework/common-utils";
-import { IDetachedBlobStorage, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Container, IDetachedBlobStorage, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IFluidCodeDetails } from "@fluidframework/core-interfaces";
 import { ICreateBlobResponse } from "@fluidframework/protocol-definitions";
@@ -137,8 +138,8 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
         detachedBlobStorage: new MockDetachedBlobStorage(),
     });
 
-    const container = await loader.createDetachedContainer(codeDetails);
-    container.on("error", (error) => {
+    const container: IContainer = await loader.createDetachedContainer(codeDetails);
+    (container as Container).on("error", (error) => {
         console.log(error);
         process.exit(-1);
     });

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -5,7 +5,7 @@
 
 import { IContainer, IHostLoader, ILoaderOptions } from "@fluidframework/container-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
-import { Container, IDetachedBlobStorage, Loader, waitContainerToCatchUp } from "@fluidframework/container-loader";
+import { IDetachedBlobStorage, Loader, waitContainerToCatchUp } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IFluidCodeDetails, IRequestHeader } from "@fluidframework/core-interfaces";
 import { IDocumentServiceFactory, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
@@ -285,10 +285,10 @@ export class TestObjectProvider {
 
     /**
      * Load a container using a default document id and code details.
-     * Container loaded is automatically added to the OpProcessingController to manage op flow
+     * IContainer loaded is automatically added to the OpProcessingController to manage op flow
      * @param testContainerConfig - optional configuring the test Container
      */
-    public async loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<Container> {
+    public async loadTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer> {
         const loader = this.makeTestLoader(testContainerConfig);
         const container = await loader.resolve({ url: await this.driver.createContainerUrl(this.documentId) });
         await waitContainerToCatchUp(container);

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -247,7 +247,7 @@ export class TestObjectProvider {
     }
 
     public async loadContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions,
-        requestHeader?: IRequestHeader) {
+        requestHeader?: IRequestHeader): Promise<IContainer> {
         const loader = this.createLoader([[defaultCodeDetails, entryPoint]], options);
         return loader.resolve({ url: await this.driver.createContainerUrl(this.documentId), headers: requestHeader });
     }

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -8,6 +8,7 @@ import child_process from "child_process";
 import fs from "fs";
 import { assert, Lazy } from "@fluidframework/common-utils";
 import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { IContainer } from "@fluidframework/container-definitions";
 import { Container } from "@fluidframework/container-loader";
 import { ChildLogger, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import {
@@ -140,7 +141,7 @@ class Logger implements ITelemetryBaseLogger {
  * Helper class holding container and providing load / snapshot capabilities
  */
 class Document {
-    private container: Container;
+    private container: IContainer;
     private replayer: Replayer;
     private documentSeqNumber = 0;
     private from = -1;
@@ -230,7 +231,7 @@ class Document {
     }
 
     public async snapshot() {
-        return this.container.snapshot(
+        return (this.container as Container).snapshot(
             `ReplayTool Snapshot: op ${this.currentOp}, ${this.getFileName()}`,
             !this.args.incremental /* generateFullTreeNoOtimizations */);
     }


### PR DESCRIPTION
This PR contains a portion of the changes from #8448

It has all of the updates required to use `IContainer` as the returned value from Loader that require casting back to `Container`. These are largely in our internal tests and require APIs such as `snapshot`, `storage`, `id`, and `on("error")` that we don't want to be directly exposed for external developers on `IContainer` itself.

This change, in combination with #8524, should set us up for a clean transition to the final PR in this phase where we have `Loader` return an `IContainer` without any compile-time breaks.