### PR TITLE
Throw original callback exception in `orderSequentially` (#8705) - release patch

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1666,6 +1666,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.setFlushMode(savedFlushMode);
         } catch(error) {
             this.closeFn(CreateProcessingError(error, "orderSequentially"));
+            throw error; // throw the original error for the consumer of the runtime
         }
     }
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -54,12 +54,12 @@ describe("Runtime", () => {
                 });
 
                 it("Can't call flush() inside orderSequentially's callback", () => {
-                    containerRuntime.orderSequentially(() => containerRuntime.flush());
+                    assert.throws(() => containerRuntime.orderSequentially(() => containerRuntime.flush()));
                     assert.strictEqual(getSingleContainerError().errorType, "dataProcessingError");
                 });
 
                 it("Can't call flush() inside orderSequentially's callback when nested", () => {
-                    containerRuntime.orderSequentially(
+                    assert.throws(
                         () => containerRuntime.orderSequentially(
                             () => containerRuntime.orderSequentially(
                                 () => containerRuntime.flush())));
@@ -68,9 +68,11 @@ describe("Runtime", () => {
                 });
 
                 it("Errors propagate to the container", () => {
-                    containerRuntime.orderSequentially(() => {
-                        throw new Error("Any");
-                    });
+                    assert.throws(
+                        () => containerRuntime.orderSequentially(
+                            () => {
+                                throw new Error("Any");
+                            }));
 
                     const error = getSingleContainerError();
                     assert.strictEqual(error.errorType, "dataProcessingError");


### PR DESCRIPTION
The previous change #8579 swallowed any exceptions from the orderSequentially flow and routed it to the container's close event. This broke existing protocol, as some consumers of the API may not have a handle on the container.