### PR TITLE
Update broken types from release/0.53

### DIFF
--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -53,7 +53,6 @@ describe("ConnectionStateHandler Tests", () => {
             mode: "read",
             version: "0.1",
             initialClients: [],
-            maxMessageSize: 1000,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             serviceConfiguration: {} as IClientConfiguration,
             checkpointSequenceNumber: undefined,

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -74,6 +74,11 @@
         "InterfaceDeclaration_IFluidDataStoreRuntime": {
           "backCompat": false
         }
+      },
+      "0.52.0": {
+        "InterfaceDeclaration_IFluidDataStoreRuntime": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/datastore-definitions/src/test/types/validate0.52.0.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validate0.52.0.ts
@@ -199,6 +199,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: old.IFluidDataStoreRuntime);
 use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -83,6 +83,17 @@
         "InterfaceDeclaration_IFluidDataStoreRuntime": {
           "backCompat": false
         }
+      },
+      "0.52.0": {
+        "InterfaceDeclaration_IContainerRuntimeBase": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContext": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContextDetached": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.52.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.52.0.ts
@@ -223,6 +223,7 @@ declare function get_current_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_old_InterfaceDeclaration_IContainerRuntimeBase(
     use: old.IContainerRuntimeBase);
 use_old_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -319,6 +320,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContext(
     use: old.IFluidDataStoreContext);
 use_old_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -343,6 +345,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContextDetached
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: old.IFluidDataStoreContextDetached);
 use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*


### PR DESCRIPTION
This PR cherry picks commits related to fixing errors caused by broken types for release 0.53.

Original commits can be found here: https://github.com/microsoft/FluidFramework/pull/8531