### PR TITLE
Stress Test: Add test Version

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2063,9 +2063,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2119,9 +2119,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2165,9 +2165,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2225,9 +2225,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2281,9 +2281,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2327,9 +2327,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2434,9 +2434,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2489,9 +2489,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2531,9 +2531,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},
@@ -2563,9 +2563,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.38",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
-					"integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
+					"version": "12.20.39",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.39.tgz",
+					"integrity": "sha512-U7PMwkDmc3bnL0e4U8oA0POpi1vfsYDc+DEUS2+rPxm9NlLcW1dBa5JcRhO633PoPUcCSWMNXrMsqhmAVEo+IQ=="
 				}
 			}
 		},

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -31,7 +31,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
     private logs: ITelemetryBaseEvent[] = [];
 
     public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {
-        super(undefined, {all:{testVersion: pkgVersion}});
+        super(undefined /* namespace */, {all:{testVersion: pkgVersion}});
     }
 
     async flush(runInfo?: { url: string, runId?: number }): Promise<void> {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -31,7 +31,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
     private logs: ITelemetryBaseEvent[] = [];
 
     public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {
-        super();
+        super(undefined, {all:{testVersion: pkgVersion}});
     }
 
     async flush(runInfo?: { url: string, runId?: number }): Promise<void> {


### PR DESCRIPTION
Certain logs, like unhandled rejections don't have a loader or runtime version, this change adds test version to the logger itself, so we always have at least that version in our logs.