### PR TITLE
Fixes method call typo

### DIFF
--- a/docs/content/docs/start/tutorial.md
+++ b/docs/content/docs/start/tutorial.md
@@ -87,7 +87,7 @@ Because both the `getContainer` and `createContainer` methods are async, the `st
 ```js
 async function start() {
   if (location.hash) {
-    await loadExistingDice(location.hash.substring[1])
+    await loadExistingDice(location.hash.substring(1))
   } else {
     const id = await createNewDice();
     location.hash = id;


### PR DESCRIPTION
Replaces an incorrect use of `[]` with `()`