### PR TITLE
Bump @fluidframework/build-tools to 0.2.49276

### DIFF
--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -456,9 +456,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -1331,9 +1331,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
         "@oclif/config": "^1.18.2",
@@ -1802,16 +1802,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -1832,11 +1832,42 @@
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
         "universal-user-agent": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
           "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
           "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -3290,9 +3321,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-limiter": {
@@ -4341,9 +4372,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -4359,7 +4390,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -4376,7 +4407,7 @@
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -4446,9 +4477,9 @@
           "dev": true
         },
         "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
           "dev": true
         },
         "supports-hyperlinks": {
@@ -9293,9 +9324,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -11120,9 +11151,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -11295,13 +11326,21 @@
       }
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -11745,9 +11784,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -13462,9 +13501,9 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-          "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
           "dev": true,
           "requires": {
             "side-channel": "^1.0.4"
@@ -13522,9 +13561,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "union-value": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/common-utils-0.32.1": "npm:@fluidframework/common-utils@0.32.1",
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -545,9 +545,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
         "@oclif/config": "^1.18.2",
@@ -972,16 +972,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -994,6 +994,15 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -1930,9 +1939,9 @@
       }
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-retry": {
@@ -2427,9 +2436,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2445,7 +2454,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -2462,7 +2471,7 @@
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -4071,9 +4080,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -4978,9 +4987,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -5047,13 +5056,21 @@
       "dev": true
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -5102,9 +5119,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-      "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -5366,9 +5383,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -5826,13 +5843,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -5945,9 +5959,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "universal-url": {
@@ -5958,6 +5972,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -6033,20 +6075,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/container-definitions-0.39.8": "npm:@fluidframework/container-definitions@0.39.8",
     "@fluidframework/container-definitions-0.40.0": "npm:@fluidframework/container-definitions@0.40.0",
     "@fluidframework/container-definitions-0.41.0": "npm:@fluidframework/container-definitions@0.41.0",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -340,9 +340,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
         "@oclif/config": "^1.18.2",
@@ -767,16 +767,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -789,6 +789,15 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -1719,9 +1728,9 @@
       }
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-retry": {
@@ -2216,9 +2225,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2234,7 +2243,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -2251,7 +2260,7 @@
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -3860,9 +3869,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -4767,9 +4776,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -4836,13 +4845,21 @@
       "dev": true
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -4891,9 +4908,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-      "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -5155,9 +5172,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -5615,13 +5632,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -5734,9 +5748,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "universal-url": {
@@ -5747,6 +5761,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -5822,20 +5864,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/core-interfaces-0.39.8": "npm:@fluidframework/core-interfaces@0.39.8",
     "@fluidframework/core-interfaces-0.40.0": "npm:@fluidframework/core-interfaces@0.40.0",
     "@fluidframework/core-interfaces-0.41.0": "npm:@fluidframework/core-interfaces@0.41.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -446,9 +446,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
         "@oclif/config": "^1.18.2",
@@ -873,16 +873,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -895,6 +895,15 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -1819,9 +1828,9 @@
       }
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-retry": {
@@ -2316,9 +2325,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2334,7 +2343,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -2351,7 +2360,7 @@
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -3960,9 +3969,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -4867,9 +4876,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -4936,13 +4945,21 @@
       "dev": true
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -4991,9 +5008,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-      "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -5255,9 +5272,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -5715,13 +5732,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -5834,9 +5848,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "universal-url": {
@@ -5847,6 +5861,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -5922,20 +5964,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/driver-definitions-0.39.8": "npm:@fluidframework/driver-definitions@0.39.8",
     "@fluidframework/driver-definitions-0.40.0": "npm:@fluidframework/driver-definitions@0.40.0",
     "@fluidframework/driver-definitions-0.41.0": "npm:@fluidframework/driver-definitions@0.41.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -354,9 +354,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
         "@oclif/config": "^1.18.2",
@@ -781,16 +781,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -803,6 +803,15 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -1342,9 +1351,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.13.tgz",
-      "integrity": "sha512-eUXZzHLHoZqj1frtUetNkUetYoJ6X55UmrVnFD4DMhVeAmwLjniZhtBmsRiemQh4uq4G3vUra/Ws/hs9vEvL3Q==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1733,9 +1742,9 @@
       }
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-retry": {
@@ -2230,9 +2239,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2248,7 +2257,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -2265,7 +2274,7 @@
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -3874,9 +3883,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -4781,9 +4790,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -4850,13 +4859,21 @@
       "dev": true
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -4905,9 +4922,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-      "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -5169,9 +5186,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -5629,13 +5646,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -5748,9 +5762,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "universal-url": {
@@ -5761,6 +5775,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -5836,20 +5878,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/protocol-definitions-0.1024.0": "npm:@fluidframework/protocol-definitions@0.1024.0",
     "@fluidframework/protocol-definitions-0.1025.1": "npm:@fluidframework/protocol-definitions@0.1025.1",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1918,9 +1918,9 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.46657",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-			"integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+			"version": "0.2.49276",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+			"integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -2037,6 +2037,18 @@
 				"@fluidframework/core-interfaces": "^0.41.0",
 				"@fluidframework/driver-definitions": "^0.43.0",
 				"@fluidframework/protocol-definitions": "^0.1026.0"
+			},
+			"dependencies": {
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/container-runtime-definitions-0.51.1": {
@@ -2175,6 +2187,16 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.53.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.53.0.tgz",
@@ -2210,6 +2232,16 @@
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.54.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.54.2.tgz",
@@ -2240,6 +2272,16 @@
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.55.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.55.0.tgz",
@@ -2397,6 +2439,16 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.53.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.53.0.tgz",
@@ -2432,6 +2484,16 @@
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.54.2",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.54.2.tgz",
@@ -2462,6 +2524,16 @@
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.55.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.55.0.tgz",
@@ -2479,9 +2551,9 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.43.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-			"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+			"version": "0.44.0-49064",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
+			"integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.41.0",
@@ -2707,6 +2779,16 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@types/node": {
 					"version": "12.20.42",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
@@ -2726,6 +2808,18 @@
 				"@fluidframework/driver-definitions": "^0.43.0",
 				"@fluidframework/protocol-definitions": "^0.1026.0",
 				"@types/node": "^14.18.0"
+			},
+			"dependencies": {
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/runtime-definitions-0.55.0": {
@@ -2740,6 +2834,18 @@
 				"@fluidframework/driver-definitions": "^0.43.0",
 				"@fluidframework/protocol-definitions": "^0.1026.0",
 				"@types/node": "^14.18.0"
+			},
+			"dependencies": {
+				"@fluidframework/driver-definitions": {
+					"version": "0.43.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+					"integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.41.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-lambdas": {
@@ -7955,9 +8061,9 @@
 			}
 		},
 		"@oclif/command": {
-			"version": "1.8.15",
-			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-			"integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+			"version": "1.8.16",
+			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+			"integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
 			"dev": true,
 			"requires": {
 				"@oclif/config": "^1.18.2",
@@ -8582,16 +8688,16 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-			"integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+			"integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.1.0",
 				"@octokit/types": "^6.16.1",
 				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.1",
+				"node-fetch": "^2.6.7",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
@@ -8627,11 +8733,42 @@
 					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				},
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				},
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+					"dev": true
+				},
 				"universal-user-agent": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
 					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
 					"dev": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -18880,9 +19017,9 @@
 			}
 		},
 		"danger": {
-			"version": "10.7.1",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-			"integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+			"version": "10.8.0",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+			"integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -18898,7 +19035,7 @@
 				"https-proxy-agent": "^2.2.1",
 				"hyperlinker": "^1.0.0",
 				"json5": "^2.1.0",
-				"jsonpointer": "^4.0.1",
+				"jsonpointer": "^5.0.0",
 				"jsonwebtoken": "^8.4.0",
 				"lodash.find": "^4.6.0",
 				"lodash.includes": "^4.3.0",
@@ -18915,7 +19052,7 @@
 				"parse-diff": "^0.7.0",
 				"parse-git-config": "^2.0.3",
 				"parse-github-url": "^1.0.2",
-				"parse-link-header": "^1.0.1",
+				"parse-link-header": "^2.0.0",
 				"pinpoint": "^1.1.0",
 				"prettyjson": "^1.2.1",
 				"readline-sync": "^1.4.9",
@@ -28180,9 +28317,9 @@
 			"dev": true
 		},
 		"jsonpointer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+			"integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
 			"dev": true
 		},
 		"jsonschema": {
@@ -34226,9 +34363,9 @@
 			}
 		},
 		"parse-link-header": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-			"integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+			"integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
 			"dev": true,
 			"requires": {
 				"xtend": "~4.0.1"
@@ -34943,13 +35080,21 @@
 			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
 		},
 		"prettyjson": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-			"integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+			"integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
 			"dev": true,
 			"requires": {
-				"colors": "^1.1.2",
+				"colors": "1.4.0",
 				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+					"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+					"dev": true
+				}
 			}
 		},
 		"printj": {
@@ -37401,9 +37546,9 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "17.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-					"integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+					"version": "17.3.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+					"integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
 					"dev": true,
 					"requires": {
 						"cliui": "^7.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -2993,9 +2993,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
         "@oclif/config": "^1.18.2",
@@ -3620,16 +3620,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -3664,6 +3664,15 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
         },
         "universal-user-agent": {
           "version": "6.0.0",
@@ -4121,9 +4130,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-retry": {
@@ -5512,9 +5521,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -5530,7 +5539,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -5547,7 +5556,7 @@
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -5961,9 +5970,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6454,17 +6463,25 @@
       }
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "merge2": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -6701,9 +6718,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "ignore-walk": {
@@ -7338,9 +7355,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
-          "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         },
         "object.assign": {
@@ -7582,9 +7599,9 @@
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -9595,9 +9612,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -9692,9 +9709,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pify": {
@@ -9710,13 +9727,21 @@
       "dev": true
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -9791,9 +9816,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-      "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -10128,9 +10153,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -10963,13 +10988,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -11105,9 +11127,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "unique-filename": {
@@ -11136,6 +11158,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -11256,20 +11306,19 @@
       }
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {
@@ -11365,9 +11414,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
-          "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         },
         "object.assign": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack:profile": "lerna run --no-sort webpack:profile --stream"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/test-tools": "^0.2.3074",
     "@microsoft/api-documenter": "^7.12.7",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/container-runtime-definitions/package-lock.json
+++ b/packages/runtime/container-runtime-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -158,6 +158,18 @@
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/driver-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        }
       }
     },
     "@fluidframework/container-runtime-definitions-0.51.1": {
@@ -324,6 +336,17 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/runtime-definitions": {
           "version": "0.53.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.53.0.tgz",
@@ -362,6 +385,17 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/runtime-definitions": {
           "version": "0.54.2",
           "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.54.2.tgz",
@@ -394,6 +428,17 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/runtime-definitions": {
           "version": "0.55.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.55.0.tgz",
@@ -417,9 +462,9 @@
       "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-      "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+      "version": "0.44.0-49064",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
+      "integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
@@ -460,7 +505,7 @@
         "@fluidframework/common-utils": "^0.32.1",
         "@fluidframework/container-definitions": "^0.44.0",
         "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.43.0",
+        "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0",
         "@types/node": "^14.18.0"
       },
@@ -5511,16 +5556,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -5533,6 +5578,15 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -10265,13 +10319,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -10416,6 +10467,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -10491,20 +10570,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/container-runtime-definitions-0.51.1": "npm:@fluidframework/container-runtime-definitions@0.51.1",
     "@fluidframework/container-runtime-definitions-0.52.0": "npm:@fluidframework/container-runtime-definitions@0.52.0",
     "@fluidframework/container-runtime-definitions-0.53.0": "npm:@fluidframework/container-runtime-definitions@0.53.0",
@@ -104,13 +104,21 @@
           "backCompat": false
         }
       },
-      "0.54.0":{
-        "InterfaceDeclaration_IContainerRuntime": {"backCompat": false},
-        "InterfaceDeclaration_IProvideContainerRuntime": {"backCompat": false}
+      "0.54.0": {
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IProvideContainerRuntime": {
+          "backCompat": false
+        }
       },
-      "0.55.0":{
-        "InterfaceDeclaration_IContainerRuntime": {"backCompat": false},
-        "InterfaceDeclaration_IProvideContainerRuntime": {"backCompat": false}
+      "0.55.0": {
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IProvideContainerRuntime": {
+          "backCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/datastore-definitions/package-lock.json
+++ b/packages/runtime/datastore-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -459,7 +459,7 @@
         "@fluidframework/common-utils": "^0.32.1",
         "@fluidframework/container-definitions": "^0.44.0",
         "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.43.0",
+        "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0",
         "@types/node": "^14.18.0"
       },
@@ -5510,16 +5510,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -5532,6 +5532,15 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -10257,13 +10266,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -10408,6 +10414,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -10483,20 +10517,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/datastore-definitions-0.51.1": "npm:@fluidframework/datastore-definitions@0.51.1",
     "@fluidframework/datastore-definitions-0.52.0": "npm:@fluidframework/datastore-definitions@0.52.0",
     "@fluidframework/datastore-definitions-0.53.0": "npm:@fluidframework/datastore-definitions@0.53.0",

--- a/packages/runtime/runtime-definitions/package-lock.json
+++ b/packages/runtime/runtime-definitions/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -157,6 +157,18 @@
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/driver-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        }
       }
     },
     "@fluidframework/core-interfaces": {
@@ -165,9 +177,9 @@
       "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-      "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+      "version": "0.44.0-49064",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
+      "integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
@@ -335,6 +347,17 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@types/node": {
           "version": "12.20.42",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
@@ -356,6 +379,19 @@
         "@fluidframework/driver-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1026.0",
         "@types/node": "^14.18.0"
+      },
+      "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        }
       }
     },
     "@fluidframework/runtime-definitions-0.55.0": {
@@ -371,6 +407,19 @@
         "@fluidframework/driver-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1026.0",
         "@types/node": "^14.18.0"
+      },
+      "dependencies": {
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -929,16 +978,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -951,6 +1000,15 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -5676,13 +5734,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -5827,6 +5882,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -5902,20 +5985,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/runtime-definitions-0.51.1": "npm:@fluidframework/runtime-definitions@0.51.1",
     "@fluidframework/runtime-definitions-0.52.0": "npm:@fluidframework/runtime-definitions@0.52.0",

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -336,15 +336,15 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.44827",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.44827.tgz",
-			"integrity": "sha512-gU6nYhF9ZhchZCZ092dABKI7AY3brO4+BQzhmH9vakZdmQ43kL7GcjHgR5N2N6idoqcCGIulzYxoXxYxhnTrMQ==",
+			"version": "0.2.49276",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+			"integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
 				"async": "^3.2.0",
 				"chalk": "^2.4.2",
-				"commander": "^2.20.0",
+				"commander": "^6.2.1",
 				"danger": "^10.4.1",
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.3",
@@ -362,6 +362,12 @@
 				"ts-morph": "^7.1.2"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+					"dev": true
+				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -3323,77 +3329,19 @@
 			}
 		},
 		"@oclif/command": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.7.tgz",
-			"integrity": "sha512-5DRLd2WHppuKsudHe8rCZnjgEpA2/6P4zxrLwWBXrGz+/kzA/RWcPJgkcdfm1uBCEgHMSWZP4MX21d4lAB1vYA==",
+			"version": "1.8.16",
+			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+			"integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
 			"dev": true,
 			"requires": {
-				"@oclif/config": "^1.18.1",
+				"@oclif/config": "^1.18.2",
 				"@oclif/errors": "^1.3.5",
+				"@oclif/help": "^1.0.1",
 				"@oclif/parser": "^3.8.6",
-				"@oclif/plugin-help": "^3.2.10",
 				"debug": "^4.1.1",
 				"semver": "^7.3.2"
 			},
 			"dependencies": {
-				"@oclif/plugin-help": {
-					"version": "3.2.10",
-					"resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.10.tgz",
-					"integrity": "sha512-U3Jk01MTnqnd9druulNSn6nTjPEE1Rr6PWhD4rJ6Z+NjLFTKhp3S1kutWDXJQd7CQ6m8tHd1AYgsIjiR+36bSw==",
-					"dev": true,
-					"requires": {
-						"@oclif/command": "^1.8.6",
-						"@oclif/config": "^1.18.1",
-						"@oclif/errors": "^1.3.5",
-						"chalk": "^4.1.2",
-						"indent-string": "^4.0.0",
-						"lodash": "^4.17.21",
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"widest-line": "^3.1.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -3402,33 +3350,13 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
 				}
 			}
 		},
 		"@oclif/config": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.1.tgz",
-			"integrity": "sha512-twRJO5RRl3CCDaAASb6LiynfFQl/SbkWWOQy1l0kJZSMPysEhz+fk3BKfmlCCm451Btkp4UezHUwI1JtH+/zYg==",
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+			"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
 			"dev": true,
 			"requires": {
 				"@oclif/errors": "^1.3.3",
@@ -3500,6 +3428,85 @@
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 					"dev": true
+				}
+			}
+		},
+		"@oclif/help": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
+			"integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
+			"dev": true,
+			"requires": {
+				"@oclif/config": "1.18.2",
+				"@oclif/errors": "1.3.5",
+				"chalk": "^4.1.2",
+				"indent-string": "^4.0.0",
+				"lodash": "^4.17.21",
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"widest-line": "^3.1.0",
+				"wrap-ansi": "^6.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
 				}
 			}
 		},
@@ -3956,16 +3963,16 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-			"integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+			"integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.1.0",
 				"@octokit/types": "^6.16.1",
 				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.1",
+				"node-fetch": "^2.6.7",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
@@ -4000,6 +4007,15 @@
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
+				},
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
 				},
 				"universal-user-agent": {
 					"version": "6.0.0",
@@ -4371,9 +4387,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.17.27",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
-			"integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw=="
+			"version": "14.18.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
+			"integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -6853,9 +6869,9 @@
 			}
 		},
 		"danger": {
-			"version": "10.7.1",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-			"integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+			"version": "10.8.0",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+			"integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -6871,7 +6887,7 @@
 				"https-proxy-agent": "^2.2.1",
 				"hyperlinker": "^1.0.0",
 				"json5": "^2.1.0",
-				"jsonpointer": "^4.0.1",
+				"jsonpointer": "^5.0.0",
 				"jsonwebtoken": "^8.4.0",
 				"lodash.find": "^4.6.0",
 				"lodash.includes": "^4.3.0",
@@ -6888,7 +6904,7 @@
 				"parse-diff": "^0.7.0",
 				"parse-git-config": "^2.0.3",
 				"parse-github-url": "^1.0.2",
-				"parse-link-header": "^1.0.1",
+				"parse-link-header": "^2.0.0",
 				"pinpoint": "^1.1.0",
 				"prettyjson": "^1.2.1",
 				"readline-sync": "^1.4.9",
@@ -8815,6 +8831,11 @@
 			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
 			"integrity": "sha1-JsrYAXlnrqhzG8QpYdBKPVmIrMw="
 		},
+		"follow-redirects": {
+			"version": "1.14.7",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+			"integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+		},
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -10182,9 +10203,9 @@
 			"dev": true
 		},
 		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
 			"dev": true
 		},
 		"is-number": {
@@ -10318,12 +10339,12 @@
 			"dev": true
 		},
 		"is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-windows": {
@@ -10631,9 +10652,9 @@
 			"dev": true
 		},
 		"jsonpointer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+			"integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
 			"dev": true
 		},
 		"jsonwebtoken": {
@@ -11545,9 +11566,9 @@
 			},
 			"dependencies": {
 				"picomatch": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+					"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 					"dev": true
 				}
 			}
@@ -12887,9 +12908,9 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-inspect": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+			"integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
 			"dev": true
 		},
 		"object-is": {
@@ -13884,9 +13905,9 @@
 			}
 		},
 		"parse-link-header": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-			"integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+			"integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
 			"dev": true,
 			"requires": {
 				"xtend": "~4.0.1"
@@ -14120,12 +14141,12 @@
 			"dev": true
 		},
 		"prettyjson": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-			"integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+			"integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
 			"dev": true,
 			"requires": {
-				"colors": "^1.1.2",
+				"colors": "1.4.0",
 				"minimist": "^1.2.0"
 			}
 		},
@@ -14672,9 +14693,9 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "17.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-					"integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+					"version": "17.3.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+					"integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
 					"dev": true,
 					"requires": {
 						"cliui": "^7.0.2",
@@ -16106,13 +16127,10 @@
 			}
 		},
 		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"traverse": {
 			"version": "0.3.9",
@@ -16129,6 +16147,12 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
 			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+			"dev": true
+		},
+		"trim-off-newlines": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
+			"integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
 			"dev": true
 		},
 		"triple-beam": {
@@ -16284,9 +16308,9 @@
 			},
 			"dependencies": {
 				"qs": {
-					"version": "6.10.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-					"integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+					"version": "6.10.3",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+					"integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
 					"dev": true,
 					"requires": {
 						"side-channel": "^1.0.4"
@@ -16375,9 +16399,9 @@
 			"dev": true
 		},
 		"underscore": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-			"integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+			"integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
 			"dev": true
 		},
 		"unique-filename": {
@@ -16406,6 +16430,34 @@
 			"requires": {
 				"hasurl": "^1.0.0",
 				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"universal-user-agent": {
@@ -16547,20 +16599,19 @@
 			}
 		},
 		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"which": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -321,9 +321,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -3435,16 +3435,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -3479,6 +3479,15 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
         },
         "universal-user-agent": {
           "version": "6.0.0",
@@ -13622,13 +13631,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -13891,6 +13897,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -14010,20 +14044,19 @@
       }
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -44,7 +44,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@fluidframework/eslint-config-fluid": "^0.23.0",
     "@types/compression": "0.0.36",
     "@types/cors": "^2.8.4",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -330,9 +330,9 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.46657",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-			"integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+			"version": "0.2.49276",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+			"integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -373,12 +373,6 @@
 						"jsonfile": "^6.0.1",
 						"universalify": "^2.0.0"
 					}
-				},
-				"ignore": {
-					"version": "5.1.9",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-					"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
-					"dev": true
 				},
 				"jsonfile": {
 					"version": "6.1.0",
@@ -3549,9 +3543,9 @@
 			}
 		},
 		"@oclif/command": {
-			"version": "1.8.15",
-			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-			"integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+			"version": "1.8.16",
+			"resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+			"integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
 			"dev": true,
 			"requires": {
 				"@oclif/config": "^1.18.2",
@@ -4220,16 +4214,16 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-			"integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+			"integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.1.0",
 				"@octokit/types": "^6.16.1",
 				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.1",
+				"node-fetch": "^2.6.7",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
@@ -4264,6 +4258,15 @@
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
+				},
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
 				},
 				"universal-user-agent": {
 					"version": "6.0.0",
@@ -8260,9 +8263,9 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"danger": {
-			"version": "10.7.1",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-			"integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+			"version": "10.8.0",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+			"integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -8278,7 +8281,7 @@
 				"https-proxy-agent": "^2.2.1",
 				"hyperlinker": "^1.0.0",
 				"json5": "^2.1.0",
-				"jsonpointer": "^4.0.1",
+				"jsonpointer": "^5.0.0",
 				"jsonwebtoken": "^8.4.0",
 				"lodash.find": "^4.6.0",
 				"lodash.includes": "^4.3.0",
@@ -8295,7 +8298,7 @@
 				"parse-diff": "^0.7.0",
 				"parse-git-config": "^2.0.3",
 				"parse-github-url": "^1.0.2",
-				"parse-link-header": "^1.0.1",
+				"parse-link-header": "^2.0.0",
 				"pinpoint": "^1.1.0",
 				"prettyjson": "^1.2.1",
 				"readline-sync": "^1.4.9",
@@ -8338,9 +8341,9 @@
 					}
 				},
 				"picomatch": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+					"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 					"dev": true
 				},
 				"to-regex-range": {
@@ -12356,9 +12359,9 @@
 			"dev": true
 		},
 		"jsonpointer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+			"integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
 			"dev": true
 		},
 		"jsonwebtoken": {
@@ -16043,9 +16046,9 @@
 			}
 		},
 		"parse-link-header": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-			"integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+			"integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
 			"dev": true,
 			"requires": {
 				"xtend": "~4.0.1"
@@ -16258,13 +16261,21 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
 		},
 		"prettyjson": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-			"integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+			"integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
 			"dev": true,
 			"requires": {
-				"colors": "^1.1.2",
+				"colors": "1.4.0",
 				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+					"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+					"dev": true
+				}
 			}
 		},
 		"printj": {
@@ -16920,9 +16931,9 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "17.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-					"integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+					"version": "17.3.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+					"integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
 					"dev": true,
 					"requires": {
 						"cliui": "^7.0.2",
@@ -17706,12 +17717,6 @@
 						"merge2": "^1.2.3",
 						"slash": "^3.0.0"
 					}
-				},
-				"ignore": {
-					"version": "5.1.9",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-					"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
-					"dev": true
 				},
 				"is-plain-obj": {
 					"version": "2.1.0",
@@ -18686,13 +18691,10 @@
 			}
 		},
 		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"traverse": {
 			"version": "0.3.9",
@@ -18883,9 +18885,9 @@
 			},
 			"dependencies": {
 				"qs": {
-					"version": "6.10.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-					"integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+					"version": "6.10.3",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+					"integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
 					"dev": true,
 					"requires": {
 						"side-channel": "^1.0.4"
@@ -18984,9 +18986,9 @@
 			"dev": true
 		},
 		"underscore": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-			"integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+			"integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
 			"dev": true
 		},
 		"union-value": {
@@ -19024,6 +19026,34 @@
 			"requires": {
 				"hasurl": "^1.0.0",
 				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"universal-user-agent": {
@@ -19384,9 +19414,9 @@
 			}
 		},
 		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
 			"dev": true
 		},
 		"webpack": {
@@ -19649,14 +19679,13 @@
 			}
 		},
 		"whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"which": {

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -278,9 +278,9 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.46657",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.46657.tgz",
-      "integrity": "sha512-lL9eo148hHA2jhORYGBBMDyh/L9QDn+lvGvTVL2SxpPCd3OazzFB/eOgZ0t8o/fPJ7s7HAHHXlfT7XAcd4rJ+Q==",
+      "version": "0.2.49276",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
+      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
@@ -2966,9 +2966,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.15.tgz",
-      "integrity": "sha512-lMRsr38sm4XBDBt2u88nvGyk3YxMjQenfX1HM140ZckTVqwuvFVZLP4HZ0rSAK9FdJzfryO/tH5hovdiC6bgsw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
         "@oclif/config": "^1.18.2",
@@ -3605,16 +3605,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -3649,6 +3649,15 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
         },
         "universal-user-agent": {
           "version": "6.0.0",
@@ -4119,9 +4128,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-retry": {
@@ -5453,9 +5462,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
+      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -5471,7 +5480,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -5488,7 +5497,7 @@
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -7407,9 +7416,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
-          "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         }
       }
@@ -7770,9 +7779,9 @@
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -9925,9 +9934,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -10074,13 +10083,21 @@
       }
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -10517,9 +10534,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-          "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -11419,13 +11436,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -11501,9 +11515,9 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.2.tgz",
-          "integrity": "sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==",
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
           "dev": true,
           "requires": {
             "side-channel": "^1.0.4"
@@ -11578,9 +11592,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "unique-filename": {
@@ -11609,6 +11623,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -11722,20 +11764,19 @@
       }
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {
@@ -11840,9 +11881,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
-          "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+          "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
           "dev": true
         }
       }

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.46657",
+    "@fluidframework/build-tools": "^0.2.49276",
     "@microsoft/api-documenter": "^7.4.6",
     "@microsoft/api-extractor": "^7.16.1",
     "concurrently": "^6.2.0",


### PR DESCRIPTION
This PR bumps `@fluidframework/build-tools` to version `0.2.49276`. This was done to fix test case generation for removed types.

Context: https://github.com/microsoft/FluidFramework/pull/8829