### PR TITLE
Docs build: generateToken is no longer a re-export

### DIFF
--- a/docs/rollup-api-data.js
+++ b/docs/rollup-api-data.js
@@ -36,12 +36,6 @@ const memberCombineInstructions = [
         ])
     },
     {
-        package: "@fluidframework/azure-service-utils",
-        sourceImports: new Map([
-            ["@fluidframework/server-services-client", ["generateToken"]],
-        ])
-    },
-    {
         package: "@fluidframework/fluid-static",
         sourceImports: new Map([
             ["@fluidframework/container-definitions", ["IAudience"]],


### PR DESCRIPTION
generateToken was changed in #8393, which caused the docs build to start failing to create API docs.