### PR TITLE
Add test for loading container from snapshot cache in offline case for odsp driver

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
@@ -96,4 +96,39 @@ describeNoCompat("Cache CreateNewSummary", (getTestObjectProvider) => {
         assert.strictEqual(fetchEvent.method, "cache",
             `second client fetched snapshot with ${fetchEvent.method} method instead of from cache`);
     });
+
+    it("should fetch from cache when second client loads the container in offline mode", async () => {
+        mockLogger = new MockLogger();
+
+        // Create a container for the first client. While attaching the odsp driver will cache the summary
+        // in persisted cache.
+        const mainContainer = await provider.createContainer(runtimeFactory, { logger: mockLogger });
+        assert.strictEqual(mainContainer.attachState, AttachState.Attached, "container was not attached");
+
+        // getting default data store and create a new data store
+        const mainDataStore = await requestFluidObject<TestDataObject>(mainContainer, "default");
+        const dataStore2 = await dataObjectFactory.createInstance(mainDataStore._context.containerRuntime);
+        mainDataStore._root.set("dataStore2", dataStore2.handle);
+
+        // second client loads the container
+        const mockDocumentServiceFactory = Object.create(provider.documentServiceFactory);
+        // Mock storage token fetch to throw so that we can mock offline case.
+        mockDocumentServiceFactory.getStorageToken = (options) => { throw new Error("TokenFail"); };
+        provider.documentServiceFactory = mockDocumentServiceFactory;
+
+        const container2 = await provider.loadContainer(runtimeFactory, { logger: mockLogger });
+        const defaultDataStore = await requestFluidObject<TestDataObject>(container2, "default");
+
+        // getting the non-default data store and validate it is loaded
+        const handle2 = await defaultDataStore._root.wait("dataStore2");
+        const testDataStore: TestDataObject = await handle2.get();
+        assert(testDataStore !== undefined, "2nd data store within loaded container is not loaded");
+
+        // validate the snapshot was fetched from cache
+        const fetchEvent = mockLogger.events.find((event) =>
+            event.eventName === "fluid:telemetry:OdspDriver:ObtainSnapshot_end");
+        assert(fetchEvent !== undefined, "odsp obtain snapshot event does not exist ");
+        assert.strictEqual(fetchEvent.method, "cache",
+            `second client fetched snapshot with ${fetchEvent.method} method instead of from cache`);
+    });
 });


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/7644
Add test to check we can load container in offline case if the snapshot is loaded from cache in odsp driver.