### PR TITLE
Add new isClpCompliantApp header for calls to Odsp

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -91,6 +91,8 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
     // (undocumented)
     hashedDocumentId: string;
     // (undocumented)
+    isClpCompliantApp?: boolean;
+    // (undocumented)
     odspResolvedUrl: true;
     shareLinkInfo?: ShareLinkInfoType;
     // (undocumented)

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -26,6 +26,12 @@ import { TokenFetcher } from '@fluidframework/odsp-driver-definitions';
 // @public
 export function checkUrl(documentUrl: URL): DriverPreCheckInfo | undefined;
 
+// @public (undocumented)
+export enum ClpCompliantAppHeader {
+    // (undocumented)
+    isClpCompliantApp = "X-CLP-Compliant-App"
+}
+
 // @public
 export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createLinkType?: ShareLinkTypes): IRequest;
 
@@ -46,6 +52,12 @@ export function getLocatorFromOdspUrl(url: URL): OdspFluidDataStoreLocator | und
 
 // @public
 export function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefined>;
+
+// @public (undocumented)
+export interface IClpCompliantAppHeader {
+    // (undocumented)
+    [ClpCompliantAppHeader.isClpCompliantApp]: boolean;
+}
 
 // @public (undocumented)
 export interface ISharingLinkHeader {

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -97,5 +97,7 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
      * Contains information about either sharing link created while creating a new file or
      * a redeemable share link created when loading an existing file
      */
-    shareLinkInfo?: ShareLinkInfoType
+    shareLinkInfo?: ShareLinkInfoType;
+
+    isClpCompliantApp?: boolean;
 }

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -22,7 +22,17 @@ export interface ISharingLinkHeader {
     [SharingLinkHeader.isSharingLinkToRedeem]: boolean;
 }
 
+export enum ClpCompliantAppHeader {
+    // Can be used in request made to resolver, to tell the resolver that the host app is CLP compliant.
+    // Odsp will not return Classified, labeled, or protected documents if the host app cannot support them.
+    isClpCompliantApp = "X-CLP-Compliant-App",
+}
+
+export interface IClpCompliantAppHeader {
+    [ClpCompliantAppHeader.isClpCompliantApp]: boolean;
+}
+
 declare module "@fluidframework/core-interfaces" {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface IRequestHeader extends Partial<ISharingLinkHeader> { }
+    export interface IRequestHeader extends Partial<ISharingLinkHeader>, Partial<IClpCompliantAppHeader> { }
 }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -246,13 +246,13 @@ export class EpochTracker implements IPersistedFileCache {
         addInBody: boolean,
         clientCorrelationId: string,
     ) {
+        const isClpCompliantApp = getOdspResolvedUrl(this.fileEntry.resolvedUrl).isClpCompliantApp;
         if (addInBody) {
             const headers: {[key: string]: string} = {};
             headers["X-RequestStats"] = clientCorrelationId;
             if (this.fluidEpoch !== undefined) {
                 headers["x-fluid-epoch"] = this.fluidEpoch;
             }
-            const isClpCompliantApp = getOdspResolvedUrl(this.fileEntry.resolvedUrl).isClpCompliantApp;
             if (isClpCompliantApp) {
                 headers[ClpCompliantAppHeader.isClpCompliantApp] = isClpCompliantApp.toString();
             }
@@ -268,6 +268,9 @@ export class EpochTracker implements IPersistedFileCache {
             addHeader("X-RequestStats", clientCorrelationId);
             if (this.fluidEpoch !== undefined) {
                 addHeader("x-fluid-epoch", this.fluidEpoch);
+            }
+            if (isClpCompliantApp) {
+                addHeader(ClpCompliantAppHeader.isClpCompliantApp, isClpCompliantApp.toString());
             }
         }
     }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -18,13 +18,14 @@ import {
 } from "@fluidframework/odsp-driver-definitions";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { PerformanceEvent, isFluidError, normalizeError } from "@fluidframework/telemetry-utils";
-import { fetchAndParseAsJSONHelper, fetchArray, IOdspResponse } from "./odspUtils";
+import { fetchAndParseAsJSONHelper, fetchArray, getOdspResolvedUrl, IOdspResponse } from "./odspUtils";
 import {
     IOdspCache,
     INonPersistentCache,
     IPersistedFileCache,
  } from "./odspCache";
 import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
+import { ClpCompliantAppHeader } from "./contractsPublic";
 
 export type FetchType = "blob" | "createBlob" | "createFile" | "joinSession" | "ops" | "test" | "snapshotTree" |
     "treesLatest" | "uploadSummary" | "push" | "versions";
@@ -250,6 +251,10 @@ export class EpochTracker implements IPersistedFileCache {
             headers["X-RequestStats"] = clientCorrelationId;
             if (this.fluidEpoch !== undefined) {
                 headers["x-fluid-epoch"] = this.fluidEpoch;
+            }
+            const isClpCompliantApp = getOdspResolvedUrl(this.fileEntry.resolvedUrl).isClpCompliantApp;
+            if (isClpCompliantApp) {
+                headers[ClpCompliantAppHeader.isClpCompliantApp] = isClpCompliantApp.toString();
             }
             this.addParamInBody(fetchOptions, headers);
         } else {

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -430,9 +430,6 @@ function getFormBodyAndHeaders(
     if (odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem) {
         formParams.push(`sl: ${odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem}`);
     }
-    if (odspResolvedUrl.isClpCompliantApp) {
-        formParams.push(`X-CLP-Compliant-App: ${odspResolvedUrl.isClpCompliantApp}`);
-    }
     formParams.push(`_post: 1`);
     formParams.push(`\r\n--${formBoundary}--`);
     const postBody = formParams.join("\r\n");

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -430,6 +430,9 @@ function getFormBodyAndHeaders(
     if (odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem) {
         formParams.push(`sl: ${odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem}`);
     }
+    if (odspResolvedUrl.isClpCompliantApp) {
+        formParams.push(`X-CLP-Compliant-App: ${odspResolvedUrl.isClpCompliantApp}`);
+    }
     formParams.push(`_post: 1`);
     formParams.push(`\r\n--${formBoundary}--`);
     const postBody = formParams.join("\r\n");

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -11,6 +11,7 @@ import { createOdspUrl } from "./createOdspUrl";
 import { getApiRoot } from "./odspUrlHelper";
 import { getOdspResolvedUrl } from "./odspUtils";
 import { getHashedDocumentId } from "./odspPublicUtils";
+import { ClpCompliantAppHeader } from "./contractsPublic";
 
 function getUrlBase(siteUrl: string, driveId: string, itemId: string, fileVersion?: string) {
     const siteOrigin = new URL(siteUrl).origin;
@@ -101,6 +102,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 },
                 fileVersion: undefined,
                 shareLinkInfo,
+                isClpCompliantApp: request.headers?.[ClpCompliantAppHeader.isClpCompliantApp],
             };
         }
         const { siteUrl, driveId, itemId, path, containerPackageName, fileVersion } = decodeOdspUrl(request.url);
@@ -142,6 +144,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
                 containerPackageName,
             },
             fileVersion,
+            isClpCompliantApp: request.headers?.[ClpCompliantAppHeader.isClpCompliantApp],
         };
     }
 

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -22,8 +22,11 @@ describe("DeltaStorageService", () => {
     const deltaStorageBasePath = "https://fake.microsoft.com";
     const deltaStorageRelativePath = "/drives/testdrive/items/testitem/opStream";
     const testDeltaStorageUrl = `${deltaStorageBasePath}${deltaStorageRelativePath}`;
-    let resolvedUrl: IOdspResolvedUrl | undefined;
-    const fileEntry = { docId: "docId", resolvedUrl: resolvedUrl! };
+    const siteUrl = "https://fake.microsoft.com";
+    const driveId = "testdrive";
+    const itemId = "testitem";
+    const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
+    const fileEntry = { docId: "docId", resolvedUrl };
 
     it("Should build the correct sharepoint delta url with auth", async () => {
         const logger = new TelemetryUTLogger();

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -71,6 +71,7 @@ describe("Odsp Driver Resolver", () => {
             summarizer: false,
             codeHint: { containerPackageName: undefined },
             shareLinkInfo: undefined,
+            isClpCompliantApp: undefined,
         };
         assert.deepStrictEqual(resolvedUrl, expected);
         const response = await resolver.getAbsoluteUrl(resolvedUrl, "/datastore");


### PR DESCRIPTION
Create a new header for host apps to signify that they support CLP (Classify, Label, & Protect) features. If a document is classified, labeled, or protected, ODSP will not return the document unless the "X-CLP-Compliant-App" header is true. 