### PR TITLE
Update broken types for `runtime-definitions`

### DIFF
--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -83,6 +83,17 @@
         "InterfaceDeclaration_IFluidDataStoreRuntime": {
           "backCompat": false
         }
+      },
+      "0.52.0": {
+        "InterfaceDeclaration_IContainerRuntimeBase": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContext": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContextDetached": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.52.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.52.0.ts
@@ -223,6 +223,7 @@ declare function get_current_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_old_InterfaceDeclaration_IContainerRuntimeBase(
     use: old.IContainerRuntimeBase);
 use_old_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -319,6 +320,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContext(
     use: old.IFluidDataStoreContext);
 use_old_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -343,6 +345,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContextDetached
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: old.IFluidDataStoreContextDetached);
 use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*


### PR DESCRIPTION
Updated broken types for `runtime-definitions` to prevent build errors

Closes https://github.com/microsoft/FluidFramework/issues/8532