### PR TITLE
Make noop logic (frequency) controllable by service

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -155,7 +155,7 @@ export interface IFluidModuleWithDetails {
 }
 
 // @public (undocumented)
-export interface ILoaderOptions extends ILoaderOptions_2 {
+export interface ILoaderOptions extends Omit<ILoaderOptions_2, "noopCountFrequency" | "noopTimeFrequency"> {
     // (undocumented)
     summarizeProtocolTree?: true;
 }

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -365,20 +365,6 @@ export type ILoaderOptions = {
      */
     provideScopeLoader?: boolean;
 
-    // Below two are the options based on which we decide how often client needs to send noops in case of active
-    // connection which is not sending any op. The end result is the "AND" of these 2 options. So the client
-    // should hit the min time and count to send the noop.
-    /**
-     * Set min time(in ms) frequency with which noops would be sent in case of active connection which is
-     * not sending any op.
-     */
-    noopTimeFrequency?: number;
-
-    /**
-     * Set min op frequency with which noops would be sent in case of active connection which is not sending any op.
-     */
-    noopCountFrequency?: number;
-
     /**
      * Max time(in ms) container will wait for a leave message of a disconnected client.
     */

--- a/common/lib/protocol-definitions/src/config.ts
+++ b/common/lib/protocol-definitions/src/config.ts
@@ -34,4 +34,20 @@ export interface IClientConfiguration {
 
     // Summary algorithm configuration. This is sent to clients when they connect
     summary: ISummaryConfiguration;
+
+    /* noopTimeFrequency & noopCountFrequency control how often client with "write" connection needs to send
+     * noop messages in case no other ops are being sent by such client. Any op (including noops) result in client
+     * communicating its reference sequence number to relay service, which can recalculate MSN based on new info.
+     * Client send noop when either noopTimeFrequency ms elapsed from receiving last op or client received
+     * noopCountFrequency ops.
+     * If no value is provided, client choses some reasonable value
+     */
+     noopTimeFrequency?: number;
+
+     /**
+      * Set min op frequency with which noops would be sent in case of active connection which is not sending any op.
+      * Please see noopTimeFrequency comment for more details.
+      * If no value is provided, client choses some reasonable value
+      */
+     noopCountFrequency?: number;
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1762,6 +1762,11 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 // back-compat: noopTimeFrequency & noopCountFrequency properties were added to
                 // IClientConfiguration in 0.54. Once newer version of protocol-definitions is picked up,
                 // remove case to any.
+                //
+                // Note that config from first connection will be used for this container's lifetime.
+                // That means that if relay service changes settings, such changes will impact only newly booted
+                // clients.
+                // All existing will continue to use settings they got earlier.
                 const config = this.serviceConfiguration as any;
                 assert(config !== undefined, "there should be service config for active connection");
                 this.collabWindowTracker = new CollabWindowTracker(

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -120,7 +120,10 @@ function createCachedResolver(resolver: IUrlResolver) {
     return cacheResolver;
 }
 
-export interface ILoaderOptions extends ILoaderOptions1{
+// back-compat: remove this interface and use one from container-definitions.
+// Omit<> part can be removed once latest version of container-definitions is picked up.
+// summarizeProtocolTree should be either removed or moved to container-definitions
+export interface ILoaderOptions extends Omit<ILoaderOptions1, "noopCountFrequency" | "noopTimeFrequency"> {
     summarizeProtocolTree?: true,
 }
 

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -7,7 +7,12 @@ import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { DebugLogger } from "@fluidframework/telemetry-utils";
-import { IClient, IDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+import {
+    IClient,
+    IDocumentMessage,
+    MessageType,
+    ISequencedDocumentMessage,
+} from "@fluidframework/protocol-definitions";
 import { MockDocumentDeltaConnection, MockDocumentService } from "@fluidframework/test-loader-utils";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import { DeltaManager } from "../deltaManager";
@@ -66,7 +71,6 @@ describe("Loader", () => {
                         // CollabWindowTracker expects every op submitted (including noops) to result in this call:
                         tracker.stopSequenceNumberUpdate();
                     },
-                    () => true,
                     expectedTimeout,
                     noopCountFrequency,
                 );
@@ -89,16 +93,21 @@ describe("Loader", () => {
                 });
             }
 
+            // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+            function generateOp(type: MessageType = MessageType.Operation) {
+                return {
+                    clientId: "Some client ID",
+                    clientSequenceNumber: ++clientSeqNumber,
+                    minimumSequenceNumber: 0,
+                    sequenceNumber: seq++,
+                    type,
+                } as any as ISequencedDocumentMessage;
+            }
+
             async function emitSequentialOps(type: MessageType = MessageType.Operation, count = 1) {
                 for (let num = 0; num < count; ++num) {
                     assert(!deltaConnection.disposed, "disposed");
-                    deltaConnection.emitOp(docId, [{
-                        clientId: "Some client ID",
-                        clientSequenceNumber: ++clientSeqNumber,
-                        minimumSequenceNumber: 0,
-                        sequenceNumber: seq++,
-                        type,
-                    }]);
+                    deltaConnection.emitOp(docId, [generateOp()]);
                 }
 
                 // Yield the event loop because the inbound op will be processed asynchronously.
@@ -140,6 +149,49 @@ describe("Loader", () => {
                     assert.strictEqual(MessageType.NoOp, messages[0].type);
                     assert.strictEqual(immediate ? "" : null, JSON.parse(messages[0].contents as string));
                 }
+
+                it("Test infinity thresholds of CollabWindowTracker", async () => {
+                    const tracker = new CollabWindowTracker(
+                        () => assert.fail("No ops should be sent with Infinite thresholds"),
+                        Infinity,
+                        Infinity,
+                    );
+                    for (let num = 0; num < 10000; ++num) {
+                        tracker.scheduleSequenceNumberUpdate(generateOp(), false);
+                    }
+                    await tickClock(1000 * 1000);
+                });
+
+                it("Test infinity timeout of CollabWindowTracker", async () => {
+                    let counter = 0;
+                    const tracker = new CollabWindowTracker(
+                        () => { counter++; tracker.stopSequenceNumberUpdate(); },
+                        Infinity,
+                        100,
+                    );
+                    for (let num = 0; num < 99; ++num) {
+                        tracker.scheduleSequenceNumberUpdate(generateOp(), false);
+                    }
+                    await tickClock(1000 * 1000);
+                    assert.equal(counter, 0, "No messages sent after 99 ops");
+                    tracker.scheduleSequenceNumberUpdate(generateOp(), false);
+                    assert.equal(counter, 1, "One message should be sent");
+                });
+
+                it("Test infinity op count of CollabWindowTracker", async () => {
+                    let counter = 0;
+                    const tracker = new CollabWindowTracker(
+                        () => { counter++; tracker.stopSequenceNumberUpdate(); },
+                        100,
+                        Infinity,
+                    );
+                    for (let num = 0; num < 100000; ++num) {
+                        tracker.scheduleSequenceNumberUpdate(generateOp(), false);
+                    }
+                    assert.equal(counter, 0, "No messages sent after 99 ops");
+                    await tickClock(100);
+                    assert.equal(counter, 1, "One message should be sent");
+                });
 
                 it("Should update after op count threshold", async () => {
                     let runCount = 0;

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -20,8 +20,6 @@ const loaderOptionsMatrix: OptionsMatrix<ILoaderOptions> = {
     cache: booleanCases,
     provideScopeLoader: booleanCases,
     maxClientLeaveWaitTime: numberCases,
-    noopCountFrequency: numberCases,
-    noopTimeFrequency: numberCases,
     summarizeProtocolTree: [undefined],
 };
 


### PR DESCRIPTION
Issue #8462.
Support Infinity as input for both duration and number of ops to process before sending non-immediate noop.
This allows to completely shut off noop sending logic.
Also move controls from loader options to relay service config, as this is more appropriate plate to control it.
