### PR TITLE
Use connected timestamp from server

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -968,8 +968,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
          * of this client's connection.
          */
          const getCurrentTimestamp = () => {
-            const audience = this.getAudience();
-            const client = this.clientId !== undefined ? audience.getMember(this.clientId) : undefined;
+            const client = this.clientId !== undefined ? this.getAudience().getMember(this.clientId) : undefined;
             const timestamp = client?.timestamp;
             return this.deltaManager.lastMessage?.timestamp ?? timestamp ?? Date.now();
         };

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -967,8 +967,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
          * we don't have an op (on demand summaries for instance). In those cases, we will use the timestamp
          * of this client's connection - https://github.com/microsoft/FluidFramework/issues/8375.
          */
-        const getCurrentTimestamp = () => {
-            return this.deltaManager.lastMessage?.timestamp ?? Date.now();
+         const getCurrentTimestamp = () => {
+            const audience = this.getAudience();
+            const client = this.clientId !== undefined ? audience.getMember(this.clientId) : undefined;
+            const timestamp = client?.timestamp;
+            return this.deltaManager.lastMessage?.timestamp ?? timestamp ?? Date.now();
         };
         this.garbageCollector = GarbageCollector.create(
             this,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -963,7 +963,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         /**
          * Function that return the current server timestamp. This is used by the garbage collector to set the
          * time when a node becomes unreferenced.
-         * We use the timestamp of the last op for gcTimestamp. However, there can be cases where
+         * We use the timestamp of the last op for current timestamp. However, there can be cases where
          * we don't have an op (on demand summaries for instance). In those cases, we will use the timestamp
          * of this client's connection.
          */

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -963,9 +963,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         /**
          * Function that return the current server timestamp. This is used by the garbage collector to set the
          * time when a node becomes unreferenced.
-         * For now, we use the timestamp of the last op for gcTimestamp. However, there can be cases where
+         * We use the timestamp of the last op for gcTimestamp. However, there can be cases where
          * we don't have an op (on demand summaries for instance). In those cases, we will use the timestamp
-         * of this client's connection - https://github.com/microsoft/FluidFramework/issues/8375.
+         * of this client's connection.
          */
          const getCurrentTimestamp = () => {
             const audience = this.getAudience();


### PR DESCRIPTION
Resolves #8375 

Grab the server timestamp when the client is connected and use it as a backup for retrieving the current timestamp for GC