### PR TITLE
Integrate existing bump tooling with break validation

### DIFF
--- a/tools/build-tools/bin/fluid-api-validator
+++ b/tools/build-tools/bin/fluid-api-validator
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../dist/typeValidator/runValidator.js");

--- a/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
@@ -65,8 +65,8 @@ function parseNameVersion(arg: string | undefined) {
 
     let version: VersionChangeType | undefined;
     if (v !== undefined) {
-        if (v === "minor" || v === "patch") {
-            version = v;
+        if (["major", "minor", "patch"].includes(v)) {
+            version = v as VersionBumpType;
         } else {
             const parsedVersion = semver.parse(v);
             if (!parsedVersion) {

--- a/tools/build-tools/src/bumpVersion/context.ts
+++ b/tools/build-tools/src/bumpVersion/context.ts
@@ -17,7 +17,7 @@ import { logVerbose } from "../common/logging";
 
 import * as semver from "semver";
 
-export type VersionBumpType = "minor" | "patch";
+export type VersionBumpType = "major" | "minor" | "patch";
 export type VersionChangeType = VersionBumpType | semver.SemVer;
 
 export class Context {

--- a/tools/build-tools/src/typeValidator/repoValidator.ts
+++ b/tools/build-tools/src/typeValidator/repoValidator.ts
@@ -31,10 +31,16 @@ interface PackageGroup {
 
 export interface IValidationOptions {
     /**
-     * Enable verbose logging for specific packages rather than everything
+     * Only check the specified packages/groups rather than everything
+     * Correctness for transitive type breaks is not expected with this option
      */
-    logForPackages?: Set<string>;
+    includeOnly?: Set<string>;
 }
+
+/**
+ * Package name: {break severity, package's group}
+ */
+export type RepoValidationResult = Map<string, { level: BreakingIncrement, group?: string }>;
 
 function buildPackageGroups(repoRoot: string): PackageGroup[] {
     const manifest = getPackageManifest(repoRoot);
@@ -65,7 +71,7 @@ function buildPackageGroups(repoRoot: string): PackageGroup[] {
     for (const name in repoPackages) {
         addGroup(name, repoPackages[name]);
     }
-    console.log(groups);
+    log(groups);
     return groups;
 }
 
@@ -114,7 +120,7 @@ function setPackageGroupIncrement(
 }
 
 
-export async function validateRepo(options?: IValidationOptions) {
+export async function validateRepo(options?: IValidationOptions): Promise<RepoValidationResult> {
     // Get all the repo packages in topological order
     const repoRoot = await getResolvedFluidRoot();
     const repo = new FluidRepoBuild(repoRoot, false);
@@ -126,15 +132,23 @@ export async function validateRepo(options?: IValidationOptions) {
 
     const groupBreaks = new Map<string, BreakingIncrement>();
     const allBrokenTypes: BrokenTypes = new Map();
-    const breakSummary: any[] = [];
+    const breakResult: RepoValidationResult = new Map();
+
+    // filter to only included packages if specified
+    if (options?.includeOnly !== undefined) {
+        packages.forEach((buildPkg, pkgName) => {
+            const pkgJsonPath = path.join(buildPkg.pkg.directory, "package.json");
+            const pkgJsonRelativePath = path.relative(repoRoot, pkgJsonPath);
+            const group = groupForPackage(packageGroups, pkgJsonRelativePath);
+            if (!(options.includeOnly?.has(pkgName) || (group !== undefined && options.includeOnly?.has(group)))) {
+                    packages.delete(pkgName);
+            }
+        });
+    }
 
     for (let i = 0; packages.size > 0; i++) {
         packages.forEach((buildPkg, pkgName) => {
             if (buildPkg.level === i) {
-                if (options?.logForPackages?.has(pkgName)) {
-                    enableLogging(true);
-                }
-
                 const packageData = getPackageDetails(buildPkg.pkg.directory);
                 const pkgJsonPath = path.join(buildPkg.pkg.directory, "package.json");
                 const pkgJsonRelativePath = path.relative(repoRoot, pkgJsonPath);
@@ -149,30 +163,32 @@ export async function validateRepo(options?: IValidationOptions) {
                     const groupName = setPackageGroupIncrement(
                         pkgJsonRelativePath, increment, packageGroups, groupBreaks);
 
-                    breakSummary.push({ name: packageData.name, level: increment, group: groupName });
+                    if (breakResult.has(packageData.name)) {
+                        throw new Error("Encountered duplicated package name");
+                    }
+
+                    breakResult.set(packageData.name, { level: increment, group: groupName });
                 }
 
                 packages.delete(pkgName);
-
-                if (options?.logForPackages?.has(pkgName)) {
-                    enableLogging(false);
-                }
             }
         })
     }
 
     // Check for inherited group breaks
-    for (const pkgBreak of breakSummary) {
-        if (pkgBreak.group !== undefined) {
-            const groupLevel = groupBreaks.get(pkgBreak.group)!;
-            if (groupLevel > pkgBreak.level) {
-                pkgBreak.level = groupLevel;
-                log(`${pkgBreak.name} inherited break from its group ${pkgBreak.group}`);
+    breakResult.forEach((value, key) => {
+        if (value.group !== undefined) {
+            const groupLevel = groupBreaks.get(value.group)!;
+            if (groupLevel > value.level) {
+                value.level = groupLevel;
+                log(`${key} inherited break from its group ${value.group}`);
             }
         }
-    }
+    });
 
-    for (const pkgBreak of breakSummary) {
-        console.log(pkgBreak);
-    }
+    breakResult.forEach((value, key) => {
+        console.log(`${key}: ${value.level} ${value.group}`);
+    });
+
+    return breakResult;
 }

--- a/tools/build-tools/src/typeValidator/runValidator.ts
+++ b/tools/build-tools/src/typeValidator/runValidator.ts
@@ -4,20 +4,77 @@
  */
 
 import program from "commander";
+import { bumpDependencies } from "../bumpVersion/bumpDependencies";
+import { bumpVersionCommand } from "../bumpVersion/bumpVersion";
+import { Context, VersionChangeType } from "../bumpVersion/context";
+import { GitRepo } from "../bumpVersion/utils";
+import { getResolvedFluidRoot } from "../common/fluidUtils";
+import { BreakingIncrement } from "./packageValidator";
 import { validateRepo } from "./repoValidator";
 import { enableLogging } from "./validatorUtils";
 
-/**
- * argument parsing
- */
-program
-    .option("-p|--packages <names...>", "Specific packages to output info, otherwise all")
-    .option('-v|--verbose', 'Verbose logging mode')
-    .parse(process.argv);
-
-const logForPackages: Set<string> | undefined = new Set([program.packages]);
-if (program.verbose !== undefined) {
-    enableLogging(true);
+function incrementToVersionChangeType(increment: BreakingIncrement): VersionChangeType | undefined {
+    switch (increment) {
+        case BreakingIncrement.major:
+            return "major";
+        case BreakingIncrement.minor:
+            return "minor";
+    }
+    return undefined;
 }
 
-validateRepo({ logForPackages }).catch((e) => console.log(e));
+async function main() {
+    /**
+     * argument parsing
+     */
+    program
+        .option("-p|--packages <names...>", "Specific packages to validate, otherwise all")
+        .option("-v|--verbose", "Verbose logging mode")
+        .option("-b|--bump", "Bump versions for packages with breaking changes")
+        .option("-d|--dep", "Bump consumers' dependencies on packages with breaking changes")
+        .parse(process.argv);
+
+    const includeOnly: Set<string> | undefined = new Set(program.packages);
+    if (program.verbose !== undefined) {
+        enableLogging(true);
+    }
+
+    // Get validation results for the repo
+    const validationResults = await validateRepo({ includeOnly });
+
+    if (program.bump !== true && program.dep !== true) {
+        return;
+    }
+
+    const resolvedRoot = await getResolvedFluidRoot();
+    console.log(`Repo: ${resolvedRoot}`);
+    const gitRepo = new GitRepo(resolvedRoot);
+    const context = new Context(gitRepo, "github.com/microsoft/FluidFramework", await gitRepo.getCurrentBranchName());
+
+    // Bump versions for packages with breaking changes if specified
+    if (program.bump === true) {
+        validationResults.forEach((value, key) => {
+            const changeType = incrementToVersionChangeType(value.level);
+            if (changeType !== undefined) {
+                bumpVersionCommand(context, key, changeType, false);
+                console.log(`Version for ${key} has been updated. Create a pre-release and update dependencies to consume it.`);
+            }
+        })
+    }
+
+    // Bump consumers' dependencies on packages with breaking changes if specified
+    if (program.dep === true) {
+        const depMap = new Map<string, undefined>();
+        validationResults.forEach((value, key) => {
+            depMap.set(key, undefined);
+        });
+        bumpDependencies(context, "Bump dependencies version", depMap, false, false, false);
+    }
+}
+
+main().catch(e => {
+    console.error("ERROR: unexpected error", JSON.stringify(e, undefined, 2))
+    if (e.stack) {
+        console.error(`Stack:\n${e.stack}`);
+    }
+});

--- a/tools/build-tools/src/typeValidator/runValidator.ts
+++ b/tools/build-tools/src/typeValidator/runValidator.ts
@@ -34,7 +34,7 @@ async function main() {
         .option("-d|--dep", "Bump consumers' dependencies on packages with breaking changes")
         .parse(process.argv);
 
-    const includeOnly: Set<string> | undefined = new Set(program.packages);
+    const includeOnly: Set<string> | undefined = program.packages ? new Set(program.packages) : undefined;
     if (program.verbose !== undefined) {
         enableLogging(true);
     }

--- a/tools/build-tools/src/typeValidator/validatorUtils.ts
+++ b/tools/build-tools/src/typeValidator/validatorUtils.ts
@@ -8,7 +8,7 @@ export function enableLogging(enable: boolean) {
     shouldLog = enable;
 }
 
-export function log(output: string) {
+export function log(output: any) {
     if (shouldLog) {
         console.log(output);
     }


### PR DESCRIPTION
Fixes #8054 

This change integrates the existing bump tooling into some of the breaking change validation tooling.  In its current form it works with the existing repo package groups (client, server, etc.) to do the currently supported bump types (minor, patch).  Additional changes in the bump tooling along with the move to having everything within the same repo will be needed before it's suitable to bump subsets of larger groups.

Next steps:
- Improve the breaking API validation to produce correct results for lower level packages (below server)
- Enable this for packages below server and adjust developer workflow to reactively bump those packages and integrate a warning system into PR validation