### PR TITLE
Fixed tsconfig for end-to-end tests writing out files to wrong folder

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/tsconfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/tsconfig.json
@@ -4,7 +4,7 @@
         "declaration": false,
         "declarationMap": false,
         "rootDir": "../",
-        "outDir": "../../dist/test",
+        "outDir": "../../dist",
         "types": [
             "mocha",
             "@fluidframework/test-driver-definitions",


### PR DESCRIPTION
The `rootDir` in tsconfig of end-to-end tests was recently changed by this PR https://github.com/microsoft/FluidFramework/pull/8516.
However, the `outDir` was not updated accordingly due to which the out files were put in the wrong place.