### PR TITLE
[r11s] Fixing SummaryReader for wholeSummaryUpload: accessing map properties correctly

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -85,7 +85,7 @@ export class ScribeLambdaFactory extends EventEmitter implements IPartitionLambd
             const tenant = await this.tenantManager.getTenant(tenantId, documentId);
             gitManager = tenant.gitManager;
 
-            summaryReader = new SummaryReader(documentId, gitManager, this.enableWholeSummaryUpload);
+            summaryReader = new SummaryReader(tenantId, documentId, gitManager, this.enableWholeSummaryUpload);
             [latestSummary, document] = await Promise.all([
                 summaryReader.readLastSummary(),
                 this.documentCollection.findOne({ documentId, tenantId }),

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -339,7 +339,7 @@ export class LocalOrderer implements IOrderer {
             this.gitManager,
             scribeMessagesCollection,
             false);
-        const summaryReader = new SummaryReader(this.documentId, this.gitManager, false);
+        const summaryReader = new SummaryReader(this.tenantId, this.documentId, this.gitManager, false);
         const checkpointManager = new CheckpointManager(
             context,
             this.tenantId,


### PR DESCRIPTION
`SummaryReader` is used to read summaries from storage. When `SummaryReader` tries to `readLastSummary()` for the first time, that is, before Scribe has written any summaries, it will just find the blank/initial summary that Alfred uploaded. In that case, there is no `.serviceProtocol` tree, and the operation is expected to fail, thus returning `SummaryReader`'s `getDefaultSummaryState()`.

However, we noticed that when WholeSummaryUpload was enabled, other calls to `readLastSummary()` would also fail, but due to a different reason. That was because `normalizedSummary.blobs` is a `Map<string, ArrayBuffer>` and we were trying to access the map contents with `map[key]`. That is not correct, as TS would interpret that as accessing the property `key` of the object. As a result, values like `attributesContent` would be `undefined` and that would cause errors later when using `bufferToString()`.

The solution is to instead use `map.get(key)` to access the map properties appropriately.