### PR TITLE
Remove stray uses of quorum proposals

### DIFF
--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -98,12 +98,6 @@ async function loadOuterLogDiv(
 ): Promise<void> {
     const logDiv = document.getElementById(logDivId) as HTMLDivElement;
 
-    const quorum = container.getQuorum();
-    if (!quorum.has("code")) {
-        // we'll never propose the code, so wait for them to do it
-        await new Promise<void>((resolve) => container.once("contextChanged", () => resolve()));
-    }
-
     const log =
         (emitter: { on(event: string, listener: (...args: any[]) => void) }, name: string, ...events: string[]) => {
             events.forEach((event) =>
@@ -113,6 +107,7 @@ async function loadOuterLogDiv(
                 }));
         };
 
+    const quorum = container.getQuorum();
     quorum.getMembers().forEach((client) => logDiv.innerHTML += `Quorum: client: ${JSON.stringify(client)}<br/>`);
     log(quorum, "Quorum", "error", "addMember", "removeMember");
     log(container, "Container", "error", "connected", "disconnected");

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -123,7 +123,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
     }
 
     private trackLastProposal(container: IContainer) {
-        container.getQuorum().on("addProposal", (proposal) => {
+        container.on("codeDetailsProposed", (value, proposal) => {
             if (proposal.sequenceNumber > this.lastProposalSeqNum) {
                 this.lastProposalSeqNum = proposal.sequenceNumber;
             }


### PR DESCRIPTION
In latest container-definitions, `IContainer.getQuorum()` returns an `IQuorumClients` rather than an `IQuorum`, causing these to break.  Remove these remaining uses that I missed.