### PR TITLE
Update Container close signature in common-definitions

### DIFF
--- a/api-report/file-driver.api.md
+++ b/api-report/file-driver.api.md
@@ -69,7 +69,7 @@ export class FileDocumentServiceFactory implements IDocumentServiceFactory {
 // @public (undocumented)
 export const FileSnapshotWriterClassFactory: <TBase extends ReaderConstructor>(Base: TBase) => {
     new (...args: any[]): {
-        blobsWriter: Map<string, ArrayBufferLike>;
+        blobsWriter: Map<string, ArrayBuffer | SharedArrayBuffer>;
         commitsWriter: {
             [key: string]: api.ITree;
         };
@@ -87,7 +87,7 @@ export const FileSnapshotWriterClassFactory: <TBase extends ReaderConstructor>(B
         buildTree(snapshotTree: api.ISnapshotTree): Promise<api.ITree>;
         repositoryUrl: string;
         readonly policies?: IDocumentStorageServicePolicies | undefined;
-        createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse>;
+        createBlob(file: ArrayBuffer | SharedArrayBuffer): Promise<api.ICreateBlobResponse>;
         uploadSummaryWithContext(summary: api.ISummaryTree, context: ISummaryContext): Promise<string>;
         downloadSummary(handle: api.ISummaryHandle): Promise<api.ISummaryTree>;
         readonly disposed?: boolean | undefined;
@@ -112,7 +112,7 @@ export class FluidFetchReader extends ReadDocumentStorageServiceBase implements 
 // @public (undocumented)
 export const FluidFetchReaderFileSnapshotWriter: {
     new (...args: any[]): {
-        blobsWriter: Map<string, ArrayBufferLike>;
+        blobsWriter: Map<string, ArrayBuffer | SharedArrayBuffer>;
         commitsWriter: {
             [key: string]: api.ITree;
         };
@@ -130,7 +130,7 @@ export const FluidFetchReaderFileSnapshotWriter: {
         buildTree(snapshotTree: api.ISnapshotTree): Promise<api.ITree>;
         repositoryUrl: string;
         readonly policies?: IDocumentStorageServicePolicies | undefined;
-        createBlob(file: ArrayBufferLike): Promise<api.ICreateBlobResponse>;
+        createBlob(file: ArrayBuffer | SharedArrayBuffer): Promise<api.ICreateBlobResponse>;
         uploadSummaryWithContext(summary: api.ISummaryTree, context: ISummaryContext): Promise<string>;
         downloadSummary(handle: api.ISummaryHandle): Promise<api.ISummaryTree>;
         readonly disposed?: boolean | undefined;

--- a/common/lib/container-definitions/src/error.ts
+++ b/common/lib/container-definitions/src/error.ts
@@ -78,7 +78,7 @@ export interface ContainerWarning extends IErrorBase {
 /**
  * Represents errors raised on container.
  */
-export type ICriticalContainerError = IErrorBase;
+export type ICriticalContainerError = IErrorBase & Error;
 
 /**
  * Generic wrapper for an unrecognized/uncategorized error object

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -117,7 +117,7 @@ export interface IContainerEvents extends IEvent {
     (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
     (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);
     (event: "disconnected" | "attached", listener: () => void);
-    (event: "closed", listener: (error?: ICriticalContainerError) => void);
+    (event: "closed", listener: (reason: string, error?: ICriticalContainerError) => void);
     (event: "warning", listener: (error: ContainerWarning) => void);
     (event: "op", listener: (message: ISequencedDocumentMessage) => void);
     (event: "dirty" | "saved", listener: (dirty: boolean) => void);
@@ -202,7 +202,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     /**
      * Closes the container
      */
-    close(error?: ICriticalContainerError): void;
+    close(reason: string, error?: ICriticalContainerError): void;
 
     /**
      * Closes the container and returns serialized local state intended to be

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -135,7 +135,7 @@ export interface IContainerContext extends IDisposable {
     readonly baseSnapshot: ISnapshotTree | undefined;
     readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
     readonly submitSignalFn: (contents: any) => void;
-    readonly closeFn: (error?: ICriticalContainerError) => void;
+    readonly closeFn: (error?: ICriticalContainerError, reason?: string) => void;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly quorum: IQuorum;
     /**

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2063,9 +2063,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2119,9 +2119,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2165,9 +2165,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2225,9 +2225,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2281,9 +2281,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2327,9 +2327,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2434,9 +2434,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2489,9 +2489,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2531,9 +2531,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2563,9 +2563,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},


### PR DESCRIPTION
* Have `ICriticalContainerError` encompass the `Error` type fully instead of `Partial<Error>` as in `IErrorBase` (the only diff here is `name` is no longer optional)
* Add `reason` param to Container close functions/event.

About compatibility:
* Container.close and "closed" event are consumed statically by hosts, so this will be a build break when they pull an updated client version that depends on this.
* IContainerContext.closeFn is across the loader/runtime boundary, so I'm doing an optional/additive change here.