### PR TITLE
Removed realizing data stores when processing attach message

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -237,10 +237,6 @@ export class DataStores implements IDisposable {
             pkg);
 
         this.contexts.addBoundOrRemoted(remotedFluidDataStoreContext);
-
-        // Equivalent of nextTick() - Prefetch once all current ops have completed
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        Promise.resolve().then(async () => remotedFluidDataStoreContext.realize());
     }
 
     public processAliasMessage(


### PR DESCRIPTION
Fixes #8494.

Data stores should not be realized on processing attach message but only when they are needed (delay loading).
Another issue as pointed out in #8667 is that because this is a floating promise, any errors with realization are thrown later.