### PR TITLE
r11s: enable socket.io long-polling as a fallback

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -23,7 +23,7 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
 export class DocumentDeltaConnection extends TypedEventEmitter<IDocumentDeltaConnectionEvents> implements IDocumentDeltaConnection, IDisposable {
-    protected constructor(socket: SocketIOClient.Socket, documentId: string, logger: ITelemetryLogger);
+    protected constructor(socket: SocketIOClient.Socket, documentId: string, logger: ITelemetryLogger, enableLongPollingDowngrades?: boolean);
     // (undocumented)
     protected addTrackedListener(event: string, listener: (...args: any[]) => void): void;
     checkpointSequenceNumber: number | undefined;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -371,13 +371,15 @@ export class DocumentDeltaConnection
                         description.target = undefined;
                     }
                 } catch(_e) {}
-                if (!this.socket.io.opts.reconnection ||
-                    this.reconnectAttempts >= (this.socket.io.opts.reconnectionAttempts ?? 0)) {
+                if (!this.socket.io.reconnection() ||
+                    this.reconnectAttempts >= (this.socket.io.reconnectionAttempts() ?? 0)) {
                     // Reconnection is disabled or maximum reconnect attempts have been reached.
                     fail(true, this.createErrorObject("connectError", error));
-                } else {
-                    this.reconnectAttempts++;
                 }
+            });
+
+            this.addConnectionListener("reconnect_attempt", () => {
+                this.reconnectAttempts++;
             });
 
             // Listen for timeouts

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -370,11 +370,11 @@ export class DocumentDeltaConnection
                 try {
                     const description = error?.description;
                     if (description && typeof description === "object") {
-                        // That's a WebSocket. Clear it as we can't log it.
-                        description.target = undefined;
                         if (error.type === "TransportError") {
                             isWebSocketTransportError = true;
                         }
+                        // That's a WebSocket. Clear it as we can't log it.
+                        description.target = undefined;
                     }
                 } catch(_e) {}
 

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -32,16 +32,25 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
                     documentId: id,
                     tenantId,
                 },
-                // Allow 1 reconnection attempt so that polling can be tried
-                reconnection: true,
-                reconnectionAttempts: 1,
-                // Enable long-polling as a downgrade option
+                reconnection: false,
+                // Enable long-polling as a downgrade option when WebSockets are not available
                 transports: ["websocket", "polling"],
                 timeout: timeoutMs,
             });
-        socket.on("connect_error", () => {
-            // Fallback to polling upgrade mechanism on connection failure
-            socket.io.opts.transports = ["polling", "websocket"];
+        // Socket.io-client and underlying engine.io-client both
+        // use `component-emitter` (@socket.io/component-emitter in engine.io-client v6)
+        // to implement event listening. Listeners are evoked in the order they are added,
+        // so we can alter the socket config before it reaches DocumentDeltaConnection's
+        // connect_error handler.
+        socket.on("connect_error", (err) => {
+            // Allow 1 reconnection attempt so that polling can be tried
+            if (err?.type === "TransportError" && typeof err?.description === "object") {
+                // The connection error is a WebSocket transport error
+                // Allow single reconnection attempt using polling upgrade mechanism
+                socket.io.reconnection(true);
+                socket.io.reconnectionAttempts(1);
+                socket.io.opts.transports = ["polling", "websocket"];
+            }
         });
 
         const connectMessage: IConnect = {

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -33,7 +33,8 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
                     tenantId,
                 },
                 reconnection: false,
-                transports: ["websocket"],
+                // Enable long-polling as a downgrade option
+                transports: ["websocket", "polling"],
                 timeout: timeoutMs,
             });
 

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -47,7 +47,9 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
             versions: protocolVersions,
         };
 
-        const deltaConnection = new R11sDocumentDeltaConnection(socket, id, logger, true);
+        // TODO: expose to host at factory level
+        const enableLongPollingDowngrades = true;
+        const deltaConnection = new R11sDocumentDeltaConnection(socket, id, logger, enableLongPollingDowngrades);
 
         await deltaConnection.initialize(connectMessage, timeoutMs);
         return deltaConnection;

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -32,11 +32,17 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
                     documentId: id,
                     tenantId,
                 },
-                reconnection: false,
+                // Allow 1 reconnection attempt so that polling can be tried
+                reconnection: true,
+                reconnectionAttempts: 1,
                 // Enable long-polling as a downgrade option
                 transports: ["websocket", "polling"],
                 timeout: timeoutMs,
             });
+        socket.on("connect_error", () => {
+            // Fallback to polling upgrade mechanism on connection failure
+            socket.io.opts.transports = ["polling", "websocket"];
+        });
 
         const connectMessage: IConnect = {
             client,

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -117,12 +117,12 @@ export function create(
 
     // Create and register a socket.io connection on the server
     const io = new Server(server, {
-        // enable compatibility with socket.io v2 clients
+        // Enable compatibility with socket.io v2 clients
         allowEIO3: true,
         // Indicates whether a connection should use compression
         perMessageDeflate: true,
-        // ensure long polling is never used
-        transports: [ "websocket" ],
+        // Enable long-polling as a fallback
+        transports: ["websocket", "polling"],
         cors: {
             // Explicitly allow all origins by reflecting request origin.
             // As a service that has potential to host countless different client apps,


### PR DESCRIPTION
This change will allow long-polling as a fallback/downgrade option in the r11s-driver and r11s server. We should be able to release this driver change before the server change, because if WebSockets are not available in a client's browser/network, then their scenario is already broken.