### PR TITLE
remove `containerPath` from `checkUrl()`

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -381,9 +381,9 @@
       "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.44.0-49064",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
-      "integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
+      "version": "0.44.0-49707",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49707.tgz",
+      "integrity": "sha512-OqhNg2IIep5k2qKZ8oQcVi3ut9icPjtaZewNljtK5g81YonHrwv7V/n2fYiW4hetyMvSg9vuy3dr39Q6gDBT+w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2583,9 +2583,9 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.44.0-49064",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
-			"integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
+			"version": "0.44.0-49707",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49707.tgz",
+			"integrity": "sha512-OqhNg2IIep5k2qKZ8oQcVi3ut9icPjtaZewNljtK5g81YonHrwv7V/n2fYiW4hetyMvSg9vuy3dr39Q6gDBT+w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/drivers/odsp-driver/src/checkUrl.ts
+++ b/packages/drivers/odsp-driver/src/checkUrl.ts
@@ -27,7 +27,6 @@ export function checkUrl(documentUrl: URL): DriverPreCheckInfo | undefined {
   } catch {}
 
   return {
-    containerPath: locator.dataStorePath,
     codeDetailsHint: locator?.containerPackageName,
     // Add the snapshot endpoint, which has the same domain as the site URL
     criticalBootDomains: siteOrigin ? [siteOrigin] : undefined,

--- a/packages/runtime/container-runtime-definitions/package-lock.json
+++ b/packages/runtime/container-runtime-definitions/package-lock.json
@@ -150,26 +150,14 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
-      "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+      "version": "0.45.0-49378",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0-49378.tgz",
+      "integrity": "sha512-IzKCtFGWHwyiXx+W695nyMvRtXMfG5znd6IJWo1vHpHmVyCrDr9vP++yGN+n6+V6oa84HXvLaXgIJmHYwhDfoA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.43.0",
+        "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
-      },
-      "dependencies": {
-        "@fluidframework/driver-definitions": {
-          "version": "0.43.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.0",
-            "@fluidframework/core-interfaces": "^0.41.0",
-            "@fluidframework/protocol-definitions": "^0.1026.0"
-          }
-        }
       }
     },
     "@fluidframework/container-runtime-definitions-0.51.1": {
@@ -385,6 +373,18 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -428,6 +428,18 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -462,9 +474,9 @@
       "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.44.0-49064",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
-      "integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
+      "version": "0.44.0-49707",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49707.tgz",
+      "integrity": "sha512-OqhNg2IIep5k2qKZ8oQcVi3ut9icPjtaZewNljtK5g81YonHrwv7V/n2fYiW4hetyMvSg9vuy3dr39Q6gDBT+w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
@@ -503,9 +515,9 @@
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^0.44.0",
+        "@fluidframework/container-definitions": "^0.45.0-0",
         "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.44.0-0",
+        "@fluidframework/driver-definitions": "0.44.0-49707",
         "@fluidframework/protocol-definitions": "^0.1026.0",
         "@types/node": "^14.18.0"
       },
@@ -621,6 +633,18 @@
             "@fluidframework/core-interfaces": "^0.41.0",
             "@fluidframework/driver-definitions": "^0.43.0",
             "@fluidframework/protocol-definitions": "^0.1026.0"
+          },
+          "dependencies": {
+            "@fluidframework/driver-definitions": {
+              "version": "0.43.0",
+              "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+              "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+              "requires": {
+                "@fluidframework/common-definitions": "^0.20.0",
+                "@fluidframework/core-interfaces": "^0.41.0",
+                "@fluidframework/protocol-definitions": "^0.1026.0"
+              }
+            }
           }
         },
         "@fluidframework/core-interfaces": {
@@ -629,9 +653,9 @@
           "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
         },
         "@fluidframework/driver-definitions": {
-          "version": "0.43.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "version": "0.44.0-49707",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49707.tgz",
+          "integrity": "sha512-OqhNg2IIep5k2qKZ8oQcVi3ut9icPjtaZewNljtK5g81YonHrwv7V/n2fYiW4hetyMvSg9vuy3dr39Q6gDBT+w==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.0",
             "@fluidframework/core-interfaces": "^0.41.0",

--- a/packages/runtime/runtime-definitions/package-lock.json
+++ b/packages/runtime/runtime-definitions/package-lock.json
@@ -149,26 +149,14 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
-      "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+      "version": "0.45.0-49378",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0-49378.tgz",
+      "integrity": "sha512-IzKCtFGWHwyiXx+W695nyMvRtXMfG5znd6IJWo1vHpHmVyCrDr9vP++yGN+n6+V6oa84HXvLaXgIJmHYwhDfoA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.43.0",
+        "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
-      },
-      "dependencies": {
-        "@fluidframework/driver-definitions": {
-          "version": "0.43.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.0",
-            "@fluidframework/core-interfaces": "^0.41.0",
-            "@fluidframework/protocol-definitions": "^0.1026.0"
-          }
-        }
       }
     },
     "@fluidframework/core-interfaces": {
@@ -177,9 +165,9 @@
       "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.44.0-49064",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
-      "integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
+      "version": "0.44.0-49707",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49707.tgz",
+      "integrity": "sha512-OqhNg2IIep5k2qKZ8oQcVi3ut9icPjtaZewNljtK5g81YonHrwv7V/n2fYiW4hetyMvSg9vuy3dr39Q6gDBT+w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
@@ -381,6 +369,18 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -409,6 +409,18 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",


### PR DESCRIPTION
This PR uses the pre-release version of `driver-definitions` (https://github.com/microsoft/FluidFramework/pull/8827) to remove the `containerPath` property from `checkUrl()` in `odsp-driver`.

There are no remaining dependencies to this property in either FF or partner repos.

Closes #8548