### PR TITLE
Fix for GC tree treated as data store when isolated channels is disabled

### DIFF
--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -8,6 +8,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import { ISequencedDocumentMessage, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
+import { gcTreeKey } from "./garbageCollection";
 
 type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
 interface IFluidDataStoreAttributes0 {
@@ -161,7 +162,7 @@ export const protocolTreeName = ".protocol";
  * isolated data stores namespace. Without the namespace, this must
  * be used to prevent name collisions with data store IDs.
  */
-export const nonDataStorePaths = [protocolTreeName, ".logTail", ".serviceProtocol", blobsTreeName];
+export const nonDataStorePaths = [protocolTreeName, ".logTail", ".serviceProtocol", blobsTreeName, gcTreeKey];
 
 export const dataStoreAttributesBlobName = ".component";
 


### PR DESCRIPTION
Fixes #8826.

The bug here is that when `disableIsolatedChannels` is set to true, the GC tree is written parallel to the data stores.
**Fix:** When reading from this summary, the GC tree needs to be excluded (by adding the gc tree name to nonDataStorePaths) when reading the data store trees.

I believe we should remove this option and always write data stores under ".channels" now. However, this is still used in FFX and I am removing that usage. After that, I will remove this option.