### PR TITLE
Check SummaryManager state before calling stop

### DIFF
--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -141,6 +141,9 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
         this.refreshSummarizer();
     };
 
+    private static readonly isStartingOrRunning = (state: SummaryManagerState) =>
+        state === SummaryManagerState.Starting || state === SummaryManagerState.Running;
+
     private getShouldSummarizeState(): ShouldSummarizeState {
         if (!this.connectedState.connected) {
             return { shouldSummarize: false, stopReason: "parentNotConnected" };
@@ -253,7 +256,9 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
                 // Note that summarizer may keep going (like doing last summary).
                 // Ideally we await stopping process, but this code path is due to a bug
                 // that needs to be fixed either way.
-                this.stop("summarizerException");
+                if (SummaryManager.isStartingOrRunning(this.state)) {
+                    this.stop("summarizerException");
+                }
             }
         }).finally(() => {
             assert(this.state !== SummaryManagerState.Off, 0x264 /* "Expected: Not Off" */);
@@ -273,8 +278,7 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
     }
 
     private stop(reason: SummarizerStopReason) {
-        assert(this.state === SummaryManagerState.Running || this.state === SummaryManagerState.Starting,
-            0x265 /* "Expected: Starting or Running" */);
+        assert(SummaryManager.isStartingOrRunning(this.state), 0x265 /* "Expected: Starting or Running" */);
         this.state = SummaryManagerState.Stopping;
 
         // Stopping the running summarizer client should trigger a change

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -278,7 +278,9 @@ export class SummaryManager extends TypedEventEmitter<ISummaryManagerEvents> imp
     }
 
     private stop(reason: SummarizerStopReason) {
-        assert(SummaryManager.isStartingOrRunning(this.state), 0x265 /* "Expected: Starting or Running" */);
+        if (!SummaryManager.isStartingOrRunning(this.state)) {
+            return;
+        }
         this.state = SummaryManagerState.Stopping;
 
         // Stopping the running summarizer client should trigger a change


### PR DESCRIPTION
0x265 asserts indicate that SummaryManager.stop is being called while SummaryManager is already in a stopped/not-started state. My guess is that we call stop() first via the "disconnected" event handler (note that these asserts all seem to coincide with a Container disconnect) and then, without checking SummaryManager.state, in the catch handler in SummaryManager.startSummarization. 2 possible solutions: 1. check the state in the catch handler before calling stop(); 2. check the state in stop() and, instead of asserting, do nothing if we're already in a stopped/stopping state. There's no reason why we couldn't do both. My preference is to add a state check to the catch handler first to confirm that that's the source of the assert.