### PR TITLE
Disabled logging gcUnknownOutboundRoute event which is too noisy because of a bug

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -792,10 +792,14 @@ export class GarbageCollector implements IGarbageCollector {
             if (route.split("/").length === 2 && !explicitReferences.includes(route)) {
                 // We should ideally throw a data corruption error here. However, send an error for now until we have
                 // implemented sweep and have reasonable confidence in the sweep process.
+
+                // To be enabled when this issue is fixed - https://github.com/microsoft/FluidFramework/issues/8672
+                /**
                 this.mc.logger.sendErrorEvent({
                     eventName: "gcUnknownOutboundRoute",
                     route,
                 });
+                */
             }
         });
     }

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -721,7 +721,8 @@ describe("Garbage Collection Tests", () => {
          * Validates that we log an error since B is detected as a referenced node but its reference was notified
          * to GC.
          */
-        it(`Scenario 7 - Reference added without notifying GC`, async () => {
+        // To be enabled when this issue is fixed - https://github.com/microsoft/FluidFramework/issues/8672
+        it.skip(`Scenario 7 - Reference added without notifying GC`, async () => {
             // Initialize node A.
             defaultGCData.gcNodes["/"] = [ nodeA ];
             defaultGCData.gcNodes[nodeA] = [];


### PR DESCRIPTION
While https://github.com/microsoft/FluidFramework/issues/8672 is being fixed, disabling the gcUnknownOutboundRoute telemetry event for the upcoming release.
The PR to fix the issue is in progress but may take longer to get in -https://github.com/microsoft/FluidFramework/pull/8734