### PR TITLE
Remove Legacy Data Objects and Factories

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,6 +18,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Removed `IFluidSerializer` from `IFluidDataStoreRuntime`](#Removed-IFluidSerializer-from-IFluidDataStoreRuntime)
 - [`IFluidConfiguration` deprecated and `IFluidConfiguration` member removed from `ContainerRuntime`](#IFluidConfiguration-deprecated-and-IFluidConfiguration-member-removed-from-ContainerRuntime)
 - [`wait()` methods deprecated on map and directory](#wait()-methods-deprecated-on-map-and-directory)
+- [Remove Legacy Data Object and Factories](#Remove-Legacy-Data-Object-and-Factories)
 
 ### `container-loader` interfaces return `IQuorumClients` rather than `IQuorum`
 
@@ -97,6 +98,15 @@ const bar = await mapWait<Bar>(someSharedMap, barKey);
 ```
 
 As-written above, these promises will silently remain pending forever if the key is never set (similar to current `wait()` functionality).  For production use, consider adding timeouts, telemetry, or other failure flow support to detect and handle failure cases appropriately.
+
+### Remove Legacy Data Object and Factories
+
+In order to ease migration to the new Aqueduct Data Object and Data Object Factory generic arguments we added legacy versions of those classes in version 0.53. 
+
+In this release we remove those legacy classes: LegacyDataObject, LegacyPureDataObject, LegacyDataObjectFactory, and LegacyPureDataObjectFactory
+
+It is recommend you migrate to the new generic arguments before consuming this release. 
+Details are here: [0.53: Generic Argument Changes to DataObjects and Factories](#Generic-Argument-Changes-to-DataObjects-and-Factories)
 
 ## 0.54 Breaking changes
 - [Removed `readAndParseFromBlobs` from `driver-utils`](#Removed-readAndParseFromBlobs-from-driver-utils)

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -151,38 +151,6 @@ export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
     createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime): Promise<IFluidRouter>;
 }
 
-// @public @deprecated (undocumented)
-export abstract class LegacyDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent> extends DataObject<{
-    OptionalProviders: O;
-    InitialState: S;
-    Events: E;
-}> {
-}
-
-// @public @deprecated (undocumented)
-export class LegacyDataObjectFactory<TObj extends LegacyDataObject<O, S, E>, O, S, E extends IEvent = IEvent> extends DataObjectFactory<TObj, {
-    OptionalProviders: O;
-    InitialState: S;
-    Events: E;
-}> {
-}
-
-// @public @deprecated (undocumented)
-export abstract class LegacyPureDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent> extends PureDataObject<{
-    OptionalProviders: O;
-    InitialState: S;
-    Events: E;
-}> {
-}
-
-// @public @deprecated (undocumented)
-export class LegacyPureDataObjectFactory<TObj extends LegacyPureDataObject<O, S, E>, O, S, E extends IEvent = IEvent> extends PureDataObjectFactory<TObj, {
-    OptionalProviders: O;
-    InitialState: S;
-    Events: E;
-}> {
-}
-
 // @public
 export const mountableViewRequestHandler: (MountableViewClass: IFluidMountableViewClass, handlers: RuntimeRequestHandler[]) => (request: RequestParser, runtime: IContainerRuntime) => Promise<IResponse>;
 

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -16,8 +16,7 @@ import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { FluidObjectSymbolProvider } from "@fluidframework/synthesize";
 import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 
-import { IEvent } from "@fluidframework/common-definitions";
-import { DataObject, DataObjectTypes, DataObjectType, IDataObjectProps, LegacyDataObject  } from "../data-objects";
+import { DataObject, DataObjectTypes, DataObjectType, IDataObjectProps  } from "../data-objects";
 import { PureDataObjectFactory } from "./pureDataObjectFactory";
 
 /**
@@ -62,19 +61,3 @@ export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectT
         );
     }
 }
-
-/**
- * @deprecated - This type is meant to ease the transition from the old PureDataObjectFactory type to the new.
- * please migrate to PureDataObjectFactory.
- *
- * DataObjectFactory is the IFluidDataStoreFactory for use with DataObjects.
- * It facilitates DataObject's features (such as its shared directory) by
- * ensuring relevant shared objects etc are available to the factory.
- *
- * @typeParam TObj - DataObject (concrete type)
- * @typeParam O - represents a type that will define optional providers that will be injected
- * @typeParam S - the initial state type that the produced data object may take during creation
- * @typeParam E - represents events that will be available in the EventForwarder
- */
- export class LegacyDataObjectFactory<TObj extends LegacyDataObject<O, S, E>, O, S, E extends IEvent = IEvent>
- extends DataObjectFactory<TObj, {OptionalProviders: O, InitialState: S, Events: E}> {}

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -28,13 +28,11 @@ import {
     IFluidDependencySynthesizer,
 } from "@fluidframework/synthesize";
 
-import { IEvent } from "@fluidframework/common-definitions";
 import {
     IDataObjectProps,
     PureDataObject,
     DataObjectType,
     DataObjectTypes,
-    LegacyPureDataObject,
 } from "../data-objects";
 /*
  * Useful interface in places where it's useful to do type erasure for PureDataObject generic
@@ -272,19 +270,3 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
         return instance;
     }
 }
-
-/**
- * @deprecated - This type is meant to ease the transition from the old PureDataObjectFactory type to the new.
- * please migrate to PureDataObjectFactory.
- *
- * PureDataObjectFactory is a barebones IFluidDataStoreFactory for use with PureDataObject.
- * Consumers should typically use DataObjectFactory instead unless creating
- * another base data store factory.
- *
- * @typeParam TObj - DataObject (concrete type)
- * @typeParam O - represents a type that will define optional providers that will be injected
- * @typeParam S - the initial state type that the produced data object may take during creation
- * @typeParam E - represents events that will be available in the EventForwarder
- */
- export class LegacyPureDataObjectFactory<TObj extends LegacyPureDataObject<O, S, E>, O, S, E extends IEvent = IEvent>
- extends PureDataObjectFactory<TObj,{OptionalProviders: O, InitialState: S, Events: E}> {}

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent } from "@fluidframework/common-definitions";
 import {
-    IFluidObject,
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
@@ -87,24 +85,3 @@ export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> ex
         return `${item} must be initialized before being accessed.`;
     }
 }
-
-/**
- * @deprecated - This type is meant to ease the transition from the old DataObject type to the new.
- * please migrate to DataObject.
- *
- * DataObject is a base data store that is primed with a root directory. It
- * ensures that it is created and ready before you can access it.
- *
- * Having a single root directory allows for easier development. Instead of creating
- * and registering channels with the runtime any new DDS that is set on the root
- * will automatically be registered.
- *
- * @typeParam O - represents a type that will define optional providers that will be injected
- * @typeParam S - the initial state type that the produced data object may take during creation
- * @typeParam E - represents events that will be available in the EventForwarder
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export abstract class LegacyDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent>
-    extends DataObject<{OptionalProviders: O, InitialState: S, Events: E}> {
-
-    }

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export { DataObject, LegacyDataObject } from "./dataObject";
-export { PureDataObject, LegacyPureDataObject } from "./pureDataObject";
+export { DataObject } from "./dataObject";
+export { PureDataObject } from "./pureDataObject";
 export { DataObjectTypes, DataObjectType, IDataObjectProps } from "./types";

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -20,7 +20,6 @@ import { FluidObjectHandle } from "@fluidframework/datastore";
 import { IDirectory } from "@fluidframework/map";
 import { assert, EventForwarder } from "@fluidframework/common-utils";
 import { handleFromLegacyUri } from "@fluidframework/request-handler";
-import { IEvent } from "@fluidframework/common-definitions";
 import { serviceRoutePathRoot } from "../container-services";
 import { defaultFluidObjectRequestHandler } from "../request-handlers";
 import { DataObjectTypes, DataObjectType, IDataObjectProps } from "./types";
@@ -158,7 +157,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     }
 
     /**
-     * Retreive Fluid object using the handle get or the older requestFluidObject_UNSAFE call to fetch by ID
+     * Retrieve Fluid object using the handle get or the older requestFluidObject_UNSAFE call to fetch by ID
      *
      * @param key - key that object (handle/id) is stored with in the directory
      * @param directory - directory containing the object
@@ -233,22 +232,4 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     public dispose(): void {
         super.dispose();
     }
-}
-
-/**
- * @deprecated - This type is meant to ease the transition from the old PureDataObject type to the new.
- * please migrate to PureDataObject.
- *
- * This is a bare-bones base class that does basic setup and enables for factory on an initialize call.
- * You probably don't want to inherit from this data store directly unless
- * you are creating another base data store class
- *
- * @typeParam O - represents a type that will define optional providers that will be injected
- * @typeParam S - the initial state type that the produced data object may take during creation
- * @typeParam E - represents events that will be available in the EventForwarder
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export abstract class LegacyPureDataObject<O extends IFluidObject = object, S = undefined, E extends IEvent = IEvent>
-extends PureDataObject<{OptionalProviders: O, InitialState: S, Events: E}> {
-
 }


### PR DESCRIPTION
### Remove Legacy Data Object and Factories

In order to ease migration to the new Aqueduct Data Object and Data Object Factory generic arguments we added legacy versions of those classes in version 0.53. 

In this release we remove those legacy classes: LegacyDataObject, LegacyPureDataObject, LegacyDataObjectFactory, and LegacyPureDataObjectFactory

It is recommend you migrate to the new generic arguments before consuming this release. 
Details are here: [0.53: Generic Argument Changes to DataObjects and Factories](#Generic-Argument-Changes-to-DataObjects-and-Factories)

related to #8074 