### PR TITLE
Stress: Override Category of Injected Errors to Generic

### DIFF
--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -21,6 +21,7 @@ import {
     INack,
     NackErrorType,
 } from "@fluidframework/protocol-definitions";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 
 export class FaultInjectionDocumentServiceFactory implements IDocumentServiceFactory {
     private  readonly _documentServices = new Map<IResolvedUrl, FaultInjectionDocumentService>();
@@ -157,10 +158,11 @@ extends EventForwarder<IDocumentDeltaConnectionEvents> implements IDocumentDelta
     }
 }
 
-export class FaultInjectionError extends Error {
+export class FaultInjectionError extends LoggingError {
     constructor(
         message: string,
         public readonly canRetry: boolean | undefined) {
-            super(message);
+            super(message, {testCategoryOverride: "generic"});
     }
+
 }

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -59,6 +59,11 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
         return baseFlushP;
     }
     send(event: ITelemetryBaseEvent): void {
+
+        if(typeof event.testCategoryOverride === "string"){
+            event.category = event.testCategoryOverride;
+        }
+
         this.baseLogger?.send({ ...event, hostName: pkgName });
 
         event.Event_Time = Date.now();


### PR DESCRIPTION
Log injected errors as generic to keep error category clean of expected errors

fixes #8666 