### PR TITLE
Remove SharedNumberSequence from shared-text and monaco

### DIFF
--- a/examples/data-objects/client-ui-lib/src/controls/flowView.ts
+++ b/examples/data-objects/client-ui-lib/src/controls/flowView.ts
@@ -196,18 +196,6 @@ const commands: IFlowViewCmd[] = [
     },
     {
         exec: (c, p, f) => {
-            f.addSequenceEntry();
-        },
-        key: "seq +",
-    },
-    {
-        exec: (c, p, f) => {
-            f.showSequenceEntries();
-        },
-        key: "seq show",
-    },
-    {
-        exec: (c, p, f) => {
             f.createComment();
         },
         key: "comment",
@@ -2870,7 +2858,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
     public bookmarks: Sequence.IntervalCollection<Sequence.SequenceInterval>;
     public tempBookmarks: Sequence.SequenceInterval[];
     public comments: Sequence.IntervalCollection<Sequence.SequenceInterval>;
-    public sequenceTest: Sequence.SharedNumberSequence;
     public persistentComponents: Map<FluidObject, PersistentComponent>;
     public sequenceObjTest: Sequence.SharedObjectSequence<ISeqTestItem>;
     public presenceSignal: PresenceSignal;
@@ -3094,18 +3081,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
         const pos = Math.floor(Math.random() * len);
         const item = <ISeqTestItem>{ x: "veal", v: Math.floor(Math.random() * 10) };
         this.sequenceObjTest.insert(pos, [item]);
-    }
-
-    public addSequenceEntry() {
-        const len = this.sequenceTest.getItemCount();
-        const pos = Math.floor(Math.random() * len);
-        const item = Math.floor(Math.random() * 10);
-        this.sequenceTest.insert(pos, [item]);
-    }
-
-    public showSequenceEntries() {
-        const items = this.sequenceTest.getItems(0);
-        this.statusMessage("seq", `seq: ${items.toString()}`);
     }
 
     public addPresenceSignal(presenceSignal: PresenceSignal) {
@@ -4623,12 +4598,6 @@ export class FlowView extends ui.Component implements SearchMenu.ISearchMenuHost
         // For examples of showing the API we do interval adds on the collection with comments.
         this.comments = this.sharedString.getIntervalCollection("comments");
 
-        this.sequenceTest = await this.docRoot
-            .get<IFluidHandle<Sequence.SharedNumberSequence>>("sequence-test")
-            .get();
-        this.sequenceTest.on("sequenceDelta", (ev: Sequence.SequenceDeltaEvent) => {
-            this.showSequenceEntries();
-        });
         this.render(0, true);
         if (clockStart > 0) {
             // eslint-disable-next-line max-len

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -27,6 +27,7 @@
     "start:r11s": "webpack-dev-server --config webpack.config.js --env.mode r11s",
     "start:spo": "webpack-dev-server --config webpack.config.js --env.mode spo",
     "start:spo-df": "webpack-dev-server --config webpack.config.js --env.mode spo-df",
+    "start:tinylicious": "webpack-dev-server --config webpack.config.js --env.mode tinylicious",
     "tsc": "tsc",
     "tsfmt": "tsfmt --verify",
     "tsfmt:fix": "tsfmt --replace",

--- a/examples/data-objects/monaco/src/index.ts
+++ b/examples/data-objects/monaco/src/index.ts
@@ -20,7 +20,6 @@ const componentFactory = new DataObjectFactory(
     [
         sequence.SharedString.getFactory(),
         sequence.SharedObjectSequence.getFactory(),
-        sequence.SharedNumberSequence.getFactory(),
     ],
     {},
 );

--- a/examples/data-objects/shared-text/src/component.ts
+++ b/examples/data-objects/shared-text/src/component.ts
@@ -29,7 +29,6 @@ import {
     IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions";
 import {
-    SharedNumberSequence,
     SharedObjectSequence,
     SharedString,
 } from "@fluidframework/sequence";
@@ -118,8 +117,6 @@ export class SharedTextRunner
 
             debug(`Not existing ${this.runtime.id} - ${performance.now()}`);
             this.rootView.set("users", this.sharedTextDocument.createMap().handle);
-            const seq = SharedNumberSequence.create(this.sharedTextDocument.runtime);
-            this.rootView.set("sequence-test", seq.handle);
             const newString = this.sharedTextDocument.createString();
 
             const template = parse(window.location.search.substr(1)).template;
@@ -285,7 +282,6 @@ export function instantiateDataStore(context: IFluidDataStoreContext, existing: 
             SharedString.getFactory(),
             SharedCell.getFactory(),
             SharedObjectSequence.getFactory(),
-            SharedNumberSequence.getFactory(),
         ].map((factory) => [factory.type, factory])),
         existing,
     );


### PR DESCRIPTION
We've talked a bit about deprecating the alternate sequence types, part of that will be removing usage.  This change removes usage of `SharedNumberSequence` from our examples.

This leaves table-document and the replay tool as the remaining usages.