### PR TITLE
Fix stress tests for Tinylicious

### DIFF
--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -154,6 +154,9 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
     const testId = Date.now().toString();
     const request = testDriver.createCreateNewRequest(testId);
     await container.attach(request);
+    assert(container.resolvedUrl !== undefined, "Container missing resolved URL after attach");
+    assert(container.resolvedUrl.type === "fluid", "Container has a non-fluid resolved URL after attach");
+    const containerId = container.resolvedUrl.id;
     container.close();
 
     if ((testConfig.detachedBlobCount ?? 0) > 0) {
@@ -161,7 +164,7 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
         const url = (testDriver as OdspTestDriver).getUrlFromItemId((container.resolvedUrl as any).itemId);
         return url;
     }
-    return testDriver.createContainerUrl(testId);
+    return testDriver.createContainerUrl(containerId);
 }
 
 export async function createTestDriver(

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -155,16 +155,15 @@ export async function initialize(testDriver: ITestDriver, seed: number, testConf
     const request = testDriver.createCreateNewRequest(testId);
     await container.attach(request);
     assert(container.resolvedUrl !== undefined, "Container missing resolved URL after attach");
-    assert(container.resolvedUrl.type === "fluid", "Container has a non-fluid resolved URL after attach");
-    const containerId = container.resolvedUrl.id;
+    const resolvedUrl = container.resolvedUrl;
     container.close();
 
     if ((testConfig.detachedBlobCount ?? 0) > 0) {
         // TODO: #7684 this should be driver-agnostic
-        const url = (testDriver as OdspTestDriver).getUrlFromItemId((container.resolvedUrl as any).itemId);
+        const url = (testDriver as OdspTestDriver).getUrlFromItemId((resolvedUrl as any).itemId);
         return url;
     }
-    return testDriver.createContainerUrl(containerId);
+    return testDriver.createContainerUrl(testId, resolvedUrl);
 }
 
 export async function createTestDriver(


### PR DESCRIPTION
Resolves #8721 

Currently the stress tests assume the created container ID will match the requested ID.  This is not true for Routerlicious/Tinylicious, which generate a GUID and ignore the requested ID.  As a result, the stress tests can't run currently on Tinylicious.

Instead, retrieve the ID from the resolved URL after attach.