### PR TITLE
Add events to createSubDirectory and deleteSubDirectory

### DIFF
--- a/packages/dds/map/src/test/directory.spec.ts
+++ b/packages/dds/map/src/test/directory.spec.ts
@@ -136,6 +136,22 @@ describe("Directory", () => {
                 assert.equal(valueChangedExpected, false, "missing valueChangedExpected event");
                 assert.equal(containedValueChangedExpected, false, "missing containedValueChanged event");
 
+                // Test createSubDirectory
+                previousValue = undefined;
+                valueChangedExpected = true;
+                containedValueChangedExpected = true;
+                directory.createSubDirectory("dwayne");
+                assert.equal(valueChangedExpected, false, "missing valueChangedExpected event");
+                assert.equal(containedValueChangedExpected, false, "missing containedValueChanged event");
+
+                // Test deleteSubDirectory
+                previousValue = directory.getSubDirectory("dwayne");
+                valueChangedExpected = true;
+                containedValueChangedExpected = true;
+                directory.deleteSubDirectory("dwayne");
+                assert.equal(valueChangedExpected, false, "missing valueChangedExpected event");
+                assert.equal(containedValueChangedExpected, false, "missing containedValueChanged event");
+
                 // Test clear
                 clearExpected = true;
                 directory.clear();


### PR DESCRIPTION
It's important that createSubDirectory and deleteSubDirectory emit events since they alter the state of the directory. I've implemented that through the existing valueChanged and containedValueChanged events, which I like because subdirectories can be treated like key:value pairs just like all the other directory key:values.