### PR TITLE
Add cache expiry to IDocumentStorageServicePolices

### DIFF
--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -167,6 +167,8 @@ export interface IDocumentStorageServicePolicies {
     readonly caching?: LoaderCachingPolicy;
     // (undocumented)
     readonly minBlobSize?: number;
+    // (undocumented)
+    readonly snapshotCacheExpiryTimeoutMs?: number;
 }
 
 // @public
@@ -282,7 +284,6 @@ export enum LoaderCachingPolicy {
     NoCaching = 0,
     Prefetch = 1
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -167,7 +167,6 @@ export interface IDocumentStorageServicePolicies {
     readonly caching?: LoaderCachingPolicy;
     // (undocumented)
     readonly minBlobSize?: number;
-    // (undocumented)
     readonly snapshotCacheExpiryTimeoutMs?: number;
 }
 

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -99,7 +99,9 @@ export interface IDocumentStorageServicePolicies {
     // Blobs that are smaller than that size should be aggregated into bigger blobs
     readonly minBlobSize?: number;
 
-    // This policy is required to be defined to run GC.
+    /**
+     * This policy tells the runtime that the driver will not use cached snapshots older than this value.
+     */
     readonly snapshotCacheExpiryTimeoutMs?: number;
 }
 

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -98,6 +98,9 @@ export interface IDocumentStorageServicePolicies {
     // If this policy is provided, it tells runtime on ideal size for blobs
     // Blobs that are smaller than that size should be aggregated into bigger blobs
     readonly minBlobSize?: number;
+
+    // This policy is required to be defined to run GC.
+    readonly snapshotCacheExpiryTimeoutMs?: number;
 }
 
 /**


### PR DESCRIPTION
Issue #8765

The snapshot cache expiry needs to be plumbed down to the container runtime so that GC can properly calculate when to run sweep/delete unreferenced datastores.