### PR TITLE
Put fetchReason in XRequestStats

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -171,8 +171,9 @@ export class EpochTracker implements IPersistedFileCache {
         fetchOptions: RequestInit,
         fetchType: FetchType,
         addInBody: boolean = false,
+        fetchReason?: string,
     ): Promise<IOdspResponse<T>> {
-        const clientCorrelationId = this.formatClientCorrelationId();
+        const clientCorrelationId = this.formatClientCorrelationId(fetchReason);
         // Add epoch in fetch request.
         this.addEpochInRequest(fetchOptions, addInBody, clientCorrelationId);
         let epochFromResponse: string | undefined;
@@ -212,8 +213,9 @@ export class EpochTracker implements IPersistedFileCache {
         fetchOptions: {[index: string]: any},
         fetchType: FetchType,
         addInBody: boolean = false,
+        fetchReason?: string,
     ) {
-        const clientCorrelationId = this.formatClientCorrelationId();
+        const clientCorrelationId = this.formatClientCorrelationId(fetchReason);
         // Add epoch in fetch request.
         this.addEpochInRequest(fetchOptions, addInBody, clientCorrelationId);
         let epochFromResponse: string | undefined;
@@ -293,8 +295,12 @@ export class EpochTracker implements IPersistedFileCache {
         fetchOptions.body = formParams.join("\r\n");
     }
 
-    private formatClientCorrelationId() {
-        return `driverId=${this.driverId}, RequestNumber=${this.networkCallNumber++}`;
+    private formatClientCorrelationId(fetchReason?: string) {
+        let clientCorrelationId = `driverId=${this.driverId}, RequestNumber=${this.networkCallNumber++}`;
+        if (fetchReason !== undefined) {
+            clientCorrelationId += `, fetchReason=${fetchReason}`;
+        }
+        return clientCorrelationId;
     }
 
     protected validateEpochFromResponse(

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -296,11 +296,11 @@ export class EpochTracker implements IPersistedFileCache {
     }
 
     private formatClientCorrelationId(fetchReason?: string) {
-        let clientCorrelationId = `driverId=${this.driverId}, RequestNumber=${this.networkCallNumber++}`;
+        const items: string[] = [`driverId=${this.driverId}`, `RequestNumber=${this.networkCallNumber++}`];
         if (fetchReason !== undefined) {
-            clientCorrelationId += `, fetchReason=${fetchReason}`;
+            items.push(`fetchReason=${fetchReason}`);
         }
-        return clientCorrelationId;
+        return items.join(", ");
     }
 
     protected validateEpochFromResponse(

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -409,13 +409,14 @@ export class EpochTrackerWithRedemption extends EpochTracker {
         fetchOptions: {[index: string]: any},
         fetchType: FetchType,
         addInBody: boolean = false,
+        fetchReason?: string,
     ): Promise<IOdspResponse<T>> {
         // Optimize the flow if we know that treesLatestDeferral was already completed by the timer we started
         // joinSession call. If we did - there is no reason to repeat the call as it will fail with same error.
         const completed = this.treesLatestDeferral.isCompleted;
 
         try {
-            return await super.fetchAndParseAsJSON<T>(url, fetchOptions, fetchType, addInBody);
+            return await super.fetchAndParseAsJSON<T>(url, fetchOptions, fetchType, addInBody, fetchReason);
         } catch (error) {
             // Only handling here treesLatest. If createFile failed, we should never try to do joinSession.
             // Similar, if getVersions failed, we should not do any further storage calls.

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -53,9 +53,6 @@ export class OdspDeltaStorageService {
             let postBody = `--${formBoundary}\r\n`;
             postBody += `Authorization: Bearer ${storageToken}\r\n`;
             postBody += `X-HTTP-Method-Override: GET\r\n`;
-            if (fetchReason !== undefined) {
-                postBody += `fetchReason: ${fetchReason}\r\n`;
-            }
 
             postBody += `_post: 1\r\n`;
             postBody += `\r\n--${formBoundary}--`;
@@ -81,6 +78,7 @@ export class OdspDeltaStorageService {
                 },
                 "ops",
                 true,
+                fetchReason,
             );
             clearTimeout(timer);
             const deltaStorageResponse = response.content;


### PR DESCRIPTION
This is request from odsp server folks. @HammondPang.
It is easier to collect it from the X-RequestStats on server and pass to different places as XRequestStats is already processed on server rather than reading it as an individual header in post body. So moving it to epoch tracker. 