### PR TITLE
Added configProvider to loader options in test object provider

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -24,6 +24,7 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidModule } from '@fluidframework/container-definitions';
 import { IHostLoader } from '@fluidframework/container-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
+import { ILoaderProps } from '@fluidframework/container-loader';
 import { IProvideFluidCodeDetailsComparer } from '@fluidframework/core-interfaces';
 import { IProvideFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
 import { IProvideFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
@@ -103,7 +104,7 @@ export interface IProvideTestFluidObject {
 // @public (undocumented)
 export interface ITestContainerConfig {
     fluidDataObjectType?: DataObjectFactoryType;
-    loaderOptions?: ITestLoaderOptions;
+    loaderProps?: Partial<ILoaderProps>;
     registry?: ChannelFactoryRegistry;
     runtimeOptions?: IContainerRuntimeOptions;
 }
@@ -123,19 +124,13 @@ export interface ITestFluidObject extends IProvideTestFluidObject, IFluidLoadabl
 }
 
 // @public (undocumented)
-export interface ITestLoaderOptions extends ILoaderOptions {
-    // (undocumented)
-    logger?: ITelemetryBaseLogger;
-}
-
-// @public (undocumented)
 export interface ITestObjectProvider {
     // (undocumented)
-    createContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions): Promise<IContainer>;
+    createContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>): Promise<IContainer>;
     // (undocumented)
     createFluidEntryPoint: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint;
     // (undocumented)
-    createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, options?: ITestLoaderOptions, detachedBlobStorage?: IDetachedBlobStorage): IHostLoader;
+    createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, loaderProps?: Partial<ILoaderProps>, detachedBlobStorage?: IDetachedBlobStorage): IHostLoader;
     // (undocumented)
     defaultCodeDetails: IFluidCodeDetails;
     // (undocumented)
@@ -147,7 +142,7 @@ export interface ITestObjectProvider {
     // (undocumented)
     ensureSynchronized(): Promise<void>;
     // (undocumented)
-    loadContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions, requestHeader?: IRequestHeader): Promise<IContainer>;
+    loadContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)
     loadTestContainer(testContainerConfig?: ITestContainerConfig, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)
@@ -239,10 +234,10 @@ export class TestFluidObjectFactory implements IFluidDataStoreFactory {
 // @public
 export class TestObjectProvider {
     constructor(LoaderConstructor: typeof Loader, driver: ITestDriver, createFluidEntryPoint: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint);
-    createContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions): Promise<IContainer>;
+    createContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>): Promise<IContainer>;
     // (undocumented)
     readonly createFluidEntryPoint: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint;
-    createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, options?: ITestLoaderOptions, detachedBlobStorage?: IDetachedBlobStorage): Loader;
+    createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, loaderProps?: Partial<ILoaderProps>, detachedBlobStorage?: IDetachedBlobStorage): Loader;
     // (undocumented)
     get defaultCodeDetails(): IFluidCodeDetails;
     // (undocumented)
@@ -254,7 +249,7 @@ export class TestObjectProvider {
     // (undocumented)
     ensureSynchronized(): Promise<void>;
     // (undocumented)
-    loadContainer(entryPoint: fluidEntryPoint, options?: ITestLoaderOptions, requestHeader?: IRequestHeader): Promise<IContainer>;
+    loadContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)
     readonly LoaderConstructor: typeof Loader;
     loadTestContainer(testContainerConfig?: ITestContainerConfig, requestHeader?: IRequestHeader): Promise<IContainer>;

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -12,7 +12,7 @@ import { IDocumentServiceFactory, IResolvedUrl, IUrlResolver } from "@fluidframe
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { ITestDriver, TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { v4 as uuid } from "uuid";
-import { ChildLogger, MultiSinkLogger } from "@fluidframework/telemetry-utils";
+import { ChildLogger, IConfigProviderBase, MultiSinkLogger } from "@fluidframework/telemetry-utils";
 import { LoaderContainerTracker } from "./loaderContainerTracker";
 import { fluidEntryPoint, LocalCodeLoader } from "./localCodeLoader";
 import { createAndAttachContainer } from "./localLoader";
@@ -92,6 +92,7 @@ export interface ITestContainerConfig {
 // new interface to help inject custom loggers to tests
 export interface ITestLoaderOptions extends ILoaderOptions {
     logger?: ITelemetryBaseLogger;
+    configProvider?: IConfigProviderBase;
 }
 
 export const createDocumentId = (): string => uuid();
@@ -219,6 +220,7 @@ export class TestObjectProvider {
             documentServiceFactory: this.documentServiceFactory,
             codeLoader,
             logger: multiSinkLogger,
+            configProvider: options?.configProvider,
             options,
             detachedBlobStorage,
         });


### PR DESCRIPTION
Partly fixes https://github.com/microsoft/FluidFramework/issues/8861.

Replaced `ITestLoaderOptions` with `Partial<ILoaderProps>`. Tests that want to pass in configs can do so by passing in a config provider when creating / loader a container or when creating a loader.

Example usage of this can be seen in this PR - https://github.com/microsoft/FluidFramework/pull/8876