### PR TITLE
r11s-driver: enable RestLess by default

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2720,18 +2720,20 @@
 			}
 		},
 		"@fluidframework/server-services-shared": {
-			"version": "0.1028.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1028.1.tgz",
-			"integrity": "sha512-vUDyWdXxRSGhwepZ0gi62cYliGfARmmQU4TJ0FwMUhVsfF3IEnWTgDRhL4oEclcbc2+y1602algz5aKlhDn22Q==",
+			"version": "0.1034.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1034.0.tgz",
+			"integrity": "sha512-rtXWde9DEoFkZBmq8Y8a2M5BQQ+1SJE2qWzFmusKnO5Fjsgiy5TmvQoDyUZqnLqPUu4PQmZRuKq7+7N3Wmj37g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "^0.1028.1",
-				"@fluidframework/protocol-base": "^0.1028.1",
-				"@fluidframework/protocol-definitions": "^0.1024.0",
-				"@fluidframework/server-services-client": "^0.1028.1",
-				"@fluidframework/server-services-core": "^0.1028.1",
+				"@fluidframework/gitresources": "^0.1034.0",
+				"@fluidframework/protocol-base": "^0.1034.0",
+				"@fluidframework/protocol-definitions": "^0.1026.0",
+				"@fluidframework/server-services-client": "^0.1034.0",
+				"@fluidframework/server-services-core": "^0.1034.0",
+				"@fluidframework/server-services-telemetry": "^0.1034.0",
 				"@socket.io/redis-adapter": "^7.0.0",
 				"debug": "^4.1.1",
+				"formidable": "2.0.0-canary.20200504.1",
 				"ioredis": "^4.24.2",
 				"lodash": "^4.17.21",
 				"moniker": "^0.1.2",
@@ -2744,81 +2746,10 @@
 				"winston": "^3.3.3"
 			},
 			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
-					"integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
-					"integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1024.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
-					"integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.0"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1028.1.tgz",
-					"integrity": "sha512-6oWGf/RmyUG1eKt9A/3v8e7XjARS8S07SmDIjkwhb03IR4poGtQHuqqE7eUnP9CVs3GBlfwQ8BdEglfe7GOYnw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-base": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@types/node": "^12.19.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.2.0",
-						"jwt-decode": "^3.0.0",
-						"sillyname": "0.1.0",
-						"uuid": "^8.3.1"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.37",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-							"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
-						}
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1028.1.tgz",
-					"integrity": "sha512-4kQwtsFfWpU8MJKZ4kNZy0lL6RHzS++FRONJQ59d5JnKaxWwdrki5utNhuSfP7OJkg1nEuGI0t7uVnq3DNJNMA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@fluidframework/server-services-client": "^0.1028.1",
-						"@types/nconf": "^0.10.0",
-						"@types/node": "^12.19.0",
-						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.37",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-							"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
-						}
-					}
-				},
 				"ioredis": {
-					"version": "4.27.9",
-					"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.9.tgz",
-					"integrity": "sha512-hAwrx9F+OQ0uIvaJefuS3UTqW+ByOLyLIV+j0EH8ClNVxvFyH9Vmb08hCL4yje6mDYT5zMquShhypkd50RRzkg==",
+					"version": "4.28.2",
+					"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.2.tgz",
+					"integrity": "sha512-kQ+Iv7+c6HsDdPP2XUHaMv8DhnSeAeKEwMbaoqsXYbO+03dItXt7+5jGQDRyjdRUV2rFJbzg7P4Qt1iX2tqkOg==",
 					"requires": {
 						"cluster-key-slot": "^1.1.0",
 						"debug": "^4.3.1",
@@ -2834,19 +2765,14 @@
 					},
 					"dependencies": {
 						"debug": {
-							"version": "4.3.2",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-							"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+							"version": "4.3.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+							"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 							"requires": {
 								"ms": "2.1.2"
 							}
 						}
 					}
-				},
-				"jwt-decode": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-					"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
 				},
 				"redis-commands": {
 					"version": "1.7.0",
@@ -2854,19 +2780,18 @@
 					"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
 				},
 				"socket.io-parser": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-					"integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.1.tgz",
+					"integrity": "sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==",
 					"requires": {
-						"@types/component-emitter": "^1.2.10",
-						"component-emitter": "~1.3.0",
+						"@socket.io/component-emitter": "~3.0.0",
 						"debug": "~4.3.1"
 					},
 					"dependencies": {
 						"debug": {
-							"version": "4.3.2",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-							"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+							"version": "4.3.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+							"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 							"requires": {
 								"ms": "2.1.2"
 							}
@@ -2893,110 +2818,30 @@
 			}
 		},
 		"@fluidframework/server-services-utils": {
-			"version": "0.1028.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1028.1.tgz",
-			"integrity": "sha512-qFLApmYsjW7YYS3pXBb8D313yWGPmGY9xDQSrL+T4P7G77wt2A0RASM/JuXuCc0757eN5TPx65m/noEctC7cjg==",
+			"version": "0.1034.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1034.0.tgz",
+			"integrity": "sha512-YB/f2qwqGqu2o0uQAs2AyeAbJUDwJ1VVYq4xrPedhpk1ikESGGmWDICAF8a42cK5bLs6Urb3y37+kvAyaIjj7w==",
 			"requires": {
-				"@fluidframework/protocol-definitions": "^0.1024.0",
-				"@fluidframework/server-services-client": "^0.1028.1",
-				"@fluidframework/server-services-core": "^0.1028.1",
-				"@fluidframework/server-services-telemetry": "^0.1028.1",
+				"@fluidframework/protocol-definitions": "^0.1026.0",
+				"@fluidframework/server-services-client": "^0.1034.0",
+				"@fluidframework/server-services-core": "^0.1034.0",
+				"@fluidframework/server-services-telemetry": "^0.1034.0",
 				"debug": "^4.1.1",
 				"express": "^4.16.3",
 				"ioredis": "^4.24.2",
 				"json-stringify-safe": "^5.0.1",
 				"jsonwebtoken": "^8.4.0",
 				"nconf": "^0.11.0",
+				"serialize-error": "^8.1.0",
 				"sillyname": "0.1.0",
 				"uuid": "^8.3.1",
 				"winston": "^3.3.3"
 			},
 			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
-					"integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
-					"integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1024.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
-					"integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.0"
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1028.1.tgz",
-					"integrity": "sha512-6oWGf/RmyUG1eKt9A/3v8e7XjARS8S07SmDIjkwhb03IR4poGtQHuqqE7eUnP9CVs3GBlfwQ8BdEglfe7GOYnw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-base": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@types/node": "^12.19.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.2.0",
-						"jwt-decode": "^3.0.0",
-						"sillyname": "0.1.0",
-						"uuid": "^8.3.1"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.37",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-							"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
-						}
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1028.1.tgz",
-					"integrity": "sha512-4kQwtsFfWpU8MJKZ4kNZy0lL6RHzS++FRONJQ59d5JnKaxWwdrki5utNhuSfP7OJkg1nEuGI0t7uVnq3DNJNMA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@fluidframework/server-services-client": "^0.1028.1",
-						"@types/nconf": "^0.10.0",
-						"@types/node": "^12.19.0",
-						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.37",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-							"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
-						}
-					}
-				},
-				"@fluidframework/server-services-telemetry": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1028.1.tgz",
-					"integrity": "sha512-y75NqXX4E/Ukkfs+bd0+mt2CWOOK6WOcfrdGMKy0yIl8Ip7l4dPI8arrWiM12U6CRF+6VmZveWWoEyyh8jEKxA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"path-browserify": "^1.0.1",
-						"uuid": "^8.3.1"
-					}
-				},
 				"ioredis": {
-					"version": "4.27.9",
-					"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.9.tgz",
-					"integrity": "sha512-hAwrx9F+OQ0uIvaJefuS3UTqW+ByOLyLIV+j0EH8ClNVxvFyH9Vmb08hCL4yje6mDYT5zMquShhypkd50RRzkg==",
+					"version": "4.28.2",
+					"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.2.tgz",
+					"integrity": "sha512-kQ+Iv7+c6HsDdPP2XUHaMv8DhnSeAeKEwMbaoqsXYbO+03dItXt7+5jGQDRyjdRUV2rFJbzg7P4Qt1iX2tqkOg==",
 					"requires": {
 						"cluster-key-slot": "^1.1.0",
 						"debug": "^4.3.1",
@@ -3012,19 +2857,14 @@
 					},
 					"dependencies": {
 						"debug": {
-							"version": "4.3.2",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-							"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+							"version": "4.3.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+							"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 							"requires": {
 								"ms": "2.1.2"
 							}
 						}
 					}
-				},
-				"jwt-decode": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-					"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
 				},
 				"redis-commands": {
 					"version": "1.7.0",
@@ -9362,10 +9202,15 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
 		},
+		"@socket.io/component-emitter": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+			"integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q=="
+		},
 		"@socket.io/redis-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.0.0.tgz",
-			"integrity": "sha512-ioqzSUH2XvrBKm70bphTeLwBSPUU0n+w/Qkz11ryKBn6IIT4GJxyVOpodVBGnmDpxhT31EImQTZRT1ZueSTiTQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.1.0.tgz",
+			"integrity": "sha512-vbsNJKUQgtVHcOqNL2ac8kSemTVNKHRzYPldqQJt0eFKvlAtAviuAMzBP0WmOp5OoRLQMjhVsVvgMzzMsVsK5g==",
 			"requires": {
 				"debug": "~4.3.1",
 				"notepack.io": "~2.2.0",
@@ -9374,9 +9219,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -11830,9 +11675,9 @@
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/component-emitter": {
-			"version": "1.2.10",
-			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
-			"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
+			"integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ=="
 		},
 		"@types/connect": {
 			"version": "3.4.35",
@@ -16673,12 +16518,12 @@
 			}
 		},
 		"color": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-			"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
 			"requires": {
-				"color-convert": "^1.9.1",
-				"color-string": "^1.5.2"
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
 			}
 		},
 		"color-convert": {
@@ -16695,9 +16540,9 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-			"integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
 			"requires": {
 				"color-name": "^1.0.0",
 				"simple-swizzle": "^0.2.2"
@@ -16714,11 +16559,11 @@
 			"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
 		},
 		"colorspace": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
-			"integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
 			"requires": {
-				"color": "3.0.x",
+				"color": "^3.1.3",
 				"text-hex": "1.0.x"
 			}
 		},
@@ -17710,12 +17555,19 @@
 			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
 		},
 		"cookie-parser": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-			"integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
 			"requires": {
-				"cookie": "0.4.0",
+				"cookie": "0.4.1",
 				"cookie-signature": "1.0.6"
+			},
+			"dependencies": {
+				"cookie": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+					"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+				}
 			}
 		},
 		"cookie-signature": {
@@ -18971,6 +18823,30 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
 		},
+		"detect-port": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
+			"integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+			"requires": {
+				"address": "^1.0.1",
+				"debug": "^2.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"detect-port-alt": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -18999,7 +18875,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
 			"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-			"dev": true,
 			"requires": {
 				"asap": "^2.0.0",
 				"wrappy": "1"
@@ -19592,44 +19467,52 @@
 			}
 		},
 		"engine.io": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.2.0.tgz",
-			"integrity": "sha512-d1DexkQx87IFr1FLuV+0f5kAm1Hk1uOVijLOb+D1sDO2QMb7YjE02VHtZtxo7xIXMgcWLb+vl3HRT0rI9tr4jQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
+			"integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
 			"requires": {
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
+				"@types/node": ">=10.0.0",
 				"accepts": "~1.3.4",
 				"base64id": "2.0.0",
 				"cookie": "~0.4.1",
 				"cors": "~2.8.5",
 				"debug": "~4.3.1",
-				"engine.io-parser": "~4.0.0",
-				"ws": "~7.4.2"
+				"engine.io-parser": "~5.0.0",
+				"ws": "~8.2.3"
 			},
 			"dependencies": {
+				"base64-arraybuffer": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
+					"integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA=="
+				},
 				"cookie": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
 					"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
 				},
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"requires": {
 						"ms": "2.1.2"
 					}
 				},
 				"engine.io-parser": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
-					"integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+					"integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
 					"requires": {
-						"base64-arraybuffer": "0.1.4"
+						"base64-arraybuffer": "~1.0.1"
 					}
 				},
 				"ws": {
-					"version": "7.4.6",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+					"version": "8.2.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
 				}
 			}
 		},
@@ -21899,6 +21782,27 @@
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
 			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
+		"formidable": {
+			"version": "2.0.0-canary.20200504.1",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.0-canary.20200504.1.tgz",
+			"integrity": "sha512-//FlGY4V1wl5+Q54Gfx8FHErl0tDrRatftGFOgis2IeH8JFs4Ve/r+hubMRfk3gjSyI8VYLg8dWfa1DqfhMdCg==",
+			"requires": {
+				"dezalgo": "1.0.3",
+				"hexoid": "1.0.0",
+				"once": "1.4.0",
+				"qs": "^6.9.3"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
+					"integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+					"requires": {
+						"side-channel": "^1.0.4"
+					}
+				}
+			}
+		},
 		"forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -23215,6 +23119,11 @@
 					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 				}
 			}
+		},
+		"hexoid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+			"integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
 		},
 		"highlight.js": {
 			"version": "10.7.3",
@@ -37602,25 +37511,22 @@
 			}
 		},
 		"socket.io": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.2.0.tgz",
-			"integrity": "sha512-sjlGfMmnaWvTRVxGRGWyhd9ctpg4APxWAxu85O/SxekkxHhfxmePWZbaYCkeX5QQX0z1YEnKOlNt6w82E4Nzug==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.0.tgz",
+			"integrity": "sha512-bnpJxswR9ov0Bw6ilhCvO38/1WPtE3eA2dtxi2Iq4/sFebiDJQzgKNYA7AuVVdGW09nrESXd90NbZqtDd9dzRQ==",
 			"requires": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
 				"debug": "~4.3.2",
-				"engine.io": "~5.2.0",
-				"socket.io-adapter": "~2.3.2",
+				"engine.io": "~6.1.0",
+				"socket.io-adapter": "~2.3.3",
 				"socket.io-parser": "~4.0.4"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -37638,9 +37544,9 @@
 			}
 		},
 		"socket.io-adapter": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz",
-			"integrity": "sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg=="
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+			"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ=="
 		},
 		"socket.io-client": {
 			"version": "2.4.0",
@@ -40291,24 +40197,24 @@
 			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
 		},
 		"tinylicious": {
-			"version": "0.4.38350",
-			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.38350.tgz",
-			"integrity": "sha512-AfB9cOZ+PiZJOk9l8lCxhDP9B9U/HdCnhr2Hfv9vnCc81w3NgLObkrm0ihfd2yXqdxSrcLkGRDt8VmTB5TpQhA==",
+			"version": "0.4.45136",
+			"resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.45136.tgz",
+			"integrity": "sha512-mWnGrqxEgT05ksYTh5Z6esSln2yOI3HjEfVYt9gX5D+y9ZiSKB4yA2b4iI6V4dcLkUVSRRBPXgwxP+trbC3T6g==",
 			"requires": {
 				"@fluidframework/common-utils": "^0.32.1",
-				"@fluidframework/gitresources": "^0.1028.1",
-				"@fluidframework/protocol-base": "^0.1028.1",
-				"@fluidframework/protocol-definitions": "^0.1024.0",
-				"@fluidframework/server-lambdas": "^0.1028.1",
-				"@fluidframework/server-local-server": "^0.1028.1",
-				"@fluidframework/server-memory-orderer": "^0.1028.1",
-				"@fluidframework/server-services-client": "^0.1028.1",
-				"@fluidframework/server-services-core": "^0.1028.1",
-				"@fluidframework/server-services-shared": "^0.1028.1",
-				"@fluidframework/server-services-telemetry": "^0.1028.1",
-				"@fluidframework/server-services-utils": "^0.1028.1",
-				"@fluidframework/server-test-utils": "^0.1028.1",
-				"axios": "^0.21.1",
+				"@fluidframework/gitresources": "^0.1034.0",
+				"@fluidframework/protocol-base": "^0.1034.0",
+				"@fluidframework/protocol-definitions": "^0.1026.0",
+				"@fluidframework/server-lambdas": "^0.1034.0",
+				"@fluidframework/server-local-server": "^0.1034.0",
+				"@fluidframework/server-memory-orderer": "^0.1034.0",
+				"@fluidframework/server-services-client": "^0.1034.0",
+				"@fluidframework/server-services-core": "^0.1034.0",
+				"@fluidframework/server-services-shared": "^0.1034.0",
+				"@fluidframework/server-services-telemetry": "^0.1034.0",
+				"@fluidframework/server-services-utils": "^0.1034.0",
+				"@fluidframework/server-test-utils": "^0.1034.0",
+				"axios": "^0.21.2",
 				"body-parser": "^1.17.1",
 				"bytes": "^3.0.0",
 				"charwise": "^3.0.1",
@@ -40332,211 +40238,6 @@
 				"winston": "^3.3.3"
 			},
 			"dependencies": {
-				"@fluidframework/gitresources": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
-					"integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
-				},
-				"@fluidframework/protocol-base": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
-					"integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"lodash": "^4.17.21"
-					}
-				},
-				"@fluidframework/protocol-definitions": {
-					"version": "0.1024.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
-					"integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
-					"requires": {
-						"@fluidframework/common-definitions": "^0.20.0"
-					}
-				},
-				"@fluidframework/server-lambdas": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1028.1.tgz",
-					"integrity": "sha512-ArSKhObVGt4WRk+tjF69L60ckC4FLm75MyprYDsJ3kFxbqqXwKKNOOieME1gpFocSivVvkm/iJ8Lz308QTZxLw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-base": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@fluidframework/server-services-client": "^0.1028.1",
-						"@fluidframework/server-services-core": "^0.1028.1",
-						"@fluidframework/server-services-telemetry": "^0.1028.1",
-						"@types/semver": "^6.0.1",
-						"async": "^3.2.0",
-						"axios": "^0.21.1",
-						"double-ended-queue": "^2.1.0-0",
-						"json-stringify-safe": "^5.0.1",
-						"lodash": "^4.17.21",
-						"nconf": "^0.11.0",
-						"semver": "^6.3.0",
-						"sha.js": "^2.4.11",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-local-server": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1028.1.tgz",
-					"integrity": "sha512-juQQp1PWQGVeJu/IDxwGem86XWCAoN4MZhf78lZf0mqzaD3G5XWWV6AHmS4ZV7IF4tCHCdu9J8HhLIfQL5fC+Q==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@fluidframework/server-lambdas": "^0.1028.1",
-						"@fluidframework/server-memory-orderer": "^0.1028.1",
-						"@fluidframework/server-services-client": "^0.1028.1",
-						"@fluidframework/server-services-core": "^0.1028.1",
-						"@fluidframework/server-services-telemetry": "^0.1028.1",
-						"@fluidframework/server-test-utils": "^0.1028.1",
-						"jsrsasign": "^10.2.0",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-memory-orderer": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1028.1.tgz",
-					"integrity": "sha512-uTkMPNQUDEA0r9eoru7DyoX1GYDw0JgY/l1VMNBH6ueUIAykerLuoHr5QGgtVndybkZt45+clYNrSahmG+SxLA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/protocol-base": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@fluidframework/server-lambdas": "^0.1028.1",
-						"@fluidframework/server-services-client": "^0.1028.1",
-						"@fluidframework/server-services-core": "^0.1028.1",
-						"@types/debug": "^4.1.5",
-						"@types/double-ended-queue": "^2.1.0",
-						"@types/lodash": "^4.14.118",
-						"@types/node": "^12.19.0",
-						"@types/ws": "^6.0.1",
-						"debug": "^4.1.1",
-						"double-ended-queue": "^2.1.0-0",
-						"lodash": "^4.17.21",
-						"moniker": "^0.1.2",
-						"uuid": "^8.3.1",
-						"ws": "^7.4.6"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.37",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-							"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
-						}
-					}
-				},
-				"@fluidframework/server-services-client": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1028.1.tgz",
-					"integrity": "sha512-6oWGf/RmyUG1eKt9A/3v8e7XjARS8S07SmDIjkwhb03IR4poGtQHuqqE7eUnP9CVs3GBlfwQ8BdEglfe7GOYnw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-base": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@types/node": "^12.19.0",
-						"axios": "^0.21.1",
-						"debug": "^4.1.1",
-						"jsrsasign": "^10.2.0",
-						"jwt-decode": "^3.0.0",
-						"sillyname": "0.1.0",
-						"uuid": "^8.3.1"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.37",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-							"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
-						}
-					}
-				},
-				"@fluidframework/server-services-core": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1028.1.tgz",
-					"integrity": "sha512-4kQwtsFfWpU8MJKZ4kNZy0lL6RHzS++FRONJQ59d5JnKaxWwdrki5utNhuSfP7OJkg1nEuGI0t7uVnq3DNJNMA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@fluidframework/server-services-client": "^0.1028.1",
-						"@types/nconf": "^0.10.0",
-						"@types/node": "^12.19.0",
-						"debug": "^4.1.1",
-						"nconf": "^0.11.0"
-					},
-					"dependencies": {
-						"@types/node": {
-							"version": "12.20.37",
-							"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-							"integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
-						}
-					}
-				},
-				"@fluidframework/server-services-telemetry": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1028.1.tgz",
-					"integrity": "sha512-y75NqXX4E/Ukkfs+bd0+mt2CWOOK6WOcfrdGMKy0yIl8Ip7l4dPI8arrWiM12U6CRF+6VmZveWWoEyyh8jEKxA==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"path-browserify": "^1.0.1",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@fluidframework/server-test-utils": {
-					"version": "0.1028.1",
-					"resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1028.1.tgz",
-					"integrity": "sha512-RaRdEdBUZhqAbnpwuhLwOt1qwR7xr4Lg4OGJNnNZLpX6mI78e+oH7Jc0AhK6XRD6hUYBJ+ZGnqV6Z9jTZDETUw==",
-					"requires": {
-						"@fluidframework/common-utils": "^0.32.1",
-						"@fluidframework/gitresources": "^0.1028.1",
-						"@fluidframework/protocol-base": "^0.1028.1",
-						"@fluidframework/protocol-definitions": "^0.1024.0",
-						"@fluidframework/server-services-client": "^0.1028.1",
-						"@fluidframework/server-services-core": "^0.1028.1",
-						"@fluidframework/server-services-telemetry": "^0.1028.1",
-						"debug": "^4.1.1",
-						"lodash": "^4.17.21",
-						"string-hash": "^1.1.3",
-						"uuid": "^8.3.1"
-					}
-				},
-				"@types/semver": {
-					"version": "6.2.3",
-					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
-					"integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A=="
-				},
-				"detect-port": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
-					"integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
-					"requires": {
-						"address": "^1.0.1",
-						"debug": "^2.6.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"requires": {
-								"ms": "2.0.0"
-							}
-						}
-					}
-				},
-				"jwt-decode": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-					"integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -43483,39 +43184,36 @@
 			}
 		},
 		"winston-transport": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
-			"integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
+			"integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
 			"requires": {
-				"readable-stream": "^2.3.7",
+				"logform": "^2.2.0",
+				"readable-stream": "^3.4.0",
 				"triple-beam": "^1.2.0"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
 				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+				},
 				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "~5.2.0"
 					}
 				}
 			}

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -32,7 +32,7 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
     maxConcurrentOrdererRequests: 100,
     aggregateBlobsSmallerThanBytes: undefined,
     enableWholeSummaryUpload: false,
-    enableRestLess: false,
+    enableRestLess: true,
 };
 
 /**

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -34,7 +34,7 @@ export interface IRouterliciousDriverPolicies {
     enableWholeSummaryUpload: boolean;
     /**
      * Enable using RestLess which avoids CORS preflight requests.
-     * Default: false
+     * Default: true
      */
     enableRestLess: boolean;
 }

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -59,7 +59,7 @@
     "mocha": "^8.4.0",
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.38350",
+    "tinylicious": "^0.4.45136",
     "typescript": "~4.1.3"
   },
   "peerDependencies": {

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -109,7 +109,7 @@
     "mocha": "^8.4.0",
     "semver": "^7.3.4",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.38350",
+    "tinylicious": "^0.4.45136",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -109,7 +109,7 @@
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.38350",
+    "tinylicious": "^0.4.45136",
     "typescript": "~4.1.3"
   }
 }

--- a/server/azure-local-service/package-lock.json
+++ b/server/azure-local-service/package-lock.json
@@ -212,44 +212,46 @@
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
-      "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1034.0.tgz",
+      "integrity": "sha512-TXuuJ6reU5mQutIAIq6BMRneh3elU8VSwoxOkeFRV8adFRLQjs3LJM61C+2P1B+tzF33h9gUS5UzCHByBebc7w=="
     },
     "@fluidframework/protocol-base": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
-      "integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1034.0.tgz",
+      "integrity": "sha512-JcCAGPtPC/lL7Q2paNTMCxvWGsRagVh4C/NoTIMWRube2mP3POBGEdYSYDQyDv3CNUycEoOrG/78jdUq7Adz4A==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
+        "@fluidframework/gitresources": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
         "lodash": "^4.17.21"
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1024.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1024.1.tgz",
-      "integrity": "sha512-AxDb2ShY2LAF585hcv54A7YT/zpSE9TstiWQHHqcKLBWm19F5lu+htZE6grlnfDLYMY/oiVic+bsFXurHYazuQ==",
+      "version": "0.1026.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0.tgz",
+      "integrity": "sha512-dDjLGrpZd02NU9oXEzgQlW50EDt75v2CSU90xhg4S1VkHHuNrQfc/jEEeYNAVqac9duPutcDK4pP1n4AESYjlw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
       }
     },
     "@fluidframework/server-lambdas": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1028.1.tgz",
-      "integrity": "sha512-ArSKhObVGt4WRk+tjF69L60ckC4FLm75MyprYDsJ3kFxbqqXwKKNOOieME1gpFocSivVvkm/iJ8Lz308QTZxLw==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1034.0.tgz",
+      "integrity": "sha512-enst4WOTpICOokD+L191GUWvYbbXjZXcXwbz8u+KotXKtQUlbpkNlGDTcrW5+HOkZYQU7/vHjgEE8sxC8iNkYQ==",
       "requires": {
+        "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1028.1",
-        "@fluidframework/protocol-base": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1028.1",
-        "@fluidframework/server-services-core": "^0.1028.1",
-        "@fluidframework/server-services-telemetry": "^0.1028.1",
+        "@fluidframework/gitresources": "^0.1034.0",
+        "@fluidframework/protocol-base": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-lambdas-driver": "^0.1034.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
         "@types/semver": "^6.0.1",
         "async": "^3.2.0",
-        "axios": "^0.21.1",
+        "axios": "^0.21.2",
         "double-ended-queue": "^2.1.0-0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.21",
@@ -259,34 +261,50 @@
         "uuid": "^8.3.1"
       }
     },
-    "@fluidframework/server-local-server": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1028.1.tgz",
-      "integrity": "sha512-juQQp1PWQGVeJu/IDxwGem86XWCAoN4MZhf78lZf0mqzaD3G5XWWV6AHmS4ZV7IF4tCHCdu9J8HhLIfQL5fC+Q==",
+    "@fluidframework/server-lambdas-driver": {
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1034.0.tgz",
+      "integrity": "sha512-g6ZZNDA2BW4H+UdCvx/9hhbqPnQag8P7hdeoXF6GvlThDbu1e6ikx4oReh8J3FwgwhyaQRpRe3o7m7+2t+LiCw==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-lambdas": "^0.1028.1",
-        "@fluidframework/server-memory-orderer": "^0.1028.1",
-        "@fluidframework/server-services-client": "^0.1028.1",
-        "@fluidframework/server-services-core": "^0.1028.1",
-        "@fluidframework/server-services-telemetry": "^0.1028.1",
-        "@fluidframework/server-test-utils": "^0.1028.1",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
+        "async": "^3.2.0",
+        "lodash": "^4.17.21",
+        "moniker": "^0.1.2"
+      }
+    },
+    "@fluidframework/server-local-server": {
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1034.0.tgz",
+      "integrity": "sha512-CeKGJIvigfqE13RF/FpAztwrdjHHjynmKZVSTiCiI5Ayf7J+8ArTa407KzYwHt813H56bDp7DgYhBjxBc7FOIA==",
+      "requires": {
+        "@fluidframework/common-utils": "^0.32.1",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-lambdas": "^0.1034.0",
+        "@fluidframework/server-memory-orderer": "^0.1034.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
+        "@fluidframework/server-test-utils": "^0.1034.0",
+        "debug": "^4.1.1",
         "jsrsasign": "^10.2.0",
         "uuid": "^8.3.1"
       }
     },
     "@fluidframework/server-memory-orderer": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1028.1.tgz",
-      "integrity": "sha512-uTkMPNQUDEA0r9eoru7DyoX1GYDw0JgY/l1VMNBH6ueUIAykerLuoHr5QGgtVndybkZt45+clYNrSahmG+SxLA==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1034.0.tgz",
+      "integrity": "sha512-SsLP2YpwqHw4g4OGGdTrLI+SJoURNrlphLnWMdEDy8kKoHQSP8O5FIf1BAUYzXsec3CJ6uLKnwvNq4AKPUOJdw==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/protocol-base": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-lambdas": "^0.1028.1",
-        "@fluidframework/server-services-client": "^0.1028.1",
-        "@fluidframework/server-services-core": "^0.1028.1",
+        "@fluidframework/protocol-base": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-lambdas": "^0.1034.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
         "@types/debug": "^4.1.5",
         "@types/double-ended-queue": "^2.1.0",
         "@types/lodash": "^4.14.118",
@@ -301,16 +319,16 @@
       }
     },
     "@fluidframework/server-services-client": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1028.1.tgz",
-      "integrity": "sha512-6oWGf/RmyUG1eKt9A/3v8e7XjARS8S07SmDIjkwhb03IR4poGtQHuqqE7eUnP9CVs3GBlfwQ8BdEglfe7GOYnw==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1034.0.tgz",
+      "integrity": "sha512-o3OLRrCm0t+xrlfFTphQTs7/zC4vAP9Za4V+TD/Un6vSQH71DI+kCP5vt8KqJN6nccZusvahxcRIqFGzsqWJPA==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1028.1",
-        "@fluidframework/protocol-base": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@types/node": "^12.19.0",
-        "axios": "^0.21.1",
+        "@fluidframework/gitresources": "^0.1034.0",
+        "@fluidframework/protocol-base": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "axios": "^0.21.2",
+        "crc-32": "1.2.0",
         "debug": "^4.1.1",
         "jsrsasign": "^10.2.0",
         "jwt-decode": "^3.0.0",
@@ -319,14 +337,15 @@
       }
     },
     "@fluidframework/server-services-core": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1028.1.tgz",
-      "integrity": "sha512-4kQwtsFfWpU8MJKZ4kNZy0lL6RHzS++FRONJQ59d5JnKaxWwdrki5utNhuSfP7OJkg1nEuGI0t7uVnq3DNJNMA==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1034.0.tgz",
+      "integrity": "sha512-vI+9pJGjvZkfh3qDtdjnmk0blBJgDjSp+kR+priX8XRhQa5JZaIrvMxfo8uzwOXU2K+yJQNfGAaXOOwx9X5UQg==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1028.1",
+        "@fluidframework/gitresources": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
         "@types/nconf": "^0.10.0",
         "@types/node": "^12.19.0",
         "debug": "^4.1.1",
@@ -334,18 +353,20 @@
       }
     },
     "@fluidframework/server-services-shared": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1028.1.tgz",
-      "integrity": "sha512-vUDyWdXxRSGhwepZ0gi62cYliGfARmmQU4TJ0FwMUhVsfF3IEnWTgDRhL4oEclcbc2+y1602algz5aKlhDn22Q==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1034.0.tgz",
+      "integrity": "sha512-rtXWde9DEoFkZBmq8Y8a2M5BQQ+1SJE2qWzFmusKnO5Fjsgiy5TmvQoDyUZqnLqPUu4PQmZRuKq7+7N3Wmj37g==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1028.1",
-        "@fluidframework/protocol-base": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1028.1",
-        "@fluidframework/server-services-core": "^0.1028.1",
+        "@fluidframework/gitresources": "^0.1034.0",
+        "@fluidframework/protocol-base": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
         "@socket.io/redis-adapter": "^7.0.0",
         "debug": "^4.1.1",
+        "formidable": "2.0.0-canary.20200504.1",
         "ioredis": "^4.24.2",
         "lodash": "^4.17.21",
         "moniker": "^0.1.2",
@@ -359,47 +380,50 @@
       }
     },
     "@fluidframework/server-services-telemetry": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1028.1.tgz",
-      "integrity": "sha512-y75NqXX4E/Ukkfs+bd0+mt2CWOOK6WOcfrdGMKy0yIl8Ip7l4dPI8arrWiM12U6CRF+6VmZveWWoEyyh8jEKxA==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1034.0.tgz",
+      "integrity": "sha512-1RQ2Xgeb3QVjuqgjlLR1fGAkD8+g+Y0WGdhgo2rim3Z7ySAC3V9y7HQAfrQ4DIXh/0cpGCOZH+RNF2u7zGBCmQ==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
+        "json-stringify-safe": "^5.0.1",
         "path-browserify": "^1.0.1",
+        "serialize-error": "^8.1.0",
         "uuid": "^8.3.1"
       }
     },
     "@fluidframework/server-services-utils": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1028.1.tgz",
-      "integrity": "sha512-qFLApmYsjW7YYS3pXBb8D313yWGPmGY9xDQSrL+T4P7G77wt2A0RASM/JuXuCc0757eN5TPx65m/noEctC7cjg==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1034.0.tgz",
+      "integrity": "sha512-YB/f2qwqGqu2o0uQAs2AyeAbJUDwJ1VVYq4xrPedhpk1ikESGGmWDICAF8a42cK5bLs6Urb3y37+kvAyaIjj7w==",
       "requires": {
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1028.1",
-        "@fluidframework/server-services-core": "^0.1028.1",
-        "@fluidframework/server-services-telemetry": "^0.1028.1",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
         "debug": "^4.1.1",
         "express": "^4.16.3",
         "ioredis": "^4.24.2",
         "json-stringify-safe": "^5.0.1",
         "jsonwebtoken": "^8.4.0",
         "nconf": "^0.11.0",
+        "serialize-error": "^8.1.0",
         "sillyname": "0.1.0",
         "uuid": "^8.3.1",
         "winston": "^3.3.3"
       }
     },
     "@fluidframework/server-test-utils": {
-      "version": "0.1028.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1028.1.tgz",
-      "integrity": "sha512-RaRdEdBUZhqAbnpwuhLwOt1qwR7xr4Lg4OGJNnNZLpX6mI78e+oH7Jc0AhK6XRD6hUYBJ+ZGnqV6Z9jTZDETUw==",
+      "version": "0.1034.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1034.0.tgz",
+      "integrity": "sha512-uvDqgimwpNohOl59d2mNjyNMcngN3HoV8rFhY/5FG2txeJGPQOUaOOqbkuEmOlKRT3X5vb1tOaxPytSJWtvyWQ==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1028.1",
-        "@fluidframework/protocol-base": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1028.1",
-        "@fluidframework/server-services-core": "^0.1028.1",
-        "@fluidframework/server-services-telemetry": "^0.1028.1",
+        "@fluidframework/gitresources": "^0.1034.0",
+        "@fluidframework/protocol-base": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.21",
         "string-hash": "^1.1.3",
@@ -1241,10 +1265,15 @@
         }
       }
     },
+    "@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q=="
+    },
     "@socket.io/redis-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.0.0.tgz",
-      "integrity": "sha512-ioqzSUH2XvrBKm70bphTeLwBSPUU0n+w/Qkz11ryKBn6IIT4GJxyVOpodVBGnmDpxhT31EImQTZRT1ZueSTiTQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.1.0.tgz",
+      "integrity": "sha512-vbsNJKUQgtVHcOqNL2ac8kSemTVNKHRzYPldqQJt0eFKvlAtAviuAMzBP0WmOp5OoRLQMjhVsVvgMzzMsVsK5g==",
       "requires": {
         "debug": "~4.3.1",
         "notepack.io": "~2.2.0",
@@ -1253,9 +1282,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -1279,9 +1308,9 @@
       "dev": true
     },
     "@types/component-emitter": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
-      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
+      "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ=="
     },
     "@types/cookie": {
       "version": "0.4.1",
@@ -1324,9 +1353,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.173",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
-      "integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg=="
+      "version": "4.14.178",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
+      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
     },
     "@types/ms": {
       "version": "0.7.31",
@@ -1339,9 +1368,9 @@
       "integrity": "sha512-5mv1YaLBjoKEHe9uztvKNVCQMBD+IGFfUo0lzHtiyHnEMMU0eMB3ithFDzMHBvIbYvjUvD9tD7rNHLyRz2bO/g=="
     },
     "@types/node": {
-      "version": "12.20.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.26.tgz",
-      "integrity": "sha512-gIt+h4u2uTho2bsH1K250fUv5fHU71ET1yWT7bM4523zV/XrFb9jlWBOV4DO8FpscY+Sz/WEr1EEjIP2H4yumQ=="
+      "version": "12.20.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.40.tgz",
+      "integrity": "sha512-RX6hFa0hxkFuktu5629zJEkWK5e0HreW4vpNSLn4nWkOui7CTGCjtKiKpvtZ4QwCZ2Am5uhrb5ULHKNyunYYqg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1710,6 +1739,11 @@
         "function-bind": "^1.1.1"
       }
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1723,9 +1757,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -1828,9 +1862,9 @@
       }
     },
     "base64-arraybuffer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
+      "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -1868,20 +1902,20 @@
       }
     },
     "body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
       "requires": {
-        "bytes": "3.1.0",
+        "bytes": "3.1.1",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
-        "http-errors": "1.7.2",
+        "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
+        "qs": "6.9.6",
+        "raw-body": "2.4.2",
+        "type-is": "~1.6.18"
       },
       "dependencies": {
         "debug": {
@@ -1891,6 +1925,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
         }
       }
     },
@@ -2027,9 +2066,9 @@
       "dev": true
     },
     "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
     },
     "bytewise": {
       "version": "1.1.0",
@@ -2069,7 +2108,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
       "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.0"
@@ -2242,12 +2280,12 @@
       }
     },
     "color": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
       "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
       }
     },
     "color-convert": {
@@ -2264,9 +2302,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -2278,11 +2316,11 @@
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "colorspace": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
-      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
       "requires": {
-        "color": "3.0.x",
+        "color": "^3.1.3",
         "text-hex": "1.0.x"
       }
     },
@@ -2507,18 +2545,11 @@
       "dev": true
     },
     "content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "requires": {
-        "safe-buffer": "5.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
+        "safe-buffer": "5.2.1"
       }
     },
     "content-type": {
@@ -2532,19 +2563,12 @@
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
       "requires": {
-        "cookie": "0.4.0",
+        "cookie": "0.4.1",
         "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-        }
       }
     },
     "cookie-signature": {
@@ -2886,6 +2910,15 @@
         }
       }
     },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2980,23 +3013,26 @@
       }
     },
     "engine.io": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.2.0.tgz",
-      "integrity": "sha512-d1DexkQx87IFr1FLuV+0f5kAm1Hk1uOVijLOb+D1sDO2QMb7YjE02VHtZtxo7xIXMgcWLb+vl3HRT0rI9tr4jQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
+      "integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
       "requires": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~4.0.0",
-        "ws": "~7.4.2"
+        "engine.io-parser": "~5.0.0",
+        "ws": "~8.2.3"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -3007,18 +3043,18 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
         }
       }
     },
     "engine.io-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
-      "integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+      "integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
       "requires": {
-        "base64-arraybuffer": "0.1.4"
+        "base64-arraybuffer": "~1.0.1"
       }
     },
     "enquirer": {
@@ -3736,16 +3772,16 @@
       }
     },
     "express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.0",
-        "content-disposition": "0.5.3",
+        "body-parser": "1.19.1",
+        "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.0",
+        "cookie": "0.4.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -3759,24 +3795,19 @@
         "on-finished": "~2.3.0",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.5",
-        "qs": "6.7.0",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.6",
         "range-parser": "~1.2.1",
-        "safe-buffer": "5.1.2",
-        "send": "0.17.1",
-        "serve-static": "1.14.1",
-        "setprototypeof": "1.1.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
         "statuses": "~1.5.0",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "cookie": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3785,10 +3816,10 @@
             "ms": "2.0.0"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        "qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
         }
       }
     },
@@ -4033,9 +4064,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
+      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4393,6 +4424,17 @@
         }
       }
     },
+    "formidable": {
+      "version": "2.0.0-canary.20200504.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.0-canary.20200504.1.tgz",
+      "integrity": "sha512-//FlGY4V1wl5+Q54Gfx8FHErl0tDrRatftGFOgis2IeH8JFs4Ve/r+hubMRfk3gjSyI8VYLg8dWfa1DqfhMdCg==",
+      "requires": {
+        "dezalgo": "1.0.3",
+        "hexoid": "1.0.0",
+        "once": "1.4.0",
+        "qs": "^6.9.3"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -4438,8 +4480,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -4456,7 +4497,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
       "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4541,7 +4581,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -4555,8 +4594,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -4616,6 +4654,11 @@
         }
       }
     },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -4623,22 +4666,15 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "requires": {
         "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
+        "toidentifier": "1.0.1"
       }
     },
     "i": {
@@ -4758,9 +4794,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.27.9",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.9.tgz",
-      "integrity": "sha512-hAwrx9F+OQ0uIvaJefuS3UTqW+ByOLyLIV+j0EH8ClNVxvFyH9Vmb08hCL4yje6mDYT5zMquShhypkd50RRzkg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.2.tgz",
+      "integrity": "sha512-kQ+Iv7+c6HsDdPP2XUHaMv8DhnSeAeKEwMbaoqsXYbO+03dItXt7+5jGQDRyjdRUV2rFJbzg7P4Qt1iX2tqkOg==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.1",
@@ -4776,9 +4812,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -5134,9 +5170,9 @@
       }
     },
     "jsrsasign": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.4.0.tgz",
-      "integrity": "sha512-C8qLhiAssh/b74KJpGhWuFGG9cFhJqMCVuuHXRibb3Z5vPuAW0ue0jUirpoExCdpdhv4nD3sZ1DAwJURYJTm9g=="
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.1.tgz",
+      "integrity": "sha512-yW0fq87KNZFw4Pn5ySllXs3ztZAROQZczEheKZTqmiNpCe/Xj9r5NhuAQ7MXTOyEZGJ/+MPHGTsfbgPFaLpwHQ=="
     },
     "jsx-ast-utils": {
       "version": "3.2.0",
@@ -5620,16 +5656,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "requires": {
-        "mime-db": "1.49.0"
+        "mime-db": "1.51.0"
       }
     },
     "mimic-response": {
@@ -5838,21 +5874,21 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "wrap-ansi": {
@@ -5883,11 +5919,6 @@
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
           }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
     },
@@ -6552,9 +6583,12 @@
       "dev": true
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
+      "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -6562,12 +6596,12 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
       "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
+        "bytes": "3.1.1",
+        "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
@@ -6843,9 +6877,9 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -6854,9 +6888,9 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.7.2",
+        "http-errors": "1.8.1",
         "mime": "1.6.0",
-        "ms": "2.1.1",
+        "ms": "2.1.3",
         "on-finished": "~2.3.0",
         "range-parser": "~1.2.1",
         "statuses": "~1.5.0"
@@ -6878,21 +6912,36 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
     },
     "serve-static": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.1"
+        "send": "0.17.2"
       }
     },
     "set-value": {
@@ -6919,9 +6968,9 @@
       }
     },
     "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -6969,7 +7018,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -6980,7 +7028,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
           "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -6990,8 +7037,7 @@
         "object-inspect": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
         }
       }
     },
@@ -7201,49 +7247,16 @@
       }
     },
     "socket.io": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.2.0.tgz",
-      "integrity": "sha512-sjlGfMmnaWvTRVxGRGWyhd9ctpg4APxWAxu85O/SxekkxHhfxmePWZbaYCkeX5QQX0z1YEnKOlNt6w82E4Nzug==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.0.tgz",
+      "integrity": "sha512-bnpJxswR9ov0Bw6ilhCvO38/1WPtE3eA2dtxi2Iq4/sFebiDJQzgKNYA7AuVVdGW09nrESXd90NbZqtDd9dzRQ==",
       "requires": {
-        "@types/cookie": "^0.4.1",
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~5.2.0",
-        "socket.io-adapter": "~2.3.2",
+        "engine.io": "~6.1.0",
+        "socket.io-adapter": "~2.3.3",
         "socket.io-parser": "~4.0.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "socket.io-adapter": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz",
-      "integrity": "sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg=="
-    },
-    "socket.io-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
-      "requires": {
-        "@types/component-emitter": "^1.2.10",
-        "component-emitter": "~1.3.0",
-        "debug": "~4.3.1"
       },
       "dependencies": {
         "component-emitter": {
@@ -7252,9 +7265,48 @@
           "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
         },
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "socket.io-parser": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+          "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+          "requires": {
+            "@types/component-emitter": "^1.2.10",
+            "component-emitter": "~1.3.0",
+            "debug": "~4.3.1"
+          }
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+      "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ=="
+    },
+    "socket.io-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.1.tgz",
+      "integrity": "sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -7669,24 +7721,24 @@
       "dev": true
     },
     "tinylicious": {
-      "version": "0.4.38350",
-      "resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.38350.tgz",
-      "integrity": "sha512-AfB9cOZ+PiZJOk9l8lCxhDP9B9U/HdCnhr2Hfv9vnCc81w3NgLObkrm0ihfd2yXqdxSrcLkGRDt8VmTB5TpQhA==",
+      "version": "0.4.45136",
+      "resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.45136.tgz",
+      "integrity": "sha512-mWnGrqxEgT05ksYTh5Z6esSln2yOI3HjEfVYt9gX5D+y9ZiSKB4yA2b4iI6V4dcLkUVSRRBPXgwxP+trbC3T6g==",
       "requires": {
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1028.1",
-        "@fluidframework/protocol-base": "^0.1028.1",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-lambdas": "^0.1028.1",
-        "@fluidframework/server-local-server": "^0.1028.1",
-        "@fluidframework/server-memory-orderer": "^0.1028.1",
-        "@fluidframework/server-services-client": "^0.1028.1",
-        "@fluidframework/server-services-core": "^0.1028.1",
-        "@fluidframework/server-services-shared": "^0.1028.1",
-        "@fluidframework/server-services-telemetry": "^0.1028.1",
-        "@fluidframework/server-services-utils": "^0.1028.1",
-        "@fluidframework/server-test-utils": "^0.1028.1",
-        "axios": "^0.21.1",
+        "@fluidframework/gitresources": "^0.1034.0",
+        "@fluidframework/protocol-base": "^0.1034.0",
+        "@fluidframework/protocol-definitions": "^0.1026.0",
+        "@fluidframework/server-lambdas": "^0.1034.0",
+        "@fluidframework/server-local-server": "^0.1034.0",
+        "@fluidframework/server-memory-orderer": "^0.1034.0",
+        "@fluidframework/server-services-client": "^0.1034.0",
+        "@fluidframework/server-services-core": "^0.1034.0",
+        "@fluidframework/server-services-shared": "^0.1034.0",
+        "@fluidframework/server-services-telemetry": "^0.1034.0",
+        "@fluidframework/server-services-utils": "^0.1034.0",
+        "@fluidframework/server-test-utils": "^0.1034.0",
+        "axios": "^0.21.2",
         "body-parser": "^1.17.1",
         "bytes": "^3.0.0",
         "charwise": "^3.0.1",
@@ -7780,9 +7832,9 @@
       "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
     },
     "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -8091,41 +8143,13 @@
       }
     },
     "winston-transport": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
-      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
+      "integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
       "requires": {
-        "readable-stream": "^2.3.7",
+        "logform": "^2.2.0",
+        "readable-stream": "^3.4.0",
         "triple-beam": "^1.2.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "word-wrap": {
@@ -8156,9 +8180,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -8195,8 +8219,7 @@
     "yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "yn": {
       "version": "3.1.1",

--- a/server/azure-local-service/package.json
+++ b/server/azure-local-service/package.json
@@ -28,7 +28,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "tinylicious": "^0.4.38350"
+    "tinylicious": "^0.4.45136"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",


### PR DESCRIPTION
RestLess circumvents CORS Preflight requests in all API calls. R11s, T9s, and Historian all support translating RestLess requests. RestLess request translation takes <1ms, which is a significant improvement over <network-roundtrip>ms delay from a CORS Preflight request.

The one trade-off is that we lose default browser caching of network requests. R11s-driver already has in-memory caching for these requests, but they are not yet persisted across refreshes/windows/tabs. WholeSummary mode already has browser network caching disabled by the server response, so this will have no negative affect on Azure Fluid Relay. ShreddedSummary mode's caching story is affected, but the benefit of halving the number of requests on shredded download appears to outweigh the negative here.