### PR TITLE
Add cache expiry policy

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -133,13 +133,12 @@ export interface IPersistedCache {
 export interface ISnapshotOptions {
     // (undocumented)
     blobs?: number;
+    cacheExpiryTimeoutOverrideMs?: number;
     // (undocumented)
     channels?: number;
     // (undocumented)
     deltas?: number;
-    // (undocumented)
     mds?: number;
-    // (undocumented)
     timeout?: number;
 }
 

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -7,19 +7,27 @@ export interface ISnapshotOptions {
     blobs?: number;
     deltas?: number;
     channels?: number;
-    /*
+    /**
      * Maximum Data size (in bytes)
      * If specified, SPO will fail snapshot request with 413 error (see OdspErrorType.snapshotTooBig)
      * if snapshot is bigger in size than specified limit.
      */
     mds?: number;
 
-    /*
+    /**
      * Maximum time limit to fetch snapshot (in seconds)
      * If specified, client will timeout the fetch request if it exceeds the time limit and
      * will try to fetch the snapshot without blobs.
      */
     timeout?: number;
+
+    /**
+     * Overrides the default cache expiry (in milliseconds)
+     * This will only override the default cache expiry if it is less than the default cache expiry.
+     * If specified, the snapshot cache will be expired earlier, and a network call will be made instead.
+     * The session expiry will be affected by setting this override.
+     */
+     cacheExpiryTimeoutOverrideMs?: number;
 }
 
 export interface IOpsCachingPolicy {

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -52,7 +52,7 @@ export class EpochTracker implements IPersistedFileCache {
         protected readonly cache: IPersistedCache,
         protected readonly fileEntry: IFileEntry,
         protected readonly logger: ITelemetryLogger,
-        protected readonly cacheExpiryTimeoutOverrideMs?: number,
+        protected readonly cacheExpiryTimeoutOverrideMs: number | undefined,
     ) {
         // Limits the max number of concurrent requests to 24.
         this.rateLimiter = new RateLimiter(24);
@@ -458,9 +458,10 @@ export function createOdspCacheAndTracker(
     persistedCacheArg: IPersistedCache,
     nonpersistentCache: INonPersistentCache,
     fileEntry: IFileEntry,
-    logger: ITelemetryLogger): ICacheAndTracker
+    logger: ITelemetryLogger,
+    cacheExpiryOverrideMs: number | undefined): ICacheAndTracker
 {
-    const epochTracker = new EpochTrackerWithRedemption(persistedCacheArg, fileEntry, logger);
+    const epochTracker = new EpochTrackerWithRedemption(persistedCacheArg, fileEntry, logger, cacheExpiryOverrideMs);
     return {
         cache: {
             ...nonpersistentCache,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -82,7 +82,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.persistedCache,
             this.nonPersistentCache,
             fileEntry,
-            odspLogger);
+            odspLogger,
+            this.hostPolicy.snapshotOptions?.cacheExpiryTimeoutOverrideMs);
 
         return PerformanceEvent.timedExecAsync(
             odspLogger,
@@ -153,7 +154,8 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
             this.persistedCache,
             this.nonPersistentCache,
             { resolvedUrl: odspResolvedUrl, docId: odspResolvedUrl.hashedDocumentId },
-            odspLogger);
+            odspLogger,
+            this.hostPolicy.snapshotOptions?.cacheExpiryTimeoutOverrideMs);
 
         const storageTokenFetcher = toInstrumentedOdspTokenFetcher(
             odspLogger,

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -96,7 +96,8 @@ describe("Create New Utils Tests", () => {
                 docId: hashedDocumentId,
                 resolvedUrl,
             },
-            new TelemetryNullLogger());
+            new TelemetryNullLogger(),
+            undefined);
 
         const filePath = "path";
         const newFileParams: INewFileInfo = {
@@ -142,7 +143,8 @@ describe("Create New Utils Tests", () => {
                 docId: hashedDocumentId,
                 resolvedUrl,
             },
-            new TelemetryNullLogger());
+            new TelemetryNullLogger(),
+            undefined);
 
         const newFileParams: INewFileInfo = {
             driveId,

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -12,7 +12,8 @@ import { EpochTracker } from "../epochTracker";
 import { mockFetchOk } from "./mockFetch";
 
 const createUtLocalCache = () => new LocalPersistentCache(2000);
-const createUtEpochTracker = (fileEntry, logger) => new EpochTracker(createUtLocalCache(), fileEntry, logger);
+const createUtEpochTracker = (fileEntry, logger) =>
+    new EpochTracker(createUtLocalCache(), fileEntry, logger, undefined);
 
 describe("DeltaStorageService", () => {
     /*

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -41,7 +41,8 @@ describe("Tests for Epoch Tracker", () => {
                 docId: hashedDocumentId,
                 resolvedUrl,
             },
-            new TelemetryNullLogger());
+            new TelemetryNullLogger(),
+            undefined);
     });
 
     it("Cache, old versions", async () => {

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -54,7 +54,8 @@ describe("Tests for Epoch Tracker With Redemption", () => {
                 docId: hashedDocumentId,
                 resolvedUrl,
             },
-            new TelemetryUTLogger());
+            new TelemetryUTLogger(),
+            undefined);
         epochCallback = new DeferralWithCallback();
         (epochTracker as any).treesLatestDeferral = epochCallback;
     });

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -105,6 +105,7 @@ describe("Tests for snapshot fetch", () => {
                 resolvedUrl,
             },
             new TelemetryNullLogger(),
+            undefined,
         );
 
         const resolved = await resolver.resolve({ url: odspUrl });

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -39,6 +39,7 @@ const odspSnapshotOptions: OptionsMatrix<ISnapshotOptions> = {
     deltas: numberCases,
     mds: numberCases,
     timeout: numberCases,
+    cacheExpiryTimeoutOverrideMs: numberCases,
 };
 
 const odspOpsCaching: OptionsMatrix<IOpsCachingPolicy> = {


### PR DESCRIPTION
Issue: #8549 

The goal of this PR is to introduce a policy allowing for the host to have the snapshot cache expire earlier than 2 days. This PR does not intend to link the timeouts between the snapshot expiry with the session expiry.