### PR TITLE
Increase timer to max and end it if container is saved in ConnectionStateHandler

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -629,6 +629,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.mc.logger,
         );
 
+        this.on("saved", () => {
+            this.connectionStateHandler.containerSaved();
+        });
+
         this._deltaManager = this.createDeltaManager();
         this._storage = new ContainerStorageAdapter(
             () => {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -629,7 +629,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.mc.logger,
         );
 
-        this.on("saved", () => {
+        this.on(savedContainerEvent, () => {
             this.connectionStateHandler.containerSaved();
         });
 

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -168,6 +168,40 @@ describe("ConnectionStateHandler Tests", () => {
             "Client 2 should now be in connected state");
     });
 
+    it("Should wait for Saved event before moving to conencted state if no leave received", async () => {
+        client.mode = "write";
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+        protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
+        connectionStateHandler.receivedAddMemberEvent(pendingClientId);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+            "Client should be in connected state");
+
+        shouldClientJoinWrite = true;
+        client.mode = "write";
+        // Disconnect the client
+        connectionStateHandler.receivedDisconnectEvent("Test");
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+            "Client should be in disconnected state");
+
+        // Make new client join so that it waits for previous client to leave
+        connectionDetails.clientId = "pendingClientId2";
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+        protocolHandler.quorum.addMember("pendingClientId2", { client, sequenceNumber: 0 });
+        connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+            "Client 2 should be in connecting state as we are waiting for timeout");
+
+        // Check state before timeout
+        await tickClock(expectedTimeout - 1);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+            "Client 2 should still be in connecting state as we are waiting for timeout");
+
+        // Fire the container saved event.
+        connectionStateHandler.containerSaved();
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+            "Client 2 should now be in connected state");
+    });
+
     it("Should wait for client 1 to leave before moving to conencted state(Client 3) when client 2 " +
         "got disconnected from connecting state", async () =>
     {
@@ -258,6 +292,58 @@ describe("ConnectionStateHandler Tests", () => {
             "Client 3 should still be in connecting state as timeout has not occured");
 
         await tickClock(1);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+            "Client 3 should move to connected state");
+        // Sending client 1 leave now should not cause any error
+        connectionStateHandler.receivedRemoveMemberEvent(pendingClientId);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+            "Client 3 should move to connected state");
+    });
+
+    it("Should wait for savedEvent before moving to conencted state(Client 3) when client 2 " +
+        "got disconnected from connecting state", async () =>
+    {
+        client.mode = "write";
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+        protocolHandler.quorum.addMember(pendingClientId, { client, sequenceNumber: 0 });
+        connectionStateHandler.receivedAddMemberEvent(pendingClientId);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
+            "Client 1 should be in connected state");
+
+        shouldClientJoinWrite = true;
+        client.mode = "write";
+        // Disconnect the client
+        connectionStateHandler.receivedDisconnectEvent("Test");
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+            "Client 1 should be in disconnected state");
+
+        // Make new client join but disconnect it from connecting state
+        connectionDetails.clientId = "pendingClientId2";
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+            "Client 2 should be in connecting state");
+        connectionStateHandler.receivedDisconnectEvent("Test");
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Disconnected,
+            "Client 2 should be in disconnected state");
+
+        // Make new client 3 join so that it waits for client 1 to leave
+        connectionDetails.clientId = "pendingClientId3";
+        connectionStateHandler.receivedConnectEvent(client.mode, connectionDetails);
+        protocolHandler.quorum.addMember("pendingClientId3", { client, sequenceNumber: 0 });
+        connectionStateHandler.receivedAddMemberEvent(connectionDetails.clientId);
+
+        // Send leave for client 2 and check that client 3 should not move to conencted state as we were waiting
+        // on client 1 leave.
+        connectionStateHandler.receivedRemoveMemberEvent("pendingClientId2");
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+            "Client 3 should still be in connecting state");
+
+        // Pass some time.
+        await tickClock(expectedTimeout - 1);
+        assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connecting,
+            "Client 3 should still be in connecting state as timeout has not occured");
+
+        connectionStateHandler.containerSaved();
         assert.strictEqual(connectionStateHandler.connectionState, ConnectionState.Connected,
             "Client 3 should move to connected state");
         // Sending client 1 leave now should not cause any error


### PR DESCRIPTION
Fixes: https://github.com/microsoft/FluidFramework/issues/8836
We got 1 instance where the timer timeout before leave op was received and we get into corruption state. Trying to increase the timer to 5 mins as it is the max time server wait to send leave op. We are now ending this timer in case the ops are already round tripped and saved event is fired as in that case we don't need to wait for leave op.