### PR TITLE
Fix code owners

### DIFF
--- a/.github/code_owners.yml
+++ b/.github/code_owners.yml
@@ -48,7 +48,6 @@ packages/loader/**:
 - anthony-murphy
 packages/runtime/**:
 - vladsud
-- arinwt
 - curtisman
 
 packages/test/**:


### PR DESCRIPTION
arinwt is no longer working on the project, so removing him from the config.

Turns out that when someone doesn't have permissions to the repo, the GitHub action errors out and reviewers aren't added.