### PR TITLE
r11s: add NGINX in front of docker-compose services

### DIFF
--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -1,11 +1,18 @@
 version: '3.4'
 services:
+    proxy:
+        image: nginx:latest
+        volumes:
+            - ./nginx.conf:/etc/nginx/nginx.conf
+        ports:
+            - "3003:3003"
+            - "3001:3001"
     alfred:
         build:
             context: .
             target: runner
-        ports:
-            - "3003:3000"
+        expose:
+            - "3000"
         command: node packages/routerlicious/dist/alfred/www.js
         environment:
             - DEBUG=fluid:*
@@ -69,8 +76,8 @@ services:
         restart: always
     historian:
         image: mcr.microsoft.com/fluidframework/routerlicious/historian:latest
-        ports:
-            - "3001:3000"
+        expose:
+            - "3000"
         environment:
             - DEBUG=fluid:*
             - NODE_ENV=development

--- a/server/routerlicious/nginx.conf
+++ b/server/routerlicious/nginx.conf
@@ -1,0 +1,53 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+
+    sendfile on;
+
+    upstream docker-alfred {
+        server alfred:3000;
+    }
+
+    upstream docker-historian {
+        server historian:3000;
+    }
+
+    # Standard proxy setup
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $server_name;
+
+    # Enable WebSockets
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    # Expose Alfred
+    server {
+        listen 3003;
+
+        location / {
+            proxy_pass http://docker-alfred;
+            proxy_redirect off;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+
+    # Expose Historian
+    server {
+        listen 3001;
+
+        location / {
+            proxy_pass http://docker-historian;
+            proxy_redirect off;
+        }
+    }
+}


### PR DESCRIPTION
#8820 prompted me to add NGINX as a reverse-proxy in front of the local r11s services in Docker so that I could disable WebSockets at the proxy layer (comment out lines 39-40 in nginx.conf).

This more closely resembles how R11s works when deployed, and we could perhaps utilize this in the future to experiment with HTTP2 locally.