### PR TITLE
Small grammar fix in collaborative text area recipe docs and sequence DDS docs

### DIFF
--- a/docs/content/docs/data-structures/sequences.md
+++ b/docs/content/docs/data-structures/sequences.md
@@ -255,7 +255,7 @@ type of content they support. SharedNumberSequence only supports numbers as cont
 any JSON serializable object. Both DDSes support inserting, removing, and annotating content. Each item -- that is, each
 number or object -- will occupy a single position in the sequence.
 
-An important note is that, unlike an array, positions are not guaranteed remain constant. The position of an item can
+An important note is that, unlike an array, positions are not guaranteed to remain constant. The position of an item can
 change as content is added or removed from the sequence. To track or pass a reference to a specific piece of content
 within the sequence you should find its segment via `segment = s.getContainingSegment(position)` and then use
 `pos = s.getPosition(segment)` to get its current position in the tree.

--- a/docs/content/docs/recipes/collaborative-text-area.md
+++ b/docs/content/docs/recipes/collaborative-text-area.md
@@ -38,7 +38,7 @@ This tutorial assumes that you are familiar with the [Fluid Framework Overview](
     |---|---|
     | `fluid-framework`    |Contains the SharedString [distributed data structure]({{< relref "dds.md" >}}) that synchronizes text across clients. *This object will hold the most recent text update made by any client.*|
     | `@fluidframework/tinylicious-client`   |Defines the connection to a Fluid server and defines the starting schema for the [Fluid container]({{< relref "containers.md" >}}).|
-    | `@fluid-experimental/react-inputs`   |Contains the SharedStringHelper class that helps provides a simple APIs to interact with the [SharedString]({{< relref "string.md" >}}) object.|
+    | `@fluid-experimental/react-inputs`   |Contains the SharedStringHelper class that provides simple APIs to interact with the [SharedString]({{< relref "string.md" >}}) object.|
     {.table}
 
     Run the following command to install the libraries.

--- a/docs/content/docs/recipes/collaborative-text-area.md
+++ b/docs/content/docs/recipes/collaborative-text-area.md
@@ -38,7 +38,7 @@ This tutorial assumes that you are familiar with the [Fluid Framework Overview](
     |---|---|
     | `fluid-framework`    |Contains the SharedString [distributed data structure]({{< relref "dds.md" >}}) that synchronizes text across clients. *This object will hold the most recent text update made by any client.*|
     | `@fluidframework/tinylicious-client`   |Defines the connection to a Fluid server and defines the starting schema for the [Fluid container]({{< relref "containers.md" >}}).|
-    | `@fluid-experimental/react-inputs`   |Contains the SharedStringHelper class that provides simple APIs to interact with the [SharedString]({{< relref "string.md" >}}) object.|
+    | `@fluid-experimental/react-inputs`   |Contains the SharedStringHelper class that provides helper APIs to interact with the [SharedString]({{< relref "string.md" >}}) object.|
     {.table}
 
     Run the following command to install the libraries.

--- a/packages/dds/sequence/README.md
+++ b/packages/dds/sequence/README.md
@@ -245,7 +245,7 @@ type of content they support. SharedNumberSequence only supports numbers as cont
 any JSON serializable object. Both DDSes support inserting, removing, and annotating content. Each item -- that is, each
 number or object -- will occupy a single position in the sequence.
 
-An important note is that, unlike an array, positions are not guaranteed remain constant. The position of an item can
+An important note is that, unlike an array, positions are not guaranteed to remain constant. The position of an item can
 change as content is added or removed from the sequence. To track or pass a reference to a specific piece of content
 within the sequence you should find its segment via `segment = s.getContainingSegment(position)` and then use
 `pos = s.getPosition(segment)` to get its current position in the tree.


### PR DESCRIPTION
`Contains the SharedStringHelper class that helps provides a simple APIs to interact with...`  ➡ `Contains the SharedStringHelper class that provides helper APIs to interact with...`