### PR TITLE
Added referenceAdded API to IFluidHandleContext

### DIFF
--- a/common/lib/core-interfaces/api-report/core-interfaces.api.md
+++ b/common/lib/core-interfaces/api-report/core-interfaces.api.md
@@ -68,6 +68,7 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
     readonly absolutePath: string;
     attachGraph(): void;
     readonly isAttached: boolean;
+    referenceAdded?(sourcePath: string, referencedHandle: IFluidHandle): void;
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
     readonly routeContext?: IFluidHandleContext;

--- a/common/lib/core-interfaces/src/handles.ts
+++ b/common/lib/core-interfaces/src/handles.ts
@@ -40,6 +40,16 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
     attachGraph(): void;
 
     resolveHandle(request: IRequest): Promise<IResponse>;
+
+    /**
+     * Should be called when a new reference is added by this context. This is required so that garbage collection can
+     * identify all references added in the system.
+     * @param sourcePath - The path of the object that added the reference.
+     * @param referencedHandle - The handle of the object that is referenced.
+     *
+     * TODO: Optional for backwards compatibility.
+     */
+    referenceAdded?(sourcePath: string, referencedHandle: IFluidHandle): void;
 }
 
 export const IFluidHandle: keyof IProvideFluidHandle = "IFluidHandle";


### PR DESCRIPTION
Needed for https://github.com/microsoft/FluidFramework/issues/7924.

Added an API `referenceAdded` to `IFluidHandleContext`. This is to be called to notify the handle context when a new reference is detected. PR for the above work item that needs this API update - https://github.com/microsoft/FluidFramework/pull/8542. 