### PR TITLE
Sample showing how to pass headers to all fetch calls.

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -85,6 +85,8 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
         deltaStorageUrl: string;
     };
     // (undocumented)
+    fetchHeaders?: Record<string, string>;
+    // (undocumented)
     fileName: string;
     // (undocumented)
     fileVersion: string | undefined;

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -102,5 +102,7 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
      * Contains information about either sharing link created while creating a new file or
      * a redeemable share link created when loading an existing file
      */
-    shareLinkInfo?: ShareLinkInfoType
+    shareLinkInfo?: ShareLinkInfoType;
+
+    fetchHeaders?: Record<string, string>;
 }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -18,7 +18,7 @@ import {
 } from "@fluidframework/odsp-driver-definitions";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { PerformanceEvent, isFluidError, normalizeError } from "@fluidframework/telemetry-utils";
-import { fetchAndParseAsJSONHelper, fetchArray, IOdspResponse } from "./odspUtils";
+import { fetchAndParseAsJSONHelper, fetchArray, IOdspResponse, getOdspResolvedUrl } from "./odspUtils";
 import {
     IOdspCache,
     INonPersistentCache,
@@ -245,7 +245,7 @@ export class EpochTracker implements IPersistedFileCache {
         clientCorrelationId: string,
     ) {
         if (addInBody) {
-            const headers: {[key: string]: string} = {};
+            const headers: {[key: string]: string} = getOdspResolvedUrl(this.fileEntry.resolvedUrl).fetchHeaders ?? {};
             headers["X-RequestStats"] = clientCorrelationId;
             if (this.fluidEpoch !== undefined) {
                 headers["x-fluid-epoch"] = this.fluidEpoch;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -364,6 +364,7 @@ async function fetchSnapshotContentsCoreV1(
     const postBody = formParams.join("\r\n");
     const headers: {[index: string]: any} = {
         "Content-Type": `multipart/form-data;boundary=${formBoundary}`,
+        ...odspResolvedUrl.fetchHeaders,
     };
 
     const fetchOptions = {
@@ -410,7 +411,7 @@ async function fetchSnapshotContentsCoreV2(
     const queryString = getQueryString(queryParams);
     const { url, headers } = getUrlAndHeadersWithAuth(`${fullUrl}${queryString}`, storageToken);
     const fetchOptions = {
-        headers,
+        headers: {...odspResolvedUrl.fetchHeaders, ...headers},
         signal: controller?.signal,
     };
     const response = await (epochTracker?.fetchArray(url, fetchOptions, "treesLatest") ??

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -101,6 +101,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 },
                 fileVersion: undefined,
                 shareLinkInfo,
+                fetchHeaders: request.headers?[DriverHeader.fetchHeaders],
             };
         }
         const { siteUrl, driveId, itemId, path, containerPackageName, fileVersion } = decodeOdspUrl(request.url);
@@ -142,6 +143,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 containerPackageName,
             },
             fileVersion,
+            fetchHeaders: request.headers?[DriverHeader.fetchHeaders],
         };
     }
 


### PR DESCRIPTION
Sample flow for Kenneth, to demonstrate possible flow of how we can add headers to support https://microsoft-my.sharepoint-df.com/:fl:/p/patelm/EZLWi0vLn_1Fq4awuIRwPNkBapY4t3XsUoPgF3f4tp9Y9A?e=1n3ehn feature.

Implements it through uri resolver, leaving possibility to modify behavior per document.
Same flow is possible through driver factory, it would remove optionally (i.e. apply to all docs).

It will not compile as it requires proper bump of @fluidframework/driver-definitions

