### PR TITLE
Integrate `container-definitions` 0.44 into repo

### DIFF
--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-example/search-menu": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/ink": "^0.54.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.54.0",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluid-example/client-ui-lib": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/merge-tree": "^0.54.0",
     "@fluidframework/runtime-definitions": "^0.54.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-example/host-service-interfaces": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/cell": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -41,7 +41,7 @@
     "@fluid-example/table-document": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/runtime-utils": "^0.54.0",
     "@fluidframework/sequence": "^0.54.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/request-handler": "^0.54.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -35,7 +35,7 @@
     "@fluid-experimental/get-container": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/map": "^0.54.0",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0"
   },
   "devDependencies": {

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.54.0",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-utils": "^0.54.0",

--- a/examples/hosts/hosts-sample/src/app.ts
+++ b/examples/hosts/hosts-sample/src/app.ts
@@ -108,8 +108,7 @@ async function start() {
     }
 
     // Wait for connection so that proposals can be sent.
-    // TODO: Remove null check after next release #8523
-    if (container !== undefined && container.connected !== undefined && !container.connected) {
+    if (container !== undefined && !container.connected) {
         await new Promise<void>((resolve, reject) => {
             // the promise resolves when the connected event fires.
             container.once("connected", () => resolve());

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-example/todo": "^0.54.0",
     "@fluid-experimental/get-container": "^0.54.0",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@fluid-example/key-value-cache": "^0.54.0",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -34,7 +34,7 @@
     "@fluid-experimental/property-changeset": "^0.54.0",
     "@fluid-experimental/property-properties": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -40,7 +40,7 @@
     "@fluid-experimental/bubblebench-common": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/map": "^0.54.0",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/map": "^0.54.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/sharejs-json1": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/map": "^0.54.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/tree": "^0.54.0",
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/map": "^0.54.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2004,9 +2004,9 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.43.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.43.0.tgz",
-			"integrity": "sha512-MzVGTRJ2WxiCXmLTlCmkrLjizRDC2Dht6fFYEvyYGw+92xt3QZHe3D0Sjd389dZe1kyMRlhsFAyuKytEPf7N4w==",
+			"version": "0.44.0-47282",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0-47282.tgz",
+			"integrity": "sha512-woVMfZ++NvcJXOGtr9Om39l/7PxX++kXu30/45CmhgMgZisVTkTQtC3ilHmQFbbN1TzJfADOi9OdIUF+qIodkg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.41.0",
@@ -2063,9 +2063,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2119,9 +2119,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2139,6 +2139,17 @@
 				"@types/node": "^12.19.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.43.0.tgz",
+					"integrity": "sha512-MzVGTRJ2WxiCXmLTlCmkrLjizRDC2Dht6fFYEvyYGw+92xt3QZHe3D0Sjd389dZe1kyMRlhsFAyuKytEPf7N4w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/driver-definitions": "^0.43.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.53.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.53.0.tgz",
@@ -2154,9 +2165,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2214,9 +2225,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2270,9 +2281,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2290,6 +2301,17 @@
 				"@types/node": "^12.19.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.43.0.tgz",
+					"integrity": "sha512-MzVGTRJ2WxiCXmLTlCmkrLjizRDC2Dht6fFYEvyYGw+92xt3QZHe3D0Sjd389dZe1kyMRlhsFAyuKytEPf7N4w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/driver-definitions": "^0.43.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.53.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.53.0.tgz",
@@ -2305,9 +2327,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2412,9 +2434,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2467,9 +2489,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2509,9 +2531,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},
@@ -2529,10 +2551,21 @@
 				"@types/node": "^12.19.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.43.0.tgz",
+					"integrity": "sha512-MzVGTRJ2WxiCXmLTlCmkrLjizRDC2Dht6fFYEvyYGw+92xt3QZHe3D0Sjd389dZe1kyMRlhsFAyuKytEPf7N4w==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/driver-definitions": "^0.43.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@types/node": {
-					"version": "12.20.37",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-					"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+					"version": "12.20.38",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
 				}
 			}
 		},

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-utils": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/fluid-static": "^0.54.0",
     "@fluidframework/map": "^0.54.0",
     "@fluidframework/sequence": "^0.54.0"

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -178,9 +178,7 @@ export class FluidContainer extends TypedEventEmitter<IFluidContainerEvents> imp
      * {@inheritDoc IFluidContainer.connected}
      */
     public get connected() {
-        // TODO: Remove null check after next release #8523
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return this.container.connected!;
+        return this.container.connected;
     }
 
     /**

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -36,9 +36,7 @@ export abstract class ServiceAudience<M extends IMember = IMember>
       protected readonly container: IContainer,
   ) {
     super();
-    // TODO: Remove null check after next release #8523
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.audience = container.audience!;
+    this.audience = container.audience;
 
     // getMembers will assign lastMembers so the removeMember event has what it needs
     // in case it would fire before getMembers otherwise gets called the first time

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/driver-definitions": "^0.43.0",
     "@fluidframework/driver-utils": "^0.54.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-utils": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/telemetry-utils": "^0.54.0"
   },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.54.0",
     "@fluidframework/datastore-definitions": "^0.54.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
@@ -67,13 +67,16 @@
     "broken": {
       "0.51.1": {
         "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IProvideContainerRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IContainerRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.52.0": {

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.51.1.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.51.1.ts
@@ -43,6 +43,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -68,6 +69,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -117,6 +119,7 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",
     "@fluidframework/container-utils": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.54.0",
@@ -67,13 +67,16 @@
     "broken": {
       "0.51.1": {
         "InterfaceDeclaration_IChannel": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IChannelFactory": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidDataStoreRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.52.0": {

--- a/packages/runtime/datastore-definitions/src/test/types/validate0.51.1.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validate0.51.1.ts
@@ -19,6 +19,7 @@ declare function get_old_InterfaceDeclaration_IChannel():
 declare function use_current_InterfaceDeclaration_IChannel(
     use: current.IChannel);
 use_current_InterfaceDeclaration_IChannel(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IChannel());
 
 /*
@@ -68,6 +69,7 @@ declare function get_old_InterfaceDeclaration_IChannelFactory():
 declare function use_current_InterfaceDeclaration_IChannelFactory(
     use: current.IChannelFactory);
 use_current_InterfaceDeclaration_IChannelFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IChannelFactory());
 
 /*
@@ -189,6 +191,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: current.IFluidDataStoreRuntime);
 use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-utils": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
@@ -67,13 +67,16 @@
     "broken": {
       "0.51.1": {
         "InterfaceDeclaration_IFluidDataStoreContextDetached": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidDataStoreContext": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IContainerRuntimeBase": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IContainerRuntime": {
           "backCompat": false
@@ -83,6 +86,38 @@
         },
         "InterfaceDeclaration_IFluidDataStoreRuntime": {
           "backCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_FluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_FluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.52.0": {

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.51.1.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.51.1.ts
@@ -115,6 +115,7 @@ declare function get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: current.FluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -127,6 +128,7 @@ declare function get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: old.FluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -211,6 +213,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: current.IContainerRuntimeBase);
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -308,6 +311,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: current.IFluidDataStoreContext);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -333,6 +337,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: current.IFluidDataStoreContextDetached);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -406,6 +411,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreFactory(
     use: current.IFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -418,6 +424,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreFactory(
     use: old.IFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -454,6 +461,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: current.IFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -466,6 +474,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: old.IFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -574,6 +583,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: current.IProvideFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -586,6 +596,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: old.IProvideFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -598,6 +609,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: current.IProvideFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -610,6 +622,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: old.IProvideFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -838,6 +851,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: current.NamedFluidDataStoreRegistryEntries);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -850,6 +864,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: old.NamedFluidDataStoreRegistryEntries);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -862,6 +877,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry()
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: current.NamedFluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*
@@ -874,6 +890,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: old.NamedFluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/azure-service-utils": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.54.0",
     "@fluidframework/driver-definitions": "^0.43.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -56,7 +56,7 @@
     "@fluid-internal/replay-tool": "^0.54.0",
     "@fluidframework/cell": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/counter": "^0.54.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/cell": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -113,12 +113,12 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
         containers.push(await loadContainer());
 
         assert.deepStrictEqual(
-            containers[0].codeDetails,
+            containers[0].getLoadedCodeDetails?.(),
             codeDetails,
             "Code proposal in containers[0] doesn't match");
 
         assert.deepStrictEqual(
-            containers[1].codeDetails,
+            containers[1].getLoadedCodeDetails?.(),
             codeDetails,
             "Code proposal in containers[1] doesn't match");
 
@@ -182,7 +182,7 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
         for (let i = 0; i < containers.length; i++) {
             assert.strictEqual(containers[i].closed, false, `containers[${i}] should not be closed`);
             assert.deepStrictEqual(
-                containers[i].codeDetails,
+                containers[i].getSpecifiedCodeDetails?.(),
                 { package: packageV1 },
                 `containers[${i}] code details should not update`);
         }
@@ -205,7 +205,7 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
         for (let i = 0; i < containers.length; i++) {
             assert.strictEqual(containers[i].closed, false, `containers[${i}] should not be closed`);
             assert.deepStrictEqual(
-                containers[i].codeDetails,
+                containers[i].getSpecifiedCodeDetails?.(),
                 { package: packageV1 },
                 `containers[${i}] code details should update`);
         }

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -205,7 +205,7 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
         for (let i = 0; i < containers.length; i++) {
             assert.strictEqual(containers[i].closed, false, `containers[${i}] should not be closed`);
             assert.deepStrictEqual(
-                containers[i].getSpecifiedCodeDetails?.(),
+                containers[i].getLoadedCodeDetails?.(),
                 { package: packageV1 },
                 `containers[${i}] code details should update`);
         }

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -91,8 +91,7 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(container.getQuorum().getMembers().size, 0, "Quorum should not contain any members");
         assert.strictEqual(container.connectionState, ConnectionState.Disconnected,
             "Container should be in disconnected state!!");
-        assert.strictEqual(container.codeDetails?.package, provider.defaultCodeDetails.package,
-            "Loaded package should be same as provided");
+
         if (container.getSpecifiedCodeDetails !== undefined) {
             assert.strictEqual(container.getSpecifiedCodeDetails()?.package, provider.defaultCodeDetails.package,
             "Specified package should be same as provided");

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/container-runtime-definitions": "^0.54.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/cell": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/cell": "^0.54.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/container-runtime": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.54.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.43.0",
+    "@fluidframework/container-definitions": "^0.44.0-0",
     "@fluidframework/container-loader": "^0.54.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-definitions": "^0.43.0",


### PR DESCRIPTION
- Update all `"@fluidframework/container-definitions"` dependencies to point to the newly released 0.44.0-0 pre-release
- Integrate compiler changes required from this update and remove optional value checks
- Update back-compat tests due to removal of `codeProposal` deprecated API