### PR TITLE
Add documentation for hosts about the 2-day snapshot expiry

### DIFF
--- a/packages/drivers/odsp-driver-definitions/README.md
+++ b/packages/drivers/odsp-driver-definitions/README.md
@@ -3,5 +3,4 @@
 Definitions for @fluidframework/odsp-driver pakcage.
 Currently it contains all the contracts for driver factory.
 
-Though the host is responsible for implementing the IPersistedCache, snapshot entries will only be persisted
-for 2 days. The ODSP driver will remove all entries if it recieves a snapshot entry two days or older.
+Though the host is responsible for implementing the IPersistedCache, snapshot entries will only be persisted for 2 days. The ODSP driver will remove all entries if it recieves a snapshot entry two days or older.

--- a/packages/drivers/odsp-driver-definitions/README.md
+++ b/packages/drivers/odsp-driver-definitions/README.md
@@ -2,3 +2,6 @@
 
 Definitions for @fluidframework/odsp-driver pakcage.
 Currently it contains all the contracts for driver factory.
+
+Though the host is responsible for implementing the IPersistedCache, snapshot entries will only be persisted
+for 2 days. The ODSP driver will remove all entries if it recieves a snapshot entry two days or older.

--- a/packages/drivers/odsp-driver-definitions/README.md
+++ b/packages/drivers/odsp-driver-definitions/README.md
@@ -1,6 +1,6 @@
 # @fluidframework/odsp-driver-definitions
 
-Definitions for @fluidframework/odsp-driver pakcage.
+Definitions for @fluidframework/odsp-driver package.
 Currently it contains all the contracts for driver factory.
 
-Though the host is responsible for implementing the IPersistedCache, snapshot entries will only be persisted for 2 days. The ODSP driver will remove all entries if it recieves a snapshot entry two days or older.
+Though the host is responsible for implementing the IPersistedCache, snapshot cached entries will be disregarded if they are older than 2 days, which is based on `defaultCacheExpiryTimeoutMs`. The ODSP driver will delete all entries if it interacts with such a file.

--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -66,7 +66,9 @@ export interface ICacheEntry extends IEntry {
 /**
  * Persistent cache. This interface can be implemented by the host to provide durable caching
  * across sessions. If not provided at driver factory construction, factory will use in-memory
- * cache implementation that does not survive across sessions.
+ * cache implementation that does not survive across sessions. Snapshot entires stored in the 
+ * IPersistedCache will be considered stale and removed after 2 days. Read the README for more
+ * information.
  */
 export interface IPersistedCache {
     /**

--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -66,7 +66,7 @@ export interface ICacheEntry extends IEntry {
 /**
  * Persistent cache. This interface can be implemented by the host to provide durable caching
  * across sessions. If not provided at driver factory construction, factory will use in-memory
- * cache implementation that does not survive across sessions. Snapshot entires stored in the 
+ * cache implementation that does not survive across sessions. Snapshot entires stored in the
  * IPersistedCache will be considered stale and removed after 2 days. Read the README for more
  * information.
  */

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -33,6 +33,7 @@ export type FetchTypeInternal = FetchType | "cache";
 
 export const Odsp409Error = "Odsp409Error";
 
+// Please update the README file in odsp-driver-definitions if you change the defaultCacheExpiryTimeoutMs.
 export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000;
 
 /**


### PR DESCRIPTION
Resolves #8713 

Adds documentation to explain the 2-day snapshot expiry for hosts.