### PR TITLE
Put defaultCacheExpiryTimeoutMs in policies

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -289,6 +289,7 @@ export class PrefetchDocumentStorageService extends DocumentStorageServiceProxy 
     get policies(): {
         caching: LoaderCachingPolicy;
         minBlobSize?: number | undefined;
+        maximumCacheDurationMs?: number | undefined;
     } | undefined;
     // (undocumented)
     readBlob(blobId: string): Promise<ArrayBufferLike>;

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -335,6 +335,19 @@
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/driver-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        }
       }
     },
     "@fluidframework/container-definitions-0.44.0": {
@@ -347,6 +360,19 @@
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/driver-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        }
       }
     },
     "@fluidframework/core-interfaces": {
@@ -355,9 +381,9 @@
       "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-      "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+      "version": "0.44.0-49064",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
+      "integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0"
   },
   "devDependencies": {

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/iframe-driver": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -27,7 +27,7 @@
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/routerlicious-driver": "^0.56.0",
     "@fluidframework/routerlicious-host": "^0.56.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/data-object-base": "^0.56.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/merge-tree": "^0.56.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@fluid-experimental/property-common": "^0.56.0",
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/local-driver": "^0.56.0",
     "@fluidframework/mocha-test-setup": "^0.56.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -29,7 +29,7 @@
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/local-driver": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/replay-driver": "^0.56.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/telemetry-utils": "^0.56.0"

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/replay-driver": "^0.56.0"

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/odsp-driver": "^0.56.0",
     "@fluidframework/odsp-driver-definitions": "^0.56.0"
   },

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/telemetry-utils": "^0.56.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-base": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/routerlicious-driver": "^0.56.0",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -30,7 +30,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/driver-definitions": "^0.43.0"
+    "@fluidframework/driver-definitions": "^0.44.0-0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/driver-base": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/gitresources": "^0.1034.0",
     "@fluidframework/odsp-doclib-utils": "^0.56.0",

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -40,7 +40,7 @@ import {
     getWithRetryForTokenRefresh,
     ISnapshotContents,
 } from "./odspUtils";
-import { EpochTracker } from "./epochTracker";
+import { defaultCacheExpiryTimeoutMs, EpochTracker } from "./epochTracker";
 import { OdspSummaryUploadManager } from "./odspSummaryUploadManager";
 import { FlushResult } from "./odspDocumentDeltaConnection";
 
@@ -167,6 +167,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
         // Note that duplication of content should not have significant impact for bytes over wire as
         // compression of http payload mostly takes care of it, but it does impact storage size and in-memory sizes.
         minBlobSize: 2048,
+        maximumCacheDurationMs: defaultCacheExpiryTimeoutMs,
     };
 
     private readonly commitCache: Map<string, api.ISnapshotTree> = new Map();

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/odsp-driver": "^0.56.0",
     "@fluidframework/odsp-driver-definitions": "^0.56.0"
   },

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/telemetry-utils": "^0.56.0"

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/driver-base": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/gitresources": "^0.1034.0",
     "@fluidframework/protocol-base": "^0.1034.0",

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "axios": "^0.21.2"
   },
   "devDependencies": {

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "nconf": "^0.11.0"
   },

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/routerlicious-driver": "^0.56.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -41,7 +41,7 @@
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/fluid-static": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/container-loader": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/fluid-static": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/container-utils": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/gitresources": "^0.1034.0",
     "@fluidframework/protocol-base": "^0.1034.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0"
   },

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",
     "@types/node": "^14.18.0"

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -63,7 +63,7 @@
     "@fluidframework/container-utils": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/garbage-collector": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/container-utils": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/garbage-collector": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@types/node": "^14.18.0"
   },

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/routerlicious-driver": "^0.56.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-base": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/ink": "^0.56.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/counter": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/file-driver": "^0.56.0",
     "@fluidframework/ink": "^0.56.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "uuid": "^8.3.1"
   },

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/local-driver": "^0.56.0",
     "@fluidframework/odsp-doclib-utils": "^0.56.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/garbage-collector": "^0.56.0",
     "@fluidframework/ink": "^0.56.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/local-driver": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -55,7 +55,7 @@
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/ink": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-runtime": "^0.56.0",
     "@fluidframework/datastore": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/odsp-doclib-utils": "^0.56.0",
     "@fluidframework/odsp-driver": "^0.56.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/core-interfaces": "^0.41.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/file-driver": "^0.56.0",
     "@fluidframework/ink": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/container-definitions": "^0.44.0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/core-interfaces": "^0.41.0",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/local-driver": "^0.56.0",
     "@fluidframework/odsp-doclib-utils": "^0.56.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/driver-definitions": "^0.43.0",
+    "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/odsp-driver-definitions": "^0.56.0",
     "@fluidframework/telemetry-utils": "^0.56.0",


### PR DESCRIPTION
Resolves #8765 

Updates the package.json to add maximumCacheDurationMs to policies. The cache expiry value will be used for garbage collection.