### PR TITLE
Refactor snapshotCacheExpiryTimeoutMs to maximumCacheDurationMs

### DIFF
--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -165,9 +165,9 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
 export interface IDocumentStorageServicePolicies {
     // (undocumented)
     readonly caching?: LoaderCachingPolicy;
+    readonly maximumCacheDurationMs?: number;
     // (undocumented)
     readonly minBlobSize?: number;
-    readonly snapshotCacheExpiryTimeoutMs?: number;
 }
 
 // @public

--- a/common/lib/driver-definitions/src/storage.ts
+++ b/common/lib/driver-definitions/src/storage.ts
@@ -102,7 +102,7 @@ export interface IDocumentStorageServicePolicies {
     /**
      * This policy tells the runtime that the driver will not use cached snapshots older than this value.
      */
-    readonly snapshotCacheExpiryTimeoutMs?: number;
+    readonly maximumCacheDurationMs?: number;
 }
 
 /**


### PR DESCRIPTION
An refactor made in relation to this comment https://github.com/microsoft/FluidFramework/pull/8763#discussion_r786210145