### PR TITLE
Remove convertToSummaryTreeWithStats from DDSs

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -27,7 +27,8 @@ The `getQuorum()` method on `IContainer` and the `quorum` member of `IContainerC
 
 ### `SharedObject` summary and GC API changes
 
-`SharedObject.snapshotCore` is renamed to `summarizeCore` and returns `ISummaryTreeWithStats`. A temporary way to fix this up quickly is to call `convertToSummaryTreeWithStats` on the `ITree` previously returned, but `convertToSummaryTreeWithStats` will be deprecated in the future and `ISummaryTreeWithStats` should be created directly.
+`SharedObject.snapshotCore` is renamed to `summarizeCore` and returns `ISummaryTreeWithStats`. Use
+`SummaryTreeBuilder` to create a summary instead of `ITree`.
 
 `SharedObject.getGCDataCore` is renamed to `processGCDataCore` and a `SummarySerializer` is passed as a parameter. The method should run the serializer over the handles as before and does not need to return anything. The caller will extract the GC data from the serializer.
 
@@ -102,11 +103,11 @@ As-written above, these promises will silently remain pending forever if the key
 
 ### Remove Legacy Data Object and Factories
 
-In order to ease migration to the new Aqueduct Data Object and Data Object Factory generic arguments we added legacy versions of those classes in version 0.53. 
+In order to ease migration to the new Aqueduct Data Object and Data Object Factory generic arguments we added legacy versions of those classes in version 0.53.
 
 In this release we remove those legacy classes: LegacyDataObject, LegacyPureDataObject, LegacyDataObjectFactory, and LegacyPureDataObjectFactory
 
-It is recommend you migrate to the new generic arguments before consuming this release. 
+It is recommend you migrate to the new generic arguments before consuming this release.
 Details are here: [0.53: Generic Argument Changes to DataObjects and Factories](#Generic-Argument-Changes-to-DataObjects-and-Factories)
 
 ### Removed `innerRequestHandler`

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -9,8 +9,8 @@ import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
+import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
-import { ITree } from '@fluidframework/protocol-definitions';
 import { Trace } from '@fluidframework/common-utils';
 
 // @public (undocumented)
@@ -190,11 +190,11 @@ export class Client {
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number | undefined;
     serializeGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void;
     // (undocumented)
-    snapshot(runtime: IFluidDataStoreRuntime, handle: IFluidHandle, serializer: IFluidSerializer, catchUpMsgs: ISequencedDocumentMessage[]): ITree;
-    // (undocumented)
     readonly specToSegment: (spec: IJSONSegment) => ISegment;
     // (undocumented)
     startOrUpdateCollaboration(longClientId: string | undefined, minSeq?: number, currentSeq?: number): void;
+    // (undocumented)
+    summarize(runtime: IFluidDataStoreRuntime, handle: IFluidHandle, serializer: IFluidSerializer, catchUpMsgs: ISequencedDocumentMessage[]): ISummaryTreeWithStats;
     // (undocumented)
     updateConsensusProperty(op: IMergeTreeAnnotateMsg, msg: ISequencedDocumentMessage): void;
     // (undocumented)
@@ -1448,7 +1448,7 @@ export class SnapshotLegacy {
     constructor(mergeTree: MergeTree, logger: ITelemetryLogger, filename?: string | undefined, onCompletion?: (() => void) | undefined);
     // (undocumented)
     static readonly body = "body";
-    emit(catchUpMsgs: ISequencedDocumentMessage[], serializer: IFluidSerializer, bind: IFluidHandle): ITree;
+    emit(catchUpMsgs: ISequencedDocumentMessage[], serializer: IFluidSerializer, bind: IFluidHandle): ISummaryTreeWithStats;
     // (undocumented)
     extractSync(): IJSONSegment[];
     // (undocumented)

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -60,7 +60,6 @@
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.55.0",
     "@fluidframework/driver-utils": "^0.55.0",
-    "@fluidframework/protocol-base": "^0.1034.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.55.0",
     "@fluidframework/runtime-utils": "^0.55.0",

--- a/packages/dds/matrix/src/handletable.ts
+++ b/packages/dds/matrix/src/handletable.ts
@@ -77,7 +77,7 @@ export class HandleTable<T> {
     private get next() { return this.handles[0] as Handle; }
     private set next(handle: Handle) { this.handles[0] = handle; }
 
-    public snapshot() {
+    public getSummaryContent() {
         return this.handles;
     }
 

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -4,12 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import {
-    FileMode,
-    ISequencedDocumentMessage,
-    ITree,
-    TreeEntry,
-} from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
     IFluidDataStoreRuntime,
     IChannelStorageService,
@@ -24,7 +19,7 @@ import {
     SummarySerializer,
 } from "@fluidframework/shared-object-base";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
-import { convertToSummaryTreeWithStats, ObjectStoragePartition } from "@fluidframework/runtime-utils";
+import { ObjectStoragePartition, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import {
     IMatrixProducer,
     IMatrixConsumer,
@@ -37,7 +32,7 @@ import { PermutationVector, PermutationSegment } from "./permutationvector";
 import { SparseArray2D } from "./sparsearray2d";
 import { SharedMatrixFactory } from "./runtime";
 import { Handle, isHandleValid } from "./handletable";
-import { deserializeBlob, serializeBlob } from "./serialization";
+import { deserializeBlob } from "./serialization";
 import { ensureRange } from "./range";
 import { IUndoConsumer } from "./types";
 import { MatrixUndoProvider } from "./undoprovider";
@@ -430,32 +425,15 @@ export class SharedMatrix<T = any>
     }
 
     protected summarizeCore(serializer: IFluidSerializer, fullTree: boolean): ISummaryTreeWithStats {
-        const tree: ITree = {
-            entries: [
-                {
-                    mode: FileMode.Directory,
-                    path: SnapshotPath.rows,
-                    type: TreeEntry.Tree,
-                    value: this.rows.snapshot(this.runtime, this.handle, serializer),
-                },
-                {
-                    mode: FileMode.Directory,
-                    path: SnapshotPath.cols,
-                    type: TreeEntry.Tree,
-                    value: this.cols.snapshot(this.runtime, this.handle, serializer),
-                },
-                serializeBlob(
-                    this.handle,
-                    SnapshotPath.cells,
-                    [
-                        this.cells.snapshot(),
-                        this.pending.snapshot(),
-                    ],
-                    serializer),
-            ],
-        };
-
-        return convertToSummaryTreeWithStats(tree, fullTree);
+        const builder = new SummaryTreeBuilder();
+        builder.addWithStats(SnapshotPath.rows, this.rows.summarize(this.runtime, this.handle, serializer));
+        builder.addWithStats(SnapshotPath.cols, this.cols.summarize(this.runtime, this.handle, serializer));
+        builder.addBlob(SnapshotPath.cells,
+            serializer.stringify([
+                this.cells.snapshot(),
+                this.pending.snapshot(),
+            ], this.handle));
+        return builder.getSummaryTree();
     }
 
     /**

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -60,6 +60,8 @@
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.55.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/runtime-definitions": "^0.55.0",
+    "@fluidframework/runtime-utils": "^0.55.0",
     "@fluidframework/shared-object-base": "^0.55.0",
     "@fluidframework/telemetry-utils": "^0.55.0"
   },

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -7,8 +7,9 @@
 
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
-import { ISequencedDocumentMessage, ITree, MessageType } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreRuntime, IChannelStorageService } from "@fluidframework/datastore-definitions";
+import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, Trace } from "@fluidframework/common-utils";
 import { LoggingError } from "@fluidframework/telemetry-utils";
@@ -874,29 +875,27 @@ export class Client {
         return new MergeTreeTextHelper(this.mergeTree);
     }
 
-    // TODO: Remove `catchUpMsgs` once new snapshot format is adopted as default.
-    //       (See https://github.com/microsoft/FluidFramework/issues/84)
-    public snapshot(
+    public summarize(
         runtime: IFluidDataStoreRuntime,
         handle: IFluidHandle,
         serializer: IFluidSerializer,
         catchUpMsgs: ISequencedDocumentMessage[],
-    ): ITree {
+    ): ISummaryTreeWithStats {
         const deltaManager = runtime.deltaManager;
         const minSeq = deltaManager.minimumSequenceNumber;
 
         // Catch up to latest MSN, if we have not had a chance to do it.
         // Required for case where FluidDataStoreRuntime.attachChannel()
-        // generates snapshot right after loading data store.
+        // generates summary right after loading data store.
 
         this.updateSeqNumbers(minSeq, deltaManager.lastSequenceNumber);
 
-        // One of the snapshots (from SPO) I observed to have chunk.chunkSequenceNumber > minSeq!
+        // One of the summaries (from SPO) I observed to have chunk.chunkSequenceNumber > minSeq!
         // Not sure why - need to catch it sooner
         assert(this.getCollabWindow().minSeq === minSeq,
             0x03e /* "minSeq mismatch between collab window and delta manager!" */);
 
-        // TODO: Remove options flag once new snapshot format is adopted as default.
+        // Must continue to support legacy
         //       (See https://github.com/microsoft/FluidFramework/issues/84)
         if (this.mergeTree.options?.newMergeTreeSnapshotFormat === true) {
             assert(

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -8,13 +8,9 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
 import { assert, bufferToString } from "@fluidframework/common-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
-import {
-    FileMode,
-    ITree,
-    TreeEntry,
-    ITreeEntry,
-} from "@fluidframework/protocol-definitions";
 import { IChannelStorageService } from "@fluidframework/datastore-definitions";
+import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
+import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import { UnassignedSequenceNumber } from "./constants";
 import {
     ISegment,
@@ -96,13 +92,13 @@ export class SnapshotV1 {
     }
 
     /**
-     * Emits the snapshot to an ITree. If provided the optional IFluidSerializer will be used when serializing
-     * the summary data rather than JSON.stringify.
+     * Emits the snapshot to an ISummarizeResult. If provided the optional IFluidSerializer will be used when
+     * serializing the summary data rather than JSON.stringify.
      */
     emit(
         serializer: IFluidSerializer,
         bind: IFluidHandle,
-    ): ITree {
+    ): ISummaryTreeWithStats {
         const chunks: MergeTreeChunkV1[] = [];
         this.header.totalSegmentCount = 0;
         this.header.totalLength = 0;
@@ -122,48 +118,28 @@ export class SnapshotV1 {
         const headerChunk = chunks.shift()!;
         headerChunk.headerMetadata = this.header;
         headerChunk.headerMetadata.orderedChunkMetadata = [{ id: SnapshotLegacy.header }];
-        const entries: ITreeEntry[] = chunks.map<ITreeEntry>((chunk, index) => {
+        const builder = new SummaryTreeBuilder();
+        chunks.forEach((chunk, index) => {
             const id = `${SnapshotLegacy.body}_${index}`;
             this.header.orderedChunkMetadata.push({ id });
-            return {
-                mode: FileMode.File,
-                path: id,
-                type: TreeEntry.Blob,
-                value: {
-                    contents: serializeAsMaxSupportedVersion(
-                        id,
-                        chunk,
-                        this.logger,
-                        this.mergeTree.options,
-                        serializer,
-                        bind),
-                    encoding: "utf-8",
-                },
-            };
+            builder.addBlob(id, serializeAsMaxSupportedVersion(
+                id,
+                chunk,
+                this.logger,
+                this.mergeTree.options,
+                serializer,
+                bind));
         });
 
-        const tree: ITree = {
-            entries: [
-                {
-                    mode: FileMode.File,
-                    path: SnapshotLegacy.header,
-                    type: TreeEntry.Blob,
-                    value: {
-                        contents: serializeAsMaxSupportedVersion(
-                            SnapshotLegacy.header,
-                            headerChunk,
-                            this.logger,
-                            this.mergeTree.options,
-                            serializer,
-                            bind),
-                        encoding: "utf-8",
-                    },
-                },
-                ...entries,
-            ],
-        };
+        builder.addBlob(SnapshotLegacy.header, serializeAsMaxSupportedVersion(
+            SnapshotLegacy.header,
+            headerChunk,
+            this.logger,
+            this.mergeTree.options,
+            serializer,
+            bind));
 
-        return tree;
+        return builder.getSummaryTree();
     }
 
     extractSync() {

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -118,19 +118,20 @@ export class SnapshotV1 {
         const headerChunk = chunks.shift()!;
         headerChunk.headerMetadata = this.header;
         headerChunk.headerMetadata.orderedChunkMetadata = [{ id: SnapshotLegacy.header }];
-        const builder = new SummaryTreeBuilder();
+        const blobs: [key: string, content: string][] = [];
         chunks.forEach((chunk, index) => {
             const id = `${SnapshotLegacy.body}_${index}`;
             this.header.orderedChunkMetadata.push({ id });
-            builder.addBlob(id, serializeAsMaxSupportedVersion(
+            blobs.push([id, serializeAsMaxSupportedVersion(
                 id,
                 chunk,
                 this.logger,
                 this.mergeTree.options,
                 serializer,
-                bind));
+                bind)]);
         });
 
+        const builder = new SummaryTreeBuilder();
         builder.addBlob(SnapshotLegacy.header, serializeAsMaxSupportedVersion(
             SnapshotLegacy.header,
             headerChunk,
@@ -138,6 +139,9 @@ export class SnapshotV1 {
             this.mergeTree.options,
             serializer,
             bind));
+        blobs.forEach((value) => {
+            builder.addBlob(value[0], value[1]);
+        });
 
         return builder.getSummaryTree();
     }

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -9,8 +9,10 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
+import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
-import { FileMode, ISequencedDocumentMessage, ITree, TreeEntry } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import { NonCollabClient, UnassignedSequenceNumber } from "./constants";
 import {
     ISegment,
@@ -87,57 +89,38 @@ export class SnapshotLegacy {
     }
 
     /**
-     * Emits the snapshot to an ITree. If provided the optional IFluidSerializer will be used when serializing
-     * the summary data rather than JSON.stringify.
+     * Emits the snapshot to an ISummarizeResult. If provided the optional IFluidSerializer will be used when
+     * serializing the summary data rather than JSON.stringify.
      */
     emit(
         catchUpMsgs: ISequencedDocumentMessage[],
         serializer: IFluidSerializer,
         bind: IFluidHandle,
-    ): ITree {
+    ): ISummaryTreeWithStats {
         const chunk1 = this.getSeqLengthSegs(this.segments!, this.segmentLengths!, this.chunkSize);
         let length: number = chunk1.chunkLengthChars;
         let segments: number = chunk1.chunkSegmentCount;
-        const tree: ITree = {
-            entries: [
-                {
-                    mode: FileMode.File,
-                    path: SnapshotLegacy.header,
-                    type: TreeEntry.Blob,
-                    value: {
-                        contents: serializeAsMinSupportedVersion(
-                            SnapshotLegacy.header,
-                            chunk1,
-                            this.logger,
-                            this.mergeTree.options,
-                            serializer,
-                            bind),
-                        encoding: "utf-8",
-                    },
-                },
-            ],
-        };
+        const builder = new SummaryTreeBuilder();
+        builder.addBlob(SnapshotLegacy.header, serializeAsMinSupportedVersion(
+            SnapshotLegacy.header,
+            chunk1,
+            this.logger,
+            this.mergeTree.options,
+            serializer,
+            bind));
 
         if (chunk1.chunkSegmentCount < chunk1.totalSegmentCount!) {
             const chunk2 = this.getSeqLengthSegs(this.segments!, this.segmentLengths!,
                 this.header!.segmentsTotalLength, chunk1.chunkSegmentCount);
             length += chunk2.chunkLengthChars;
             segments += chunk2.chunkSegmentCount;
-            tree.entries.push({
-                mode: FileMode.File,
-                path: SnapshotLegacy.body,
-                type: TreeEntry.Blob,
-                value: {
-                    contents: serializeAsMinSupportedVersion(
-                        SnapshotLegacy.body,
-                        chunk2,
-                        this.logger,
-                        this.mergeTree.options,
-                        serializer,
-                        bind),
-                    encoding: "utf-8",
-                },
-            });
+            builder.addBlob(SnapshotLegacy.body, serializeAsMinSupportedVersion(
+                SnapshotLegacy.body,
+                chunk2,
+                this.logger,
+                this.mergeTree.options,
+                serializer,
+                bind));
         }
 
         assert(
@@ -149,18 +132,12 @@ export class SnapshotLegacy {
             0x05e /* "emit: mismatch in totalSegmentCount" */);
 
         if(catchUpMsgs !== undefined && catchUpMsgs.length > 0) {
-            tree.entries.push({
-                mode: FileMode.File,
-                path: this.mergeTree.options?.catchUpBlobName ?? SnapshotLegacy.catchupOps,
-                type: TreeEntry.Blob,
-                value: {
-                    contents: serializer ? serializer.stringify(catchUpMsgs, bind) : JSON.stringify(catchUpMsgs),
-                    encoding: "utf-8",
-                },
-            });
+            builder.addBlob(
+                this.mergeTree.options?.catchUpBlobName ?? SnapshotLegacy.catchupOps,
+                serializer ? serializer.stringify(catchUpMsgs, bind) : JSON.stringify(catchUpMsgs));
         }
 
-        return tree;
+        return builder.getSummaryTree();
     }
 
     extractSync() {

--- a/packages/dds/merge-tree/src/test/snapshot.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { ISequencedDocumentMessage, ITree } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, ISummaryTree } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { MockStorage } from "@fluidframework/test-runtime-utils";
 import { IMergeTreeOp } from "../ops";
@@ -12,9 +12,9 @@ import { SnapshotV1 } from "../snapshotV1";
 import { TestSerializer } from "./testSerializer";
 import { TestClient } from ".";
 
-// Reconstitutes a MergeTree client from a snapshot
-async function loadSnapshot(tree: ITree) {
-    const services = new MockStorage(tree);
+// Reconstitutes a MergeTree client from a summary
+async function loadSnapshot(summary: ISummaryTree) {
+    const services = MockStorage.createFromSummary(summary);
     const client2 = new TestClient(undefined);
     const runtime: Partial<IFluidDataStoreRuntime> = {
         logger: client2.logger,
@@ -62,7 +62,7 @@ class TestString {
     // Ensures the MergeTree client's contents successfully roundtrip through a snapshot.
     public async checkSnapshot() {
         this.applyPending();
-        const tree = this.getSnapshot();
+        const tree = this.getSummary();
         const client2 = await loadSnapshot(tree);
 
         assert.equal(this.client.getText(), client2.getText(),
@@ -76,11 +76,11 @@ class TestString {
         this.client = client2;
     }
 
-    public getSnapshot() {
+    public getSummary() {
         const snapshot = new SnapshotV1(this.client.mergeTree, this.client.logger);
         snapshot.extractSync();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return snapshot.emit(TestClient.serializer, undefined!);
+        return snapshot.emit(TestClient.serializer, undefined!).summary;
     }
 
     public getText() { return this.client.getText(); }
@@ -126,7 +126,7 @@ describe("snapshot", () => {
 
         // Invoke `load/getSnapshot()` directly instead of `str.expect()` to avoid ACKing the
         // pending insert op.
-        const client2 = await loadSnapshot(str.getSnapshot());
+        const client2 = await loadSnapshot(str.getSummary());
 
         // Original client has inserted text, but the one loaded from the snapshot should be empty.
         // This is because un-ACKed ops are not included in snapshots.  Instead, these ops are

--- a/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshotlegacy.spec.ts
@@ -26,8 +26,8 @@ describe("snapshot", () => {
         const snapshot = new SnapshotLegacy(client1.mergeTree, client1.logger);
         snapshot.extractSync();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const snapshotTree = snapshot.emit([], serializer, undefined!);
-        const services = new MockStorage(snapshotTree);
+        const summaryTree = snapshot.emit([], serializer, undefined!);
+        const services = MockStorage.createFromSummary(summaryTree.summary);
 
         const client2 = new TestClient(undefined);
         const runtime: Partial<IFluidDataStoreRuntime> = {
@@ -59,8 +59,8 @@ describe("snapshot", () => {
             const snapshot = new SnapshotLegacy(client1.mergeTree, client1.logger);
             snapshot.extractSync();
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const snapshotTree = snapshot.emit([], serializer, undefined!);
-            const services = new MockStorage(snapshotTree);
+            const summaryTree = snapshot.emit([], serializer, undefined!);
+            const services = MockStorage.createFromSummary(summaryTree.summary);
             const runtime: Partial<IFluidDataStoreRuntime> = {
                 logger: client2.logger,
                 clientId: (i + 1).toString(),

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { DebugLogger } from "@fluidframework/telemetry-utils";
-import { ISequencedDocumentMessage, ITree, MessageType } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, ISummaryTree, MessageType } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { MockStorage } from "@fluidframework/test-runtime-utils";
 import random from "random-js";
@@ -54,15 +54,15 @@ export class TestClient extends Client {
         const snapshot = new SnapshotLegacy(client1.mergeTree, DebugLogger.create("fluid:snapshot"));
         snapshot.extractSync();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const snapshotTree = snapshot.emit([], TestClient.serializer, undefined!);
-        return TestClient.createFromSnapshot(snapshotTree, newLongClientId, client1.specToSegment);
+        const summaryTree = snapshot.emit([], TestClient.serializer, undefined!).summary;
+        return TestClient.createFromSummary(summaryTree, newLongClientId, client1.specToSegment);
     }
 
-    public static async createFromSnapshot(
-        snapshotTree: ITree,
+    public static async createFromSummary(
+        summaryTree: ISummaryTree,
         newLongClientId: string,
         specToSeg: (spec: IJSONSegment) => ISegment): Promise<TestClient> {
-        const services = new MockStorage(snapshotTree);
+        const services = MockStorage.createFromSummary(summaryTree);
 
         const client2 = new TestClient(undefined, specToSeg);
         const { catchupOpsP } = await client2.load(

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -5,11 +5,8 @@
 import { Deferred, bufferToString, assert } from "@fluidframework/common-utils";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
 import {
-    FileMode,
     ISequencedDocumentMessage,
-    ITree,
     MessageType,
-    TreeEntry,
 } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
@@ -41,7 +38,7 @@ import {
     ReferenceType,
     SegmentGroup,
 } from "@fluidframework/merge-tree";
-import { convertToSummaryTreeWithStats, ObjectStoragePartition } from "@fluidframework/runtime-utils";
+import { ObjectStoragePartition, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import {
     IFluidSerializer,
     makeHandlesSerializable,
@@ -426,33 +423,17 @@ export abstract class SharedSegmentSequence<T extends ISegment>
     }
 
     protected summarizeCore(serializer: IFluidSerializer, fullTree: boolean): ISummaryTreeWithStats {
-        const entries = [];
+        const builder = new SummaryTreeBuilder();
+
         // conditionally write the interval collection blob
         // only if it has entries
         if (this.intervalMapKernel.size > 0) {
-            entries.push(
-                {
-                    mode: FileMode.File,
-                    path: snapshotFileName,
-                    type: TreeEntry.Blob,
-                    value: {
-                        contents: this.intervalMapKernel.serialize(serializer),
-                        encoding: "utf-8",
-                    },
-                });
+            builder.addBlob(snapshotFileName, this.intervalMapKernel.serialize(serializer));
         }
-        entries.push(
-            {
-                mode: FileMode.Directory,
-                path: contentPath,
-                type: TreeEntry.Tree,
-                value: this.snapshotMergeTree(serializer),
-            });
-        const tree: ITree = {
-            entries,
-        };
 
-        return convertToSummaryTreeWithStats(tree, fullTree);
+        builder.addWithStats(contentPath, this.summarizeMergeTree(serializer));
+
+        return builder.getSummaryTree();
     }
 
     /**
@@ -607,7 +588,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
         this.loadFinished();
     }
 
-    private snapshotMergeTree(serializer: IFluidSerializer): ITree {
+    private summarizeMergeTree(serializer: IFluidSerializer): ISummaryTreeWithStats {
         // Are we fully loaded? If not, things will go south
         assert(this.loadedDeferred.isCompleted, 0x074 /* "Snapshot called when not fully loaded" */);
         const minSeq = this.runtime.deltaManager.minimumSequenceNumber;
@@ -616,7 +597,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 
         this.messagesSinceMSNChange.forEach((m) => m.minimumSequenceNumber = minSeq);
 
-        return this.client.snapshot(this.runtime, this.handle, serializer, this.messagesSinceMSNChange);
+        return this.client.summarize(this.runtime, this.handle, serializer, this.messagesSinceMSNChange);
     }
 
     private processMergeTreeMsg(


### PR DESCRIPTION
Change remaining summarizeCore implementations to directly create ISummaryTreeWithStats instead of creating ITree and then converting. This completes the work started in #8592 which changed the return type from ITree to ISummaryTreeWithStats.

There are uses of conversion functions in container runtime (will be fixed with #8286), summarizer node, and data stores so I can't remove them yet.

I'll remove the fullTree parameter in summarizeCore in a separate PR to keep this change cleaner.

Closes #8652