### PR TITLE
fixes for #8755 Dubious switch fallthrough case in undo-redo

### DIFF
--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -125,7 +125,6 @@ export class SharedSegmentSequenceRevertible implements IRevertible {
                                     undefined);
                             }
                             break;
-                        // fallthrough
                         default:
                             throw new Error("operationt type not revertible");
                     }

--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -124,6 +124,7 @@ export class SharedSegmentSequenceRevertible implements IRevertible {
                                     tracked.propertyDelta,
                                     undefined);
                             }
+			    break;
                         // fallthrough
                         default:
                             throw new Error("operationt type not revertible");

--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -124,7 +124,7 @@ export class SharedSegmentSequenceRevertible implements IRevertible {
                                     tracked.propertyDelta,
                                     undefined);
                             }
-			    break;
+                            break;
                         // fallthrough
                         default:
                             throw new Error("operationt type not revertible");


### PR DESCRIPTION
break statement was missing before fall through / default in case for MergeTreeDeltaType.ANNOTATE