### PR TITLE
Access sharingLinkToRedeem from IOdspResolvedUrl.shareLinkInfo

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -10,6 +10,12 @@ There are a few steps you can take to write a good change note and avoid needing
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
 
+## 0.56 Breaking changes
+- [Removed `IOdspResolvedUrl.sharingLinkToRedeem`](#Removed-IOdspResolvedUrl.sharingLinkToRedeem)
+
+### Removed `IOdspResolvedUrl.sharingLinkToRedeem`
+The `sharingLinkToRedeem` property is removed from the `IOdspResolvedUrl` interface. The property can be accesed from `IOdspResolvedUrl.shareLinkInfo` instead.
+
 ## 0.55 Breaking changes
 - [`container-loader` interfaces return `IQuorumClients` rather than `IQuorum`](#container-loader-interfaces-return-IQuorumClients-rather-than-IQuorum)
 - [`SharedObject` summary and GC API changes](#SharedObject-summary-and-GC-API-changes)

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -93,8 +93,6 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     // (undocumented)
     odspResolvedUrl: true;
     shareLinkInfo?: ShareLinkInfoType;
-    // @deprecated (undocumented)
-    sharingLinkToRedeem?: string;
     // (undocumented)
     summarizer: boolean;
     // (undocumented)

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -84,11 +84,6 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
 
     summarizer: boolean;
 
-    /**
-     * @deprecated Use shareLinkInfo.sharingLinkToRedeem instead
-     */
-     sharingLinkToRedeem?: string;
-
     codeHint?: {
         // containerPackageName is used for adding the package name to the request headers.
         // This may be used for preloading the container package when loading Fluid content.

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -88,7 +88,6 @@ export async function fetchSnapshotWithRedeem(
     removeEntries: () => Promise<void>,
     enableRedeemFallback?: boolean,
 ): Promise<ISnapshotContents> {
-
     // For back. compatibility purposes. To be removed with #8784.
     const sharingLinkToRedeem = (odspResolvedUrl as any).sharingLinkToRedeem;
     if(sharingLinkToRedeem) {
@@ -472,7 +471,6 @@ export async function downloadSnapshot(
     controller?: AbortController,
     epochTracker?: EpochTracker,
 ): Promise<ISnapshotRequestAndResponseOptions> {
-
     // For back. compatibility purposes. To be removed with #8784.
     const sharingLinkToRedeem = (odspResolvedUrl as any).sharingLinkToRedeem;
     if(sharingLinkToRedeem) {
@@ -489,8 +487,7 @@ export async function downloadSnapshot(
 }
 
 function isRedeemSharingLinkError(odspResolvedUrl: IOdspResolvedUrl, error: any) {
-    const sharingLinkToRedeem = odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem;
-    if (sharingLinkToRedeem !== undefined
+    if (odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem !== undefined
         && (typeof error === "object" && error !== null)
         && (error.errorType === DriverErrorType.authorizationError
         || error.errorType === DriverErrorType.fileNotFoundOrAccessDeniedError)) {

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -88,7 +88,7 @@ export async function fetchSnapshotWithRedeem(
     removeEntries: () => Promise<void>,
     enableRedeemFallback?: boolean,
 ): Promise<ISnapshotContents> {
-    // back-compat: This block to be removed with #8784 when we only consume/consider odsp resolvers that are 0.51+
+    // back-compat: This block to be removed with #8784 when we only consume/consider odsp resolvers that are >= 0.51
     const sharingLinkToRedeem = (odspResolvedUrl as any).sharingLinkToRedeem;
     if(sharingLinkToRedeem) {
         odspResolvedUrl.shareLinkInfo = {...odspResolvedUrl.shareLinkInfo, sharingLinkToRedeem}
@@ -471,7 +471,7 @@ export async function downloadSnapshot(
     controller?: AbortController,
     epochTracker?: EpochTracker,
 ): Promise<ISnapshotRequestAndResponseOptions> {
-    // back-compat: This block to be removed with #8784 when we only consume/consider odsp resolvers that are 0.51+
+    // back-compat: This block to be removed with #8784 when we only consume/consider odsp resolvers that are >= 0.51
     const sharingLinkToRedeem = (odspResolvedUrl as any).sharingLinkToRedeem;
     if(sharingLinkToRedeem) {
         odspResolvedUrl.shareLinkInfo = {...odspResolvedUrl.shareLinkInfo, sharingLinkToRedeem}

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -88,7 +88,7 @@ export async function fetchSnapshotWithRedeem(
     removeEntries: () => Promise<void>,
     enableRedeemFallback?: boolean,
 ): Promise<ISnapshotContents> {
-    // For back. compatibility purposes. To be removed with #8784.
+    // back-compat: This block to be removed with #8784 when we only consume/consider odsp resolvers that are 0.51+
     const sharingLinkToRedeem = (odspResolvedUrl as any).sharingLinkToRedeem;
     if(sharingLinkToRedeem) {
         odspResolvedUrl.shareLinkInfo = {...odspResolvedUrl.shareLinkInfo, sharingLinkToRedeem}
@@ -471,7 +471,7 @@ export async function downloadSnapshot(
     controller?: AbortController,
     epochTracker?: EpochTracker,
 ): Promise<ISnapshotRequestAndResponseOptions> {
-    // For back. compatibility purposes. To be removed with #8784.
+    // back-compat: This block to be removed with #8784 when we only consume/consider odsp resolvers that are 0.51+
     const sharingLinkToRedeem = (odspResolvedUrl as any).sharingLinkToRedeem;
     if(sharingLinkToRedeem) {
         odspResolvedUrl.shareLinkInfo = {...odspResolvedUrl.shareLinkInfo, sharingLinkToRedeem}

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -133,9 +133,8 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
             // We need to remove the nav param if set by host when setting the sharelink as otherwise the shareLinkId
             // when redeeming the share link during the redeem fallback for trees latest call becomes greater than
             // the eligible length.
-            odspResolvedUrl.sharingLinkToRedeem = this.removeNavParam(request.url);
             odspResolvedUrl.shareLinkInfo = Object.assign(odspResolvedUrl.shareLinkInfo || {},
-                {sharingLinkToRedeem: odspResolvedUrl.sharingLinkToRedeem});
+                {sharingLinkToRedeem: this.removeNavParam(request.url)});
         }
         if (odspResolvedUrl.itemId) {
             // Kick start the sharing link request if we don't have it already as a performance optimization.

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -182,7 +182,6 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
             return urlResolverWithShareLinkFetcher.resolve(
                 { url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
-        assert(resolvedUrl.sharingLinkToRedeem !== undefined, "Sharing link should be set in resolved url");
         assert(resolvedUrl.shareLinkInfo?.sharingLinkToRedeem !== undefined, "Sharing link should be set in resolved url");
     });
 
@@ -206,6 +205,6 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
                 { url: url.toString(), headers: { [SharingLinkHeader.isSharingLinkToRedeem]: true } });
         });
         assert.strictEqual(
-            resolvedUrl.sharingLinkToRedeem, customShareLink, "Nav param should not exist on sharelink");
+            resolvedUrl.shareLinkInfo?.sharingLinkToRedeem, customShareLink, "Nav param should not exist on sharelink");
     });
 });


### PR DESCRIPTION
This PR should close https://github.com/microsoft/FluidFramework/issues/8268.

Here we consider backward compatibility between newer ODSP drivers and older ODSP resolvers, as hosts may have bundled (older) resolvers while still relying on new (CDN delivered) drivers.

The changes do NOT consider backward compatibility between new ODSP resolvers and old ODSP drivers, for couple of reasons:
1. ODSP resolvers and drivers are commonly sourced from the same package. This is what we do, for example, for all of our E2E regression tests.
2. In the current cases where there is a mismatch (as it may be with OWH), it is the driver that is delivered via service, and resolver that was bundled. I did not see the use cases to justify added work around providing transient N-1 compatibility in this direction.
3. Makes this transition a 2-step process, vs 3-step.

Follow up work: https://github.com/microsoft/FluidFramework/issues/8784

Targeting 0.56 release.


