### PR TITLE
Convert Container and ContainerContext to use IQuorumClients where possible

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -30,7 +30,7 @@ import { ILoader } from '@fluidframework/container-definitions';
 import { ILoaderOptions as ILoaderOptions_2 } from '@fluidframework/container-definitions';
 import { IProvideFluidCodeDetailsComparer } from '@fluidframework/core-interfaces';
 import { IProxyLoaderFactory } from '@fluidframework/container-definitions';
-import { IQuorum } from '@fluidframework/protocol-definitions';
+import { IQuorumClients } from '@fluidframework/protocol-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResponse } from '@fluidframework/core-interfaces';
@@ -77,7 +77,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     // (undocumented)
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getLoadedCodeDetails(): IFluidCodeDetails | undefined;
-    getQuorum(): IQuorum;
+    getQuorum(): IQuorumClients;
     getSpecifiedCodeDetails(): IFluidCodeDetails | undefined;
     // (undocumented)
     get id(): string;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -64,24 +64,24 @@ import {
     ICommittedProposal,
     IDocumentAttributes,
     IDocumentMessage,
+    IPendingProposal,
     IProcessMessageResult,
-    IQuorum,
+    IQuorumClients,
+    IQuorumProposals,
     ISequencedClient,
     ISequencedDocumentMessage,
     ISequencedProposal,
     ISignalClient,
     ISignalMessage,
     ISnapshotTree,
+    ISummaryContent,
+    ISummaryTree,
     ITree,
     ITreeEntry,
     IVersion,
     MessageType,
-    TreeEntry,
-    ISummaryTree,
-    IPendingProposal,
     SummaryType,
-    ISummaryContent,
-    IQuorumProposals,
+    TreeEntry,
 } from "@fluidframework/protocol-definitions";
 import {
     ChildLogger,
@@ -692,7 +692,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     /**
      * Retrieves the quorum associated with the document
      */
-    public getQuorum(): IQuorum {
+    public getQuorum(): IQuorumClients {
         return this.protocolHandler.quorum;
     }
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -34,13 +34,14 @@ import {
     IClientDetails,
     IDocumentMessage,
     IQuorum,
+    IQuorumClients,
     ISequencedDocumentMessage,
     ISignalMessage,
     ISnapshotTree,
-    ITree,
-    MessageType,
     ISummaryTree,
+    ITree,
     IVersion,
+    MessageType,
 } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { assert, LazyPromise } from "@fluidframework/common-utils";
@@ -163,8 +164,7 @@ export class ContainerContext implements IContainerContext {
     public get codeDetails() { return this._codeDetails; }
 
     private readonly _quorum: IQuorum;
-    // Update to return IQuorumClients after 0.45 container definitions are picked up.
-    public get quorum(): IQuorum { return this._quorum; }
+    public get quorum(): IQuorumClients { return this._quorum; }
 
     private readonly _fluidModuleP: Promise<IFluidModuleWithDetails>;
 
@@ -195,6 +195,11 @@ export class ContainerContext implements IContainerContext {
         this.attachListener();
     }
 
+    /**
+     * @deprecated - Temporary migratory API, to be removed when customers no longer need it.  When removed,
+     * ContainerContext should only take an IQuorumClients rather than an IQuorum.  See IContainerContext for more
+     * details.
+     */
     public getSpecifiedCodeDetails(): IFluidCodeDetails | undefined {
         return (this._quorum.get("code") ?? this._quorum.get("code2")) as IFluidCodeDetails | undefined;
     }


### PR DESCRIPTION
Remaining usage of `IQuorum` by `ContainerContext` is required for `IContainerContext.getSpecifiedCodeDetails()`, so its removal can be tracked by that same issue and fixed at the same time.  That usage is fully private however, so this PR resolves #8044 