### PR TITLE
Re-enable ODSP GetOps

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -234,7 +234,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 
         // Reference to this client supporting get_ops flow.
         connectMessage.supportedFeatures = { };
-        if (mc.config.getBoolean("Fluid.Driver.Odsp.GetOpsEnabled") === true) {
+        if (mc.config.getBoolean("Fluid.Driver.Odsp.GetOpsEnabled") === false) {
             connectMessage.supportedFeatures[feature_get_ops] = true;
         }
 


### PR DESCRIPTION
There has been a server side fix for the issue surrounding get ops. This change re-enables get ops by default on the client for the next release.