### PR TITLE
Added tests for detecting references between summaries

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -148,9 +148,9 @@ class UnreferencedStateTracker {
         if (this.inactive && !this.inactiveEventsLogged.has(eventName)) {
             logger.sendErrorEvent({
                 eventName,
-                unreferencedDuratonMs: currentTimestampMs - this.unreferencedTimestampMs,
-                deleteTimeoutMs,
-                inactiveNodeId,
+                age: currentTimestampMs - this.unreferencedTimestampMs,
+                timeout: deleteTimeoutMs,
+                id: inactiveNodeId,
             });
             this.inactiveEventsLogged.add(eventName);
         }

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -4,7 +4,8 @@
  */
 
 import { strict as assert } from "assert";
-import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { concatGarbageCollectionStates } from "@fluidframework/garbage-collector";
+import { ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import {
     gcBlobKey,
     IGarbageCollectionData,
@@ -31,11 +32,8 @@ describe("Garbage Collection Tests", () => {
     ];
 
     let mockLogger: MockLogger;
-
     // Time after which unreferenced nodes can be deleted.
     const deleteTimeoutMs = 500;
-    const inactiveObjectRevivedEvent = "GarbageCollector:inactiveObjectRevived";
-    const inactiveObjectChangedEvent = "GarbageCollector:inactiveObjectChanged";
 
     // The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
     const defaultGCData: IGarbageCollectionData = { gcNodes: {} };
@@ -49,41 +47,6 @@ describe("Garbage Collection Tests", () => {
         updateUsedRoutes,
     };
 
-    // Waits for > deleteTimeoutMs. To be called to make sure that any unreferenced nodes have been deleted.
-    async function waitForDeleteTimeout(): Promise<void> {
-        await new Promise<void>((resolve) => {
-            setTimeout(resolve, deleteTimeoutMs + 100);
-        });
-    }
-
-    // Validates that no inactive event has been fired.
-    function validateNoInactiveEvents() {
-        assert(
-            !mockLogger.matchAnyEvent([
-                { eventName: inactiveObjectRevivedEvent },
-                { eventName: inactiveObjectChangedEvent },
-            ]),
-            "inactive object events should not have been logged",
-        );
-    }
-
-    // Simulates node changed activity for all the nodes in the graph.
-    function changeAllNodes(garbageCollector: IGarbageCollector) {
-        nodes.forEach((nodeId) => {
-            garbageCollector.nodeChanged(nodeId);
-        });
-    }
-
-    // Returns a dummy snapshot tree to be built upon.
-    const getDummySnapshotTree = (): ISnapshotTree => {
-        return {
-            id: "dummy",
-            blobs: {},
-            commits: {},
-            trees: {},
-        };
-    };
-
     // The GC details in the summary blob of a node. This is used by the garbage collector to initialize GC state.
     // Update this for individual node to update the initial GC state of that node.
     const emptyGCDetails: IGarbageCollectionSummaryDetails = {};
@@ -92,9 +55,10 @@ describe("Garbage Collection Tests", () => {
         baseSnapshot: ISnapshotTree | undefined = undefined,
         getNodeGCDetails: (id: string) => IGarbageCollectionSummaryDetails = () => emptyGCDetails,
     ) => {
+        mockLogger = new MockLogger();
         return GarbageCollector.create(
             gcRuntime,
-            { deleteTimeoutMs },
+            { gcAllowed: true, deleteTimeoutMs },
             (unusedRoutes: string[]) => {},
             () => Date.now(),
             baseSnapshot,
@@ -104,266 +68,583 @@ describe("Garbage Collection Tests", () => {
         );
     };
 
-    beforeEach(async () => {
-        mockLogger = new MockLogger();
+    describe("Inactive events", () => {
+        const inactiveObjectRevivedEvent = "GarbageCollector:inactiveObjectRevived";
+        const inactiveObjectChangedEvent = "GarbageCollector:inactiveObjectChanged";
 
-        // Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
-        defaultGCData.gcNodes["/"] = [ nodes[0] ];
-        defaultGCData.gcNodes[nodes[0]] = [ nodes[1] ];
-        defaultGCData.gcNodes[nodes[1]] = [ nodes[0], nodes[2] ];
-        defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
-        defaultGCData.gcNodes[nodes[3]] = [ nodes[0] ];
-    });
+        // Waits for > deleteTimeoutMs. To be called to make sure that any unreferenced nodes have been deleted.
+        async function waitForDeleteTimeout(): Promise<void> {
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, deleteTimeoutMs + 100);
+            });
+        }
 
-    it("doesn't generate inactive events for referenced nodes", async () => {
-        const garbageCollector = createGarbageCollector();
+        // Validates that no inactive event has been fired.
+        function validateNoInactiveEvents() {
+            assert(
+                !mockLogger.matchAnyEvent([
+                    { eventName: inactiveObjectRevivedEvent },
+                    { eventName: inactiveObjectChangedEvent },
+                ]),
+                "inactive object events should not have been logged",
+            );
+        }
 
-        // Run garbage collection on the default GC data where everything is referenced.
-        await garbageCollector.collectGarbage({ runGC: true });
+        // Simulates node changed activity for all the nodes in the graph.
+        function changeAllNodes(garbageCollector: IGarbageCollector) {
+            nodes.forEach((nodeId) => {
+                garbageCollector.nodeChanged(nodeId);
+            });
+        }
 
-        // Change all nodes.
-        changeAllNodes(garbageCollector);
-
-        // Validate that no inactive events are generated yet.
-        validateNoInactiveEvents();
-
-        // Wait for unreferenced timer (if any) to expire.
-        await waitForDeleteTimeout();
-
-        // Change all nodes again.
-        changeAllNodes(garbageCollector);
-
-        // Validate that no inactive events are generated since everything is referenced.
-        validateNoInactiveEvents();
-    });
-
-    it("generates inactive events when inactive node is changed or revived", async () => {
-        const garbageCollector = createGarbageCollector();
-
-        // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-        defaultGCData.gcNodes[nodes[1]] = [];
-
-        await garbageCollector.collectGarbage({ runGC: true });
-
-        // Change all nodes.
-        changeAllNodes(garbageCollector);
-
-        // Validate that no inactive events are generated yet.
-        validateNoInactiveEvents();
-
-        // Wait for unreferenced timer (if any) to expire.
-        await waitForDeleteTimeout();
-
-        // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
-        // are inactive.
-        changeAllNodes(garbageCollector);
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[2] },
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectChanged event not generated as expected",
-        );
-
-        // Add reference to node 3 from node 1.
-        defaultGCData.gcNodes[nodes[1]] = [ nodes[3] ];
-
-        // Run GC and validate that we get inactiveObjectRevived for node 3.
-        await garbageCollector.collectGarbage({ runGC: true });
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectRevived event not generated as expected",
-        );
-    });
-
-    it("generates inactive events once per node", async () => {
-        const garbageCollector = createGarbageCollector();
-
-        // Remove node 3's reference from node 2.
-        defaultGCData.gcNodes[nodes[2]] = [];
-
-        await garbageCollector.collectGarbage({ runGC: true });
-
-        await waitForDeleteTimeout();
-
-        // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
-        // are inactive.
-        changeAllNodes(garbageCollector);
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectChanged event not generated as expected",
-        );
-
-        // Change all nodes. There shouldn't be any more inactive events since for each node the event is only
-        // once.
-        changeAllNodes(garbageCollector);
-        validateNoInactiveEvents();
-    });
-
-    it("generates inactive events for nodes that are inactive on load", async () => {
-        // Create GC state where node 3's unreferenced time was > deleteTimeoutMs ago.
-        // This means this node should become inactive as soon as its data is loaded.
-
-        // Create a snapshot tree to be used as the GC snapshot tree.
-        const gcSnapshotTree = getDummySnapshotTree();
-        const gcBlobId = "gc_blob";
-        // Add a GC blob with prefix `gcBlobPrefix` to the GC snapshot tree.
-        gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
-
-        // Create a base snapshot that contains the GC snapshot tree.
-        const baseSnapshot = getDummySnapshotTree();
-        baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-        // Create GC state with node 3 expired. This will be returned when the garbage collector asks
-        // for the GC blob with `gcBlobId`.
-        const gcState: IGarbageCollectionState = { gcNodes: {} };
-        const node3Data: IGarbageCollectionNodeData = {
-            outboundRoutes: [],
-            unreferencedTimestampMs: Date.now() - (deleteTimeoutMs + 100),
+        // Returns a dummy snapshot tree to be built upon.
+        const getDummySnapshotTree = (): ISnapshotTree => {
+            return {
+                id: "dummy",
+                blobs: {},
+                commits: {},
+                trees: {},
+            };
         };
-        gcState.gcNodes[nodes[3]] = node3Data;
 
-        // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
-        const getNodeGCDetails = (blobId: string) => {
-            if (blobId === gcBlobId) {
-                return gcState;
+        beforeEach(async () => {
+            // Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
+            defaultGCData.gcNodes["/"] = [ nodes[0] ];
+            defaultGCData.gcNodes[nodes[0]] = [ nodes[1] ];
+            defaultGCData.gcNodes[nodes[1]] = [ nodes[0], nodes[2] ];
+            defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
+            defaultGCData.gcNodes[nodes[3]] = [ nodes[0] ];
+        });
+
+        it("doesn't generate inactive events for referenced nodes", async () => {
+            const garbageCollector = createGarbageCollector();
+
+            // Run garbage collection on the default GC data where everything is referenced.
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Change all nodes.
+            changeAllNodes(garbageCollector);
+
+            // Validate that no inactive events are generated yet.
+            validateNoInactiveEvents();
+
+            // Wait for unreferenced timer (if any) to expire.
+            await waitForDeleteTimeout();
+
+            // Change all nodes again.
+            changeAllNodes(garbageCollector);
+
+            // Validate that no inactive events are generated since everything is referenced.
+            validateNoInactiveEvents();
+        });
+
+        it("generates inactive events when inactive node is changed or revived", async () => {
+            const garbageCollector = createGarbageCollector();
+
+            // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+            defaultGCData.gcNodes[nodes[1]] = [];
+
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Change all nodes.
+            changeAllNodes(garbageCollector);
+
+            // Validate that no inactive events are generated yet.
+            validateNoInactiveEvents();
+
+            // Wait for unreferenced timer (if any) to expire.
+            await waitForDeleteTimeout();
+
+            // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
+            // are inactive.
+            changeAllNodes(garbageCollector);
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[2] },
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectChanged event not generated as expected",
+            );
+
+            // Add reference to node 3 from node 1.
+            defaultGCData.gcNodes[nodes[1]] = [ nodes[3] ];
+
+            // Run GC and validate that we get inactiveObjectRevived for node 3.
+            await garbageCollector.collectGarbage({ runGC: true });
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectRevived event not generated as expected",
+            );
+        });
+
+        it("generates inactive events once per node", async () => {
+            const garbageCollector = createGarbageCollector();
+
+            // Remove node 3's reference from node 2.
+            defaultGCData.gcNodes[nodes[2]] = [];
+
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            await waitForDeleteTimeout();
+
+            // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
+            // are inactive.
+            changeAllNodes(garbageCollector);
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectChanged event not generated as expected",
+            );
+
+            // Change all nodes. There shouldn't be any more inactive events since for each node the event is only
+            // once.
+            changeAllNodes(garbageCollector);
+            validateNoInactiveEvents();
+        });
+
+        it("generates inactive events for nodes that are inactive on load", async () => {
+            // Create GC state where node 3's unreferenced time was > deleteTimeoutMs ago.
+            // This means this node should become inactive as soon as its data is loaded.
+
+            // Create a snapshot tree to be used as the GC snapshot tree.
+            const gcSnapshotTree = getDummySnapshotTree();
+            const gcBlobId = "gc_blob";
+            // Add a GC blob with prefix `gcBlobPrefix` to the GC snapshot tree.
+            gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
+
+            // Create a base snapshot that contains the GC snapshot tree.
+            const baseSnapshot = getDummySnapshotTree();
+            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+            // Create GC state with node 3 expired. This will be returned when the garbage collector asks
+            // for the GC blob with `gcBlobId`.
+            const gcState: IGarbageCollectionState = { gcNodes: {} };
+            const node3Data: IGarbageCollectionNodeData = {
+                outboundRoutes: [],
+                unreferencedTimestampMs: Date.now() - (deleteTimeoutMs + 100),
+            };
+            gcState.gcNodes[nodes[3]] = node3Data;
+
+            // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
+            const getNodeGCDetails = (blobId: string) => {
+                if (blobId === gcBlobId) {
+                    return gcState;
+                }
+                return {};
+            };
+            const garbageCollector = createGarbageCollector(baseSnapshot, getNodeGCDetails);
+
+            // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
+            // summary is not loaded until the first time GC is run, so run GC.
+            defaultGCData.gcNodes[nodes[2]] = [];
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
+            garbageCollector.nodeChanged(nodes[3]);
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectChanged event not generated as expected",
+            );
+
+            // Add a reference to node 3 from node 2. Run GC and validate that we get inactiveObjectRevived for node 3.
+            defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
+            await garbageCollector.collectGarbage({ runGC: true });
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectRevived event not generated as expected",
+            );
+        });
+
+        it("generates inactive events for nodes that are inactive on load - snapshot is in old format", async () => {
+            // Create GC details for node 3's GC blob whose unreferenced time was > deleteTimeoutMs ago.
+            // This means this node should become inactive as soon as its data is loaded.
+            const node3GCDetails: IGarbageCollectionSummaryDetails = {
+                gcData: { gcNodes: { "/": [] } },
+                unrefTimestamp: Date.now() - (deleteTimeoutMs + 100),
+            };
+            const node3Snapshot = getDummySnapshotTree();
+            node3Snapshot.blobs[gcBlobKey] = "node3GCDetails";
+
+            // Create a base snapshot that contains snapshot tree of node 3.
+            const baseSnapshot = getDummySnapshotTree();
+            baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
+
+            // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
+            const getNodeGCDetails = (blobId: string) => {
+                if (blobId === "node3GCDetails") {
+                    return node3GCDetails;
+                }
+                return {};
+            };
+            const garbageCollector = createGarbageCollector(baseSnapshot, getNodeGCDetails);
+
+            // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
+            // summary is not loaded until the first time GC is run, so do that immediately.
+            defaultGCData.gcNodes[nodes[2]] = [];
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
+            garbageCollector.nodeChanged(nodes[3]);
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectChanged event not generated as expected",
+            );
+
+            // Add a reference to node 3 from node 2. Run GC and validate that we get inactiveObjectRevived for node 3.
+            defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
+            await garbageCollector.collectGarbage({ runGC: true });
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectRevived event not generated as expected",
+            );
+        });
+
+        it(`generates inactive events for nodes that are inactive on load - GC state is present in multiple` +
+            `blobs in base snapshot`, async () => {
+            const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
+            const expiredTimestampMs = Date.now() - (deleteTimeoutMs + 100);
+
+            // Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
+            // time was > deletedTimeoutMs ago. These three GC blobs are the added to the GC tree in summary.
+            const blob1Id = "blob1";
+            const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
+            blob1GCState.gcNodes[nodes[1]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+            gcBlobMap.set(blob1Id, blob1GCState);
+
+            const blob2Id = "blob2";
+            const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
+            blob2GCState.gcNodes[nodes[2]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+            gcBlobMap.set(blob2Id, blob2GCState);
+
+            const blob3Id = "blob3";
+            const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
+            blob3GCState.gcNodes[nodes[3]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+            gcBlobMap.set(blob3Id, blob3GCState);
+
+            // Create a GC snapshot tree and add the above three GC blob ids to it.
+            const gcSnapshotTree = getDummySnapshotTree();
+            gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
+            gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
+            gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
+
+            // Create a base snapshot that contains the above GC snapshot tree.
+            const baseSnapshot = getDummySnapshotTree();
+            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+            const getNodeGCDetails = (blobId: string) => {
+                return gcBlobMap.get(blobId) ?? {};
+            };
+            const garbageCollector = createGarbageCollector(baseSnapshot, getNodeGCDetails);
+
+            // For the nodes in the GC snapshot blobs, remove their references from the default GC data.
+            defaultGCData.gcNodes[nodes[0]] = [];
+            defaultGCData.gcNodes[nodes[1]] = [];
+            defaultGCData.gcNodes[nodes[2]] = [];
+
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Change the nodes and validate that an inactiveObjectChanged event is generated for each.
+            garbageCollector.nodeChanged(nodes[1]);
+            garbageCollector.nodeChanged(nodes[2]);
+            garbageCollector.nodeChanged(nodes[3]);
+            assert(
+                mockLogger.matchEvents([
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[1] },
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[2] },
+                    { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
+                ]),
+                "inactiveObjectChanged event not generated as expected",
+            );
+        });
+    });
+
+    /**
+     * These tests validate such scenarios where nodes transition from unreferenced -> referenced -> ureferenced state
+     * by verifing that their unreferenced timestamps are updated correctly.
+     *
+     * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
+     */
+     describe("References between summaries - state transition from unreferenced -> referenced -> unreferenced", () => {
+        let garbageCollector: IGarbageCollector;
+        const nodeA = "/A";
+        const nodeB = "/B";
+        const nodeC = "/C";
+        const nodeD = "/D";
+
+        /**
+         * Function that asserts the given test result fails. This is because all the scenarios here currently fail.
+         * These should pass once this issue is fixed - https://github.com/microsoft/FluidFramework/issues/7924. The
+         * assert condition will be flipped then.
+         */
+        function assertTestFails(testResult: boolean, message: string) {
+            assert(!testResult, message);
+        }
+
+        // Adds a small delay between two GC runs so that the unreferenced timestamp can be updated.
+        async function addDelay(): Promise<void> {
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 100);
+            });
+        }
+
+        // Runs GC and returns the unreferenced timestamps of all nodes in the GC summary.
+        async function getUnreferencedTimestamps() {
+            // Add delay before running GC.
+            await addDelay();
+
+            await garbageCollector.collectGarbage({ runGC: true });
+
+            // Mimic latest summary refresh so that the latest summary state tracked by GC is updated after the GC run.
+            await garbageCollector.latestSummaryStateRefreshed(
+                { wasSummaryTracked: true, latestSummaryUpdated: true },
+                async <T>(id: string) => { assert(false, "readAndParseBlob should not have been called"); },
+            );
+
+            const summaryTree = garbageCollector.summarize()?.summary;
+            assert(summaryTree !== undefined, "Nothing to summarize after running GC");
+
+            let rootGCState: IGarbageCollectionState = { gcNodes: {} };
+            for (const key of Object.keys(summaryTree.tree)) {
+                // Skip blobs that do not stsart with the GC prefix.
+                if (!key.startsWith(gcBlobPrefix)) {
+                    continue;
+                }
+
+                const gcBlob = summaryTree.tree[key];
+                assert(gcBlob?.type === SummaryType.Blob, `GC blob not available`);
+                const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;
+                // Merge the GC state of this blob into the root GC state.
+                rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
             }
-            return {};
-        };
-        const garbageCollector = createGarbageCollector(baseSnapshot, getNodeGCDetails);
-
-        // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base summary
-        // are not loaded until the first time GC is run, so run GC.
-        defaultGCData.gcNodes[nodes[2]] = [];
-        await garbageCollector.collectGarbage({ runGC: true });
-
-        // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
-        garbageCollector.nodeChanged(nodes[3]);
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectChanged event not generated as expected",
-        );
-
-        // Add a reference to node 3 from node 2. Run GC and validate that we get inactiveObjectRevived for node 3.
-        defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
-        await garbageCollector.collectGarbage({ runGC: true });
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectRevived event not generated as expected",
-        );
-    });
-
-    it("generates inactive events for nodes that are inactive on load - snapshot is in old format", async () => {
-        // Create GC details for node 3's GC blob whose unreferenced time was > deleteTimeoutMs ago.
-        // This means this node should become inactive as soon as its data is loaded.
-        const node3GCDetails: IGarbageCollectionSummaryDetails = {
-            gcData: { gcNodes: { "/": [] } },
-            unrefTimestamp: Date.now() - (deleteTimeoutMs + 100),
-        };
-        const node3Snapshot = getDummySnapshotTree();
-        node3Snapshot.blobs[gcBlobKey] = "node3GCDetails";
-
-        // Create a base snapshot that contains snapshot tree of node 3.
-        const baseSnapshot = getDummySnapshotTree();
-        baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
-
-        // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
-        const getNodeGCDetails = (blobId: string) => {
-            if (blobId === "node3GCDetails") {
-                return node3GCDetails;
+            const nodeTimestamps: Map<string, number | undefined> = new Map();
+            for (const [nodeId, nodeData] of Object.entries(rootGCState.gcNodes)) {
+                nodeTimestamps.set(nodeId, nodeData.unreferencedTimestampMs);
             }
-            return {};
-        };
-        const garbageCollector = createGarbageCollector(baseSnapshot, getNodeGCDetails);
+            return nodeTimestamps;
+        }
 
-        // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base summary
-        // are not loaded until the first time GC is run, so do that immediately.
-        defaultGCData.gcNodes[nodes[2]] = [];
-        await garbageCollector.collectGarbage({ runGC: true });
+        beforeEach(() => {
+            defaultGCData.gcNodes = {};
+            garbageCollector = createGarbageCollector();
+        });
 
-        // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
-        garbageCollector.nodeChanged(nodes[3]);
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectChanged event not generated as expected",
-        );
+        /**
+         * Validates that we can detect references that were added and then removed.
+         * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
+         * 2. Reference from A to B added. E = [A -> B].
+         * 3. Reference from A to B removed. E = [].
+         * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
+         * Validates that the unreferenced time for B is t2 which is > t1.
+         */
+        it(`Scenario 1 - An unreferenced node B is referenced and then unreferenced`, async () => {
+            // Initialize nodes A and B.
+            defaultGCData.gcNodes["/"] = [ nodeA ];
+            defaultGCData.gcNodes[nodeA] = [];
+            defaultGCData.gcNodes[nodeB] = [];
 
-        // Add a reference to node 3 from node 2. Run GC and validate that we get inactiveObjectRevived for node 3.
-        defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
-        await garbageCollector.collectGarbage({ runGC: true });
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectRevivedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectRevived event not generated as expected",
-        );
-    });
+            // 1. Run GC and generate summary 1. E = [].
+            const timestamps1 = await getUnreferencedTimestamps();
+            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
 
-    it(`generates inactive events for nodes that are inactive on load - GC state is present in multiple` +
-        `blobs in base snapshot`, async () => {
-        const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
-        const expiredTimestampMs = Date.now() - (deleteTimeoutMs + 100);
+            const nodeBTime1 = timestamps1.get(nodeB);
+            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
 
-        // Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
-        // time was > deletedTimeoutMs ago. These three GC blobs are the added to the GC tree in summary.
-        const blob1Id = "blob1";
-        const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
-        blob1GCState.gcNodes[nodes[1]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-        gcBlobMap.set(blob1Id, blob1GCState);
+            // 2. Add reference from A to B. E = [A -> B].
+            defaultGCData.gcNodes[nodeA] = [ nodeB ];
 
-        const blob2Id = "blob2";
-        const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
-        blob2GCState.gcNodes[nodes[2]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-        gcBlobMap.set(blob2Id, blob2GCState);
+            // 3. Remove reference from A to B. E = [].
+            defaultGCData.gcNodes[nodeA] = [];
 
-        const blob3Id = "blob3";
-        const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
-        blob3GCState.gcNodes[nodes[3]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-        gcBlobMap.set(blob3Id, blob3GCState);
+            // 4. Run GC and generate summary 2. E = [].
+            const timestamps2 = await getUnreferencedTimestamps();
+            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
 
-        // Create a GC snapshot tree and add the above three GC blob ids to it.
-        const gcSnapshotTree = getDummySnapshotTree();
-        gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
-        gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
-        gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
+            const nodeBTime2 = timestamps2.get(nodeB);
 
-        // Create a base snapshot that contains the above GC snapshot tree.
-        const baseSnapshot = getDummySnapshotTree();
-        baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+            assertTestFails(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+        });
 
-        const getNodeGCDetails = (blobId: string) => {
-            return gcBlobMap.get(blobId) ?? {};
-        };
-        const garbageCollector = createGarbageCollector(baseSnapshot, getNodeGCDetails);
+        /**
+         * Validates that we can detect references that were added transitively and then removed.
+         * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t2.
+         * 2. Reference from A to B added. E = [A -> B, B -> C].
+         * 3. Reference from B to C removed. E = [A -> B].
+         * 4. Reference from A to B removed. E = [].
+         * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
+         * Validates that the unreferenced time for B and C is t2 which is > t1.
+         */
+        it(`Scenario 2 - An unreferenced node B has reference to node C. B is referenced, removes reference to C ` +
+            `and is unreferenced`, async () => {
+            // Initialize nodes A, B and C.
+            defaultGCData.gcNodes["/"] = [ nodeA ];
+            defaultGCData.gcNodes[nodeA] = [];
+            defaultGCData.gcNodes[nodeB] = [ nodeC ];
+            defaultGCData.gcNodes[nodeC] = [];
 
-        // For the nodes in the GC snapshot blobs, remove their references from the default GC data.
-        defaultGCData.gcNodes[nodes[0]] = [];
-        defaultGCData.gcNodes[nodes[1]] = [];
-        defaultGCData.gcNodes[nodes[2]] = [];
+            // 1. Run GC and generate summary 1. E = [B -> C].
+            const timestamps1 = await getUnreferencedTimestamps();
+            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
 
-        await garbageCollector.collectGarbage({ runGC: true });
+            const nodeBTime1 = timestamps1.get(nodeB);
+            const nodeCTime1 = timestamps1.get(nodeC);
+            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
 
-        // Change the nodes and validate that an inactiveObjectChanged event is generated for each.
-        garbageCollector.nodeChanged(nodes[1]);
-        garbageCollector.nodeChanged(nodes[2]);
-        garbageCollector.nodeChanged(nodes[3]);
-        assert(
-            mockLogger.matchEvents([
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[1] },
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[2] },
-                { eventName: inactiveObjectChangedEvent, deleteTimeoutMs, inactiveNodeId: nodes[3] },
-            ]),
-            "inactiveObjectChanged event not generated as expected",
-        );
+            // 2. Add reference from A to B. E = [A -> B, B -> C].
+            defaultGCData.gcNodes[nodeA] = [ nodeB ];
+
+            // 3. Remove reference from B to C. E = [A -> B].
+            defaultGCData.gcNodes[nodeB] = [];
+
+            // 4. Remove reference from A to B. E = [].
+            defaultGCData.gcNodes[nodeA] = [];
+
+            // 5. Run GC and generate summary 2. E = [].
+            const timestamps2 = await getUnreferencedTimestamps();
+            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+            const nodeBTime2 = timestamps2.get(nodeB);
+            const nodeCTime2 = timestamps2.get(nodeC);
+            assertTestFails(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+            assertTestFails(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+        });
+
+        /**
+         * Validates that we can detect chain of references in which the first reference was added and then removed.
+         * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
+         * 2. Reference from A to B added. E = [A -> B, B -> C, C -> D].
+         * 3. Reference from A to B removed. E = [B -> C, C -> D].
+         * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
+         * Validates that the unreferenced time for B, C and D is t2 which is > t1.
+         */
+        it(`Scenario 3 - An unreferenced node B has reference to node C which has reference to node D. ` +
+            `B is referenced and then unreferenced`, async () => {
+            // Initialize nodes A, B, C and D.
+            defaultGCData.gcNodes["/"] = [ nodeA ];
+            defaultGCData.gcNodes[nodeA] = [];
+            defaultGCData.gcNodes[nodeB] = [ nodeC ];
+            defaultGCData.gcNodes[nodeC] = [ nodeD ];
+            defaultGCData.gcNodes[nodeD] = [];
+
+            // 1. Run GC and generate summary 1. E = [B -> C, C -> D].
+            const timestamps1 = await getUnreferencedTimestamps();
+            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+            const nodeBTime1 = timestamps1.get(nodeB);
+            const nodeCTime1 = timestamps1.get(nodeC);
+            const nodeDTime1 = timestamps1.get(nodeD);
+            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+            assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
+
+            // 2. Add reference from A to B. E = [A -> B, B -> C, C -> D].
+            defaultGCData.gcNodes[nodeA] = [ nodeB ];
+
+            // 3. Remove reference from A to B. E = [B -> C, C -> D].
+            defaultGCData.gcNodes[nodeA] = [];
+
+            // 4. Run GC and generate summary 2. E = [B -> C, C -> D].
+            const timestamps2 = await getUnreferencedTimestamps();
+            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+            const nodeBTime2 = timestamps2.get(nodeB);
+            const nodeCTime2 = timestamps2.get(nodeC);
+            const nodeDTime2 = timestamps2.get(nodeD);
+            assertTestFails(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+            assertTestFails(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+            assertTestFails(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+        });
+
+        /**
+         * Validates that we can detect references that were added and removed via new nodes.
+         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+         * 2. Node B is created. E = [].
+         * 3. Reference from A to B added. E = [A -> B].
+         * 4. Reference from B to C added. E = [A -> B, B -> C].
+         * 5. Reference from B to C removed. E = [A -> B].
+         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
+         * Validates that the unreferenced time for C is t2 which is > t1.
+         */
+        it(`Scenario 4 - A new node B is referenced, adds reference to an unreferenced node C and then removes ` +
+            `the reference to C`, async () => {
+            // Initialize nodes A, B and C.
+            defaultGCData.gcNodes["/"] = [ nodeA ];
+            defaultGCData.gcNodes[nodeA] = [];
+            defaultGCData.gcNodes[nodeC] = [];
+
+            // 1. Run GC and generate summary 1. E = [].
+            const timestamps1 = await getUnreferencedTimestamps();
+            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+            const nodeCTime1 = timestamps1.get(nodeC);
+            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+            // 2. Create node B, i.e., add B to GC data. E = [].
+            defaultGCData.gcNodes[nodeB] = [];
+
+            // 3. Add reference from A to B. E = [A -> B].
+            defaultGCData.gcNodes[nodeA] = [ nodeB ];
+
+            // 4. Add reference from B to C. E = [A -> B, B -> C].
+            defaultGCData.gcNodes[nodeB] = [ nodeC ];
+
+            // 5. Remove reference from B to C. E = [A -> B].
+            defaultGCData.gcNodes[nodeB] = [];
+
+            // 6. Run GC and generate summary 2. E = [A -> B].
+            const timestamps2 = await getUnreferencedTimestamps();
+            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+            assert(timestamps2.get(nodeB) === undefined, "B should be referenced");
+
+            const nodeCTime2 = timestamps2.get(nodeC);
+            assertTestFails(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+        });
+
+        /**
+         * Validates that references added by unreferences nodes do not show up as references.
+         * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+         * 2. Reference from B to C. E = [B -> C].
+         * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t1.
+         * Validates that the unreferenced time for B and C is still t1.
+         */
+         it(`Scenario 5 - An unreferenced node B adds reference to another node C`, async () => {
+            // Initialize nodes A, B and C.
+            defaultGCData.gcNodes["/"] = [ nodeA ];
+            defaultGCData.gcNodes[nodeA] = [];
+            defaultGCData.gcNodes[nodeB] = [];
+            defaultGCData.gcNodes[nodeC] = [];
+
+            // 1. Run GC and generate summary 1. E = [B -> C].
+            const timestamps1 = await getUnreferencedTimestamps();
+            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+            const nodeBTime1 = timestamps1.get(nodeB);
+            const nodeCTime1 = timestamps1.get(nodeC);
+            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+            // 2. Add reference from B to C. E = [B -> C].
+            defaultGCData.gcNodes[nodeB] = [ nodeC ];
+
+            // 3. Run GC and generate summary 2. E = [B -> C].
+            const timestamps2 = await getUnreferencedTimestamps();
+            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+            const nodeBTime2 = timestamps2.get(nodeB);
+            const nodeCTime2 = timestamps2.get(nodeC);
+            assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+            assert(nodeCTime2 === nodeCTime1, "C's timestamp should be unchanged");
+        });
     });
 });

--- a/packages/test/test-end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/test-end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-end-to-end-tests";
-export const pkgVersion = "0.53.0";
+export const pkgVersion = "0.54.0";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -122,8 +122,8 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
             mockLogger.matchEvents([
                 {
                     eventName: inactiveObjectChangedEvent,
-                    deleteTimeoutMs,
-                    inactiveNodeId: `/${dataStore1.id}`,
+                    timeout: deleteTimeoutMs,
+                    id: `/${dataStore1.id}`,
                 },
             ]),
             "inactiveObjectChanged event not generated as expected",
@@ -148,8 +148,8 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
             mockLogger.matchEvents([
                 {
                     eventName: inactiveObjectRevivedEvent,
-                    deleteTimeoutMs,
-                    inactiveNodeId: `/${dataStore1.id}`,
+                    timeout: deleteTimeoutMs,
+                    id: `/${dataStore1.id}`,
                 },
             ]),
             "inactiveObjectRevived event not generated as expected",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -205,7 +205,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
      * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
      * The nodes are data stores represented by alphabets A, B, C and so on.
      */
-    describe("References between summaries - state transition from unreferenced -> referenced -> unreferenced", () => {
+    describe("References between summaries", () => {
         /**
          * Function that asserts the given test result fails. This is because all the scenarios here currently fail.
          * These should pass once this issue is fixed - https://github.com/microsoft/FluidFramework/issues/7924. The
@@ -223,7 +223,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
          * Validates that the unreferenced time for B is t2 which is > t1.
          */
-        it(`Scenario 1 - An unreferenced node B is referenced and then unreferenced`, async () => {
+        it(`Scenario 1 - Reference added and then removed`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data store B and mark it as referenced by storing its handle in A.
@@ -261,8 +261,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
          * Validates that the unreferenced time for B and C is t2 which is > t1.
          */
-        it(`Scenario 2 - An unreferenced node B has reference to node C. B is referenced, removes reference to C ` +
-            `and is unreferenced`, async () => {
+        it(`Scenario 2 - Reference transitively added and removed`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data stores B and C and mark them referenced as follows by storing their handles as follows:
@@ -309,8 +308,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
          * Validates that the unreferenced time for B, C and D is t2 which is > t1.
          */
-        it(`Scenario 3 - An unreferenced node B has reference to node C which has reference to node D. ` +
-            `B is referenced and then unreferenced`, async () => {
+        it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data stores B, C and D and mark them referenced as follows by storing their handles as follows:
@@ -362,8 +360,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
          * Validates that the unreferenced time for C is t2 which is > t1.
          */
-        it(`Scenario 4 - A new node B is referenced, adds reference to an unreferenced node C and then removes ` +
-            `the reference to C`, async () => {
+        it(`Scenario 4 - Reference added and removed via new nodes`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data store C and mark it referenced by storing its handle in data store A.
@@ -411,8 +408,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * The difference from the previous tests is that the new data stores is a root data store. So, this validates
          * that we can detect new root data stores and outbound references from them.
          */
-        it(`Scenario 5 - A new root node B is referenced, adds reference to an unreferenced node C and then removes` +
-         ` the reference to C`, async () => {
+        it(`Scenario 5 - Reference added via new root nodes and removed`, async () => {
          const summarizerClient = await getNewSummarizer();
 
          // Create data store C and mark it referenced by storing its handle in data store A.
@@ -458,8 +454,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * The difference from previous test case is that the reference from B to C is added before B is referenced and
          * observed by summarizer. So, the summarizer does not see this reference directly but only when B is realized.
          */
-        it(`Scenario 6 - A new node B adds reference to an unreferenced node C, B becomes referenced ` +
-            `and removes the reference to C`, async () => {
+        it(`Scenario 6 - Reference added via new unreferenced nodes and removed`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data store C and mark it referenced by storing its handle in data store A.
@@ -509,8 +504,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * This difference from the previous test case is that there is another level of indirection here that
          * references the node which was unreferenced in previous summary.
          */
-        it(`Scenario 7 - Two new nodes B and C transitively add reference to an unreferenced node D, B and C ` +
-            `become referenced and remove the reference to D`, async () => {
+        it(`Scenario 7 - Reference added transitively via new nodes and removed`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data store D and mark it referenced by storing its handle in data store A.
@@ -556,7 +550,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t1.
          * Validates that the unreferenced time for B and C is still t1.
          */
-         it(`Scenario 8 - An unreferenced node B adds reference to another node C`, async () => {
+         it(`Scenario 8 - Reference added via unreferenced nodes`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data stores B and C and mark them referenced.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -229,7 +229,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
             // Create data store B and mark it as referenced by storing its handle in A.
             const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // Remove the reference to B which marks is as unreferenced.
             dataStoreA._root.delete("dataStoreB");
@@ -241,7 +240,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
             // 2. Add referenced from A to B. E = [A -> B].
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // 3. Remove reference from A to B. E = [].
             dataStoreA._root.delete("dataStoreB");
@@ -270,7 +268,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
             const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
             dataStoreB._root.set("dataStoreC", dataStoreC.handle);
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // Remove the reference to B which marks both B and C as unreferenced.
             dataStoreA._root.delete("dataStoreB");
@@ -284,7 +281,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
             // 2. Add reference from A to B. E = [A -> B, B -> C].
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // 3. Remove reference from B to C. E = [A -> B].
             dataStoreB._root.delete("dataStoreC");
@@ -319,7 +315,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
             dataStoreB._root.set("dataStoreC", dataStoreC.handle);
             dataStoreC._root.set("dataStoreD", dataStoreD.handle);
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // Remove the reference to B which marks B, C and D as unreferenced.
             dataStoreA._root.delete("dataStoreB");
@@ -335,7 +330,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
             // 2. Add reference from A to B. E = [A -> B, B -> C, C -> D].
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // 3. Remove reference from A to B. E = [B -> C, C -> D].
             dataStoreA._root.delete("dataStoreB");
@@ -366,7 +360,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
             // Create data store C and mark it referenced by storing its handle in data store A.
             const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
             dataStoreA._root.set("dataStoreC", dataStoreC.handle);
-            await provider.ensureSynchronized();
 
             // Remove the reference to C to make it unreferenced.
             dataStoreA._root.delete("dataStoreC");
@@ -384,7 +377,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
             // 4. Add reference from B to C. E = [A -> B, B -> C].
             dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-            await provider.ensureSynchronized();
 
             // 5. Remove reference from B to C. E = [A -> B].
             dataStoreB._root.delete("dataStoreC");
@@ -414,7 +406,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          // Create data store C and mark it referenced by storing its handle in data store A.
          const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
          dataStoreA._root.set("dataStoreC", dataStoreC.handle);
-         await provider.ensureSynchronized();
 
          // Remove the reference to C to make it unreferenced.
          dataStoreA._root.delete("dataStoreC");
@@ -429,7 +420,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
          // 4. Add reference from B to C. E = [A -> B, B -> C].
          dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-         await provider.ensureSynchronized();
 
          // 5. Remove reference from B to C. E = [A -> B].
          dataStoreB._root.delete("dataStoreC");
@@ -460,7 +450,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
             // Create data store C and mark it referenced by storing its handle in data store A.
             const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
             dataStoreA._root.set("dataStoreC", dataStoreC.handle);
-            await provider.ensureSynchronized();
 
             // Remove the reference to C to make it unreferenced.
             dataStoreA._root.delete("dataStoreC");
@@ -478,7 +467,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
             // 4. Add reference from A to B. E = [A -> B, B -> C].
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // 5. Remove reference from B to C. E = [A -> B].
             dataStoreB._root.delete("dataStoreC");
@@ -510,7 +498,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
             // Create data store D and mark it referenced by storing its handle in data store A.
             const dataStoreD = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
             dataStoreA._root.set("dataStoreD", dataStoreD.handle);
-            await provider.ensureSynchronized();
 
             // Remove the reference to D which marks it as unreferenced.
             dataStoreA._root.delete("dataStoreD");
@@ -532,7 +519,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
             // 5. Add reference from A to B. E = [A -> B, B -> C, C -> D].
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            await provider.ensureSynchronized();
 
             // 6. Remove reference from C to D. E = [A -> B, B -> C].
             dataStoreC._root.delete("dataStoreD");
@@ -558,7 +544,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
             const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
             dataStoreA._root.set("dataStoreB", dataStoreB.handle);
             dataStoreA._root.set("dataStoreC", dataStoreC.handle);
-            await provider.ensureSynchronized();
 
             // Mark B and C as unreferenced for the first summary.
             dataStoreA._root.delete("dataStoreB");
@@ -573,7 +558,6 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
             // 2. Add reference from B to C. E = [B -> C].
             dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-            await provider.ensureSynchronized();
 
             // 3. Get summary 2 and validate that both B and C's unreferenced timestamps haven't changed. E = [B -> C].
             const timestamps2 = await getUnreferencedTimestamps(summarizerClient);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -57,7 +57,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
     let latestAckedSummary: IAckedSummary | undefined;
 
     let mainContainer: IContainer;
-    let mainDataStore: TestDataObject;
+    let dataStoreA: TestDataObject;
 
     const createContainer = async (): Promise<IContainer> => {
         return provider.createContainer(runtimeFactory);
@@ -121,7 +121,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         );
 
         mainContainer = await createContainer();
-        mainDataStore = await requestFluidObject<TestDataObject>(mainContainer, "default");
+        dataStoreA = await requestFluidObject<TestDataObject>(mainContainer, "default");
 
         await provider.ensureSynchronized();
     });
@@ -132,165 +132,461 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         latestUploadedSummary = undefined;
     });
 
-    it("adds / removes unreferenced timestamp from data stores correctly", async () => {
-        const summarizerClient = await getNewSummarizer();
+    describe("unreferenced timestamp in in summary", () => {
+        it("adds / removes unreferenced timestamp from data stores correctly", async () => {
+            const summarizerClient = await getNewSummarizer();
 
-        // Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
-        const dataStoreA = await dataObjectFactory.createInstance(mainDataStore.containerRuntime);
-        mainDataStore._root.set("dataStoreA", dataStoreA.handle);
+            // Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
-        // Validate that the new data store does not have unreferenced timestamp.
-        const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
-        const dsATimestamp1 = timestamps1.get(dataStoreA.id);
-        assert(dsATimestamp1 === undefined, `new data store should not have unreferenced timestamp`);
+            // Validate that the new data store does not have unreferenced timestamp.
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTimestamp1 = timestamps1.get(dataStoreB.id);
+            assert(dsBTimestamp1 === undefined, `new data store should not have unreferenced timestamp`);
 
-        // Mark the data store as unreferenced by deleting its handle from the DDS and validate that it now has an
-        // unreferenced timestamp.
-        mainDataStore._root.delete("dataStoreA");
-        const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
-        const dsATimestamp2 = timestamps2.get(dataStoreA.id);
-        assert(dsATimestamp2 !== undefined, `data store should have unreferenced timestamp after being unreferenced`);
+            // Mark the data store as unreferenced by deleting its handle from the DDS and validate that it now has an
+            // unreferenced timestamp.
+            dataStoreA._root.delete("dataStoreB");
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTimestamp2 = timestamps2.get(dataStoreB.id);
+            assert(dsBTimestamp2 !== undefined, `data store should have unreferenced timestamp`);
 
-        // Perform some operations and generate another summary. Validate that the data store still has the same
-        // unreferenced timestamp.
-        mainDataStore._root.set("key", "value");
-        const timestamps3 = await getUnreferencedTimestamps(summarizerClient);
-        const dsATimestamp3 = timestamps3.get(dataStoreA.id);
-        assert(dsATimestamp3 !== undefined, `data store should still have unreferenced timestamp`);
-        assert.strictEqual(dsATimestamp2, dsATimestamp3, "unreferenced timestamp should not have changed");
+            // Perform some operations and generate another summary. Validate that the data store still has the same
+            // unreferenced timestamp.
+            dataStoreA._root.set("key", "value");
+            const timestamps3 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTimestamp3 = timestamps3.get(dataStoreB.id);
+            assert(dsBTimestamp3 !== undefined, `data store should still have unreferenced timestamp`);
+            assert.strictEqual(dsBTimestamp2, dsBTimestamp3, "unreferenced timestamp should not have changed");
 
-        // Mark the data store as referenced again and validate that the unreferenced timestamp is removed.
-        mainDataStore._root.set("dataStoreA", dataStoreA.handle);
-        // Validate that the data store does not have unreferenced timestamp after being referenced.
-        const timestamps4 = await getUnreferencedTimestamps(summarizerClient);
-        const dsATimestamp4 = timestamps4.get(dataStoreA.id);
-        assert(dsATimestamp4 === undefined, `data store should not have unreferenced timestamp anymore`);
+            // Mark the data store as referenced again and validate that the unreferenced timestamp is removed.
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            // Validate that the data store does not have unreferenced timestamp after being referenced.
+            const timestamps4 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTimestamp4 = timestamps4.get(dataStoreB.id);
+            assert(dsBTimestamp4 === undefined, `data store should not have unreferenced timestamp anymore`);
+        }).timeout(20000);
 
-    // This test has increased timeout because it waits for multiple summaries to be uploaded to server. It then also
-    // waits for those summaries to be ack'd. This may take a while.
-    }).timeout(20000);
+        it("uses unreferenced timestamp from previous summary correctly", async () => {
+            const summarizerClient1 = await getNewSummarizer();
 
-    it("uses unreferenced timestamp from previous summary correctly", async () => {
-        const summarizerClient1 = await getNewSummarizer();
+            // Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
-        // Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
-        const dataStoreA = await dataObjectFactory.createInstance(mainDataStore.containerRuntime);
-        mainDataStore._root.set("dataStoreA", dataStoreA.handle);
+            // Validate that the new data store does not have unreferenced timestamp.
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient1);
+            const dsBTimestamp1 = timestamps1.get(dataStoreB.id);
+            assert(dsBTimestamp1 === undefined, `new data store should not have unreferenced timestamp`);
 
-        // Validate that the new data store does not have unreferenced timestamp.
-        const timestamps1 = await getUnreferencedTimestamps(summarizerClient1);
-        const dsATimestamp1 = timestamps1.get(dataStoreA.id);
-        assert(dsATimestamp1 === undefined, `new data store should not have unreferenced timestamp`);
+            // Mark the data store as unreferenced by deleting its handle from the DDS and validate that it now has an
+            // unreferenced timestamp.
+            dataStoreA._root.delete("dataStoreB");
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient1);
+            const dsBTimestamp2 = timestamps2.get(dataStoreB.id);
+            assert(dsBTimestamp2 !== undefined, `new data store should have unreferenced timestamp`);
 
-        // Mark the data store as unreferenced by deleting its handle from the DDS and validate that it now has an
-        // unreferenced timestamp.
-        mainDataStore._root.delete("dataStoreA");
-        const timestamps2 = await getUnreferencedTimestamps(summarizerClient1);
-        const dsATimestamp2 = timestamps2.get(dataStoreA.id);
-        assert(dsATimestamp2 !== undefined, `new data store should have unreferenced timestamp`);
-
-        // Load a new summarizer from the last summary and validate that the unreferenced timestamp from the summary is
-        // used for the data store.
-        assert(latestAckedSummary !== undefined, "Summary ack isn't available as expected");
-        const summarizerClient2 = await getNewSummarizer(latestAckedSummary.summaryAck.contents.handle);
-        const timestamps3 = await getUnreferencedTimestamps(summarizerClient2);
-        const dsATimestamp3 = timestamps3.get(dataStoreA.id);
-        assert(dsATimestamp3 !== undefined, `new data store should still have unreferenced timestamp`);
-        assert.strictEqual(dsATimestamp2, dsATimestamp3, "The unreferenced timestamp should not have changed");
-
-    // This test has increased timeout because it waits for multiple summaries to be uploaded to server. It then also
-    // waits for those summaries to be ack'd. This may take a while.
-    }).timeout(20000);
+            // Load a new summarizer from the last summary and validate that the unreferenced timestamp from the summary
+            // is used for the data store.
+            assert(latestAckedSummary !== undefined, "Summary ack isn't available as expected");
+            const summarizerClient2 = await getNewSummarizer(latestAckedSummary.summaryAck.contents.handle);
+            const timestamps3 = await getUnreferencedTimestamps(summarizerClient2);
+            const dsBTimestamp3 = timestamps3.get(dataStoreB.id);
+            assert(dsBTimestamp3 !== undefined, `new data store should still have unreferenced timestamp`);
+            assert.strictEqual(dsBTimestamp2, dsBTimestamp3, "The unreferenced timestamp should not have changed");
+        }).timeout(20000);
+    });
 
     /**
-     * This scenario is currently broken. Re-enable test once the following item is completed -
-     * https://github.com/microsoft/FluidFramework/issues/7924
-     */
-    it.skip(`updates unreferenced timestamp when data store transitions between ` +
-       `unreferenced -> referenced -> unreferenced between summaries`, async () => {
-        const summarizerClient = await getNewSummarizer();
-
-        // Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
-        const dataStoreA = await dataObjectFactory.createInstance(mainDataStore.containerRuntime);
-        mainDataStore._root.set("dataStoreA", dataStoreA.handle);
-        await provider.ensureSynchronized();
-
-        // Mark the data store as unreferenced by deleting its handle from the DDS and validate that it now has an
-        // unreferenced timestamp.
-        mainDataStore._root.delete("dataStoreA");
-        const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
-        const dsATimestamp1 = timestamps1.get(dataStoreA.id);
-        assert(dsATimestamp1 !== undefined, `data store should have unreferenced timestamp after being unreferenced`);
-
-        // Store the data store's handle in the referenced DDS again and the delete it again. The data store will
-        // transition from unreferened -> referenced -> unreferenced before the next summary happens. The data store
-        // will still be unreferenced but the unreferenced timestamp should update.
-        mainDataStore._root.set("dataStoreA", dataStoreA.handle);
-        await provider.ensureSynchronized();
-        mainDataStore._root.delete("dataStoreA");
-
-        const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
-        const dsATimestamp2 = timestamps2.get(dataStoreA.id);
-        assert(dsATimestamp2 !== undefined, `data store should still have unreferenced timestamp`);
-        assert(dsATimestamp2 > dsATimestamp1, `new timestamp should be greater that the previous one`);
-    // This test has increased timeout because it waits for multiple summaries to be uploaded to server. It then also
-    // waits for those summaries to be ack'd. This may take a while.
-    }).timeout(20000);
-
-    /**
-     * Tests the following scenario where A, B and C are data stores:
-     * 1. Summary 1 at t1. Reference graph: A -> B -> C.
-     * 2. Summary 2 at t2. Reference graph: A    B (t2) -> C (t2). B and C have unreferenced time t2.
-     * 3. Op adds reference from A -> B.
-     *    Op removes reference from B -> C.
-     *    Op removes reference from A -> B.
-     *    A client could have added in-memory references to both B and C.
-     * 4. Summary 3 at t3. Reference graph: A    B (t3)    C (t3).
-     * Validates that the unreferenced time for B and C are t3.
+     * These tests validate such scenarios where nodes transition from unreferenced -> referenced -> ureferenced state
+     * by verifing that their unreferenced timestamps are updated correctly.
      *
-     * This scenario is currently broken. Re-enable test once the following item is completed -
-     * https://github.com/microsoft/FluidFramework/issues/7924
-    */
-    it.skip(`updates unreferenced timestamp when data store has outbound references, and transitions between ` +
-       `unreferenced -> referenced -> unreferenced between summaries`, async () => {
-        const summarizerClient = await getNewSummarizer();
-        const dataStoreA = mainDataStore;
+     * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
+     * The nodes are data stores represented by alphabets A, B, C and so on.
+     */
+    describe("References between summaries - state transition from unreferenced -> referenced -> unreferenced", () => {
+        /**
+         * Function that asserts the given test result fails. This is because all the scenarios here currently fail.
+         * These should pass once this issue is fixed - https://github.com/microsoft/FluidFramework/issues/7924. The
+         * assert condition will be flipped then.
+         */
+         function assertTestFails(testResult: boolean, message: string) {
+            assert(!testResult, message);
+        }
 
-        // Create data stores A and B and mark them referenced as follows by storing their handles accordingly:
-        // dataStoreA -> dataStoreB -> dataStoreC
-        const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
-        const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
-        dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-        dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-        await provider.ensureSynchronized();
+        /**
+         * Validates that we can detect references that were added and then removed.
+         * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
+         * 2. Op adds reference from A to B. E = [A -> B].
+         * 3. Op removes reference from A to B. E = [].
+         * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
+         * Validates that the unreferenced time for B is t2 which is > t1.
+         */
+        it(`Scenario 1 - An unreferenced node B is referenced and then unreferenced`, async () => {
+            const summarizerClient = await getNewSummarizer();
 
-        // Remove the reference to dataStoreB which marks both B and C as unreferenced.
-        dataStoreA._root.delete("dataStoreB");
+            // Create data store B and mark it as referenced by storing its handle in A.
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
 
-        // Validate that both B and C are both marked unreferenced at the same time.
-        const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
-        const dsBTimestamp1 = timestamps1.get(dataStoreB.id);
-        const dsCTimestamp1 = timestamps1.get(dataStoreC.id);
-        assert(dsBTimestamp1 !== undefined, `data store B should have unreferenced timestamp after being unreferenced`);
-        assert(dsBTimestamp1 === dsCTimestamp1, `data stores B and C should have the same unreferenced time`);
+            // Remove the reference to B which marks is as unreferenced.
+            dataStoreA._root.delete("dataStoreB");
 
-        // Now update the references via ops as follows:
-        // 1. Add reference from A -> B
-        // 2. Remove reference from B -> C
-        // 3. Remove reference from A -> B
-        dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-        await provider.ensureSynchronized();
-        dataStoreB._root.delete("dataStoreC");
-        dataStoreA._root.delete("dataStoreB");
+            // 1. Get summary 1 and validate that B has unreferenced timestamp. E = [].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime1 = timestamps1.get(dataStoreB.id);
+            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
 
-        // Validate that both B and C's unreferenced timestamps are updated and are the same.
-        const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
-        const dsBTimestamp2 = timestamps2.get(dataStoreB.id);
-        const dsCTimestamp2 = timestamps2.get(dataStoreC.id);
-        assert(dsBTimestamp2 !== undefined, `data store B should still have unreferenced timestamp`);
-        assert(dsBTimestamp2 > dsBTimestamp1, `The unreferenced timestamp should have been updated`);
-        assert(dsBTimestamp2 === dsCTimestamp2, `data stores B and C should have the same unreferenced time`);
-    // This test has increased timeout because it waits for multiple summaries to be uploaded to server. It then also
-    // waits for those summaries to be ack'd. This may take a while.
-    }).timeout(20000);
+            // 2. Add referenced from A to B. E = [A -> B].
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
+
+            // 3. Remove reference from A to B. E = [].
+            dataStoreA._root.delete("dataStoreB");
+
+            // 4. Get summary 2 and validate B's unreferenced timestamp updated. E = [].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime2 = timestamps2.get(dataStoreB.id);
+            assertTestFails(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
+        }).timeout(20000);
+
+        /**
+         * Validates that we can detect references that were added transitively and then removed.
+         * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t2.
+         * 2. Op adds reference from A to B. E = [A -> B, B -> C].
+         * 3. Op removes reference from B to C. E = [A -> B].
+         * 4. Op removes reference from A to B. E = [].
+         * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
+         * Validates that the unreferenced time for B and C is t2 which is > t1.
+         */
+        it(`Scenario 2 - An unreferenced node B has reference to node C. B is referenced, removes reference to C ` +
+            `and is unreferenced`, async () => {
+            const summarizerClient = await getNewSummarizer();
+
+            // Create data stores B and C and mark them referenced as follows by storing their handles as follows:
+            // dataStoreA -> dataStoreB -> dataStoreC
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
+
+            // Remove the reference to B which marks both B and C as unreferenced.
+            dataStoreA._root.delete("dataStoreB");
+
+            // 1. Get summary 1 and validate that both B and C have unreferenced timestamps. E = [B -> C].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime1 = timestamps1.get(dataStoreB.id);
+            const dsCTime1 = timestamps1.get(dataStoreC.id);
+            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+            // 2. Add reference from A to B. E = [A -> B, B -> C].
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
+
+            // 3. Remove reference from B to C. E = [A -> B].
+            dataStoreB._root.delete("dataStoreC");
+
+            // 4. Remove reference from A to B. E = [].
+            dataStoreA._root.delete("dataStoreB");
+
+            // 5. Get summary 2 and validate that both B and C's unreferenced timestamps updated. E = [].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime2 = timestamps2.get(dataStoreB.id);
+            const dsCTime2 = timestamps2.get(dataStoreC.id);
+            assertTestFails(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
+            assertTestFails(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+        }).timeout(20000);
+
+        /**
+         * Validates that we can detect chain of references in which the first reference was added and then removed.
+         * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
+         * 2. Op adds reference from A to B. E = [A -> B, B -> C, C -> D].
+         * 3. Op removes reference from A to B. E = [B -> C, C -> D].
+         * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
+         * Validates that the unreferenced time for B, C and D is t2 which is > t1.
+         */
+        it(`Scenario 3 - An unreferenced node B has reference to node C which has reference to node D. ` +
+            `B is referenced and then unreferenced`, async () => {
+            const summarizerClient = await getNewSummarizer();
+
+            // Create data stores B, C and D and mark them referenced as follows by storing their handles as follows:
+            // dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            const dataStoreD = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+            dataStoreC._root.set("dataStoreD", dataStoreD.handle);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
+
+            // Remove the reference to B which marks B, C and D as unreferenced.
+            dataStoreA._root.delete("dataStoreB");
+
+            // 1. Get summary 1 and validate that B, C and D have unreferenced timestamps. E = [B -> C, C -> D].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime1 = timestamps1.get(dataStoreB.id);
+            const dsCTime1 = timestamps1.get(dataStoreC.id);
+            const dsDTime1 = timestamps1.get(dataStoreD.id);
+            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+            assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
+
+            // 2. Add reference from A to B. E = [A -> B, B -> C, C -> D].
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
+
+            // 3. Remove reference from A to B. E = [B -> C, C -> D].
+            dataStoreA._root.delete("dataStoreB");
+
+            // 4. Get summary 2 and validate that B, C and D's unreferenced timestamps updated. E = [B -> C, C -> D].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime2 = timestamps2.get(dataStoreB.id);
+            const dsCTime2 = timestamps2.get(dataStoreC.id);
+            const dsDTime2 = timestamps2.get(dataStoreD.id);
+            assertTestFails(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
+            assertTestFails(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+            assertTestFails(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+        }).timeout(20000);
+
+        /**
+         * Validates that we can detect references that were added and removed via new data stores.
+         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+         * 2. Data store B is created. E = [].
+         * 3. Op adds reference from A to B. E = [A -> B].
+         * 4. Op adds reference from B to C. E = [A -> B, B -> C].
+         * 5. Op removes reference from B to C. E = [A -> B].
+         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
+         * Validates that the unreferenced time for C is t2 which is > t1.
+         */
+        it(`Scenario 4 - A new node B is referenced, adds reference to an unreferenced node C and then removes ` +
+            `the reference to C`, async () => {
+            const summarizerClient = await getNewSummarizer();
+
+            // Create data store C and mark it referenced by storing its handle in data store A.
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+            await provider.ensureSynchronized();
+
+            // Remove the reference to C to make it unreferenced.
+            dataStoreA._root.delete("dataStoreC");
+
+            // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsCTime1 = timestamps1.get(dataStoreC.id);
+            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+            // 2. Create data store B. E = [].
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+
+            // 3. Add reference from A to B. E = [A -> B].
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+            // 4. Add reference from B to C. E = [A -> B, B -> C].
+            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+            await provider.ensureSynchronized();
+
+            // 5. Remove reference from B to C. E = [A -> B].
+            dataStoreB._root.delete("dataStoreC");
+
+            // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsCTime2 = timestamps2.get(dataStoreC.id);
+            assertTestFails(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+        }).timeout(20000);
+
+        /**
+         * Validates that we can detect references that were added and removed via new root data stores.
+         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+         * 2. Root data store B is created. E = [].
+         * 3. Op adds reference from A to B. E = [A -> B].
+         * 4. Op adds reference from B to C. E = [A -> B, B -> C].
+         * 5. Op removes reference from B to C. E = [A -> B].
+         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
+         * Validates that the unreferenced time for C is t2 which is > t1.
+         *
+         * The difference from the previous tests is that the new data stores is a root data store. So, this validates
+         * that we can detect new root data stores and outbound references from them.
+         */
+        it(`Scenario 5 - A new root node B is referenced, adds reference to an unreferenced node C and then removes` +
+         ` the reference to C`, async () => {
+         const summarizerClient = await getNewSummarizer();
+
+         // Create data store C and mark it referenced by storing its handle in data store A.
+         const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+         dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+         await provider.ensureSynchronized();
+
+         // Remove the reference to C to make it unreferenced.
+         dataStoreA._root.delete("dataStoreC");
+
+         // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+         const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+         const dsCTime1 = timestamps1.get(dataStoreC.id);
+         assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+         // 2. Create data store B. E = [].
+         const dataStoreB = await dataObjectFactory.createRootInstance("dataStoreA", dataStoreA.containerRuntime);
+
+         // 4. Add reference from B to C. E = [A -> B, B -> C].
+         dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+         await provider.ensureSynchronized();
+
+         // 5. Remove reference from B to C. E = [A -> B].
+         dataStoreB._root.delete("dataStoreC");
+
+         // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
+         const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+         const dsCTime2 = timestamps2.get(dataStoreC.id);
+         assertTestFails(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+     }).timeout(20000);
+
+        /**
+         * Validates that we can detect references that were added via new data stores before they are referenced
+         * themselves, and then the reference from the new data store is removed.
+         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+         * 2. Data store B is created. E = [].
+         * 3. Add reference from B to C. E = [].
+         * 4. Op adds reference from A to B. E = [A -> B, B -> C].
+         * 5. Op removes reference from B to C. E = [A -> B].
+         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
+         * Validates that the unreferenced time for C is t2 which is > t1.
+         *
+         * The difference from previous test case is that the reference from B to C is added before B is referenced and
+         * observed by summarizer. So, the summarizer does not see this reference directly but only when B is realized.
+         */
+        it(`Scenario 6 - A new node B adds reference to an unreferenced node C, B becomes referenced ` +
+            `and removes the reference to C`, async () => {
+            const summarizerClient = await getNewSummarizer();
+
+            // Create data store C and mark it referenced by storing its handle in data store A.
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+            await provider.ensureSynchronized();
+
+            // Remove the reference to C to make it unreferenced.
+            dataStoreA._root.delete("dataStoreC");
+
+            // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsCTime1 = timestamps1.get(dataStoreC.id);
+            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+            // 2. Create data store B. E = [].
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+
+            // 3. Add reference from B to C. E = [].
+            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+
+            // 4. Add reference from A to B. E = [A -> B, B -> C].
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
+
+            // 5. Remove reference from B to C. E = [A -> B].
+            dataStoreB._root.delete("dataStoreC");
+
+            // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsCTime2 = timestamps2.get(dataStoreC.id);
+            assertTestFails(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+        }).timeout(20000);
+
+        /**
+         * Validates that we can detect references that were added transitively via new data stores before they are
+         * references themselves, and then the reference from the new data store is removed.
+         * 1. Summary 1 at t1. V = [A*, D]. E = []. D has unreferenced time t1.
+         * 2. Data stores B and C are created. E = [].
+         * 3. Add reference from B to C. E = [].
+         * 4. Add reference from C to D. E = [].
+         * 5. Op adds reference from A to B. E = [A -> B, B -> C, C -> D].
+         * 6. Op removes reference from C to D. E = [A -> B, B -> C].
+         * 7. Summary 2 at t2. V = [A*, B, C]. E = [A -> B, B -> C]. D has unreferenced time t2.
+         * Validates that the unreferenced time for D is t2 which is > t1.
+         *
+         * This difference from the previous test case is that there is another level of indirection here that
+         * references the node which was unreferenced in previous summary.
+         */
+        it(`Scenario 7 - Two new nodes B and C transitively add reference to an unreferenced node D, B and C ` +
+            `become referenced and remove the reference to D`, async () => {
+            const summarizerClient = await getNewSummarizer();
+
+            // Create data store D and mark it referenced by storing its handle in data store A.
+            const dataStoreD = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreD", dataStoreD.handle);
+            await provider.ensureSynchronized();
+
+            // Remove the reference to D which marks it as unreferenced.
+            dataStoreA._root.delete("dataStoreD");
+
+            // 1. Get summary 1 and validate that D is has unreferenced timestamp. E = [].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsDTime1 = timestamps1.get(dataStoreD.id);
+            assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
+
+            // 2. Create data stores B and C. E = [].
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+
+            // 3. Add reference from B to C. E = [].
+            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+
+            // 4. Add reference from C to D. E = [].
+            dataStoreC._root.set("dataStoreD", dataStoreD.handle);
+
+            // 5. Add reference from A to B. E = [A -> B, B -> C, C -> D].
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            await provider.ensureSynchronized();
+
+            // 6. Remove reference from C to D. E = [A -> B, B -> C].
+            dataStoreC._root.delete("dataStoreD");
+
+            // 7. Get summary 2 and validate that D's unreferenced timestamps updated. E = [A -> B, B -> C].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsDTime2 = timestamps2.get(dataStoreD.id);
+            assertTestFails(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+        }).timeout(20000);
+
+        /**
+         * Validates that references added by unreferences nodes do not show up as references.
+         * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+         * 2. Op adds reference from B to C. E = [B -> C].
+         * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t1.
+         * Validates that the unreferenced time for B and C is still t1.
+         */
+         it(`Scenario 8 - An unreferenced node B adds reference to another node C`, async () => {
+            const summarizerClient = await getNewSummarizer();
+
+            // Create data stores B and C and mark them referenced.
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+            await provider.ensureSynchronized();
+
+            // Mark B and C as unreferenced for the first summary.
+            dataStoreA._root.delete("dataStoreB");
+            dataStoreA._root.delete("dataStoreC");
+
+            // 1. Get summary 1 and validate that both B and C have unreferenced timestamps. E = [].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime1 = timestamps1.get(dataStoreB.id);
+            const dsCTime1 = timestamps1.get(dataStoreC.id);
+            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+            // 2. Add reference from B to C. E = [B -> C].
+            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+            await provider.ensureSynchronized();
+
+            // 3. Get summary 2 and validate that both B and C's unreferenced timestamps haven't changed. E = [B -> C].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsBTime2 = timestamps2.get(dataStoreB.id);
+            const dsCTime2 = timestamps2.get(dataStoreC.id);
+            assert(dsBTime2 === dsBTime1, `B's unreferenced timestamp should be unchanged`);
+            assert(dsCTime2 === dsCTime1, `C's unreferenced timestamp should be unchanged`);
+        }).timeout(20000);
+    });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -401,34 +401,34 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * that we can detect new root data stores and outbound references from them.
          */
         it(`Scenario 5 - Reference added via new root nodes and removed`, async () => {
-         const summarizerClient = await getNewSummarizer();
+            const summarizerClient = await getNewSummarizer();
 
-         // Create data store C and mark it referenced by storing its handle in data store A.
-         const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
-         dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+            // Create data store C and mark it referenced by storing its handle in data store A.
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
 
-         // Remove the reference to C to make it unreferenced.
-         dataStoreA._root.delete("dataStoreC");
+            // Remove the reference to C to make it unreferenced.
+            dataStoreA._root.delete("dataStoreC");
 
-         // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
-         const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
-         const dsCTime1 = timestamps1.get(dataStoreC.id);
-         assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+            // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+            const timestamps1 = await getUnreferencedTimestamps(summarizerClient);
+            const dsCTime1 = timestamps1.get(dataStoreC.id);
+            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
 
-         // 2. Create data store B. E = [].
-         const dataStoreB = await dataObjectFactory.createRootInstance("dataStoreA", dataStoreA.containerRuntime);
+            // 2. Create data store B. E = [].
+            const dataStoreB = await dataObjectFactory.createRootInstance("dataStoreA", dataStoreA.containerRuntime);
 
-         // 4. Add reference from B to C. E = [A -> B, B -> C].
-         dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+            // 4. Add reference from B to C. E = [A -> B, B -> C].
+            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
 
-         // 5. Remove reference from B to C. E = [A -> B].
-         dataStoreB._root.delete("dataStoreC");
+            // 5. Remove reference from B to C. E = [A -> B].
+            dataStoreB._root.delete("dataStoreC");
 
-         // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
-         const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
-         const dsCTime2 = timestamps2.get(dataStoreC.id);
-         assertTestFails(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-     }).timeout(20000);
+            // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
+            const timestamps2 = await getUnreferencedTimestamps(summarizerClient);
+            const dsCTime2 = timestamps2.get(dataStoreC.id);
+            assertTestFails(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+        }).timeout(20000);
 
         /**
          * Validates that we can detect references that were added via new data stores before they are referenced
@@ -536,7 +536,7 @@ describeFullCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
          * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t1.
          * Validates that the unreferenced time for B and C is still t1.
          */
-         it(`Scenario 8 - Reference added via unreferenced nodes`, async () => {
+        it(`Scenario 8 - Reference added via unreferenced nodes`, async () => {
             const summarizerClient = await getNewSummarizer();
 
             // Create data stores B and C and mark them referenced.


### PR DESCRIPTION
Added tests for validating that we can detect object references between summaries and update the unreferenced timestamp for such objects (if applicable).
Currently, we cannot detect these references and so the tests don't work as expected. I added a function `assertTestFails` that asserts that the final test result infact fails. This is a setup for the this GC work item - https://github.com/microsoft/FluidFramework/issues/7924.

Basically, these tests fail now and once the above work item is completed, they should pass (the condition in `assertTestFails` will be reverted).