### PR TITLE
IDeltaManager cleanup

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,9 +12,14 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 0.54 Breaking changes
 - [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)
+- [IDeltaManager cleanup](#IDeltaManager-cleanup)
 
 ### Removed `readAndParseFromBlobs` from `driver-utils`
 The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
+
+### IDeltaManager cleanup
+A bunch of IDeltaManager properties are deprecated and will be removed in future releases. They expose internal mechanics that should not be relevant to container runtime layer.
+Plus "connect" event payload (first argument) changed from IConnectionDetails interface to { clientId: string }. IConnectionDetails is removed from public service.
 
 ## 0.53 Breaking changes
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -12,10 +12,18 @@ There are a few steps you can take to write a good change note and avoid needing
 
 ## 0.54 Breaking changes
 - [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)
+- [Audience event ordering](#Audience-event-ordering)
 - [IDeltaManager cleanup](#IDeltaManager-cleanup)
 
 ### Removed `readAndParseFromBlobs` from `driver-utils`
 The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
+
+### Audience event ordering
+Before this release, Container.audience was mostly updated with latest state by the time "connected" event fired across all layers. Mostly, because in practice we observed cases where clientId for newly established connection was added to audience later.
+With this release, Audience will always be populated asynchronously relative to "connect" & "connected" events. I.e. at the time of "connected" event firing, you are more likely not to find Container.clientId in Audience list.
+In practice though, rules did not change:
+- Audience may contain clientId of previous connection (that's always true while client is disconnected or goes through connection transition)
+- Audience may contain clientId for new connection, but such clientId yet did not reflect through other APIs (like Container.clientId - it has for a while clientId of previous connection)
 
 ### IDeltaManager cleanup
 A number of IDeltaManager properties are deprecated and will be removed in future releases. They expose internal mechanics that should not be relevant to container runtime layer.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,8 +18,8 @@ There are a few steps you can take to write a good change note and avoid needing
 The `readAndParseFromBlobs` function from `driver-utils` was deprecated in 0.44, and has now been removed from the `driver-utils` package.
 
 ### IDeltaManager cleanup
-A bunch of IDeltaManager properties are deprecated and will be removed in future releases. They expose internal mechanics that should not be relevant to container runtime layer.
-Plus "connect" event payload (first argument) changed from IConnectionDetails interface to { clientId: string }. IConnectionDetails is removed from public service.
+A number of IDeltaManager properties are deprecated and will be removed in future releases. They expose internal mechanics that should not be relevant to container runtime layer.
+"connect" event payload (first argument) changed from IConnectionDetails interface to { clientId: string }. IConnectionDetails is removed from public surface.
 
 ## 0.53 Breaking changes
 - [`IContainer` interface updated to expose actively used `Container` public APIs](#IContainer-interface-updated-to-expose-actively-used-Container-public-APIs)

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -48,7 +48,7 @@ export enum ConnectionState {
     Disconnected = 0
 }
 
-// @public (undocumented)
+// @public
 export class Container extends EventEmitterWithErrorHandling<IContainerEvents> implements IContainer {
     constructor(loader: Loader, config: IContainerConfig);
     // (undocumented)

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -5,36 +5,12 @@
 
 import { IDisposable, IEventProvider, IEvent, IErrorEvent } from "@fluidframework/common-definitions";
 import {
-    ConnectionMode,
     IClientConfiguration,
     IClientDetails,
     IDocumentMessage,
     ISequencedDocumentMessage,
-    ISignalClient,
     ISignalMessage,
-    ITokenClaims,
 } from "@fluidframework/protocol-definitions";
-
-/**
- * Contract representing the result of a newly established connection to the server for syncing deltas
- */
-export interface IConnectionDetails {
-    clientId: string;
-    claims: ITokenClaims;
-    existing: boolean;
-    mode: ConnectionMode;
-    version: string;
-    initialClients: ISignalClient[];
-    serviceConfiguration: IClientConfiguration;
-    /**
-     * Last known sequence number to ordering service at the time of connection
-     * It may lap actual last sequence number (quite a bit, if container  is very active).
-     * But it's best information for client to figure out how far it is behind, at least
-     * for "read" connections. "write" connections may use own "join" op to similar information,
-     * that is likely to be more up-to-date.
-     */
-    checkpointSequenceNumber: number | undefined;
-}
 
 /**
  * Interface used to define a strategy for handling incoming delta messages
@@ -94,7 +70,7 @@ export interface IDeltaManagerEvents extends IEvent {
      * The connect event fires once we've received the connect_document_success message from the
      * server.  This happens prior to the client's join message (if there is a join message).
      */
-    (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void);
+    (event: "connect", listener: (details: { clientId: string }, opsBehind?: number) => void);
     (event: "disconnect", listener: (reason: string) => void);
     (event: "readonly", listener: (readonly: boolean) => void);
 }
@@ -106,10 +82,10 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     /** The queue of inbound delta messages */
     readonly inbound: IDeltaQueue<T>;
 
-    /** The queue of outbound delta messages */
+    /** @deprecated in 0.54 - should not be exposed */
     readonly outbound: IDeltaQueue<U[]>;
 
-    /** The queue of inbound delta signals */
+    /** @deprecated in 0.54 - should not be exposed */
     readonly inboundSignal: IDeltaQueue<ISignalMessage>;
 
     /** The current minimum sequence number */
@@ -127,16 +103,13 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     /** The initial sequence number set when attaching the op handler */
     readonly initialSequenceNumber: number;
 
-    /**
-     * Tells if  current connection has checkpoint information.
-     * I.e. we know how far behind the client was at the time of establishing connection
-     */
+    /** @deprecated in 0.54 - should not be exposed */
     readonly hasCheckpointSequenceNumber: boolean;
 
     /** Details of client */
     readonly clientDetails: IClientDetails;
 
-    /** Protocol version being used to communicate with the service */
+    /** @deprecated in 0.54 - low level protocol should not be exposed to runtime */
     readonly version: string;
 
     /** Max message size allowed to the delta manager */
@@ -165,10 +138,10 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 
     readonly readOnlyInfo: ReadOnlyInfo;
 
-    /** Terminate the connection to storage */
+    /** @deprecated in 0.54 - please use IContainerContext.closeFn */
     close(): void;
 
-    /** Submit a signal to the service to be broadcast to other connected clients, but not persisted */
+    /** @deprecated in 0.54 - please use IContainerContext.submitSignalFn */
     submitSignal(content: any): void;
 }
 

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -58,7 +58,6 @@ import {
     ReconnectMode,
     IConnectionManager,
     IConnectionManagerFactoryArgs,
-    IConnectionDetails,
 } from "./contracts";
 
 const MaxReconnectDelayInMs = 8000;
@@ -274,17 +273,6 @@ export class ConnectionManager implements IConnectionManager {
         }
 
         return { readonly: this._readonlyPermissions };
-    }
-
-    private static detailsFromConnection(connection: IDocumentDeltaConnection): IConnectionDetails {
-        return {
-            claims: connection.claims,
-            clientId: connection.clientId,
-            checkpointSequenceNumber: connection.checkpointSequenceNumber,
-            mode: connection.mode,
-            serviceConfiguration: connection.serviceConfiguration,
-            version: connection.version,
-        };
     }
 
     constructor(
@@ -673,9 +661,11 @@ export class ConnectionManager implements IConnectionManager {
             this.props.signalHandler({ clientId: null, content: { type: MessageType.ClientJoin, content }});
         }
 
-        const details = ConnectionManager.detailsFromConnection(connection);
-        details.checkpointSequenceNumber = checkpointSequenceNumber;
-        this.props.connectHandler(details);
+        this.props.connectHandler({
+            clientId: connection.clientId,
+            checkpointSequenceNumber,
+            mode: connection.mode,
+        });
 
         this.connectFirstConnection = false;
     }

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -11,7 +11,6 @@ import {
 import {
     IDeltaQueue,
     ReadOnlyInfo,
-    IConnectionDetails,
 } from "@fluidframework/container-definitions";
 import { assert, performance, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
@@ -59,6 +58,7 @@ import {
     ReconnectMode,
     IConnectionManager,
     IConnectionManagerFactoryArgs,
+    IConnectionDetails,
 } from "./contracts";
 
 const MaxReconnectDelayInMs = 8000;
@@ -280,9 +280,7 @@ export class ConnectionManager implements IConnectionManager {
         return {
             claims: connection.claims,
             clientId: connection.clientId,
-            existing: connection.existing,
             checkpointSequenceNumber: connection.checkpointSequenceNumber,
-            get initialClients() { return connection.initialClients; },
             mode: connection.mode,
             serviceConfiguration: connection.serviceConfiguration,
             version: connection.version,
@@ -669,6 +667,10 @@ export class ConnectionManager implements IConnectionManager {
             for (const signal of connection.initialSignals) {
                 this.props.signalHandler(signal);
             }
+        }
+
+        for (const content of connection.initialClients ?? []) {
+            this.props.signalHandler({ clientId: null, content: { type: MessageType.ClientJoin, content }});
         }
 
         const details = ConnectionManager.detailsFromConnection(connection);

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -648,6 +648,16 @@ export class ConnectionManager implements IConnectionManager {
             }
         }
 
+        this.props.connectHandler({
+            clientId: connection.clientId,
+            checkpointSequenceNumber,
+            mode: connection.mode,
+        });
+
+        /**
+         * The rest of the processing is async on DeltaManager side (inbound & inboundSignal queues)
+         */
+
         this.props.incomingOpHandler(
             initialMessages,
             this.connectFirstConnection ? "InitialOps" : "ReconnectOps");
@@ -662,12 +672,6 @@ export class ConnectionManager implements IConnectionManager {
                 this.props.signalHandler(signal);
             }
         }
-
-        this.props.connectHandler({
-            clientId: connection.clientId,
-            checkpointSequenceNumber,
-            mode: connection.mode,
-        });
 
         this.connectFirstConnection = false;
     }

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -652,15 +652,15 @@ export class ConnectionManager implements IConnectionManager {
             initialMessages,
             this.connectFirstConnection ? "InitialOps" : "ReconnectOps");
 
+        this.props.signalHandler({ clientId: null, content: { type: SystemSignalType.ClearClients } });
+        for (const content of connection.initialClients ?? []) {
+            this.props.signalHandler({ clientId: null, content: { type: SystemSignalType.ClientJoin, content } });
+        }
+
         if (connection.initialSignals !== undefined) {
             for (const signal of connection.initialSignals) {
                 this.props.signalHandler(signal);
             }
-        }
-
-        this.props.signalHandler({ clientId: null, content: { type: SystemSignalType.ClearClients } });
-        for (const content of connection.initialClients ?? []) {
-            this.props.signalHandler({ clientId: null, content: { type: SystemSignalType.ClientJoin, content } });
         }
 
         this.props.connectHandler({

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -58,6 +58,7 @@ import {
     ReconnectMode,
     IConnectionManager,
     IConnectionManagerFactoryArgs,
+    SystemSignalType,
 } from "./contracts";
 
 const MaxReconnectDelayInMs = 8000;
@@ -657,8 +658,9 @@ export class ConnectionManager implements IConnectionManager {
             }
         }
 
+        this.props.signalHandler({ clientId: null, content: { type: SystemSignalType.ClearClients } });
         for (const content of connection.initialClients ?? []) {
-            this.props.signalHandler({ clientId: null, content: { type: MessageType.ClientJoin, content }});
+            this.props.signalHandler({ clientId: null, content: { type: SystemSignalType.ClientJoin, content } });
         }
 
         this.props.connectHandler({

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -4,7 +4,6 @@
  */
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
-import { IConnectionDetails } from "@fluidframework/container-definitions";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import { ConnectionMode, ISequencedClient } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
@@ -163,7 +162,7 @@ export class ConnectionStateHandler {
 
     public receivedConnectEvent(
         connectionMode: ConnectionMode,
-        details: IConnectionDetails,
+        details: {clientId: string },
     ) {
         const oldState = this._connectionState;
         this._connectionState = ConnectionState.Connecting;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -20,7 +20,6 @@ import {
 } from "@fluidframework/core-interfaces";
 import {
     IAudience,
-    IConnectionDetails,
     IContainer,
     IContainerEvents,
     IDeltaManager,
@@ -1557,14 +1556,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         deltaManager.inboundSignal.pause();
 
-        deltaManager.on("connect", (details: IConnectionDetails, opsBehind?: number) => {
-            // Back-compat for new client and old server.
-            this._audience.clear();
-
-            for (const priorClient of details.initialClients ?? []) {
-                this._audience.addMember(priorClient.clientId, priorClient.client);
-            }
-
+        deltaManager.on("connect", (details) => {
             this.connectionStateHandler.receivedConnectEvent(
                 this.connectionMode,
                 details,
@@ -1575,6 +1567,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.manualReconnectInProgress = false;
             this.collabWindowTracker.stopSequenceNumberUpdate();
             this.connectionStateHandler.receivedDisconnectEvent(reason);
+            this._audience.clear();
         });
 
         deltaManager.on("throttled", (warning: IThrottlingWarning) => {

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -9,7 +9,6 @@ import {
 import {
     IDeltaQueue,
     ReadOnlyInfo,
-    IConnectionDetails,
 } from "@fluidframework/container-definitions";
 import {
     ConnectionMode,
@@ -18,6 +17,7 @@ import {
     IClientConfiguration,
     IClientDetails,
     ISignalMessage,
+    ITokenClaims,
 } from "@fluidframework/protocol-definitions";
 
 export enum ReconnectMode {
@@ -27,7 +27,26 @@ export enum ReconnectMode {
 }
 
 /**
- * Connection manager (implements this interface) is responsible for maintaining connection
+ * Contract representing the result of a newly established connection to the server for syncing deltas
+ */
+ export interface IConnectionDetails {
+    clientId: string;
+    claims: ITokenClaims;
+    mode: ConnectionMode;
+    version: string;
+    serviceConfiguration: IClientConfiguration;
+    /**
+     * Last known sequence number to ordering service at the time of connection
+     * It may lap actual last sequence number (quite a bit, if container  is very active).
+     * But it's best information for client to figure out how far it is behind, at least
+     * for "read" connections. "write" connections may use own "join" op to similar information,
+     * that is likely to be more up-to-date.
+     */
+    checkpointSequenceNumber: number | undefined;
+}
+
+/**
+* Connection manager (implements this interface) is responsible for maintaining connection
  * to relay service.
  */
 export interface IConnectionManager {

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -17,7 +17,6 @@ import {
     IClientConfiguration,
     IClientDetails,
     ISignalMessage,
-    ITokenClaims,
 } from "@fluidframework/protocol-definitions";
 
 export enum ReconnectMode {
@@ -31,10 +30,7 @@ export enum ReconnectMode {
  */
  export interface IConnectionDetails {
     clientId: string;
-    claims: ITokenClaims;
     mode: ConnectionMode;
-    version: string;
-    serviceConfiguration: IClientConfiguration;
     /**
      * Last known sequence number to ordering service at the time of connection
      * It may lap actual last sequence number (quite a bit, if container  is very active).

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -17,12 +17,30 @@ import {
     IClientConfiguration,
     IClientDetails,
     ISignalMessage,
+    ISequencedClient,
 } from "@fluidframework/protocol-definitions";
 
 export enum ReconnectMode {
     Never = "Never",
     Disabled = "Disabled",
     Enabled = "Enabled",
+}
+
+export interface ILocalSequencedClient extends ISequencedClient {
+    shouldHaveLeft?: boolean;
+}
+
+/**
+ * Needs to be moved to protocol-definitions, next to MessageType!
+ * And ideally update server code to use these definitions as well.
+ * */
+export enum SystemSignalType {
+    /** new client joined audience */
+    ClientJoin = "join",
+    /** client left audience */
+    ClientLeave = "leave",
+    /** clear all clients in audience */
+    ClearClients = "clear",
 }
 
 /**

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -18,7 +18,6 @@ import {
     IDeltaQueue,
     ICriticalContainerError,
     IThrottlingWarning,
-    IConnectionDetails,
 } from "@fluidframework/container-definitions";
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
@@ -52,6 +51,7 @@ import { DeltaQueue } from "./deltaQueue";
 import {
     IConnectionManagerFactoryArgs,
     IConnectionManager,
+    IConnectionDetails,
  } from "./contracts";
 
 export interface IConnectionArgs {
@@ -176,6 +176,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
     // Forwarding connection manager properties / IDeltaManager implementation
     public get maxMessageSize(): number { return this.connectionManager.maxMessageSize; }
+
+    /** @deprecated Low level protocol should not be exposed to runtime */
     public get version() { return this.connectionManager.version; }
     public get serviceConfiguration() { return this.connectionManager.serviceConfiguration; }
     public get outbound() { return this.connectionManager.outbound; }
@@ -355,7 +357,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
         this.emit(
             "connect",
-            connection,
+            { clientId: connection.clientId },
             checkpointSequenceNumber !== undefined ?
                 this.lastObservedSeqNumber - this.lastSequenceNumber : undefined);
 

--- a/packages/loader/container-loader/src/deltaManagerProxy.ts
+++ b/packages/loader/container-loader/src/deltaManagerProxy.ts
@@ -76,9 +76,14 @@ export class DeltaQueueProxy<T> extends EventForwarder<IDeltaQueueEvents<T>> imp
  */
 export class DeltaManagerProxy
     extends EventForwarder<IDeltaManagerEvents>
-    implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
+    implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>
+{
     public readonly inbound: IDeltaQueue<ISequencedDocumentMessage>;
+
+    /** @deprecated - should not be exposed */
     public readonly outbound: IDeltaQueue<IDocumentMessage[]>;
+
+    /** @deprecated - should not be exposed */
     public readonly inboundSignal: IDeltaQueue<ISignalMessage>;
 
     public get IDeltaSender(): IDeltaSender {
@@ -105,6 +110,7 @@ export class DeltaManagerProxy
         return this.deltaManager.initialSequenceNumber;
     }
 
+    /** @deprecated - should not be exposed */
     public get hasCheckpointSequenceNumber() {
         return this.deltaManager.hasCheckpointSequenceNumber;
     }
@@ -113,6 +119,7 @@ export class DeltaManagerProxy
         return this.deltaManager.clientDetails;
     }
 
+    /** @deprecated Low level protocol should not be exposed to runtime */
     public get version(): string {
         return this.deltaManager.version;
     }
@@ -152,10 +159,12 @@ export class DeltaManagerProxy
         super.dispose();
     }
 
+    /** @deprecated Please use IContainerContext.closeFn */
     public close(): void {
         return this.deltaManager.close();
     }
 
+    /** @deprecated Please use IContainerContext.submitSignalFn */
     public submitSignal(content: any): void {
         return this.deltaManager.submitSignal(content);
     }

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -6,18 +6,17 @@
 import { strict as assert } from "assert";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
-import { IClient, IClientConfiguration, ITokenClaims } from "@fluidframework/protocol-definitions";
+import { IClient } from "@fluidframework/protocol-definitions";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import { ConnectionState } from "../container";
 import { ConnectionStateHandler } from "../connectionStateHandler";
-import { IConnectionDetails } from "../contracts";
 
 describe("ConnectionStateHandler Tests", () => {
     let clock: SinonFakeTimers;
     let connectionStateHandler: ConnectionStateHandler;
     let protocolHandler: ProtocolOpHandler;
     let shouldClientJoinWrite: boolean;
-    let connectionDetails: IConnectionDetails;
+    let connectionDetails: { clientId: string };
     let client: IClient;
     const expectedTimeout = 90000;
     const pendingClientId = "pendingClientId";
@@ -47,13 +46,6 @@ describe("ConnectionStateHandler Tests", () => {
         protocolHandler = new ProtocolOpHandler(0, 0, 1, [], [], [], (key, value) => 0, (seqNum) => undefined);
         connectionDetails = {
             clientId: pendingClientId,
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            claims: {} as ITokenClaims,
-            mode: "read",
-            version: "0.1",
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            serviceConfiguration: {} as IClientConfiguration,
-            checkpointSequenceNumber: undefined,
         };
         client = {
             mode: "read",

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -7,10 +7,10 @@ import { strict as assert } from "assert";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ProtocolOpHandler } from "@fluidframework/protocol-base";
 import { IClient, IClientConfiguration, ITokenClaims } from "@fluidframework/protocol-definitions";
-import { IConnectionDetails } from "@fluidframework/container-definitions";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import { ConnectionState } from "../container";
 import { ConnectionStateHandler } from "../connectionStateHandler";
+import { IConnectionDetails } from "../contracts";
 
 describe("ConnectionStateHandler Tests", () => {
     let clock: SinonFakeTimers;
@@ -49,10 +49,8 @@ describe("ConnectionStateHandler Tests", () => {
             clientId: pendingClientId,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             claims: {} as ITokenClaims,
-            existing: true,
             mode: "read",
             version: "0.1",
-            initialClients: [],
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             serviceConfiguration: {} as IClientConfiguration,
             checkpointSequenceNumber: undefined,


### PR DESCRIPTION
I've started with deprecating a bunch of things on IDeltaManager, but getting rid of IConnectionDetails ("connect" event payload) caused a bunch of changes in how loader layers communicate between each other RE audience & signals which forced me to refactor code a bit and also change slightly timing of events.

Based on me inspecting FFX code base, they already handle correctly Audience events no matter in which order (relative to "connected" event) they arrive. It's pretty obvious that for a split of a second one will see "self" in UX as with current structure it's hard to filter out "self" from the list as Audience will update (in most cases, at least for "write" connection) before "connected" event fires (before and after this change). This is something we can further improve.

But fundamentally it does not change assumptions. But some code that was not tested enough and was relying on some weak assumptions about event ordering can be reliably broken by this change and be forced to adapt.