### PR TITLE
Fix Stress Issue: Blob write when Runtime is closed

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -13,7 +13,7 @@ import {ISharedCounter, SharedCounter} from "@fluidframework/counter";
 import { ITaskManager, TaskManager } from "@fluid-experimental/task-manager";
 import { IDirectory, ISharedDirectory } from "@fluidframework/map";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import random, { integer } from "random-js";
+import random from "random-js";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { delay, assert } from "@fluidframework/common-utils";
@@ -101,7 +101,7 @@ export class LoadTestDataStoreModel {
     /**
      * For GC testing - We create a data store for each client pair. The url of the data store is stored in a key
      * common to both the clients. Each client adds a reference to this data store when it becomes a writer
-     * and removes the reference before it transtions to a reader.
+     * and removes the reference before it transitions to a reader.
      * So, at any point in time, the data store can have 0, 1 or 2 references.
      */
     private static async getGCDataStore(
@@ -160,7 +160,7 @@ export class LoadTestDataStoreModel {
             throw new Error("counter not available");
         }
         if(taskmanager === undefined) {
-            throw new Error("taskmanger not available");
+            throw new Error("taskmanager not available");
         }
 
         const gcDataStore = await this.getGCDataStore(config, root, containerRuntime);

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -13,7 +13,7 @@ import {ISharedCounter, SharedCounter} from "@fluidframework/counter";
 import { ITaskManager, TaskManager } from "@fluid-experimental/task-manager";
 import { IDirectory, ISharedDirectory } from "@fluidframework/map";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import random from "random-js";
+import random, { integer } from "random-js";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { delay, assert } from "@fluidframework/common-utils";
@@ -285,12 +285,14 @@ export class LoadTestDataStoreModel {
      * Upload a unique attachment blob and store the handle in a unique key on the root map
      */
     public async writeBlob(blobNumber: number) {
-        const blobSize = this.config.testConfig.blobSize ?? defaultBlobSize;
-        // upload a unique blob, since they may be deduped otherwise
-        const buffer = Buffer.alloc(blobSize, `${this.config.runId}/${blobNumber}:`);
-        assert(buffer.byteLength === blobSize, "incorrect buffer size");
-        const handle = await this.runtime.uploadBlob(buffer);
-        this.root.set(this.blobKey(blobNumber), handle);
+        if (!this.runtime.disposed) {
+            const blobSize = this.config.testConfig.blobSize ?? defaultBlobSize;
+            // upload a unique blob, since they may be deduped otherwise
+            const buffer = Buffer.alloc(blobSize, `${this.config.runId}/${blobNumber}:`);
+            assert(buffer.byteLength === blobSize, "incorrect buffer size");
+            const handle = await this.runtime.uploadBlob(buffer);
+            this.root.set(this.blobKey(blobNumber), handle);
+        }
     }
 
     public async getPartnerCounter() {


### PR DESCRIPTION
seeing issues in stress test logs due to this test issue:
Event_Time | Data_eventName | Data_error | Data_message | Data_stack
-- | -- | -- | -- | --
2021-12-29 18:55:02.7420000 | UnhandledPromiseRejection | Runtime is closed |   | Error at ContainerRuntime.verifyNotClosed (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/containerRuntime.js:1563:19) at ContainerRuntime.submit (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/containerRuntime.js:1481:14) at BlobManager.attachBlobCallback (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/containerRuntime.js:466:136) at BlobManager.createBlob (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/blobManager.js:92:18) at runMicrotasks (<anonymous>) at processTicksAndRejections (internal/process/task_queues.js:95:5) at async LoadTestDataStoreModel.writeBlob (/mnt/vss/_work/1/test/node_modules/@fluid-internal/test-service-load/dist/loadTestDataStore.js:228:24)
