### PR TITLE
Move sinon to dependencies from devDependencies

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -108,6 +108,7 @@
     "cross-env": "^7.0.2",
     "mocha": "^8.4.0",
     "semver": "^7.3.4",
+    "sinon": "^7.4.2",
     "start-server-and-test": "^1.11.7",
     "tinylicious": "^0.4.45136",
     "uuid": "^8.3.1"
@@ -134,7 +135,6 @@
     "nock": "^10.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "sinon": "^7.4.2",
     "typescript": "~4.1.3",
     "typescript-formatter": "7.1.0"
   }


### PR DESCRIPTION
The e2e pipeline tests were failing. They were passing locally, implementing a fix for those issues. This regression was due to a missing sinon module.

Here's the test branch with the change: https://github.com/microsoft/FluidFramework/tree/test/tyler-cai-microsoft-pipeline