### PR TITLE
FluidBuild - don't warn about --fix-type in lint command

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -54,7 +54,6 @@
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/local-driver": "^0.56.0",
     "@fluidframework/mocha-test-setup": "^0.56.0",
-    "@fluidframework/runtime-utils": "^0.55.0",
     "@fluidframework/sequence": "^0.56.0",
     "@fluidframework/server-local-server": "^0.1034.0",
     "@fluidframework/test-runtime-utils": "^0.56.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -50,7 +50,6 @@
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.56.0",
-    "@fluidframework/runtime-definitions": "^0.55.0",
     "@fluidframework/runtime-utils": "^0.56.0",
     "@fluidframework/test-drivers": "^0.56.0",
     "@fluidframework/test-runtime-utils": "^0.56.0",

--- a/packages/dds/shared-object-base/tsconfig.json
+++ b/packages/dds/shared-object-base/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
-        "dist",
-        "node_modules",
         "src/test/**/*"
     ],
     "compilerOptions": {

--- a/packages/drivers/fluidapp-odsp-urlResolver/.npmignore
+++ b/packages/drivers/fluidapp-odsp-urlResolver/.npmignore
@@ -1,3 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test
+

--- a/packages/framework/azure-client/src/test/tsconfig.json
+++ b/packages/framework/azure-client/src/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
-        "rootDir": ".",
+        "rootDir": "./",
         "outDir": "../../dist/test",
         "composite": true,
         "types": [

--- a/packages/framework/tinylicious-client/src/test/tsconfig.json
+++ b/packages/framework/tinylicious-client/src/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "compilerOptions": {
-        "rootDir": ".",
+        "rootDir": "./",
         "outDir": "../../dist/test",
         "composite": true,
         "types": [

--- a/packages/runtime/container-runtime-definitions/tsconfig.json
+++ b/packages/runtime/container-runtime-definitions/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
-        "dist",
-        "node_modules",
         "src/test/**/*"
     ],
     "compilerOptions": {

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -11,7 +11,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "npm run build:gen && concurrently npm:build:compile npm:lint && npm run build:docs",
-    "build:compile": "npm run tsc  && npm run build:test",
+    "build:compile": "npm run tsc && npm run build:test",
     "build:docs": "api-extractor run --local --typescript-compiler-folder ../../../node_modules/typescript && copyfiles -u 1 ./_api-extractor-temp/doc-models/* ../../../_api-extractor-temp/",
     "build:full": "npm run build",
     "build:full:compile": "npm run build:compile",

--- a/packages/runtime/datastore-definitions/tsconfig.json
+++ b/packages/runtime/datastore-definitions/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
-        "dist",
-        "node_modules",
         "src/test/**/*"
     ],
     "compilerOptions": {

--- a/packages/runtime/runtime-definitions/tsconfig.json
+++ b/packages/runtime/runtime-definitions/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "@fluidframework/build-common/ts-common-config.json",
     "exclude": [
-        "dist",
-        "node_modules",
         "src/test/**/*"
     ],
     "compilerOptions": {

--- a/packages/tools/fetch-tool/.npmignore
+++ b/packages/tools/fetch-tool/.npmignore
@@ -1,3 +1,5 @@
 nyc
 *.log
 **/*.tsbuildinfo
+src/test
+dist/test

--- a/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
+++ b/tools/build-tools/src/fluidBuild/tasks/leaf/lintTasks.ts
@@ -4,7 +4,7 @@
  */
 
 import { LeafTask } from "./leafTask";
-import { TscTask, TscDependentTask } from "./tscTask";
+import { TscDependentTask } from "./tscTask";
 import { existsSync, readFileSync } from "fs";
 import * as path from "path";
 import * as JSON5 from "json5";
@@ -82,8 +82,11 @@ export class EsLintTask extends LintBaseTask {
     }
 
     protected get useWorker() {
-        // eslint can't use worker thread as it needs to change the current working directory
-        return this.node.buildContext.workerPool?.useWorkerThreads === false;
+        if (this.command === "eslint --format stylish src") {
+            // eslint can't use worker thread as it needs to change the current working directory
+            return this.node.buildContext.workerPool?.useWorkerThreads === false;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
Additionally, fix the experiemental worker mode to support the new eslint which
doesn't allow cli to be import any more.  Switch to use the engine
directly instead.

Normalize minor deviation in package.json and tsconfig.json found from fluid build
checks.