### PR TITLE
Fix on-demand summary test failure with real service

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -216,6 +216,9 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
         const broadcastResult = await result.summaryOpBroadcasted;
         assert(broadcastResult.success, "summary op should be broadcast");
 
+        const ackNackResult = await result.receivedSummaryAckOrNack;
+        assert(ackNackResult.success, "summary should be acked");
+
         const { stats, summary } = await containerRuntime.summarize({
             runGC: false,
             fullTree: false,


### PR DESCRIPTION
Make sure the ack/nack of the final on-demand summary occurs before attempting to stop the summarizer. Otherwise, the summarizer won't stop (it will be waiting for the lock to be released), and an assert in the test will fire when we let a summary go ahead after the stop call returns.