### PR TITLE
[r11s] Allow retrying and appropriate error handling in SummaryWriter operations

### DIFF
--- a/server/historian/packages/historian-base/src/utils.ts
+++ b/server/historian/packages/historian-base/src/utils.ts
@@ -100,9 +100,9 @@ export function getRequestErrorTranslator(
             // Here, we log information associated with the error for debugging purposes, and re-throw.
             const networkError = error as NetworkError;
             // eslint-disable-next-line max-len
-            winston.error(`${standardLogErrorMessage}: [statusCode: ${networkError.code}], [details: ${networkError.details ?? "undefined"}]`);
+            winston.error(`${standardLogErrorMessage}: [statusCode: ${networkError.code}], [details: ${safeStringify(networkError.details) ?? "undefined"}]`);
             // eslint-disable-next-line max-len
-            Lumberjack.error(`${standardLogErrorMessage}: [statusCode: ${networkError.code}], [details: ${networkError.details ?? "undefined"}]`, lumberProperties);
+            Lumberjack.error(`${standardLogErrorMessage}: [statusCode: ${networkError.code}], [details: ${safeStringify(networkError.details) ?? "undefined"}]`, lumberProperties);
             throw error;
         } else if (typeof error === "number" || !Number.isNaN(Number.parseInt(error, 10))) {
             // The legacy implementation of BasicRestWrapper used to throw status codes only, when status codes

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -41,6 +41,7 @@ import {
     LumberEventName,
     Lumberjack,
 } from "@fluidframework/server-services-telemetry";
+import safeStringify from "json-stringify-safe";
 import { ISummaryWriteResponse, ISummaryWriter } from "./interfaces";
 
 /**
@@ -305,7 +306,7 @@ export class SummaryWriter implements ISummaryWriter {
                 if (!networkError.isFatal) {
                     return {
                         message: {
-                            errorMessage: `A non-fatal error happened when trying to write client summary. Error: ${networkError.details}`,
+                            errorMessage: `A non-fatal error happened when trying to write client summary. Error: ${safeStringify(networkError.details)}`,
                             summaryProposal: {
                                 summarySequenceNumber: op.sequenceNumber,
                             },

--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -8,22 +8,22 @@
  */
 export interface INetworkErrorDetails {
     /**
-     * Indicates whether this is an error that can be retried. Refer to {@link NetworkError#canRetry}.
+     * Indicates whether this is an error that can be retried. Refer to {@link NetworkError.canRetry}.
      */
     canRetry?: boolean;
     /**
      * Indicates whether this error is fatal. This generally indicates that the error causes
      * negative, non-recoverable impact to the component/caller and cannot be ignored.
-     * Refer to {@link NetworkError#isFatal}.
+     * Refer to {@link NetworkError.isFatal}.
      */
     isFatal?: boolean;
     /**
-     * Represents the message associated with the error. Refer to {@link NetworkError#message}.
+     * Represents the message associated with the error. Refer to {@link NetworkError}'s message.
      */
     message?: string;
     /**
      * Represents the time in milliseconds that should be waited before retrying.
-     * Refer to {@link NetworkError#retryAfterMs}.
+     * Refer to {@link NetworkError.retryAfterMs}.
      */
     retryAfter?: number;
 }
@@ -51,7 +51,7 @@ export class NetworkError extends Error {
         message: string,
         /**
          * Optional boolean indicating whether this is an error that can be retried.
-         * Only relevant when {@link NetworkError#isFatal} is false.
+         * Only relevant when {@link NetworkError.isFatal} is false.
          * @public
          */
         public readonly canRetry?: boolean,

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -5,8 +5,11 @@
 
 import { delay } from "@fluidframework/common-utils";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { NetworkError } from "@fluidframework/server-services-client";
 import { ILogger } from "./lambdas";
+
 /**
+ * Executes a given API while providing support to retry on failures, ignore failures, and taking action on error.
  * @param  {()=>Promise<T>} api - function to run and retry in case of error
  * @param  {string} callName - name of the api function we are calling
  * @param  {number} maxRetries - maximum retries after which error is thrown. Retry infinitely if set to -1
@@ -72,4 +75,81 @@ export async function runWithRetry<T>(
     } while (!success);
 
     return result;
+}
+
+/**
+ * Executes a given request action while providing support to retry on failures and taking action on error.
+ * @summary
+ * The difference between {@link requestWithRetry} and {@link runWithRetry} is that {@link runWithRetry} allows the user
+ * to decide whether to ignore the error or not, on a sort of "fire and forget fashion". That makes the return type of
+ * {@link runWithRetry} be slightly different, as `undefined` is a possible return value. That is not the case for
+ * {@link requestWithRetry}, which focuses on requests/operations where the user always wants the error to be
+ * bubbled up, e.g. network requests. It allows for a simpler return type, `T`, since the function would never return
+ * anything other than a `T` value - the only other possibility is a promise rejection.
+ * @param  {()=>Promise<T>} request - function to run and retry in case of error
+ * @param  {string} callName - name of the api function we are calling
+ * @param  {number} maxRetries - maximum retries after which error is thrown. Retry infinitely if set to -1
+ * @param  {number} retryAfterMs - interval factor to wait before retrying. Param to calculateIntervalMs
+ * @param  {(error)=>boolean} shouldRetry? - function that takes error and decides whether to retry on it
+ * @param  {(error, numRetries, retryAfterInterval)=>number} calculateIntervalMs
+ * function which calculates interval to wait before retrying based on error, retryAfterMs and retries so far
+ * @param  {(error)=>void} onErrorFn? - function allowing caller to define custom logic to run on error e.g. custom logs
+ */
+ export async function requestWithRetry<T>(
+    request: () => Promise<T>,
+    callName: string,
+    maxRetries: number,
+    retryAfterMs: number,
+    shouldRetry?: (error) => boolean,
+    calculateIntervalMs = (error, numRetries, retryAfterInterval) => retryAfterInterval * 2 ** numRetries,
+    onErrorFn?: (error) => void,
+): Promise<T> {
+    let result: T;
+    let retryCount = 0;
+    let success = false;
+    do  {
+        try {
+            result = await request();
+            success = true;
+            if (retryCount >= 1) {
+                Lumberjack.info(`Succeeded in executing ${callName} with ${retryCount} retries`);
+            }
+        } catch (error) {
+            Lumberjack.error(`Error running ${callName}: retryCount ${retryCount}`, undefined, error);
+            if (onErrorFn !== undefined) {
+                onErrorFn(error);
+            }
+            if (shouldRetry !== undefined && shouldRetry(error) === false)
+            {
+                Lumberjack.error(`Should not retry ${callName} for the current error, rejecting`, undefined, error);
+                return Promise.reject(error);
+            }
+            // if maxRetries is -1, we retry indefinitely
+            // unless shouldRetry returns false at some point.
+            if (maxRetries !== -1 && retryCount >= maxRetries) {
+                Lumberjack.error(`Error after retrying ${retryCount} times, rejecting`, undefined, error);
+                // Needs to be a full rejection here
+                return Promise.reject(error);
+            }
+
+            const intervalMs = calculateIntervalMs(error, retryCount, retryAfterMs);
+            await delay(intervalMs);
+            retryCount++;
+        }
+    } while (!success);
+
+    return result;
+}
+
+/**
+ * Helper function to decide when or not to retry a {@link @fluidframework/server-services-client#NetworkError}.
+ * Can be used with {@link runWithRetry} and {@link requestWithRetry}.
+ * @param  {any} error - the error parameter to be inspected when deciding whether to retry or not.
+ */
+export function shouldRetryNetworkError(error: any): boolean {
+    if (error instanceof Error && error?.name === "NetworkError") {
+        const networkError = error as NetworkError;
+        return !networkError.isFatal && networkError.canRetry !== undefined && networkError.canRetry;
+    }
+    return false;
 }

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -78,7 +78,7 @@ export async function runWithRetry<T>(
 }
 
 /**
- * Executes a given request action while providing support to retry on failures and taking action on error.
+ * Executes a given request action while providing support for retrying on failures and taking action on error.
  * @summary
  * The difference between {@link requestWithRetry} and {@link runWithRetry} is that {@link runWithRetry} allows the user
  * to decide whether to ignore the error or not, on a sort of "fire and forget fashion". That makes the return type of

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -81,7 +81,7 @@ export async function runWithRetry<T>(
  * Executes a given request action while providing support for retrying on failures and taking action on error.
  * @summary
  * The difference between {@link requestWithRetry} and {@link runWithRetry} is that {@link runWithRetry} allows the user
- * to decide whether to ignore the error or not, on a sort of "fire and forget fashion". That makes the return type of
+ * to decide whether to ignore the error or not, on a "fire and forget" fashion. That makes the return type of
  * {@link runWithRetry} be slightly different, as `undefined` is a possible return value. That is not the case for
  * {@link requestWithRetry}, which focuses on requests/operations where the user always wants the error to be
  * bubbled up, e.g. network requests. It allows for a simpler return type, `T`, since the function would never return

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -101,7 +101,8 @@ export async function runWithRetry<T>(
     shouldRetry: (error) => boolean = shouldRetryNetworkError,
     maxRetries: number = -1,
     retryAfterMs: number = 1000,
-    calculateIntervalMs = calculateRetryIntervalForNetworkError,
+    calculateIntervalMs: (error: any, numRetries: number, retryAfterInterval: number) => number
+        = calculateRetryIntervalForNetworkError,
     onErrorFn?: (error) => void,
 ): Promise<T> {
     let result: T;
@@ -167,9 +168,10 @@ export function calculateRetryIntervalForNetworkError(
     error: any,
     numRetries: number,
     retryAfterInterval: number): number {
-    let overwriteRetryAfterInterval: number | undefined;
-    if (error instanceof Error && error?.name === "NetworkError") {
-        overwriteRetryAfterInterval = (error as NetworkError).retryAfterMs;
+    if (error instanceof Error
+        && error?.name === "NetworkError"
+        && (error as NetworkError).retryAfterMs) {
+        return (error as NetworkError).retryAfterMs;
     }
-    return (overwriteRetryAfterInterval ?? retryAfterInterval) * 2 ** numRetries;
+    return retryAfterInterval * 2 ** numRetries;
 }

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -142,7 +142,7 @@ export async function runWithRetry<T>(
 }
 
 /**
- * Helper function to decide when or not to retry a {@link @fluidframework/server-services-client#NetworkError}.
+ * Helper function to decide when or not to retry a {@link NetworkError}.
  * Can be used with {@link runWithRetry} and {@link requestWithRetry}.
  * @param  {any} error - the error parameter to be inspected when deciding whether to retry or not.
  */

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -169,8 +169,7 @@ export function calculateRetryIntervalForNetworkError(
     retryAfterInterval: number): number {
     let overwriteRetryAfterInterval: number | undefined;
     if (error instanceof Error && error?.name === "NetworkError") {
-        const networkError = error as NetworkError;
-        overwriteRetryAfterInterval = networkError.retryAfterMs;
+        overwriteRetryAfterInterval = (error as NetworkError).retryAfterMs;
     }
     return (overwriteRetryAfterInterval ?? retryAfterInterval) * 2 ** numRetries;
 }


### PR DESCRIPTION
SummaryWriter (as well as many other components in the system) relies on network calls for executing operations. For example, SummaryWriter makes calls to the summary storage manager to upload summaries, get refs, etc. Those calls are subject to network failures, in which case we would like to retry them. The calls can also fail with particular errors that should not corrupt the document (that is, those errors are not fatal). But we currently do not have support for detecting those non-fatal scenarios yet. So, following up on #8537 and #8552, this PR adds support for appropriate error handling and retries in SummaryWriter. Details:
* Introduces new `requestWithRetry` helper function that, similar to the current `runWithRetry` but with a different return type, meeting the needs of SummaryWriter and others that might never want to provide an `ignoreOnFailure` argument and thus avoiding all the unnecessary undefined/null-checking
* Applies `requestWithRetry` in SummaryWriter and appropriately handles `NetworkError`s that can happen as a result
* Rearranges the try/catch blocks in SummaryWriter to handle all those possible `NetworkErrors`
* Fixes logging (including in Historian) 