### PR TITLE
AttachLifecycle Tests: Split attach and dirty checks to avoid deadlock on tinylicious

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
@@ -40,6 +40,7 @@ describeFullCompat("Validate Attach lifecycle", (getTestObjectProvider) => {
         const provider  = getTestObjectProvider();
         switch(provider.driver.type){
             case "local":
+            case "tinylicious":
                 break;
             default:
                 this.skip();
@@ -128,8 +129,14 @@ describeFullCompat("Validate Attach lifecycle", (getTestObjectProvider) => {
                         await attachDds();
                     }
                 }
-                while(initContainer.isDirty 
-                    || initContainer.attachState !== AttachState.Attached){
+
+                while(initContainer.attachState !== AttachState.Attached){
+                    await timeoutPromise<void>(
+                        (resolve)=>initContainer.once("attached", ()=>resolve()),
+                        {durationMs: timeoutDurationMs, errorMsg:"container attach timeout"});
+                }
+
+                while(initContainer.isDirty){
                     await timeoutPromise<void>(
                         (resolve)=>initContainer.once("saved", ()=>resolve()),
                         {durationMs: timeoutDurationMs, errorMsg:"final save timeout"});


### PR DESCRIPTION
In putting together the issue for this i happened across the fix. The save loop was too tight which lead to basically a synchronous busy wait that blocked the container from reaching the attached state. splitting attached check and ditry check fixes it.

fixes: #8889