### PR TITLE
Update parseAuthErrorTenant utility to account for www-authenticate format returned in case call is made on Consumer stack

### DIFF
--- a/packages/utils/odsp-doclib-utils/src/parseAuthErrorTenant.ts
+++ b/packages/utils/odsp-doclib-utils/src/parseAuthErrorTenant.ts
@@ -24,14 +24,15 @@ export function parseAuthErrorTenant(responseHeader: Headers): string | undefine
         return undefined;
     }
 
-    // header value must start with Bearer scheme
-    if (authHeaderData.indexOf(oAuthBearerScheme) !== 0) {
+    // header value must contain 'Bearer' scheme
+    const indexOfBearerInfo = authHeaderData.indexOf(oAuthBearerScheme);
+    if (indexOfBearerInfo < 0) {
         return undefined;
     }
 
     let tenantId: string | undefined;
     authHeaderData
-        .substr(oAuthBearerScheme.length)
+        .substring(indexOfBearerInfo + oAuthBearerScheme.length)
         .split(",")
         .map((section) => {
             if (!tenantId) {

--- a/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
@@ -12,8 +12,10 @@ const invalidWwwAuthenticateHeaderWithoutBearerScheme =
   "Random_scheme client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
 const invalidWwwAuthenticateHeaderWithoutRealm =
   "Bearer client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
-const validWwwAuthenticateHeader =
-  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
+const validWwwAuthenticateHeaderForOrgId =
+  "Bearer realm=\"6c482541-f706-4168-9e58-8e35a9992f58\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\",error=\"insufficient_claims\",claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTU5Nzk1OTA5MCJ9fX0=\"";
+const validWwwAuthenticateHeaderForMsa =
+  "Wlid1.1 realm=\"WindowsLive\", fault=\"BadContextToken\", policy=\"MBI_SSL\", ver=\"6.7.6631.0\", target=\"ssl.live.com\", siteId=\"ssl.live.com\", Bearer realm=\"9188040d-6c67-4c5b-b112-36a304b66dad\",client_id=\"00000003-0000-0ff1-ce00-000000000000\",trusted_issuers=\"00000001-0000-0000-c000-000000000000@*,D3776938-3DBA-481F-A652-4BEDFCAB7CD8@*,https://sts.windows.net/*/,00000003-0000-0ff1-ce00-000000000000@90140122-8516-11e1-8eff-49304924019b\",authorization_uri=\"https://login.windows.net/common/oauth2/authorize\"";
 
 describe("parseAuthErrorTenant", () => {
   it("returns undefined if headers does not have expected entry", () => {
@@ -40,11 +42,19 @@ describe("parseAuthErrorTenant", () => {
     assert.strictEqual(result, undefined);
   });
 
-  it("returns realm value", () => {
+  it("returns realm value in OrgId case", () => {
     const headers = {
-      get: (name: string) => name.toLowerCase() === "www-authenticate" ? validWwwAuthenticateHeader : undefined,
+      get: (name: string) => name.toLowerCase() === "www-authenticate" ? validWwwAuthenticateHeaderForOrgId : undefined,
     };
     const result = parseAuthErrorTenant(headers as any);
     assert.strictEqual(result, "6c482541-f706-4168-9e58-8e35a9992f58");
+  });
+
+  it("returns realm value in MSA case", () => {
+    const headers = {
+      get: (name: string) => name.toLowerCase() === "www-authenticate" ? validWwwAuthenticateHeaderForMsa : undefined,
+    };
+    const result = parseAuthErrorTenant(headers as any);
+    assert.strictEqual(result, "9188040d-6c67-4c5b-b112-36a304b66dad");
   });
 });


### PR DESCRIPTION
Utility has to be updated to account for how www-authenticate header is returned for caller with MSA account.