### PR TITLE
r11s: Add config for server connection timeout

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -118,6 +118,9 @@ data:
             "kafkaClientId": "{{ template "scribe.fullname" . }}"
         },
         "system": {
+            "httpServer": {
+                "connectionTimeout": {{ .Values.system.httpServer.connectionTimeout }}
+            },
             "topics": {
                 "send": "{{ .Values.kafka.topics.deltas }}"
             }

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -67,6 +67,10 @@ zookeeper:
   local: false
   url: zookeeper_url:port
 
+system:
+  httpServer:
+    connectionTimeout: 0
+
 mongodb:
   operationsDbEndpoint: mongodb_url
   globalDbEndpoint: mongoglobaldb_url

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -92,9 +92,14 @@ export class AlfredResources implements core.IResources {
         public port: any,
         public documentsCollectionName: string,
         public metricClientConfig: any,
-        public globalDbMongoManager?: core.MongoManager) {
+        public globalDbMongoManager?: core.MongoManager,
+    ) {
         const socketIoAdapterConfig = config.get("alfred:socketIoAdapter");
-        this.webServerFactory = new services.SocketIoWebServerFactory(this.redisConfig, socketIoAdapterConfig);
+        const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
+        this.webServerFactory = new services.SocketIoWebServerFactory(
+            this.redisConfig,
+            socketIoAdapterConfig,
+            httpServerConfig);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -3,18 +3,24 @@
  * Licensed under the MIT License.
  */
 
-import * as http from "http";
 import { Deferred } from "@fluidframework/common-utils";
-import { MongoManager, IRunner, ISecretManager } from "@fluidframework/server-services-core";
+import {
+    MongoManager,
+    IRunner,
+    ISecretManager,
+    IWebServerFactory,
+    IWebServer,
+} from "@fluidframework/server-services-core";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import * as winston from "winston";
 import * as app from "./app";
 
 export class RiddlerRunner implements IRunner {
-    private server: http.Server;
+    private server: IWebServer;
     private runningDeferred: Deferred<void>;
 
     constructor(
+        private readonly serverFactory: IWebServerFactory,
         private readonly collectionName: string,
         private readonly port: string | number,
         private readonly mongoManager: MongoManager,
@@ -41,11 +47,12 @@ export class RiddlerRunner implements IRunner {
             this.secretManager);
         riddler.set("port", this.port);
 
-        this.server = http.createServer(riddler);
+        this.server = this.serverFactory.create(riddler);
+        const httpServer = this.server.httpServer;
 
-        this.server.listen(this.port);
-        this.server.on("error", (error) => this.onError(error));
-        this.server.on("listening", () => this.onListening());
+        httpServer.listen(this.port);
+        httpServer.on("error", (error) => this.onError(error));
+        httpServer.on("listening", () => this.onListening());
 
         return this.runningDeferred.promise;
     }
@@ -53,9 +60,14 @@ export class RiddlerRunner implements IRunner {
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     public stop(): Promise<void> {
         // Close the underlying server and then resolve the runner once closed
-        this.server.close(() => {
-            this.runningDeferred.resolve();
-        });
+        this.server.close().then(
+            () => {
+                this.runningDeferred.resolve();
+            },
+            (error) => {
+                this.runningDeferred.reject(error);
+            },
+        );
         return this.runningDeferred.promise;
     }
 
@@ -88,7 +100,7 @@ export class RiddlerRunner implements IRunner {
      * Event listener for HTTP server "listening" event.
      */
     private onListening() {
-        const addr = this.server.address();
+        const addr = this.server.httpServer.address();
         const bind = typeof addr === "string"
             ? `pipe ${addr}`
             : `port ${addr.port}`;

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -115,6 +115,9 @@
         "kafkaClientId": "scribe"
     },
     "system": {
+        "httpServer": {
+            "connectionTimeoutMs": 0
+        },
         "topics": {
             "send": "deltas"
         }

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -46,13 +46,37 @@ export class WebServer implements core.IWebServer {
     }
 }
 
+export interface IHttpServerConfig {
+    /**
+     * The number of milliseconds of inactivity before a socket is presumed to have timed out.
+     * A value of 0 will disable the timeout behavior on incoming connections.
+     * Default: 0 (disabled)
+     */
+     connectionTimeoutMs?: number;
+}
+
+const defaultHttpServerConfig: IHttpServerConfig = {
+    connectionTimeoutMs: 0,
+};
+const createAndConfigureHttpServer = (
+    requestListener: RequestListener,
+    httpServerConfig: IHttpServerConfig | undefined,
+): http.Server => {
+    const server = http.createServer(requestListener);
+    server.timeout = httpServerConfig?.connectionTimeoutMs ?? defaultHttpServerConfig.connectionTimeoutMs;
+    return server;
+};
+
 export class SocketIoWebServerFactory implements core.IWebServerFactory {
-    constructor(private readonly redisConfig: any, private readonly socketIoAdapterConfig?: any) {
+    constructor(
+        private readonly redisConfig: any,
+        private readonly socketIoAdapterConfig?: any,
+        private readonly httpServerConfig?: IHttpServerConfig) {
     }
 
     public create(requestListener: RequestListener): core.IWebServer {
         // Create the base HTTP server and register the provided request listener
-        const server = http.createServer(requestListener);
+        const server = createAndConfigureHttpServer(requestListener, this.httpServerConfig);
         const httpServer = new HttpServer(server);
 
         const socketIoServer = socketIo.create(this.redisConfig, server, this.socketIoAdapterConfig);
@@ -62,9 +86,12 @@ export class SocketIoWebServerFactory implements core.IWebServerFactory {
 }
 
 export class BasicWebServerFactory implements core.IWebServerFactory {
+    constructor(private readonly httpServerConfig?: IHttpServerConfig) {
+    }
+
     public create(requestListener: RequestListener): core.IWebServer {
         // Create the base HTTP server and register the provided request listener
-        const server = http.createServer(requestListener);
+        const server = createAndConfigureHttpServer(requestListener, this.httpServerConfig);
         const httpServer = new HttpServer(server);
 
         return new WebServer(httpServer, null);


### PR DESCRIPTION
Currently, Node.js http servers in R11s, Historian, GitRest, and T9s are at the whim of the current Node.js version's default value. This is known to change between versions (Node.js v12 had a 2min timeout by default, Node.js v14 has no timeout). We have seen internal connection timeouts caused by long-running storage operations, so we would like to first disable Node.js connection timeouts (done by upgrading to Node 14), but then be able to fine tune timeouts in the future.

Next steps: Utilize this change in GitRest and Historian