### PR TITLE
Fix an edge case conflict for aliases vs ids

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -175,6 +175,15 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             assert(await dataCorruption);
         });
 
+        it("Create root datastore using a previously used alias breaks the container", async () => {
+            const dataCorruption = anyDataCorruption([container1, container2]);
+            const ds1 = await createRootDataStore(dataObject1, "1");
+            await trySetAlias(runtimeOf(dataObject1), ds1, alias);
+
+            await createRootDataStore(dataObject2, alias);
+            assert(await dataCorruption);
+        });
+
         it("Assign multiple data stores to the same alias, first write wins, different containers", async () => {
             const ds1 = await createRootDataStore(dataObject1, "1");
             const ds2 = await createRootDataStore(dataObject2, "2");


### PR DESCRIPTION
Related to https://github.com/microsoft/FluidFramework/issues/6465

If during the migration between APIs (create root vs alias) a document creates and aliases a datastore, then a root datastore is created with the (customer provided) id equal to the aforementioned alias, a hidden conflict is created as the attach op does not inspect the alias map. Any calls to get the datastore by id will return the aliased datastore. The behavior should be consistent with the current conflict resolution and just fail the container with a data corruption error.
