### PR TITLE
Mark IDeltaManager.close() as deprecated

### DIFF
--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -256,6 +256,7 @@ export interface IDeltaHandlerStrategy {
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender, IDisposable {
     readonly active: boolean;
     readonly clientDetails: IClientDetails;
+    // @deprecated (undocumented)
     close(): void;
     readonly hasCheckpointSequenceNumber: boolean;
     readonly inbound: IDeltaQueue<T>;

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -165,7 +165,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 
     readonly readOnlyInfo: ReadOnlyInfo;
 
-    /** Terminate the connection to storage */
+    /** @deprecated - Use Container.close() or IContainerContext.closeFn() */
     close(): void;
 
     /** Submit a signal to the service to be broadcast to other connected clients, but not persisted */


### PR DESCRIPTION
Jump-starting this for the sake of #6936  (too bad we didn't do this months ago!)