### PR TITLE
r11s: fix internal request error logs

### DIFF
--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -128,7 +128,7 @@ export class BasicRestWrapper extends RestWrapper {
                 .catch((error: AxiosError) => {
                     if (error && error.config) {
                         // eslint-disable-next-line max-len
-                        debug(`[${error.config.method}] request to [${error.config.url}] failed with [${error.code}] [${error.message}]`);
+                        debug(`[${error.config.method}] request to [${error.config.baseURL ?? ""}${error.config.url ?? ""}] failed with [${error.response?.status}] [${error.response?.data}]`);
                     } else {
                         debug(`request to ${options.url} failed ${error ? error.message : ""}`);
                     }


### PR DESCRIPTION
Currently, most internal request errors are logged with incomplete information. For example, an internal request from Alfred to Historian that fails with a `401 "Expired Token"` would be logged like

```
fluid:services-client [post] request to [/git/summaries/<document-id>?token=<base64-tenant-id>] failed with [undefined] [Request failed with status code 401]
```

This PR will fix that error log to instead be

```
fluid:services-client [post] request to [http://historian:3000/repos/<tenant-id>/git/summaries/<document-id>?token=<base64-tenant-id>] failed with [401] [Expired Token]
```