### PR TITLE
Upgrade all packages to TypeScript 4.5

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -6457,9 +6457,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/common-definitions/tsconfig.json
+++ b/common/lib/common-definitions/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -14331,9 +14331,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -117,7 +117,7 @@
     "sinon": "^7.4.2",
     "ts-jest": "^26.4.4",
     "ts-node": "^7.0.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "jest-junit": {

--- a/common/lib/common-utils/src/test/jest/tsconfig.json
+++ b/common/lib/common-utils/src/test/jest/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../../dist/test/jest",
         "types": [

--- a/common/lib/common-utils/src/test/mocha/tsconfig.json
+++ b/common/lib/common-utils/src/test/mocha/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../../dist/test/mocha",
         "types": [

--- a/common/lib/common-utils/src/test/types/tsconfig.json
+++ b/common/lib/common-utils/src/test/types/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../../dist/test/types",
     },

--- a/common/lib/common-utils/tsconfig.json
+++ b/common/lib/common-utils/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -6348,9 +6348,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/container-definitions/src/test/types/tsconfig.json
+++ b/common/lib/container-definitions/src/test/types/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../../dist/test/types",
         "declaration": false,

--- a/common/lib/container-definitions/tsconfig.json
+++ b/common/lib/container-definitions/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -6175,9 +6175,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/core-interfaces/tsconfig.json
+++ b/common/lib/core-interfaces/tsconfig.json
@@ -6,6 +6,7 @@
         "test-d"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -6275,9 +6275,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/driver-definitions/tsconfig.json
+++ b/common/lib/driver-definitions/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -6189,9 +6189,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typescript-formatter": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/common/lib/protocol-definitions/tsconfig.json
+++ b/common/lib/protocol-definitions/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/examples/agents/intelligence-runner-agent/package.json
+++ b/examples/agents/intelligence-runner-agent/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/examples/agents/intelligence-runner-agent/tsconfig.json
+++ b/examples/agents/intelligence-runner-agent/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist"

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -76,7 +76,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/apps/collaborative-textarea/tsconfig.json
+++ b/examples/apps/collaborative-textarea/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -74,7 +74,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/apps/contact-collection/tsconfig.json
+++ b/examples/apps/contact-collection/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/apps/likes-and-comments/package.json
+++ b/examples/apps/likes-and-comments/package.json
@@ -76,7 +76,7 @@
     "style-loader": "^1.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/apps/likes-and-comments/tsconfig.json
+++ b/examples/apps/likes-and-comments/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "allowSyntheticDefaultImports": true,
         "target": "es6",
         "module": "esnext",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -94,7 +94,7 @@
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.43.0",

--- a/examples/apps/spaces/tsconfig.json
+++ b/examples/apps/spaces/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "declarationDir": "./dist",
         "outDir": "./dist",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/apps/view-framework-sampler/tsconfig.json
+++ b/examples/apps/view-framework-sampler/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/badge/tsconfig.json
+++ b/examples/data-objects/badge/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "module": "esnext",
         "outDir": "dist",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -76,7 +76,7 @@
     "rimraf": "^2.6.2",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.43.0",

--- a/examples/data-objects/canvas/tsconfig.json
+++ b/examples/data-objects/canvas/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "outDir": "dist",
         "jsx": "react",
         "types": ["jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer", "react", "react-dom"],

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.8.0",
     "webpack-merge": "^4.1.4"

--- a/examples/data-objects/clicker-react/clicker-context/tsconfig.json
+++ b/examples/data-objects/clicker-react/clicker-context/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.8.0",
     "webpack-merge": "^4.1.4"

--- a/examples/data-objects/clicker-react/clicker-function/tsconfig.json
+++ b/examples/data-objects/clicker-react/clicker-function/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -73,7 +73,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/clicker-react/clicker-react/tsconfig.json
+++ b/examples/data-objects/clicker-react/clicker-react/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -72,7 +72,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.8.0",
     "webpack-merge": "^4.1.4"

--- a/examples/data-objects/clicker-react/clicker-reducer/tsconfig.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -72,7 +72,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.8.0",
     "webpack-merge": "^4.1.4"

--- a/examples/data-objects/clicker-react/clicker-with-hook/tsconfig.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/clicker/tsconfig.json
+++ b/examples/data-objects/clicker/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -90,7 +90,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/examples/data-objects/client-ui-lib/src/test/tsconfig.json
+++ b/examples/data-objects/client-ui-lib/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/examples/data-objects/client-ui-lib/tsconfig.json
+++ b/examples/data-objects/client-ui-lib/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "noUnusedLocals": false,
         "strictNullChecks": false,
         "rootDir": "./src",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^2.6.2",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/codemirror/tsconfig.json
+++ b/examples/data-objects/codemirror/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "module": "esnext",
         "outDir": "dist",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -74,7 +74,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/diceroller/tsconfig.json
+++ b/examples/data-objects/diceroller/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "outDir": "dist",
         "jsx": "react",
         "types": ["react", "react-dom", "jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"]

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -80,7 +80,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/examples/data-objects/flow-util-lib/src/test/tsconfig.json
+++ b/examples/data-objects/flow-util-lib/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/examples/data-objects/flow-util-lib/tsconfig.json
+++ b/examples/data-objects/flow-util-lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "strictNullChecks": false,
         "rootDir": "./src",

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/focus-tracker/tsconfig.json
+++ b/examples/data-objects/focus-tracker/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^2.6.2",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "typings-for-css-modules-loader": "^1.7.0",
     "webpack": "^4.43.0",

--- a/examples/data-objects/image-gallery/tsconfig.json
+++ b/examples/data-objects/image-gallery/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "module": "esnext",
         "outDir": "dist",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -63,7 +63,7 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/key-value-cache/tsconfig.json
+++ b/examples/data-objects/key-value-cache/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "outDir": "dist",
         "lib": [

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -69,7 +69,7 @@
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.43.0",

--- a/examples/data-objects/monaco/tsconfig.json
+++ b/examples/data-objects/monaco/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "outDir": "dist"
     },

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/constellation-model/tsconfig.json
+++ b/examples/data-objects/multiview/constellation-model/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -74,7 +74,7 @@
     "style-loader": "^1.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/constellation-view/tsconfig.json
+++ b/examples/data-objects/multiview/constellation-view/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -85,7 +85,7 @@
     "style-loader": "^1.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/container/tsconfig.json
+++ b/examples/data-objects/multiview/container/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/coordinate-model/tsconfig.json
+++ b/examples/data-objects/multiview/coordinate-model/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -47,7 +47,7 @@
     "puppeteer": "^1.20.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/interface/tsconfig.json
+++ b/examples/data-objects/multiview/interface/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -73,7 +73,7 @@
     "style-loader": "^1.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/plot-coordinate-view/tsconfig.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -73,7 +73,7 @@
     "style-loader": "^1.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/slider-coordinate-view/tsconfig.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -73,7 +73,7 @@
     "style-loader": "^1.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/multiview/triangle-view/tsconfig.json
+++ b/examples/data-objects/multiview/triangle-view/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^2.6.2",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.43.0",

--- a/examples/data-objects/musica/tsconfig.json
+++ b/examples/data-objects/musica/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "module": "esnext",
         "outDir": "dist",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -79,7 +79,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/pond/tsconfig.json
+++ b/examples/data-objects/pond/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/primitives/tsconfig.json
+++ b/examples/data-objects/primitives/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -86,7 +86,7 @@
     "rimraf": "^2.6.2",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/prosemirror/tsconfig.json
+++ b/examples/data-objects/prosemirror/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/scribe/tsconfig.json
+++ b/examples/data-objects/scribe/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "outDir": "dist"
     },
     "include": [

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "fluid": {

--- a/examples/data-objects/search-menu/tsconfig.json
+++ b/examples/data-objects/search-menu/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "outDir": "dist"
     },

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -100,7 +100,7 @@
     "puppeteer": "^1.20.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/shared-text/tsconfig.json
+++ b/examples/data-objects/shared-text/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/simple-fluidobject-embed/tsconfig.json
+++ b/examples/data-objects/simple-fluidobject-embed/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^2.6.2",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/smde/tsconfig.json
+++ b/examples/data-objects/smde/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "module": "esnext",
         "outDir": "dist",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -84,7 +84,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "fluid": {

--- a/examples/data-objects/table-document/src/test/tsconfig.json
+++ b/examples/data-objects/table-document/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/examples/data-objects/table-document/tsconfig.json
+++ b/examples/data-objects/table-document/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/table-view/tsconfig.json
+++ b/examples/data-objects/table-view/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/task-selection/tsconfig.json
+++ b/examples/data-objects/task-selection/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -81,7 +81,7 @@
     "puppeteer": "^1.20.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/data-objects/todo/tsconfig.json
+++ b/examples/data-objects/todo/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "strict": false,
         "alwaysStrict": false,

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -89,7 +89,7 @@
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.43.0",

--- a/examples/data-objects/vltava/tsconfig.json
+++ b/examples/data-objects/vltava/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "module": "esnext",
         "outDir": "dist",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -118,7 +118,7 @@
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
     "ts-node": "^7.0.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.43.0",

--- a/examples/data-objects/webflow/src/test/tsconfig.json
+++ b/examples/data-objects/webflow/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/examples/data-objects/webflow/tsconfig.json
+++ b/examples/data-objects/webflow/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "strictNullChecks": false,
         "rootDir": "./src",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/hosts/app-integration/container-views/tsconfig.json
+++ b/examples/hosts/app-integration/container-views/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -72,7 +72,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/hosts/app-integration/external-controller/tsconfig.json
+++ b/examples/hosts/app-integration/external-controller/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/hosts/app-integration/external-views/tsconfig.json
+++ b/examples/hosts/app-integration/external-views/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "dist",
         "jsx": "react",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/examples/hosts/host-service-interfaces/tsconfig.json
+++ b/examples/hosts/host-service-interfaces/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -55,7 +55,7 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/examples/hosts/hosts-sample/tsconfig.json
+++ b/examples/hosts/hosts-sample/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "module": "esnext",
         "outDir": "dist",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.8.0"

--- a/examples/hosts/iframe-host/tsconfig.json
+++ b/examples/hosts/iframe-host/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -51,6 +51,6 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/examples/hosts/node-host/tsconfig.json
+++ b/examples/hosts/node-host/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "dist",
         "types": [

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-bundle-analyzer": "^3.8.0",

--- a/examples/utils/bundle-size-tests/tsconfig.json
+++ b/examples/utils/bundle-size-tests/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "outDir": "lib",
         "jsx": "react",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/examples/utils/example-utils/tsconfig.json
+++ b/examples/utils/example-utils/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist"

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -88,7 +88,7 @@
     "sass-loader": "^7.1.0",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.8.0"

--- a/experimental/PropertyDDS/examples/partial-checkout/tsconfig.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "allowSyntheticDefaultImports": true,
         "target": "es6",
         "module": "esnext",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -92,7 +92,7 @@
     "source-map-loader": "^0.2.4",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.8.0"

--- a/experimental/PropertyDDS/examples/property-inspector/tsconfig.json
+++ b/experimental/PropertyDDS/examples/property-inspector/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "allowSyntheticDefaultImports": true,
         "target": "es6",
         "module": "esnext",

--- a/experimental/PropertyDDS/examples/schemas/package.json
+++ b/experimental/PropertyDDS/examples/schemas/package.json
@@ -31,6 +31,6 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/experimental/PropertyDDS/examples/schemas/tsconfig.json
+++ b/experimental/PropertyDDS/examples/schemas/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -99,7 +99,7 @@
     "ts-loader": "^6.1.2",
     "ts-node": "^7.0.1",
     "typedoc": "^0.12.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "jest-junit": {
     "outputDirectory": "nyc",

--- a/experimental/PropertyDDS/packages/property-binder/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "experimentalDecorators": true,
         "allowJs": true,
         "jsx": "react",

--- a/experimental/PropertyDDS/packages/property-binder/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-binder/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "experimentalDecorators": true,
         "allowJs": true,
         "outDir": "./dist",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -89,7 +89,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": false,
         "allowJs": true,
         "checkJs": false,

--- a/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": false,
         "declarationDir": "./dist",
         "rootDir": "./src",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -89,7 +89,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/PropertyDDS/packages/property-common/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-common/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/experimental/PropertyDDS/packages/property-common/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-common/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "rootDir": "./src",
         "outDir": "./dist"

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -76,6 +76,6 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/experimental/PropertyDDS/packages/property-dds/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-dds/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
 		"composite": true,
 		"downlevelIteration": true,
 		"noUnusedLocals": false,

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -98,7 +98,7 @@
     "svgo-loader": "^2.1.0",
     "ts-jest": "^26.4.4",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.8.0",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -75,7 +75,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/PropertyDDS/packages/property-properties/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-properties/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": false,
         "allowJs": true,
         "checkJs": false,

--- a/experimental/PropertyDDS/packages/property-properties/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-properties/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": false,
         "allowJs": true,
         "checkJs": false,

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -61,7 +61,7 @@
     "source-map-support": "^0.5.16",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "jest-junit": {
     "outputDirectory": "nyc",

--- a/experimental/PropertyDDS/packages/property-proxy/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-proxy/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/experimental/PropertyDDS/packages/property-proxy/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-proxy/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -87,7 +87,7 @@
     "nyc": "^15.0.0",
     "quill-delta": "^4.2.2",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/dds/ot/ot/src/test/tsconfig.json
+++ b/experimental/dds/ot/ot/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/experimental/dds/ot/ot/tsconfig.json
+++ b/experimental/dds/ot/ot/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -89,7 +89,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/dds/ot/sharejs/json1/src/test/tsconfig.json
+++ b/experimental/dds/ot/sharejs/json1/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/experimental/dds/ot/sharejs/json1/tsconfig.json
+++ b/experimental/dds/ot/sharejs/json1/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/experimental/dds/tree-graphql/package.json
+++ b/experimental/dds/tree-graphql/package.json
@@ -61,6 +61,6 @@
     "nyc": "^15.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -74,6 +74,6 @@
     "nyc": "^15.0.0",
     "prettier": "^2.3.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -91,7 +91,7 @@
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.16",
     "ts-node": "^7.0.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "uuid": "^8.3.1"
   }

--- a/experimental/dds/xtree/src/test/tsconfig.json
+++ b/experimental/dds/xtree/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/experimental/dds/xtree/tsconfig.json
+++ b/experimental/dds/xtree/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -78,7 +78,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/experimental/examples/bubblebench/baseline/tsconfig.json
+++ b/experimental/examples/bubblebench/baseline/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "lib": ["ESNext", "DOM"],
         "outDir": "dist",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -84,7 +84,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "fluid": {

--- a/experimental/examples/bubblebench/common/tsconfig.json
+++ b/experimental/examples/bubblebench/common/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "lib": ["ESNext", "DOM"],
         "outDir": "dist",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -80,7 +80,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/experimental/examples/bubblebench/ot/tsconfig.json
+++ b/experimental/examples/bubblebench/ot/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "lib": ["ESNext", "DOM"],
         "outDir": "dist",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -79,7 +79,7 @@
     "rimraf": "^2.6.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",

--- a/experimental/examples/bubblebench/sharedtree/tsconfig.json
+++ b/experimental/examples/bubblebench/sharedtree/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "lib": ["ESNext", "DOM"],
         "outDir": "dist",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/framework/data-objects/tsconfig.json
+++ b/experimental/framework/data-objects/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "module": "esnext",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/framework/get-container/tsconfig.json
+++ b/experimental/framework/get-container/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -80,7 +80,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/framework/last-edited/tsconfig.json
+++ b/experimental/framework/last-edited/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/framework/react-inputs/tsconfig.json
+++ b/experimental/framework/react-inputs/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/experimental/framework/react/package.json
+++ b/experimental/framework/react/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/experimental/framework/react/tsconfig.json
+++ b/experimental/framework/react/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -41117,9 +41117,9 @@
 			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
 			"dev": true
 		},
 		"typescript-formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11054,9 +11054,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lerna": "^4.0.0",
     "rimraf": "^2.6.2",
     "run-script-os": "^1.1.6",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "c8": {
     "all": true,

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -86,7 +86,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/cell/src/test/tsconfig.json
+++ b/packages/dds/cell/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/cell/tsconfig.json
+++ b/packages/dds/cell/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -83,6 +83,6 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/packages/dds/counter/src/test/tsconfig.json
+++ b/packages/dds/counter/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/counter/tsconfig.json
+++ b/packages/dds/counter/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -85,7 +85,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/ink/src/test/tsconfig.json
+++ b/packages/dds/ink/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/ink/tsconfig.json
+++ b/packages/dds/ink/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -89,7 +89,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/map/src/test/tsconfig.json
+++ b/packages/dds/map/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/packages/dds/map/tsconfig.json
+++ b/packages/dds/map/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/dds/matrix/bench/tsconfig.json
+++ b/packages/dds/matrix/bench/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "..",
         "outDir": "./dist",
         "types": ["node"]

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -96,7 +96,7 @@
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.16",
     "ts-node": "^7.0.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "uuid": "^8.3.1"
   }

--- a/packages/dds/matrix/src/test/tsconfig.json
+++ b/packages/dds/matrix/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/packages/dds/matrix/tsconfig.json
+++ b/packages/dds/matrix/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -90,7 +90,7 @@
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.16",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/merge-tree/src/test/tsconfig.json
+++ b/packages/dds/merge-tree/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/packages/dds/merge-tree/tsconfig.json
+++ b/packages/dds/merge-tree/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -86,7 +86,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/ordered-collection/src/test/tsconfig.json
+++ b/packages/dds/ordered-collection/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/ordered-collection/tsconfig.json
+++ b/packages/dds/ordered-collection/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -86,7 +86,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/register-collection/src/test/tsconfig.json
+++ b/packages/dds/register-collection/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/register-collection/tsconfig.json
+++ b/packages/dds/register-collection/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -99,7 +99,7 @@
     "nyc": "^15.0.0",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/sequence/src/test/tsconfig.json
+++ b/packages/dds/sequence/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/packages/dds/sequence/tsconfig.json
+++ b/packages/dds/sequence/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/shared-object-base/tsconfig.json
+++ b/packages/dds/shared-object-base/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -88,7 +88,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/shared-summary-block/src/test/tsconfig.json
+++ b/packages/dds/shared-summary-block/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/shared-summary-block/tsconfig.json
+++ b/packages/dds/shared-summary-block/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -90,7 +90,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/task-manager/src/test/tsconfig.json
+++ b/packages/dds/task-manager/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/dds/task-manager/tsconfig.json
+++ b/packages/dds/task-manager/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/dds/test-dds-utils/tsconfig.json
+++ b/packages/dds/test-dds-utils/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/debugger/tsconfig.json
+++ b/packages/drivers/debugger/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "lib": [ "ES2017", "ES2018.Promise", "ES2018.AsyncIterable", "DOM", "DOM.Iterable" ]

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/driver-base/tsconfig.json
+++ b/packages/drivers/driver-base/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/file-driver/tsconfig.json
+++ b/packages/drivers/file-driver/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [ "node" ],

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/fluidapp-odsp-urlResolver/src/test/tsconfig.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/fluidapp-odsp-urlResolver/tsconfig.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -60,7 +60,7 @@
     "mocha": "^8.4.0",
     "nock": "^10.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/iframe-driver/tsconfig.json
+++ b/packages/drivers/iframe-driver/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -88,7 +88,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/local-driver/src/test/tsconfig.json
+++ b/packages/drivers/local-driver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/local-driver/tsconfig.json
+++ b/packages/drivers/local-driver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/odsp-driver-definitions/tsconfig.json
+++ b/packages/drivers/odsp-driver-definitions/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -97,7 +97,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/odsp-driver/src/test/tsconfig.json
+++ b/packages/drivers/odsp-driver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/odsp-driver/tsconfig.json
+++ b/packages/drivers/odsp-driver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/odsp-urlResolver/src/test/tsconfig.json
+++ b/packages/drivers/odsp-urlResolver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/odsp-urlResolver/tsconfig.json
+++ b/packages/drivers/odsp-urlResolver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -57,7 +57,7 @@
     "mocha": "^8.4.0",
     "nock": "^10.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/replay-driver/tsconfig.json
+++ b/packages/drivers/replay-driver/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -98,7 +98,7 @@
     "nock": "^10.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/routerlicious-driver/src/test/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/routerlicious-driver/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/routerlicious-host/src/test/tsconfig.json
+++ b/packages/drivers/routerlicious-host/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/routerlicious-host/tsconfig.json
+++ b/packages/drivers/routerlicious-host/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/routerlicious-urlResolver/src/test/tsconfig.json
+++ b/packages/drivers/routerlicious-urlResolver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/routerlicious-urlResolver/tsconfig.json
+++ b/packages/drivers/routerlicious-urlResolver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/drivers/tinylicious-driver/src/test/tsconfig.json
+++ b/packages/drivers/tinylicious-driver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/drivers/tinylicious-driver/tsconfig.json
+++ b/packages/drivers/tinylicious-driver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -97,7 +97,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "module:es5": "es5/index.js"

--- a/packages/framework/aqueduct/src/test/tsconfig.json
+++ b/packages/framework/aqueduct/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/framework/aqueduct/tsconfig.json
+++ b/packages/framework/aqueduct/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -67,7 +67,7 @@
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "peerDependencies": {
     "fluid-framework": "^0.50.0"

--- a/packages/framework/azure-client/src/test/tsconfig.json
+++ b/packages/framework/azure-client/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": ".",
         "outDir": "../../dist/test",
         "composite": true,

--- a/packages/framework/azure-client/tsconfig.json
+++ b/packages/framework/azure-client/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/framework/azure-service-utils/package.json
+++ b/packages/framework/azure-service-utils/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/azure-service-utils/tsconfig.json
+++ b/packages/framework/azure-service-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -87,7 +87,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "module:es5": "es5/index.js"

--- a/packages/framework/data-object-base/tsconfig.json
+++ b/packages/framework/data-object-base/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -89,7 +89,7 @@
     "nyc": "^15.0.0",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/dds-interceptions/src/test/tsconfig.json
+++ b/packages/framework/dds-interceptions/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/framework/dds-interceptions/tsconfig.json
+++ b/packages/framework/dds-interceptions/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/fluid-framework/tsconfig.json
+++ b/packages/framework/fluid-framework/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/fluid-static/tsconfig.json
+++ b/packages/framework/fluid-static/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -87,7 +87,7 @@
     "nyc": "^15.0.0",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/request-handler/src/test/tsconfig.json
+++ b/packages/framework/request-handler/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/framework/request-handler/tsconfig.json
+++ b/packages/framework/request-handler/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -83,7 +83,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/synthesize/src/test/tsconfig.json
+++ b/packages/framework/synthesize/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/framework/synthesize/tsconfig.json
+++ b/packages/framework/synthesize/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/test-client-utils/tsconfig.json
+++ b/packages/framework/test-client-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
     "tinylicious": "^0.4.38350",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "peerDependencies": {
     "fluid-framework": "^0.50.0"

--- a/packages/framework/tinylicious-client/src/test/tsconfig.json
+++ b/packages/framework/tinylicious-client/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": ".",
         "outDir": "../../dist/test",
         "composite": true,

--- a/packages/framework/tinylicious-client/tsconfig.json
+++ b/packages/framework/tinylicious-client/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -87,7 +87,7 @@
     "nyc": "^15.0.0",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/undo-redo/src/test/tsconfig.json
+++ b/packages/framework/undo-redo/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/framework/undo-redo/tsconfig.json
+++ b/packages/framework/undo-redo/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/view-adapters/tsconfig.json
+++ b/packages/framework/view-adapters/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/framework/view-interfaces/tsconfig.json
+++ b/packages/framework/view-interfaces/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declarationDir": "./dist",
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -98,7 +98,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/loader/container-loader/src/test/tsconfig.json
+++ b/packages/loader/container-loader/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/loader/container-loader/tsconfig.json
+++ b/packages/loader/container-loader/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -83,6 +83,6 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/packages/loader/container-utils/src/test/tsconfig.json
+++ b/packages/loader/container-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/loader/container-utils/tsconfig.json
+++ b/packages/loader/container-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -89,7 +89,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/loader/driver-utils/src/test/tsconfig.json
+++ b/packages/loader/driver-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/loader/driver-utils/tsconfig.json
+++ b/packages/loader/driver-utils/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "rootDir": "./src",
         "outDir": "./dist"

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/loader/test-loader-utils/tsconfig.json
+++ b/packages/loader/test-loader-utils/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/loader/web-code-loader/tsconfig.json
+++ b/packages/loader/web-code-loader/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -76,7 +76,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "fluid": {

--- a/packages/runtime/agent-scheduler/tsconfig.json
+++ b/packages/runtime/agent-scheduler/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/packages/runtime/container-runtime-definitions/src/test/tsconfig.json
+++ b/packages/runtime/container-runtime-definitions/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "declaration": false,

--- a/packages/runtime/container-runtime-definitions/tsconfig.json
+++ b/packages/runtime/container-runtime-definitions/tsconfig.json
@@ -6,6 +6,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -101,7 +101,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/runtime/container-runtime/src/test/tsconfig.json
+++ b/packages/runtime/container-runtime/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/packages/runtime/container-runtime/tsconfig.json
+++ b/packages/runtime/container-runtime/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "rootDir": "./src",
         "outDir": "./dist"

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/packages/runtime/datastore-definitions/src/test/tsconfig.json
+++ b/packages/runtime/datastore-definitions/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "declaration": false,

--- a/packages/runtime/datastore-definitions/tsconfig.json
+++ b/packages/runtime/datastore-definitions/tsconfig.json
@@ -6,6 +6,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -97,7 +97,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/runtime/datastore/src/test/tsconfig.json
+++ b/packages/runtime/datastore/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/packages/runtime/datastore/tsconfig.json
+++ b/packages/runtime/datastore/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "composite": true,
         "rootDir": "./src",
         "outDir": "./dist"

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -85,6 +85,6 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/packages/runtime/garbage-collector/src/test/tsconfig.json
+++ b/packages/runtime/garbage-collector/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/runtime/garbage-collector/tsconfig.json
+++ b/packages/runtime/garbage-collector/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {

--- a/packages/runtime/runtime-definitions/src/test/tsconfig.json
+++ b/packages/runtime/runtime-definitions/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "declaration": false,

--- a/packages/runtime/runtime-definitions/tsconfig.json
+++ b/packages/runtime/runtime-definitions/tsconfig.json
@@ -6,6 +6,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -72,7 +72,6 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/eslint-config-fluid": "^0.24.0",
     "@fluidframework/mocha-test-setup": "^0.54.0",
-    "@fluidframework/telemetry-utils": "^0.53.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@types/benchmark": "^2.1.0",
     "@types/mocha": "^8.2.2",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -95,7 +95,7 @@
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
     "ts-node": "^7.0.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/runtime/runtime-utils/src/test/tsconfig.json
+++ b/packages/runtime/runtime-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/runtime/runtime-utils/tsconfig.json
+++ b/packages/runtime/runtime-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -92,7 +92,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/runtime/test-runtime-utils/src/test/tsconfig.json
+++ b/packages/runtime/test-runtime-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/runtime/test-runtime-utils/tsconfig.json
+++ b/packages/runtime/test-runtime-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -78,7 +78,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"

--- a/packages/test/functional-tests/tsconfig.json
+++ b/packages/test/functional-tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -110,7 +110,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "uuid": "^8.3.1",
     "webpack": "^4.43.0",

--- a/packages/test/local-server-tests/src/test/tsconfig.json
+++ b/packages/test/local-server-tests/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "./",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-unicorn": "~26.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/test/mocha-test-setup/tsconfig.json
+++ b/packages/test/mocha-test-setup/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [ "node", "mocha" ]

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -95,7 +95,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/test/snapshots/src/test/tsconfig.json
+++ b/packages/test/snapshots/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/test/snapshots/tsconfig.json
+++ b/packages/test/snapshots/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -72,7 +72,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/test/test-app-insights-logger/tsconfig.json
+++ b/packages/test/test-app-insights-logger/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [ "mocha" ]

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -75,7 +75,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/test/test-driver-definitions/tsconfig.json
+++ b/packages/test/test-driver-definitions/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [ "node", "mocha" ]

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -91,7 +91,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/test/test-drivers/tsconfig.json
+++ b/packages/test/test-drivers/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [ "node", "mocha" ]

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -133,7 +133,7 @@
     "nock": "^10.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/test/test-end-to-end-tests/src/test/tsconfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "declaration": false,
         "declarationMap": false,
         "rootDir": "../",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -69,6 +69,6 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/packages/test/test-pairwise-generator/tsconfig.json
+++ b/packages/test/test-pairwise-generator/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -110,6 +110,6 @@
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
     "tinylicious": "^0.4.38350",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/packages/test/test-service-load/src/test/tsconfig.json
+++ b/packages/test/test-service-load/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/test/test-service-load/tsconfig.json
+++ b/packages/test/test-service-load/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -98,7 +98,7 @@
     "nyc": "^15.0.0",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/test/test-utils/tsconfig.json
+++ b/packages/test/test-utils/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [ "mocha" ]

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -97,7 +97,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "uuid": "^8.3.1",
     "webpack": "^4.43.0",

--- a/packages/test/test-version-utils/tsconfig.json
+++ b/packages/test/test-version-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/tools/fetch-tool/tsconfig.json
+++ b/packages/tools/fetch-tool/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/tools/merge-tree-client-replay/tsconfig.json
+++ b/packages/tools/merge-tree-client-replay/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/tools/replay-tool/tsconfig.json
+++ b/packages/tools/replay-tool/tsconfig.json
@@ -1,10 +1,11 @@
-{    
+{
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -111,7 +111,7 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"

--- a/packages/tools/webpack-fluid-loader/src/test/tsconfig.json
+++ b/packages/tools/webpack-fluid-loader/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/tools/webpack-fluid-loader/tsconfig.json
+++ b/packages/tools/webpack-fluid-loader/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "jsx": "react",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -82,7 +82,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/utils/odsp-doclib-utils/src/test/tsconfig.json
+++ b/packages/utils/odsp-doclib-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/utils/odsp-doclib-utils/tsconfig.json
+++ b/packages/utils/odsp-doclib-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -90,6 +90,6 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^7.4.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/packages/utils/telemetry-utils/src/test/tsconfig.json
+++ b/packages/utils/telemetry-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/utils/telemetry-utils/tsconfig.json
+++ b/packages/utils/telemetry-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -89,7 +89,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/packages/utils/tool-utils/src/test/tsconfig.json
+++ b/packages/utils/tool-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/packages/utils/tool-utils/tsconfig.json
+++ b/packages/utils/tool-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/server/azure-local-service/package-lock.json
+++ b/server/azure-local-service/package-lock.json
@@ -7860,9 +7860,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typewise": {

--- a/server/azure-local-service/package.json
+++ b/server/azure-local-service/package.json
@@ -49,7 +49,7 @@
     "forever": "^3.0.4",
     "rimraf": "^2.6.2",
     "ts-node": "^8.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "engines": {
     "node": ">=12.17.0"

--- a/server/azure-local-service/tsconfig.json
+++ b/server/azure-local-service/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -675,9 +675,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1026.0-43898",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0-43898.tgz",
-      "integrity": "sha512-KOs5CPa1hWcFkuw+/TPLfcv097hYloEbLyaQ530K0P3+jLj1ADWb2FI00bXo6uiowHUU1HHc4Dv6oBB3gHR+FA==",
+      "version": "0.1026.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0.tgz",
+      "integrity": "sha512-dDjLGrpZd02NU9oXEzgQlW50EDt75v2CSU90xhg4S1VkHHuNrQfc/jEEeYNAVqac9duPutcDK4pP1n4AESYjlw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
       }
@@ -7819,9 +7819,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uid2": {

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -77,6 +77,6 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.3",
     "supertest": "^3.4.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/server/gitrest/tsconfig.json
+++ b/server/gitrest/tsconfig.json
@@ -4,6 +4,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "target": "es6",
         "declaration": true,

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -336,15 +336,15 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.44827",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.44827.tgz",
-			"integrity": "sha512-gU6nYhF9ZhchZCZ092dABKI7AY3brO4+BQzhmH9vakZdmQ43kL7GcjHgR5N2N6idoqcCGIulzYxoXxYxhnTrMQ==",
+			"version": "0.2.46657",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
+			"integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
 				"async": "^3.2.0",
 				"chalk": "^2.4.2",
-				"commander": "^2.20.0",
+				"commander": "^6.2.1",
 				"danger": "^10.4.1",
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.3",
@@ -362,6 +362,12 @@
 				"ts-morph": "^7.1.2"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+					"dev": true
+				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -3323,77 +3329,19 @@
 			}
 		},
 		"@oclif/command": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.7.tgz",
-			"integrity": "sha512-5DRLd2WHppuKsudHe8rCZnjgEpA2/6P4zxrLwWBXrGz+/kzA/RWcPJgkcdfm1uBCEgHMSWZP4MX21d4lAB1vYA==",
+			"version": "1.8.15",
+			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
+			"integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
 			"dev": true,
 			"requires": {
-				"@oclif/config": "^1.18.1",
+				"@oclif/config": "^1.18.2",
 				"@oclif/errors": "^1.3.5",
+				"@oclif/help": "^1.0.1",
 				"@oclif/parser": "^3.8.6",
-				"@oclif/plugin-help": "^3.2.10",
 				"debug": "^4.1.1",
 				"semver": "^7.3.2"
 			},
 			"dependencies": {
-				"@oclif/plugin-help": {
-					"version": "3.2.10",
-					"resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.10.tgz",
-					"integrity": "sha512-U3Jk01MTnqnd9druulNSn6nTjPEE1Rr6PWhD4rJ6Z+NjLFTKhp3S1kutWDXJQd7CQ6m8tHd1AYgsIjiR+36bSw==",
-					"dev": true,
-					"requires": {
-						"@oclif/command": "^1.8.6",
-						"@oclif/config": "^1.18.1",
-						"@oclif/errors": "^1.3.5",
-						"chalk": "^4.1.2",
-						"indent-string": "^4.0.0",
-						"lodash": "^4.17.21",
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"widest-line": "^3.1.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -3402,33 +3350,13 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
 				}
 			}
 		},
 		"@oclif/config": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.1.tgz",
-			"integrity": "sha512-twRJO5RRl3CCDaAASb6LiynfFQl/SbkWWOQy1l0kJZSMPysEhz+fk3BKfmlCCm451Btkp4UezHUwI1JtH+/zYg==",
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+			"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
 			"dev": true,
 			"requires": {
 				"@oclif/errors": "^1.3.3",
@@ -3500,6 +3428,85 @@
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 					"dev": true
+				}
+			}
+		},
+		"@oclif/help": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
+			"integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
+			"dev": true,
+			"requires": {
+				"@oclif/config": "1.18.2",
+				"@oclif/errors": "1.3.5",
+				"chalk": "^4.1.2",
+				"indent-string": "^4.0.0",
+				"lodash": "^4.17.21",
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"widest-line": "^3.1.0",
+				"wrap-ansi": "^6.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
 				}
 			}
 		},
@@ -4371,9 +4378,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.17.27",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
-			"integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw=="
+			"version": "14.18.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+			"integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -10187,9 +10194,9 @@
 			"dev": true
 		},
 		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
 			"dev": true
 		},
 		"is-number": {
@@ -10323,12 +10330,12 @@
 			"dev": true
 		},
 		"is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-windows": {
@@ -12892,9 +12899,9 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-inspect": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+			"integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
 			"dev": true
 		},
 		"object-is": {
@@ -16127,7 +16134,7 @@
 		"tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-			"integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
 			"dev": true
 		},
 		"trim-newlines": {
@@ -16295,9 +16302,9 @@
 			},
 			"dependencies": {
 				"qs": {
-					"version": "6.10.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-					"integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
+					"integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
 					"dev": true,
 					"requires": {
 						"side-channel": "^1.0.4"
@@ -16321,9 +16328,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -321,15 +321,15 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.44827",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.44827.tgz",
-      "integrity": "sha512-gU6nYhF9ZhchZCZ092dABKI7AY3brO4+BQzhmH9vakZdmQ43kL7GcjHgR5N2N6idoqcCGIulzYxoXxYxhnTrMQ==",
+      "version": "0.2.46657",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
+      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
-        "commander": "^2.20.0",
+        "commander": "^6.2.1",
         "danger": "^10.4.1",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
@@ -347,6 +347,12 @@
         "ts-morph": "^7.1.2"
       },
       "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2795,77 +2801,19 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.7.tgz",
-      "integrity": "sha512-5DRLd2WHppuKsudHe8rCZnjgEpA2/6P4zxrLwWBXrGz+/kzA/RWcPJgkcdfm1uBCEgHMSWZP4MX21d4lAB1vYA==",
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
+      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
       "dev": true,
       "requires": {
-        "@oclif/config": "^1.18.1",
+        "@oclif/config": "^1.18.2",
         "@oclif/errors": "^1.3.5",
+        "@oclif/help": "^1.0.1",
         "@oclif/parser": "^3.8.6",
-        "@oclif/plugin-help": "^3.2.10",
         "debug": "^4.1.1",
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "@oclif/plugin-help": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.10.tgz",
-          "integrity": "sha512-U3Jk01MTnqnd9druulNSn6nTjPEE1Rr6PWhD4rJ6Z+NjLFTKhp3S1kutWDXJQd7CQ6m8tHd1AYgsIjiR+36bSw==",
-          "dev": true,
-          "requires": {
-            "@oclif/command": "^1.8.6",
-            "@oclif/config": "^1.18.1",
-            "@oclif/errors": "^1.3.5",
-            "chalk": "^4.1.2",
-            "indent-string": "^4.0.0",
-            "lodash": "^4.17.21",
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "widest-line": "^3.1.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2874,33 +2822,13 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
         }
       }
     },
     "@oclif/config": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.1.tgz",
-      "integrity": "sha512-twRJO5RRl3CCDaAASb6LiynfFQl/SbkWWOQy1l0kJZSMPysEhz+fk3BKfmlCCm451Btkp4UezHUwI1JtH+/zYg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
       "dev": true,
       "requires": {
         "@oclif/errors": "^1.3.3",
@@ -2972,6 +2900,85 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        }
+      }
+    },
+    "@oclif/help": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
+      "integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
+      "dev": true,
+      "requires": {
+        "@oclif/config": "1.18.2",
+        "@oclif/errors": "1.3.5",
+        "chalk": "^4.1.2",
+        "indent-string": "^4.0.0",
+        "lodash": "^4.17.21",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
       }
     },
@@ -8790,9 +8797,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+          "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
           "dev": true
         }
       }
@@ -8813,12 +8820,12 @@
       }
     },
     "is-weakref": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "is-windows": {
@@ -13626,7 +13633,7 @@
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "trim-newlines": {
@@ -13776,9 +13783,9 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
+          "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
           "dev": true,
           "requires": {
             "side-channel": "^1.0.4"
@@ -13802,9 +13809,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uglify-js": {
@@ -14121,9 +14128,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+          "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
           "dev": true
         }
       }

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -76,6 +76,6 @@
     "run-script-os": "^1.1.5",
     "supertest": "^3.3.0",
     "tslint": "^5.12.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -80,6 +80,6 @@
     "rimraf": "^2.6.2",
     "sinon": "^9.2.3",
     "supertest": "^3.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/server/historian/packages/historian-base/src/test/tsconfig.json
+++ b/server/historian/packages/historian-base/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/historian/packages/historian-base/tsconfig.json
+++ b/server/historian/packages/historian-base/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -67,6 +67,6 @@
     "rimraf": "^2.6.2",
     "supertest": "^3.3.0",
     "tslint": "^5.12.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/server/historian/packages/historian/tsconfig.json
+++ b/server/historian/packages/historian/tsconfig.json
@@ -4,6 +4,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "target": "es6",
         "declaration": true,
         "module": "commonjs",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -20031,9 +20031,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
 			"dev": true
 		},
 		"typescript-formatter": {

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -11527,9 +11527,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uglify-js": {

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -82,6 +82,6 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "run-script-os": "^1.1.5",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/gitresources/tsconfig.json
+++ b/server/routerlicious/packages/gitresources/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/kafka-orderer/tsconfig.json
+++ b/server/routerlicious/packages/kafka-orderer/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist"
     },

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -76,7 +76,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/lambdas-driver/src/test/tsconfig.json
+++ b/server/routerlicious/packages/lambdas-driver/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/lambdas-driver/tsconfig.json
+++ b/server/routerlicious/packages/lambdas-driver/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -93,7 +93,7 @@
     "rimraf": "^2.6.2",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0"
   }

--- a/server/routerlicious/packages/lambdas/src/test/tsconfig.json
+++ b/server/routerlicious/packages/lambdas/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/lambdas/tsconfig.json
+++ b/server/routerlicious/packages/lambdas/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -88,7 +88,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "ts-loader": "^6.1.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"

--- a/server/routerlicious/packages/local-server/src/test/tsconfig.json
+++ b/server/routerlicious/packages/local-server/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/local-server/tsconfig.json
+++ b/server/routerlicious/packages/local-server/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -88,7 +88,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/memory-orderer/src/test/tsconfig.json
+++ b/server/routerlicious/packages/memory-orderer/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/memory-orderer/tsconfig.json
+++ b/server/routerlicious/packages/memory-orderer/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -81,7 +81,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/protocol-base/src/test/tsconfig.json
+++ b/server/routerlicious/packages/protocol-base/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/server/routerlicious/packages/protocol-base/tsconfig.json
+++ b/server/routerlicious/packages/protocol-base/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -116,7 +116,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "supertest": "^3.1.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/routerlicious-base/tsconfig.json
+++ b/server/routerlicious/packages/routerlicious-base/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/routerlicious/tsconfig.json
+++ b/server/routerlicious/packages/routerlicious/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -90,7 +90,7 @@
     "mocha": "^8.4.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-client/src/test/tsconfig.json
+++ b/server/routerlicious/packages/services-client/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/services-client/tsconfig.json
+++ b/server/routerlicious/packages/services-client/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-react": "~7.22.0",
     "eslint-plugin-unicorn": "~26.0.1",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-core/tsconfig.json
+++ b/server/routerlicious/packages/services-core/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -53,7 +53,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-ordering-kafkanode/tsconfig.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -54,7 +54,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/tsconfig.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "types": [

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -50,7 +50,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-ordering-zookeeper/tsconfig.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -95,7 +95,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "supertest": "^3.1.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-shared/src/test/tsconfig.json
+++ b/server/routerlicious/packages/services-shared/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/services-shared/tsconfig.json
+++ b/server/routerlicious/packages/services-shared/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -75,7 +75,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-telemetry/src/test/tsconfig.json
+++ b/server/routerlicious/packages/services-telemetry/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/services-telemetry/tsconfig.json
+++ b/server/routerlicious/packages/services-telemetry/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": true,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -88,7 +88,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "supertest": "^3.1.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services-utils/tsconfig.json
+++ b/server/routerlicious/packages/services-utils/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": true,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -96,7 +96,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/services/tsconfig.json
+++ b/server/routerlicious/packages/services/tsconfig.json
@@ -5,6 +5,7 @@
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -80,7 +80,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^9.2.1",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "typescript-formatter": "7.1.0"
   }
 }

--- a/server/routerlicious/packages/test-utils/src/test/tsconfig.json
+++ b/server/routerlicious/packages/test-utils/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./",
         "outDir": "../../dist/test",

--- a/server/routerlicious/packages/test-utils/tsconfig.json
+++ b/server/routerlicious/packages/test-utils/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -321,6 +321,7 @@
         "@types/debug": "^4.1.5",
         "@types/double-ended-queue": "^2.1.0",
         "@types/lodash": "^4.14.118",
+        "@types/node": "^12.19.0",
         "@types/ws": "^6.0.1",
         "debug": "^4.1.1",
         "double-ended-queue": "^2.1.0-0",
@@ -328,6 +329,13 @@
         "moniker": "^0.1.2",
         "uuid": "^8.3.1",
         "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
+          "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+        }
       }
     },
     "@fluidframework/server-services-client": {
@@ -359,8 +367,16 @@
         "@fluidframework/server-services-client": "^0.1034.0",
         "@fluidframework/server-services-telemetry": "^0.1034.0",
         "@types/nconf": "^0.10.0",
+        "@types/node": "^12.19.0",
         "debug": "^4.1.1",
         "nconf": "^0.11.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
+          "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+        }
       }
     },
     "@fluidframework/server-services-shared": {
@@ -8520,9 +8536,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "typewise": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -105,7 +105,7 @@
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
     "ts-node": "^8.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "engines": {
     "node": ">=12.17.0"

--- a/server/tinylicious/src/test/tsconfig.json
+++ b/server/tinylicious/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [

--- a/server/tinylicious/tsconfig.json
+++ b/server/tinylicious/tsconfig.json
@@ -4,6 +4,7 @@
         "src/test/**/*"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strictNullChecks": false,
         "rootDir": "./src",
         "outDir": "./dist",

--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -4544,9 +4544,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -56,6 +56,6 @@
     "mocha": "^8.1.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/tools/benchmark/src/test/tsconfig.json
+++ b/tools/benchmark/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [ "mocha" ],

--- a/tools/benchmark/tsconfig.json
+++ b/tools/benchmark/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "rootDir": "./src",
         "outDir": "./dist",
         "composite": true,

--- a/tools/build-tools/package-lock.json
+++ b/tools/build-tools/package-lock.json
@@ -2879,9 +2879,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
-      "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -63,10 +63,10 @@
     "@types/semver": "^7.1.0",
     "@types/shelljs": "^0.8.8",
     "@types/webpack": "^4.41.22",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   },
   "peerDependencies": {
     "eslint": "~7.18.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.3"
   }
 }

--- a/tools/build-tools/tsconfig.json
+++ b/tools/build-tools/tsconfig.json
@@ -41,7 +41,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
@@ -51,7 +51,8 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  },
+    "useUnknownInCatchVariables": false
+},
   "include": [
     "src/**/*.ts"
   ],

--- a/tools/generator-fluid/app/templates/package.json
+++ b/tools/generator-fluid/app/templates/package.json
@@ -37,7 +37,7 @@
     "puppeteer": "^1.20.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^4.5.0",
-    "typescript": "~4.1.3",
+    "typescript": "~4.5.3",
     "webpack": "^4.43.0",
     "webpack-cli": "3.1.0",
     "webpack-dev-server": "^3.8.0",

--- a/tools/generator-fluid/app/templates/tsconfig.json
+++ b/tools/generator-fluid/app/templates/tsconfig.json
@@ -1,9 +1,10 @@
-{    
+{
     "exclude": [
         "dist",
         "node_modules"
     ],
     "compilerOptions": {
+        "useUnknownInCatchVariables": false,
         "strict": true,
         "strictNullChecks": true,
         "target": "es2017",


### PR DESCRIPTION
Upgrading to TypeScript 4.5.

This includes the new compiler flag [`useUnknownInCatchVariables`](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables), which defaults to true in strict mode.  This causes a ton of build breaks, almost everywhere we access the error object in a catch block or callback.  So I'm overriding it to false for now, and will open an issue to remove the override and fix up the code in a later set of changes (aiming for week after Christmas when it'll be pretty quiet).

For reference, here are the breaking changes listed for each version since 4.1:
* https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#breaking-changes
* https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#breaking-changes
* https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/#breaking-changes
* https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#breaking-changes