### PR TITLE
[bump] package version for eslint-config-fluid (patch)

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",

--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -176,9 +176,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.44827",
     "@fluidframework/common-definitions-0.20.0": "npm:@fluidframework/common-definitions@0.20.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -584,9 +584,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.46657",
     "@fluidframework/common-utils-0.32.1": "npm:@fluidframework/common-utils@0.32.1",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/base64-js": "^1.3.0",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -365,9 +365,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/container-definitions-0.42.0": "npm:@fluidframework/container-definitions@0.42.0",
     "@fluidframework/container-definitions-0.43.0": "npm:@fluidframework/container-definitions@0.43.0",
     "@fluidframework/container-definitions-0.44.0": "npm:@fluidframework/container-definitions@0.44.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -194,9 +194,9 @@
       "dev": true
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/core-interfaces-0.39.8": "npm:@fluidframework/core-interfaces@0.39.8",
     "@fluidframework/core-interfaces-0.40.0": "npm:@fluidframework/core-interfaces@0.40.0",
     "@fluidframework/core-interfaces-0.41.0": "npm:@fluidframework/core-interfaces@0.41.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -292,9 +292,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/driver-definitions-0.41.0": "npm:@fluidframework/driver-definitions@0.41.0",
     "@fluidframework/driver-definitions-0.42.0": "npm:@fluidframework/driver-definitions@0.42.0",
     "@fluidframework/driver-definitions-0.43.0": "npm:@fluidframework/driver-definitions@0.43.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -181,9 +181,9 @@
       "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.46657",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/protocol-definitions-0.1024.0": "npm:@fluidframework/protocol-definitions@0.1024.0",
     "@fluidframework/protocol-definitions-0.1025.1": "npm:@fluidframework/protocol-definitions@0.1025.1",
     "@fluidframework/protocol-definitions-0.1026.0": "npm:@fluidframework/protocol-definitions@0.1026.0",

--- a/examples/agents/intelligence-runner-agent/package.json
+++ b/examples/agents/intelligence-runner-agent/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/request": "^2.47.1",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/apps/view-framework-sampler/package.json
+++ b/examples/apps/view-framework-sampler/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-context/package.json
+++ b/examples/data-objects/clicker-react/clicker-context/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-function/package.json
+++ b/examples/data-objects/clicker-react/clicker-function/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-react/package.json
+++ b/examples/data-objects/clicker-react/clicker-react/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-reducer/package.json
+++ b/examples/data-objects/clicker-react/clicker-reducer/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker-react/clicker-with-hook/package.json
+++ b/examples/data-objects/clicker-react/clicker-with-hook/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/flow-util-lib/package.json
+++ b/examples/data-objects/flow-util-lib/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/benchmark": "^2.1.0",

--- a/examples/data-objects/focus-tracker/package.json
+++ b/examples/data-objects/focus-tracker/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/image-gallery/package.json
+++ b/examples/data-objects/image-gallery/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/musica/package.json
+++ b/examples/data-objects/musica/package.json
@@ -47,7 +47,7 @@
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/babel__core": "^7",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/orderedmap": "^1",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/async": "^3.2.6",
     "@types/lodash": "^4.14.118",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/examples/data-objects/simple-fluidobject-embed/package.json
+++ b/examples/data-objects/simple-fluidobject-embed/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@types/react": "^16.9.15",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/marked": "^2.0.2",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/runtime-utils": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -86,7 +86,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/runtime-utils": "^0.55.0",
     "@fluidframework/test-utils": "^0.55.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/app-integration/external-controller/package.json
+++ b/examples/hosts/app-integration/external-controller/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/fluid-static": "^0.55.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",

--- a/examples/hosts/app-integration/external-views/package.json
+++ b/examples/hosts/app-integration/external-views/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",
     "@types/semver": "^7.3.6",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/bundle-size-tools": "^0.0.8505",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@mixer/webpack-bundle-compare": "^0.1.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -50,7 +50,7 @@
     "@fluid-experimental/property-common": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/driver-definitions": "^0.43.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/local-driver": "^0.55.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/runtime-utils": "^0.55.0",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -40,7 +40,7 @@
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/container-loader": "^0.55.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/runtime-definitions": "^0.55.0",
     "@fluidframework/runtime-utils": "^0.55.0",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@fluid-tools/webpack-fluid-loader": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/expect-puppeteer": "2.2.1",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/experimental/framework/react/package.json
+++ b/experimental/framework/react/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2088,9 +2088,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2144,9 +2144,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2190,9 +2190,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2280,9 +2280,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2336,9 +2336,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2382,9 +2382,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2429,9 +2429,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "0.25.0-47766",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-			"integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+			"integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
 			"requires": {
 				"@rushstack/eslint-config": "^2.5.1",
 				"@rushstack/eslint-patch": "^1.1.0",
@@ -2519,9 +2519,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2574,9 +2574,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2616,9 +2616,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},
@@ -2648,9 +2648,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.41",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-					"integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+					"version": "12.20.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
 				}
 			}
 		},

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/gitresources": "^0.1034.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/server-services-client": "^0.1034.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@fluid-internal/test-dds-utils": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/aqueduct": "^0.55.0",
     "@fluidframework/azure-local-service": "^0.1.38773",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/test-client-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/azure-service-utils/package.json
+++ b/packages/framework/azure-service-utils/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@fluid-experimental/get-container": "^0.55.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/datastore": "^0.55.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/aqueduct": "^0.55.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^16.9.15",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-loader-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",
     "@typescript-eslint/parser": "~5.9.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/container-runtime-definitions-0.52.0": "npm:@fluidframework/container-runtime-definitions@0.52.0",
     "@fluidframework/container-runtime-definitions-0.53.0": "npm:@fluidframework/container-runtime-definitions@0.53.0",
     "@fluidframework/container-runtime-definitions-0.54.0": "npm:@fluidframework/container-runtime-definitions@0.54.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/datastore-definitions-0.52.0": "npm:@fluidframework/datastore-definitions@0.52.0",
     "@fluidframework/datastore-definitions-0.53.0": "npm:@fluidframework/datastore-definitions@0.53.0",
     "@fluidframework/datastore-definitions-0.54.0": "npm:@fluidframework/datastore-definitions@0.54.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/test-runtime-utils": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/build-tools": "^0.2.46657",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/runtime-definitions-0.51.1": "npm:@fluidframework/runtime-definitions@0.51.1",
     "@fluidframework/runtime-definitions-0.52.0": "npm:@fluidframework/runtime-definitions@0.52.0",
     "@fluidframework/runtime-definitions-0.53.0": "npm:@fluidframework/runtime-definitions@0.53.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-loader": "^0.55.0",
     "@fluidframework/container-runtime": "^0.55.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/sequence": "^0.55.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/driver-base": "^0.55.0",
     "@fluidframework/driver-definitions": "^0.43.0",
     "@fluidframework/driver-utils": "^0.55.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/ink": "^0.55.0",
     "@fluidframework/local-driver": "^0.55.0",
     "@fluidframework/map": "^0.55.0",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.18.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -114,7 +114,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -89,7 +89,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/packages/tools/merge-tree-client-replay/package.json
+++ b/packages/tools/merge-tree-client-replay/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/express": "^4.11.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.55.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/azure-local-service/package-lock.json
+++ b/server/azure-local-service/package-lock.json
@@ -90,9 +90,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/server/azure-local-service/package.json
+++ b/server/azure-local-service/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",
     "@typescript-eslint/eslint-plugin": "~5.9.0",

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -97,9 +97,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.27.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",

--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -412,9 +412,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "0.25.0-47766",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0-47766.tgz",
-      "integrity": "sha512-DP1kyEmljV99fZR2uiJkCYTsfk+b7/FtRgTpeMdFlChLK38THfYZYSOmhAXvb+6nxR0twZFfGovEsvQiM+Q9Jw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-0.25.0.tgz",
+      "integrity": "sha512-x6PTbUTWQ/gX6vlU7RPLZ9Qp6BoZczpby1TV7RJwCmo9nuOQYdmo5ctOSXHxEVZBpEJ+gcl5Hapvw4mH+VDnUQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-config": "^2.5.1",

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/eslint-config-fluid": "^0.25.0-0",
+    "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.41.0",
     "@microsoft/api-extractor": "^7.16.1",
     "@rushstack/eslint-config": "^2.5.1",


### PR DESCRIPTION
```            @fluidframework/build-common:     0.24.0 (unchanged)
     @fluidframework/eslint-config-fluid:     0.25.0 -> 0.25.1
      @fluidframework/common-definitions:     0.21.0 (unchanged)
            @fluidframework/common-utils:     0.33.0 (unchanged)
         @fluidframework/core-interfaces:     0.42.0 (unchanged)
    @fluidframework/protocol-definitions:   0.1027.0 (unchanged)
      @fluidframework/driver-definitions:     0.44.0 (unchanged)
   @fluidframework/container-definitions:     0.45.0 (unchanged)
                                  Server:   0.1035.0 (unchanged)
                                  Client:     0.55.0 (unchanged)
                  @fluid-tools/benchmark:     0.40.0 (unchanged)
                         generator-fluid:      0.3.0 (unchanged)
                             tinylicious:      0.4.0 (unchanged)
     @fluidframework/azure-local-service:      0.1.0 (unchanged)
                             dice-roller:      0.0.1 (unchanged)

Also remove pre-release dependencies for eslint-config-fluid
     @fluidframework/eslint-config-fluid -> ^0.25.0