### PR TITLE
Website: Fix responsive layout of homepage and community page

### DIFF
--- a/docs/.editorconfig
+++ b/docs/.editorconfig
@@ -4,6 +4,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.{json,md,toml,yml}]
+[*.{json,md,scss,toml,yml}]
 indent_style = space
 indent_size = 2

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -9,7 +9,6 @@ footer {
 
 .ctas {
     font-size: 2rem;
-    font-family: #000000;
     text-align: center;
     background-color: #404049;
 }

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -71,7 +71,6 @@ footer {
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 1rem;
-    display: block;
 }
 
 .cta-icon.get-started {

--- a/docs/content/community/_index.md
+++ b/docs/content/community/_index.md
@@ -4,10 +4,19 @@ title: Welcome to the Fluid Community
 
 {{< in_your_face
     lead=`Community`
-    subText=`We believe that an <strong>open, inclusive, and respectful</strong> community will help shape a better
-        future for this project. That's why Fluid Framework is <strong>Open Source</strong>. Below you will find various
-        ways to get <strong>involved</strong>.`
->}}
+    subText=`
+We believe that an **open, inclusive, and respectful** community will help shape a better future for this project. That's why Fluid Framework is **Open Source**. Below you will find various ways to get **involved**.
+
+Fluid Framework is made available as an **Open Source** project under
+the [MIT license](https://github.com/microsoft/FluidFramework/blob/main/LICENSE).
+
+This project has adopted the [Microsoft Open Source Code of
+Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct
+FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [Microsoft](mailto:opencode@microsoft.com)
+with any additional questions or comments.`
+    >}}
 
 {{< cta_container  >}}
   {{< cta
@@ -23,8 +32,7 @@ title: Welcome to the Fluid Community
     linkURL="https://www.github.com/Microsoft/fluidframework/discussions"
     iconClasses="gh-discussions"
     linkText="Ask Technical Questions"
-    subtext=`Our GitHub Discussions are a great way to participate. Feel free to ask questions or,
-        if you can, give us a hand by answering some.`
+    subtext=`Our GitHub Discussions are a great way to participate. Feel free to ask questions or, if you can, give us a hand by answering some.`
   >}}
 
   {{< cta
@@ -36,22 +44,3 @@ title: Welcome to the Fluid Community
   >}}
 {{< /cta_container  >}}
 
-<div class="omt">
-<div class="container">
-<div class="row">
-<div class="col-sm-12 col-xs-12 no-gutters">
-
-Fluid Framework is made available as an **Open Source** project under
-the [MIT license](https://github.com/microsoft/FluidFramework/blob/main/LICENSE).
-
-This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [Microsoft](mailto:opencode@microsoft.com)
-with any additional questions or comments.
-
-</div>
-</div>
-</div>
-</div>

--- a/docs/content/community/_index.md
+++ b/docs/content/community/_index.md
@@ -4,11 +4,11 @@ title: Welcome to the Fluid Community
 
 {{< in_your_face
     lead=`Community`
-    subText=`
-We believe that an **open, inclusive, and respectful** community will help shape a better future for this project. That's why Fluid Framework is **Open Source**. Below you will find various ways to get **involved**.
-
-Fluid Framework is made available as an **Open Source** project under
-the [MIT license](https://github.com/microsoft/FluidFramework/blob/main/LICENSE).
+    subtext=`
+We believe that an **open, inclusive, and respectful** community will help shape a better future for this project.
+That's why Fluid Framework is is made available as an **Open Source** project under the
+[MIT license](https://github.com/microsoft/FluidFramework/blob/main/LICENSE). Below you will find various ways to get
+**involved**.
 
 This project has adopted the [Microsoft Open Source Code of
 Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/docs/themes/thxvscode/assets/scss/includes/_footer.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_footer.scss
@@ -88,7 +88,7 @@ footer {
 }
 
 .ctas {
-  height: $ctaHeight;
+  min-height: $ctaHeight;
   width: 100%;
   position: absolute;
   bottom: $footerheight;
@@ -99,6 +99,15 @@ footer {
   align-content: center;
   flex-wrap: wrap;
   flex-direction: row;
+
+  p a {
+    color: $banner-link-color;
+  }
+}
+
+.cta-icon-wrapper {
+  display: flex;
+  flex-flow: column;
 }
 
 // under 767px
@@ -116,9 +125,18 @@ footer {
   //   display: block;
   //   margin-left: 0;
   // }
+  .cta-icon-wrapper {
+    display: flex;
+    flex-flow: column;
+  }
   .ctas {
-    height: $ctaHeight;
+    min-height: $ctaHeight;
     bottom: $footerheight;
+
+    .cta {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
   }
 }
 
@@ -155,7 +173,7 @@ footer {
   //   margin-left: 0;
   // }
   .ctas {
-    height: $ctaHeight;
+    min-height: $ctaHeight;
     // min-height: $ctaHeight;
     bottom: $footerheight;
   }

--- a/docs/themes/thxvscode/assets/scss/includes/_footer.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_footer.scss
@@ -2,7 +2,8 @@
 // Make footer stick to the bottom of each page
 
 // Medium screen size footer height
-$footerheight: 135px;
+$footerheight: 90px; //135px;
+$ctaHeight: 178.5px; //200px;
 
 body {
   margin-bottom: $footerheight;
@@ -86,62 +87,115 @@ footer {
   }
 }
 
-@media (max-width: $screen-xs) {
+.ctas {
+  height: $ctaHeight;
+  width: 100%;
+  position: absolute;
+  bottom: $footerheight;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-content: center;
+  flex-wrap: wrap;
+  flex-direction: row;
+}
+
+// under 767px
+@media (max-width: $screen-xs-max) {
   //Larger footer for smaller screen sizes
   $footerheight: 170px;
+  $ctaHeight: 461.3px;
   footer {
     height: $footerheight;
   }
   body {
-    margin-bottom: $footerheight;
+    margin-bottom: $footerheight + $ctaHeight;
   }
-  footer .copyright {
-    display: block;
-    margin-left: 0;
+  // footer .copyright {
+  //   display: block;
+  //   margin-left: 0;
+  // }
+  .ctas {
+    height: $ctaHeight;
+    bottom: $footerheight;
   }
 }
 
+// under 991px
+// @media (max-width: $screen-sm-max) {
+// //   $ctaHeight: 461.3px;
+//   $ctaHeight: 178.5px;
+//   footer {
+//     height: $footerheight;
+//   }
+//   body {
+//     margin-bottom: $footerheight + $ctaHeight;
+//   }
+//   .ctas {
+//     height: $ctaHeight;
+//     // min-height: $ctaHeight;
+//     bottom: $footerheight;
+//   }
+// }
+
+// under 380px
 @media (max-width: 380px) {
   //Even larger footer for very small screen sizes (e.g. iPhone 4)
-  $footerheight: 200px;
+  //   $footerheight: 200px;
+  $ctaHeight: 461.3px;
   footer {
     height: $footerheight;
   }
   body {
-    margin-bottom: $footerheight;
+    margin-bottom: $footerheight + $ctaHeight;
   }
-  footer .copyright {
-    display: block;
-    margin-left: 0;
-  }
-}
-
-@media (min-width: $screen-lg) {
-  //Smaller footer for very large screen sizes
-  $footerheight: 90px;
-  footer {
-    height: $footerheight;
-  }
-  body {
-    margin-bottom: $footerheight;
+  // footer .copyright {
+  //   display: block;
+  //   margin-left: 0;
+  // }
+  .ctas {
+    height: $ctaHeight;
+    // min-height: $ctaHeight;
+    bottom: $footerheight;
   }
 }
 
-@media (min-width: 400px) {
-  footer .twitter-follow-button {
-    height: 20px; /* DO NOT REMOVE: Weird prerendering issue, causes scrollbar to show if not set */
-  }
-}
+// over 1200px
+// @media (min-width: $screen-lg) {
+//   //Smaller footer for very large screen sizes
+//   $footerheight: 90px;
+//   footer {
+//     height: $footerheight;
+//   }
+//   body {
+//     margin-bottom: $footerheight + $ctaHeight;
+//   }
+//   .ctas {
+//     height: $ctaHeight;
+//     // min-height: $ctaHeight;
+//     bottom: $footerheight;
+//   }
+// }
 
-@media (min-width: 530px) {
-  footer .message {
-    display: inline-block;
-  }
-  .twitter-follow-button {
-    margin-left: 15px;
-  }
-}
+// over 400px
+// @media (min-width: 400px) {
+//   footer .twitter-follow-button {
+//     height: 20px; /* DO NOT REMOVE: Weird prerendering issue, causes scrollbar to show if not set */
+//   }
+// }
 
+// over 530px
+// @media (min-width: 530px) {
+//   footer .message {
+//     display: inline-block;
+//   }
+//   .twitter-follow-button {
+//     margin-left: 15px;
+//   }
+// }
+
+// over 992px
 @media (min-width: $screen-md) {
   footer {
     .github-star-button,

--- a/docs/themes/thxvscode/assets/scss/includes/_footer.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_footer.scss
@@ -3,7 +3,7 @@
 
 // Medium screen size footer height
 $footerheight: 90px; //135px;
-$ctaHeight: 178.5px; //200px;
+$ctaHeight: 124.7px; //200px;
 
 body {
   margin-bottom: $footerheight;
@@ -121,10 +121,6 @@ footer {
   body {
     margin-bottom: $footerheight + $ctaHeight;
   }
-  // footer .copyright {
-  //   display: block;
-  //   margin-left: 0;
-  // }
   .cta-icon-wrapper {
     display: flex;
     flex-flow: column;
@@ -132,30 +128,8 @@ footer {
   .ctas {
     min-height: $ctaHeight;
     bottom: $footerheight;
-
-    .cta {
-      padding-top: 0;
-      padding-bottom: 0;
-    }
   }
 }
-
-// under 991px
-// @media (max-width: $screen-sm-max) {
-// //   $ctaHeight: 461.3px;
-//   $ctaHeight: 178.5px;
-//   footer {
-//     height: $footerheight;
-//   }
-//   body {
-//     margin-bottom: $footerheight + $ctaHeight;
-//   }
-//   .ctas {
-//     height: $ctaHeight;
-//     // min-height: $ctaHeight;
-//     bottom: $footerheight;
-//   }
-// }
 
 // under 380px
 @media (max-width: 380px) {
@@ -178,40 +152,6 @@ footer {
     bottom: $footerheight;
   }
 }
-
-// over 1200px
-// @media (min-width: $screen-lg) {
-//   //Smaller footer for very large screen sizes
-//   $footerheight: 90px;
-//   footer {
-//     height: $footerheight;
-//   }
-//   body {
-//     margin-bottom: $footerheight + $ctaHeight;
-//   }
-//   .ctas {
-//     height: $ctaHeight;
-//     // min-height: $ctaHeight;
-//     bottom: $footerheight;
-//   }
-// }
-
-// over 400px
-// @media (min-width: 400px) {
-//   footer .twitter-follow-button {
-//     height: 20px; /* DO NOT REMOVE: Weird prerendering issue, causes scrollbar to show if not set */
-//   }
-// }
-
-// over 530px
-// @media (min-width: 530px) {
-//   footer .message {
-//     display: inline-block;
-//   }
-//   .twitter-follow-button {
-//     margin-left: 15px;
-//   }
-// }
 
 // over 992px
 @media (min-width: $screen-md) {

--- a/docs/themes/thxvscode/assets/scss/includes/_home.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_home.scss
@@ -18,7 +18,7 @@
     }
     @media (min-width: $screen-sm) {
       .row:first-child {
-        height: 511px;
+        height: 200px; //511px;
       }
       .copy {
         @include vertical-center(0, -50%);

--- a/docs/themes/thxvscode/assets/scss/includes/_in_your_face.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_in_your_face.scss
@@ -47,6 +47,7 @@
       padding: 8px 8px;
       margin-top: 1.5rem;
       position: relative;
+      min-height: 180px;
       &::after {
         $triangle-size: 1.4rem;
         content: '';

--- a/docs/themes/thxvscode/assets/scss/includes/_in_your_face.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_in_your_face.scss
@@ -4,6 +4,9 @@
     background-color: $header-background;
     color: white;
     padding: 0;
+    a {
+      color: $banner-link-color;
+    }
     &.home {
       text-align: center;
       overflow: visible;

--- a/docs/themes/thxvscode/assets/scss/includes/_jumbotron.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_jumbotron.scss
@@ -35,7 +35,7 @@
       }
       @media (min-width: $screen-sm) {
         .row:first-child {
-          height: 511px;
+          height: 200px; //511px;
         }
         .copy {
           @include vertical-center(0, -50%);

--- a/docs/themes/thxvscode/layouts/partials/footer.html
+++ b/docs/themes/thxvscode/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <footer role="contentinfo">
     <div class="container">
         <div class="row">
-            <div class="left col-md-7">
+            <div class="left col-md-3">
                 <ul class="links">
                     <li>
                         <a href="https://twitter.com/{{.Site.Params.twitterHandle}}" onclick="followOnTwitter()"
@@ -20,7 +20,7 @@
                     </script>
                 </ul>
             </div>
-            <div class="right col-md-5">
+            <div class="right col-md-5 col-md-offset-4">
                 <ul class="links">
                     <li><a id="footer-privacy-link" href="https://privacy.microsoft.com/privacystatement"
                             target="_blank">Privacy</a></li>

--- a/docs/themes/thxvscode/layouts/shortcodes/cta.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/cta.html
@@ -6,10 +6,15 @@
 
 <div class="col-sm-4 col-xs-12 no-gutters">
     <a class="cta {{$linkClasses}}" href="{{$linkURL}}">
+        {{ if ne $subtext ""}}
+        <div class="cta-icon-wrapper">
+            <span class="cta-icon {{$iconClasses}}"></span>
+            <span>{{$linkText}}</span>
+        </div>
+        <span class="cta-subtext hidden-xs">{{$subtext}}</span>
+        {{ else }}
         <span class="cta-icon {{$iconClasses}}"></span>
         <span>{{$linkText}}</span>
-        {{ if ne $subtext ""}}
-        <span class="cta-subtext">{{$subtext}}</span>
         {{ end }}
     </a>
 </div>

--- a/docs/themes/thxvscode/layouts/shortcodes/in_your_face.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/in_your_face.html
@@ -1,13 +1,13 @@
 {{ $allParams := .Params }}
 {{ $lead := "" }}
-{{ $subText := "" }}
+{{ $subtext := "" }}
 
 {{ if .IsNamedParams }}
 {{ $lead = .Get "lead" | safeHTML}}
-{{ $subText = .Get "subText" | safeHTML}}
+{{ $subtext = .Get "subtext" | safeHTML}}
 {{ else }}
 {{ $lead  = index $allParams 0 | safeHTML}}
-{{ $subText = index $allParams 1}}
+{{ $subtext = index $allParams 1}}
 {{ end }}
 
 <div class="in-your-face">
@@ -16,8 +16,8 @@
             <div class="col-md-2 col-lg-3"></div>
             <div class="col-md-8 col-lg-6 copy">
                 <h1 class="lead">{{$lead}}</h1>
-                <div class="subText">
-                    <p>{{ $subText | markdownify }}</p>
+                <div class="subtext">
+                    <p>{{ $subtext | markdownify }}</p>
                 </div>
             </div>
         </div>

--- a/docs/themes/thxvscode/layouts/shortcodes/in_your_face.html
+++ b/docs/themes/thxvscode/layouts/shortcodes/in_your_face.html
@@ -13,11 +13,11 @@
 <div class="in-your-face">
     <div class="container">
         <div class="row">
-            <div class="col-md-4"></div>
-            <div class="col-md-4 copy">
+            <div class="col-md-2 col-lg-3"></div>
+            <div class="col-md-8 col-lg-6 copy">
                 <h1 class="lead">{{$lead}}</h1>
                 <div class="subText">
-                    <p>{{ $subText }}</p>
+                    <p>{{ $subText | markdownify }}</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
When the viewport was wide but not tall, the main homepage links were hidden below the fold. With this change, the call-to-action links are anchored to the bottom and reflow properly as the window size scales  horizontally.

## Before
![image](https://user-images.githubusercontent.com/19589/150239207-0cedd9e7-3b65-4605-838c-97647eef74e7.png)

![image](https://user-images.githubusercontent.com/19589/150239221-9fc5711a-fd5e-4e4e-aede-e19b0305824c.png)

## After

![image](https://user-images.githubusercontent.com/19589/150239426-cbe4b5e3-dcc0-4983-8f90-21fb6c9546c7.png)

![image](https://user-images.githubusercontent.com/19589/150243284-3cd98825-0f8e-4913-9033-4a7ce441a0fb.png)
