### PR TITLE
Added feature flag to control writing GC data at the root of summary tree

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -188,7 +188,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
-    }
+    get writeGCDataAtRoot(): boolean;
+}
 
 // @public (undocumented)
 export interface ContainerRuntimeMessage {

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -188,8 +188,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
-    get writeGCDataAtRoot(): boolean;
-}
+    }
 
 // @public (undocumented)
 export interface ContainerRuntimeMessage {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -895,14 +895,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private readonly dataStores: DataStores;
 
     /**
-     * True, if GC data should be written at root of the summary tree.
-     * False, if data stores should write GC blobs in their summary tree.
-     */
-    public get writeGCDataAtRoot(): boolean {
-       return this.garbageCollector.writeDataAtRoot;
-    }
-
-    /**
      * True if generating summaries with isolated channels is
      * explicitly disabled. This only affects how summaries are written,
      * and is the single source of truth for this container.
@@ -1043,6 +1035,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             async () => this.garbageCollector.getDataStoreBaseGCDetails(),
             (id: string) => this.garbageCollector.nodeChanged(id),
             new Map<string, string>(dataStoreAliasMap),
+            this.garbageCollector.writeDataAtRoot,
         );
 
         this.blobManager = new BlobManager(
@@ -1400,7 +1393,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             addTreeToSummary(summaryTree, blobsTreeName, blobsTree);
         }
 
-        if (this.writeGCDataAtRoot) {
+        if (this.garbageCollector.writeDataAtRoot) {
             const gcSummary = this.garbageCollector.summarize();
             if (gcSummary !== undefined) {
                 addTreeToSummary(summaryTree, gcTreeKey, gcSummary);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -895,6 +895,14 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private readonly dataStores: DataStores;
 
     /**
+     * True, if GC data should be written at root of the summary tree.
+     * False, if data stores should write GC blobs in their summary tree.
+     */
+    public get writeGCDataAtRoot(): boolean {
+       return this.garbageCollector.writeDataAtRoot;
+    }
+
+    /**
      * True if generating summaries with isolated channels is
      * explicitly disabled. This only affects how summaries are written,
      * and is the single source of truth for this container.
@@ -1392,9 +1400,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             addTreeToSummary(summaryTree, blobsTreeName, blobsTree);
         }
 
-        const gcSummary = this.garbageCollector.summarize();
-        if (gcSummary !== undefined) {
-            addTreeToSummary(summaryTree, gcTreeKey, gcSummary);
+        if (this.writeGCDataAtRoot) {
+            const gcSummary = this.garbageCollector.summarize();
+            if (gcSummary !== undefined) {
+                addTreeToSummary(summaryTree, gcTreeKey, gcSummary);
+            }
         }
     }
 

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -43,6 +43,7 @@ import {
     CreateChildSummarizerNodeFn,
     CreateChildSummarizerNodeParam,
     FluidDataStoreRegistryEntry,
+    gcBlobKey,
     IAttachMessage,
     IFluidDataStoreChannel,
     IFluidDataStoreContext,
@@ -187,6 +188,11 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
     protected get disableIsolatedChannels(): boolean {
         return this._containerRuntime.disableIsolatedChannels;
+    }
+
+    /** Tells whether GC data will be written at the root of the summary tree. If so, data store should not write it. */
+    protected get writeGCDataAtRoot(): boolean {
+       return this._containerRuntime.writeGCDataAtRoot;
     }
 
     protected registry: IFluidDataStoreRegistry | undefined;
@@ -416,6 +422,11 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         const { pkg, isRootDataStore } = await this.getInitialSnapshotDetails();
         const attributes = createAttributes(pkg, isRootDataStore, this.disableIsolatedChannels);
         addBlobToSummary(summarizeResult, dataStoreAttributesBlobName, JSON.stringify(attributes));
+
+        // Add GC data to the summary if it's not written at the root.
+        if (!this.writeGCDataAtRoot) {
+            addBlobToSummary(summarizeResult, gcBlobKey, JSON.stringify(this.summarizerNode.getGCSummaryDetails()));
+        }
 
         // If we are not referenced, mark the summary tree as unreferenced. Also, update unreferenced blob
         // size in the summary stats with the blobs size of this data store.

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -190,11 +190,6 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         return this._containerRuntime.disableIsolatedChannels;
     }
 
-    /** Tells whether GC data will be written at the root of the summary tree. If so, data store should not write it. */
-    protected get writeGCDataAtRoot(): boolean {
-       return this._containerRuntime.writeGCDataAtRoot;
-    }
-
     protected registry: IFluidDataStoreRegistry | undefined;
 
     protected detachedRuntimeCreation = false;
@@ -224,6 +219,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         private bindState: BindState,
         public readonly isLocalDataStore: boolean,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
+        private writeGCDataAtRoot: boolean,
         protected pkg?: readonly string[],
     ) {
         super();
@@ -714,6 +710,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
         storage: IDocumentStorageService,
         scope: FluidObject,
         createSummarizerNode: CreateChildSummarizerNodeFn,
+        writeGCDataAtRoot: boolean,
         pkg?: string[],
     ) {
         super(
@@ -728,6 +725,7 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
             () => {
                 throw new Error("Already attached");
             },
+            writeGCDataAtRoot,
             pkg,
         );
 
@@ -841,6 +839,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         private readonly snapshotTree: ISnapshotTree | undefined,
         protected isRootDataStore: boolean | undefined,
+        writeGCDataAtRoot: boolean,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */
@@ -856,6 +855,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
             snapshotTree ? BindState.Bound : BindState.NotBound,
             true,
             bindChannel,
+            writeGCDataAtRoot,
             pkg);
         this.attachListeners();
     }
@@ -975,6 +975,7 @@ export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         snapshotTree: ISnapshotTree | undefined,
         isRootDataStore: boolean | undefined,
+        writeGCDataAtRoot: boolean,
         /**
          * @deprecated 0.16 Issue #1635, #3631
          */
@@ -990,6 +991,7 @@ export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
             bindChannel,
             snapshotTree,
             isRootDataStore,
+            writeGCDataAtRoot,
             createProps);
     }
 }
@@ -1013,6 +1015,7 @@ export class LocalDetachedFluidDataStoreContext
         createSummarizerNode: CreateChildSummarizerNodeFn,
         bindChannel: (channel: IFluidDataStoreChannel) => void,
         isRootDataStore: boolean,
+        writeGCDataAtRoot: boolean,
     ) {
         super(
             id,
@@ -1024,6 +1027,7 @@ export class LocalDetachedFluidDataStoreContext
             bindChannel,
             undefined,
             isRootDataStore,
+            writeGCDataAtRoot,
         );
         this.detachedRuntimeCreation = true;
     }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -117,6 +117,7 @@ export class DataStores implements IDisposable {
         getBaseGCDetails: () => Promise<Map<string, IGarbageCollectionDetailsBase>>,
         private readonly dataStoreChanged: (id: string) => void,
         private readonly aliasMap: Map<string, string>,
+        private readonly writeGCDataAtRoot: boolean,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
         this.logger = ChildLogger.create(baseLogger);
@@ -157,7 +158,9 @@ export class DataStores implements IDisposable {
                     this.runtime,
                     this.runtime.storage,
                     this.runtime.scope,
-                    this.getCreateChildSummarizerNodeFn(key, { type: CreateSummarizerNodeSource.FromSummary }));
+                    this.getCreateChildSummarizerNodeFn(key, { type: CreateSummarizerNodeSource.FromSummary }),
+                    this.writeGCDataAtRoot,
+                );
             } else {
                 if (typeof value !== "object") {
                     throw new Error("Snapshot should be there to load from!!");
@@ -173,6 +176,7 @@ export class DataStores implements IDisposable {
                     (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
                     snapshotTree,
                     undefined,
+                    this.writeGCDataAtRoot,
                 );
             }
             this.contexts.addBoundOrRemoted(dataStoreContext);
@@ -247,7 +251,9 @@ export class DataStores implements IDisposable {
                         )],
                     },
                 }),
-            pkg);
+            this.writeGCDataAtRoot,
+            pkg,
+        );
 
         this.contexts.addBoundOrRemoted(remotedFluidDataStoreContext);
     }
@@ -331,6 +337,7 @@ export class DataStores implements IDisposable {
             this.getCreateChildSummarizerNodeFn(id, { type: CreateSummarizerNodeSource.Local }),
             (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
             isRoot,
+            this.writeGCDataAtRoot,
         );
         this.contexts.addUnbound(context);
         return context;
@@ -347,6 +354,7 @@ export class DataStores implements IDisposable {
             (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
             undefined,
             isRoot,
+            this.writeGCDataAtRoot,
             props,
         );
         this.contexts.addUnbound(context);

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -783,17 +783,6 @@ export class GarbageCollector implements IGarbageCollector {
      * @param currentGCData - The GC data (reference graph) from the current GC run.
      */
     private validateReferenceCorrectness(currentGCData: IGarbageCollectionData) {
-        /**
-         * We cannot validate reference correctness until the following issue is resolved -
-         * https://github.com/microsoft/FluidFramework/issues/8878.
-         * It is because of this bug - https://github.com/microsoft/FluidFramework/issues/8672. This bug will not happen
-         * when GC data is written at the root of the summary tree. However, that change is behind a feature flag and we
-         * have to wait until it is written to the root by default.
-         */
-        if (!this._writeDataAtRoot) {
-            return;
-        }
-
         assert(this.gcDataFromLastRun !== undefined, 0x2b7
             /* "Can't validate correctness without GC data from last run" */);
 

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -102,7 +102,9 @@ describe("Data Store Context Tests", () => {
                     createSummarizerNodeFn,
                     attachCb,
                     undefined,
-                    true /* isRootDataStore */);
+                    true /* isRootDataStore */,
+                    true /* writeGCDataAtRoot */,
+                );
 
                 await localDataStoreContext.realize();
                 const attachMessage = localDataStoreContext.generateAttachMessage();
@@ -141,7 +143,9 @@ describe("Data Store Context Tests", () => {
                     createSummarizerNodeFn,
                     attachCb,
                     undefined,
-                    false /* isRootDataStore */);
+                    false /* isRootDataStore */,
+                    true /* writeGCDataAtRoot */,
+                );
 
                 await localDataStoreContext.realize()
                     .catch((error) => {
@@ -172,7 +176,9 @@ describe("Data Store Context Tests", () => {
                     createSummarizerNodeFn,
                     attachCb,
                     undefined,
-                    false /* isRootDataStore */);
+                    false /* isRootDataStore */,
+                    true /* writeGCDataAtRoot */,
+                );
 
                 await localDataStoreContext.realize();
 
@@ -209,7 +215,9 @@ describe("Data Store Context Tests", () => {
                     createSummarizerNodeFn,
                     attachCb,
                     undefined,
-                    true /* isRootDataStore */);
+                    true /* isRootDataStore */,
+                    true /* writeGCDataAtRoot */,
+                );
 
                 const isRootNode = await localDataStoreContext.isRoot();
                 assert.strictEqual(isRootNode, true, "The data store should be root.");
@@ -225,7 +233,9 @@ describe("Data Store Context Tests", () => {
                     createSummarizerNodeFn,
                     attachCb,
                     undefined,
-                    false /* isRootDataStore */);
+                    false /* isRootDataStore */,
+                    true /* writeGCDataAtRoot */,
+                );
 
                 const isRootNode = await localDataStoreContext.isRoot();
                 assert.strictEqual(isRootNode, false, "The data store should not be root.");
@@ -243,7 +253,9 @@ describe("Data Store Context Tests", () => {
                     createSummarizerNodeFn,
                     attachCb,
                     undefined,
-                    true /* isRootDataStore */);
+                    true /* isRootDataStore */,
+                    true /* writeGCDataAtRoot */,
+                );
 
                 const gcData = await localDataStoreContext.getGCData();
                 assert.deepStrictEqual(gcData, emptyGCData, "GC data from getGCData should be empty.");
@@ -259,7 +271,9 @@ describe("Data Store Context Tests", () => {
                     createSummarizerNodeFn,
                     attachCb,
                     undefined,
-                    false /* isRootDataStore */);
+                    false /* isRootDataStore */,
+                    true /* writeGCDataAtRoot */,
+                );
 
                 // Get the summarizer node for this data store which tracks its referenced state.
                 const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
@@ -376,6 +390,7 @@ describe("Data Store Context Tests", () => {
                         new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                         scope,
                         createSummarizerNodeFn,
+                        true /* writeGCDataAtRoot */,
                     );
 
                     const isRootNode = await remotedDataStoreContext.isRoot();
@@ -474,6 +489,7 @@ describe("Data Store Context Tests", () => {
                     new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
+                    true /* writeGCDataAtRoot */,
                 );
 
                 const gcData = await remotedDataStoreContext.getGCData();
@@ -509,6 +525,7 @@ describe("Data Store Context Tests", () => {
                     new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
+                    true /* writeGCDataAtRoot */,
                 );
 
                 const gcData = await remotedDataStoreContext.getGCData();
@@ -549,6 +566,7 @@ describe("Data Store Context Tests", () => {
                     new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
+                    true /* writeGCDataAtRoot */,
                 );
 
                 const gcData = await remotedDataStoreContext.getGCData();
@@ -584,6 +602,7 @@ describe("Data Store Context Tests", () => {
                     new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
+                    true /* writeGCDataAtRoot */,
                 );
 
                 // Since GC is enabled, GC must run before summarize. Get the GC data and update used routes to
@@ -627,6 +646,7 @@ describe("Data Store Context Tests", () => {
                     new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
+                    true /* writeGCDataAtRoot */,
                 );
 
                 // Get the summarizer node for this data store which tracks its referenced state.

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -121,7 +121,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await context.realize();
@@ -145,7 +147,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await context.realize();
@@ -169,7 +173,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await contextA.realize();
@@ -193,7 +199,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await contextB.realize();
@@ -217,7 +225,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreBId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await contextB.realize();
@@ -238,7 +248,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreCId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await contextC.realize();
@@ -262,7 +274,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await contextFake.realize();
@@ -286,7 +300,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await contextFake.realize();
@@ -310,7 +326,9 @@ describe("Data Store Creation Tests", () => {
                 getCreateSummarizerNodeFn(dataStoreId),
                 attachCb,
                 undefined,
-                false /* isRootDataStore */);
+                false /* isRootDataStore */,
+                true /* writeGCDataAtRoot */,
+            );
 
             try {
                 await contextC.realize();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -22,6 +22,7 @@ import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeFullCompat, getContainerRuntimeApi } from "@fluidframework/test-version-utils";
 import { pkgVersion } from "../../packageVersion";
 import { wrapDocumentServiceFactory } from "./gcDriverWrappers";
+import { mockConfigProvider } from "./mockConfigProivder";
 import { loadSummarizer, TestDataObject, submitAndAckSummary, getGCStateFromSummary } from "./mockSummarizerClient";
 
 /**
@@ -57,6 +58,10 @@ describeFullCompat("GC summary compatibility tests", (getTestObjectProvider) => 
     );
     const logger = new TelemetryNullLogger();
 
+    // Enable config provider setting to write GC data at the root.
+    const settings = { "Fluid.GarbageCollection.WriteDataAtRoot": "true" };
+    const configProvider = mockConfigProvider(settings);
+
     // Stores the latest summary uploaded to the server.
     let latestUploadedSummary: ISummaryTree | undefined;
     // Stores the latest summary context uploaded to the server.
@@ -68,11 +73,17 @@ describeFullCompat("GC summary compatibility tests", (getTestObjectProvider) => 
     let dataStoreA: TestDataObject;
 
     const createContainer = async (factory: IRuntimeFactory): Promise<IContainer> => {
-        return provider.createContainer(factory);
+        return provider.createContainer(factory, { configProvider });
     };
 
     const getNewSummarizer = async (factory: IRuntimeFactory, summaryVersion?: string) => {
-        return loadSummarizer(provider, factory, mainContainer.deltaManager.lastSequenceNumber, summaryVersion);
+        return loadSummarizer(
+            provider,
+            factory,
+            mainContainer.deltaManager.lastSequenceNumber,
+            summaryVersion,
+            { configProvider },
+        );
     };
 
     /**

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+
+export const mockConfigProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => {
+    return {
+        getRawConfig: (name: string): ConfigTypes => settings[name],
+    };
+});

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
@@ -22,6 +22,7 @@ import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { IGarbageCollectionState } from "@fluidframework/runtime-definitions";
+import { ILoaderProps } from "@fluidframework/container-loader";
 
 // data store that exposes container runtime for testing.
 export class TestDataObject extends DataObject {
@@ -46,6 +47,7 @@ export async function loadSummarizer(
     runtimeFactory: IRuntimeFactory,
     sequenceNumber: number,
     summaryVersion?: string,
+    loaderProps?: Partial<ILoaderProps>,
 ) {
     const requestHeader = {
         [LoaderHeader.cache]: false,
@@ -58,7 +60,7 @@ export async function loadSummarizer(
         [LoaderHeader.sequenceNumber]: sequenceNumber,
         [LoaderHeader.version]: summaryVersion,
     };
-    const summarizer = await provider.loadContainer(runtimeFactory, undefined /* options */, requestHeader);
+    const summarizer = await provider.loadContainer(runtimeFactory, loaderProps, requestHeader);
 
     // Fail fast if we receive a nack as something must have gone wrong.
     const summaryCollection = new SummaryCollection(summarizer.deltaManager, new TelemetryNullLogger());

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -117,6 +117,7 @@ export async function loadContainer(
     // ops than "maxOpsSinceLastSummary". So set it to a higher number to suppress those errors and run tests.
     const runtimeOptions: IContainerRuntimeOptions = {
         summaryOptions: { disableSummaries: true, maxOpsSinceLastSummary: 100000 },
+        gcOptions: { writeDataAtRoot: true },
     };
     const codeLoader = new ReplayCodeLoader(new ReplayRuntimeFactory(runtimeOptions, dataStoreRegistries));
 


### PR DESCRIPTION
Fixes #8834.

#8734 moved writing the GC state to the root of the summary. Added this behind a feature flag so that it can be rolled out in stages and we can observe issues, if any, before enabling it be default.