### PR TITLE
bump deps on common-def to 20.1

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -176,9 +176,9 @@
       }
     },
     "@fluidframework/common-definitions": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0.tgz",
-      "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
+      "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/container-definitions-0.39.8": {
       "version": "npm:@fluidframework/container-definitions@0.39.8",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -40,7 +40,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.45.2000-0",
     "@fluidframework/protocol-definitions": "^0.1027.1000"

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/driver-definitions",
-  "version": "0.45.2000-58205",
+  "version": "0.45.2000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -176,9 +176,9 @@
       }
     },
     "@fluidframework/common-definitions": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0.tgz",
-      "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
+      "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/core-interfaces": {
       "version": "0.42.0",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -38,7 +38,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0",
+    "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/protocol-definitions": "^0.1027.1000"
   },

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -176,9 +176,9 @@
       }
     },
     "@fluidframework/common-definitions": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.0.tgz",
-      "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
+      "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/eslint-config-fluid": {
       "version": "0.27.0",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -38,7 +38,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/common-definitions": "^0.20.0"
+    "@fluidframework/common-definitions": "^0.20.1"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2421,9 +2421,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.9",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.9.tgz",
-					"integrity": "sha512-gP4hC9QK2ognMzfhLHHaWkgJ35JBTc3fYG+ESKYlfZ8JTCbkYp9m8c0lHFiUhPvCkw32V3ecxnQ1/+hsSvt8Rw==",
+					"version": "0.56.11",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.11.tgz",
+					"integrity": "sha512-3bZpZK7OrBugfrXWCTfyFROCYEphy1Sne4pIjHlZPi3KwXsPyEynSvln5NObaT1IYRMEDyvUEFwvyZa63sOlwg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2520,9 +2520,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.58.2000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.58.2000.tgz",
-					"integrity": "sha512-ZVfQHlLw95KGd73AAQpLzcHvBbF3TdjbSKmdV9KlPXLRdwHVvdhjoOoq6sUZq0EWRRgAaelkJldg9nfIyjFhsw==",
+					"version": "0.58.2002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.58.2002.tgz",
+					"integrity": "sha512-6a/P130KbBGFZ2mqRT7GhDQG3vLqyIO9fth+gFDMVHm8OjP7xmjgl1rOtfKHfqf0+PbBHl0S1zIpohLo27M3qg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2905,9 +2905,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.9",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.9.tgz",
-					"integrity": "sha512-gP4hC9QK2ognMzfhLHHaWkgJ35JBTc3fYG+ESKYlfZ8JTCbkYp9m8c0lHFiUhPvCkw32V3ecxnQ1/+hsSvt8Rw==",
+					"version": "0.56.11",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.11.tgz",
+					"integrity": "sha512-3bZpZK7OrBugfrXWCTfyFROCYEphy1Sne4pIjHlZPi3KwXsPyEynSvln5NObaT1IYRMEDyvUEFwvyZa63sOlwg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -3004,9 +3004,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.58.2000",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.58.2000.tgz",
-					"integrity": "sha512-ZVfQHlLw95KGd73AAQpLzcHvBbF3TdjbSKmdV9KlPXLRdwHVvdhjoOoq6sUZq0EWRRgAaelkJldg9nfIyjFhsw==",
+					"version": "0.58.2002",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.58.2002.tgz",
+					"integrity": "sha512-6a/P130KbBGFZ2mqRT7GhDQG3vLqyIO9fth+gFDMVHm8OjP7xmjgl1rOtfKHfqf0+PbBHl0S1zIpohLo27M3qg==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",


### PR DESCRIPTION
Months ago I made the mistake of introducing a breaking change between 20.0 and 20.1, and client consumes 0.20.1.  So it's best to get everyone on the same page here.  Anyway, due to semver and npm install behavior, I'm pretty certain that anyone consuming client will be installing 0.20.1 so this shouldn't cause any changes as it rolls out.

Specifically, this causes breaks in some cases when trying to do --symlink:full.

It's not urgent, so not planning to proactively consume these from client/server, but wanting to have it staged.  I believe this will resolve the symlink issue, but if not then I will move forward with fanning out through the dependency tree.