### PR TITLE
[Phase 1.5 of 3 IContainer Updates] Update `Loader` to return `IContainer` instead of `Container`

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -14,17 +14,17 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)
 - [Loader now returns `IContainer` instead of `Container`](#Loader-now-returns-IContainer-instead-of-Container)
 
+### Removed `readAndParseFromBlobs` from `driver-utils`
+The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
+
 ### Loader now returns `IContainer` instead of `Container`
 
-The following public API functions on `Loader` now return `IContainer`:
+The following public API functions on `Loader`, from `"@fluidframework/container-loader"` package, now return `IContainer`:
 - `createDetachedContainer`
 - `rehydrateDetachedContainerFromSnapshot`
 - `resolve`
 
 All of the required functionality from a `Container` instance should be available on `IContainer`. If the function or property you require is not available, please file an issue on GitHub describing which function and what you are planning on using it for. They can still be used by casting the returned object to `Container`, i.e. `const container = await loader.resolve(request) as Container;`, however, this should be avoided whenever possible and the `IContainer` API should be used instead.
-
-### Removed `readAndParseFromBlobs` from `driver-utils`
-The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
 
 ## 0.53 Breaking changes
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,6 +12,16 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 0.54 Breaking changes
 - [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)
+- [Loader now returns `IContainer` instead of `Container`](#Loader-now-returns-IContainer-instead-of-Container)
+
+### Loader now returns `IContainer` instead of `Container`
+
+The following public API functions on `Loader` now return `IContainer`:
+- `createDetachedContainer`
+- `rehydrateDetachedContainerFromSnapshot`
+- `resolve`
+
+All of the required functionality from a `Container` instance should be available on `IContainer`. If the function or property you require is not available, please file an issue on GitHub describing which function and what you are planning on using it for. They can still be used by casting the returned object to `Container`, i.e. `const container = await loader.resolve(request) as Container;`, however, this should be avoided whenever possible and the `IContainer` API should be used instead.
 
 ### Removed `readAndParseFromBlobs` from `driver-utils`
 The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -188,15 +188,15 @@ export interface ILoaderServices {
 export class Loader implements IHostLoader {
     constructor(loaderProps: ILoaderProps);
     // (undocumented)
-    createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<Container>;
+    createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<IContainer>;
     // (undocumented)
     get IFluidRouter(): IFluidRouter;
     // (undocumented)
-    rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<Container>;
+    rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer>;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
-    resolve(request: IRequest, pendingLocalState?: string): Promise<Container>;
+    resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
     // (undocumented)
     readonly services: ILoaderServices;
 }

--- a/experimental/framework/get-container/src/getContainer.ts
+++ b/experimental/framework/get-container/src/getContainer.ts
@@ -4,9 +4,10 @@
  */
 
 import {
+    IContainer,
     IRuntimeFactory,
 } from "@fluidframework/container-definitions";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { Loader } from "@fluidframework/container-loader";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {
     IDocumentServiceFactory,
@@ -22,7 +23,7 @@ export interface IGetContainerParams {
 
 export async function createContainer(
     params: IGetContainerParams,
-): Promise<Container> {
+): Promise<IContainer> {
     const module = { fluidExport: params.containerRuntimeFactory };
     const codeLoader = { load: async () => module };
 
@@ -43,7 +44,7 @@ export async function createContainer(
 
 export async function getContainer(
     params: IGetContainerParams,
-): Promise<Container> {
+): Promise<IContainer> {
     const module = { fluidExport: params.containerRuntimeFactory };
     const codeLoader = { load: async () => module };
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -304,7 +304,7 @@ export class Loader implements IHostLoader {
 
     public get IFluidRouter(): IFluidRouter { return this; }
 
-    public async createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<Container> {
+    public async createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<IContainer> {
         const container = await Container.createDetached(
             this,
             codeDetails,
@@ -323,11 +323,11 @@ export class Loader implements IHostLoader {
         return container;
     }
 
-    public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<Container> {
+    public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer> {
         return Container.rehydrateDetachedFromSnapshot(this, snapshot);
     }
 
-    public async resolve(request: IRequest, pendingLocalState?: string): Promise<Container> {
+    public async resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer> {
         const eventName = pendingLocalState === undefined ? "Resolve" : "ResolveWithPendingState";
         return PerformanceEvent.timedExecAsync(this.logger, { eventName }, async () => {
             const resolved = await this.resolveCore(

--- a/packages/test/test-end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/test-end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-end-to-end-tests";
-export const pkgVersion = "0.53.0";
+export const pkgVersion = "0.54.0";

--- a/packages/test/test-end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/test-end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-end-to-end-tests";
-export const pkgVersion = "0.54.0";
+export const pkgVersion = "0.53.0";

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -5,7 +5,8 @@
 
 import { strict } from "assert";
 import fs from "fs";
-import { Container, Loader } from "@fluidframework/container-loader";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import {
     IDocumentServiceFactory,
@@ -71,7 +72,7 @@ export async function loadContainer(
     documentServiceFactory: IDocumentServiceFactory,
     documentName: string,
     logger?: TelemetryLogger,
-): Promise<Container> {
+): Promise<IContainer> {
     const resolved: IFluidResolvedUrl = {
         endpoints: {
             deltaStorageUrl: "example.com",


### PR DESCRIPTION
This is the third and final PR for the changes required for #8317

With the code already checked in to use `IContainer` instead of `Container` in most of the code, this applies the final change to actually update the container returns from `Loader`'s public API to be `IContainer`. It also includes a few remaining changes in packages required for the full `build` to pass with this change.