### PR TITLE
Fix GetOpsEnabled condition

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -234,7 +234,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 
         // Reference to this client supporting get_ops flow.
         connectMessage.supportedFeatures = { };
-        if (mc.config.getBoolean("Fluid.Driver.Odsp.GetOpsEnabled") === false) {
+        if (mc.config.getBoolean("Fluid.Driver.Odsp.GetOpsEnabled") !== false) {
             connectMessage.supportedFeatures[feature_get_ops] = true;
         }
 


### PR DESCRIPTION
The pervious check was incorrect. We want to enable get ops if GetOpsEnabled is true or undefined, and only disable if GetOpsEnabled is false.