### PR TITLE
fix historian docker-compose.dev.yml mistake

### DIFF
--- a/server/historian/docker-compose.dev.yml
+++ b/server/historian/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
         ports:
             - 3001:3000
         volumes:
-            - .:/usr/src/server
+            - .:/home/node/server
         restart: always
 networks:
   default:


### PR DESCRIPTION
Historian image's working dir is /home/node/server, not /usr/src/server