### PR TITLE
[r11s] Updating Scribe to use both message and of errorMessage in ISummaryNack

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -260,6 +260,8 @@ export class ScribeLambda implements IPartitionLambda {
                             if (this.serviceConfiguration.scribe.ignoreStorageException) {
                                 await this.sendSummaryNack(
                                     {
+                                        message: "Failed to summarize the document.",
+                                        // errorMessage in ISummaryNack will be deprecated soon
                                         errorMessage: "Failed to summarize the document.",
                                         summaryProposal: {
                                             summarySequenceNumber: value.operation.sequenceNumber,

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -104,6 +104,8 @@ export class SummaryWriter implements ISummaryWriter {
                     clientSummaryMetric.error(`Proposed parent summary does not match actual parent summary`);
                     return {
                         message: {
+                            message: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef ? existingRef.object.sha : "n/a"}".`,
+                            // errorMessage in ISummaryNack will be deprecated soon
                             errorMessage: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef ? existingRef.object.sha : "n/a"}".`,
                             summaryProposal: {
                                 summarySequenceNumber: op.sequenceNumber,
@@ -116,6 +118,8 @@ export class SummaryWriter implements ISummaryWriter {
                 clientSummaryMetric.error(`Proposed parent summary does not match actual parent summary`);
                 return {
                     message: {
+                        message: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef.object.sha}".`,
+                        // errorMessage in ISummaryNack will be deprecated soon
                         errorMessage: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef.object.sha}".`,
                         summaryProposal: {
                             summarySequenceNumber: op.sequenceNumber,
@@ -136,6 +140,8 @@ export class SummaryWriter implements ISummaryWriter {
                     clientSummaryMetric.error(`One or more parent summaries are invalid`, e);
                     return {
                         message: {
+                            message: "One or more parent summaries are invalid",
+                            // errorMessage in ISummaryNack will be deprecated soon
                             errorMessage: "One or more parent summaries are invalid",
                             summaryProposal: {
                                 summarySequenceNumber: op.sequenceNumber,
@@ -151,6 +157,8 @@ export class SummaryWriter implements ISummaryWriter {
                 clientSummaryMetric.error(`Proposed summary reference sequence number less than current sequence number`);
                 return {
                     message: {
+                        message: `Proposed summary reference sequence number ${op.referenceSequenceNumber} is less than current sequence number ${checkpoint.protocolState.sequenceNumber}`,
+                        // errorMessage in ISummaryNack will be deprecated soon
                         errorMessage: `Proposed summary reference sequence number ${op.referenceSequenceNumber} is less than current sequence number ${checkpoint.protocolState.sequenceNumber}`,
                         summaryProposal: {
                             summarySequenceNumber: op.sequenceNumber,
@@ -272,6 +280,8 @@ export class SummaryWriter implements ISummaryWriter {
                 if (!networkError.isFatal) {
                     return {
                         message: {
+                            message: `A non-fatal error happened when trying to write client summary. Error: ${safeStringify(networkError.details)}`,
+                            // errorMessage in ISummaryNack will be deprecated soon
                             errorMessage: `A non-fatal error happened when trying to write client summary. Error: ${safeStringify(networkError.details)}`,
                             summaryProposal: {
                                 summarySequenceNumber: op.sequenceNumber,


### PR DESCRIPTION
In #8445, `ISummaryNack` was updated in protocol-definitions and had the `errorMessage` field removed. In that PR, some changes were made to Scribe's lambda, but there were other necessary changes in SummaryWriter that were missed. In this PR, I address those changes, making sure that Scribe's SummaryWriter (and Lambda) use both the `errorMessage` and `message` fields. This is a temporary change until Scribe is updated with a new protocol-definition version - when that happens, we would naturally remove the support for `errorMessage`, but we would not have to do anything else since support for `message` is being implemented here.