### PR TITLE
Remove tech debt for client session expired error

### DIFF
--- a/api-report/container-utils.api.md
+++ b/api-report/container-utils.api.md
@@ -17,7 +17,7 @@ import { LoggingError } from '@fluidframework/telemetry-utils';
 export class ClientSessionExpiredError extends LoggingError implements IFluidErrorBase {
     constructor(fluidErrorCode: string, expiryMs: number);
     // (undocumented)
-    readonly errorType = "clientSessionExpiredError";
+    readonly errorType = ContainerErrorType.clientSessionExpiredError;
     // (undocumented)
     readonly expiryMs: number;
     // (undocumented)

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -88,7 +88,7 @@ export class UsageError extends LoggingError implements IFluidErrorBase {
 
 /** Error indicating that a client's session has reached its time limit and is closed. */
 export class ClientSessionExpiredError extends LoggingError implements IFluidErrorBase {
-    readonly errorType = "clientSessionExpiredError";
+    readonly errorType = ContainerErrorType.clientSessionExpiredError;
 
     constructor(
         readonly fluidErrorCode: string,

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -315,7 +315,7 @@ export class GarbageCollector implements IGarbageCollector {
         if (this.sessionExpiryTimeoutMs !== undefined) {
             const expiryMs = this.sessionExpiryTimeoutMs;
             this.sessionExpiryTimer = setTimeout(() => this.closeFn(
-                new ClientSessionExpiredError(`Client session expired.`,expiryMs)), expiryMs);
+                new ClientSessionExpiredError(`Client session expired.`, expiryMs)), expiryMs);
         }
 
         // For existing document, the latest summary is the one that we loaded from. So, use its GC version as the

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -315,9 +315,7 @@ export class GarbageCollector implements IGarbageCollector {
         if (this.sessionExpiryTimeoutMs !== undefined) {
             const expiryMs = this.sessionExpiryTimeoutMs;
             this.sessionExpiryTimer = setTimeout(() => this.closeFn(
-                new ClientSessionExpiredError(`Client expired, it has lasted ${expiryMs} ms.`,
-                expiryMs)),
-                expiryMs);
+                new ClientSessionExpiredError(`Client session expired.`,expiryMs)), expiryMs);
         }
 
         // For existing document, the latest summary is the one that we loaded from. So, use its GC version as the

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -6,6 +6,7 @@
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, LazyPromise, Timer } from "@fluidframework/common-utils";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
+import { ClientSessionExpiredError } from "@fluidframework/container-utils";
 import {
     cloneGCData,
     concatGarbageCollectionStates,
@@ -312,15 +313,11 @@ export class GarbageCollector implements IGarbageCollector {
 
         // If session expiry is enabled, we need to close the container when the timeout expires
         if (this.sessionExpiryTimeoutMs !== undefined) {
-            // TODO: Change to ClientSessionExpiredError, issue https://github.com/microsoft/FluidFramework/issues/8605
-            // this.sessionExpiryTimer = setTimeout(() => this.closeFn(
-            //     new ClientSessionExpiredError(`Client expired, it has lasted ${this.sessionExpiryTimeoutMs} ms.`,
-            //     this.sessionExpiryTimeoutMs)),
-            //     this.sessionExpiryTimeoutMs);
-            this.sessionExpiryTimer = setTimeout(() => this.closeFn({
-                errorType: "clientSessionExpiredError",
-                message: `The client has reached the expiry time of ${this.sessionExpiryTimeoutMs} ms.`,
-            }), this.sessionExpiryTimeoutMs);
+            const expiryMs = this.sessionExpiryTimeoutMs;
+            this.sessionExpiryTimer = setTimeout(() => this.closeFn(
+                new ClientSessionExpiredError(`Client expired, it has lasted ${expiryMs} ms.`,
+                expiryMs)),
+                expiryMs);
         }
 
         // For existing document, the latest summary is the one that we loaded from. So, use its GC version as the


### PR DESCRIPTION
Resolves #8605 

This fixes the tech debt using ClientSessionExpiredError and update the error type to ContainerErrorType.clientSessionExpiredError