### PR TITLE
Test that the container session matches for the same document

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -133,6 +133,7 @@
     "nock": "^10.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
+    "sinon": "^7.4.2",
     "typescript": "~4.1.3",
     "typescript-formatter": "7.1.0"
   }


### PR DESCRIPTION
Resolves #8608 

These tests validate whether not containers created from the same document will have the same session expiry.