### PR TITLE
Bump core-interfaces dependency version in common

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -312,6 +312,12 @@
         "@fluidframework/protocol-definitions": "^0.1026.0"
       },
       "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.42.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -337,6 +343,12 @@
         "@fluidframework/protocol-definitions": "^0.1026.0"
       },
       "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -362,6 +374,12 @@
         "@fluidframework/protocol-definitions": "^0.1026.0"
       },
       "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -376,9 +394,9 @@
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
-      "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+      "version": "0.42.0-49742",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+      "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
     },
     "@fluidframework/driver-definitions": {
       "version": "0.44.0-49064",
@@ -388,6 +406,13 @@
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+        }
       }
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0"
   },
@@ -297,10 +297,12 @@
           "backCompat": false
         },
         "InterfaceDeclaration_ICodeLoader": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidModule": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.43.0": {
@@ -341,16 +343,20 @@
           "forwardCompat": false
         },
         "InterfaceDeclaration_ICodeDetailsLoader": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_ICodeLoader": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidModule": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidModuleWithDetails": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IProvideRuntimeFactory": {
           "backCompat": false,
@@ -366,10 +372,12 @@
           "backCompat": false
         },
         "InterfaceDeclaration_ICodeDetailsLoader": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_ICodeLoader": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IContainer": {
           "backCompat": false,
@@ -380,10 +388,12 @@
           "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidModule": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidModuleWithDetails": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IGenericError": {
           "backCompat": false

--- a/common/lib/container-definitions/src/test/types/validate0.42.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.42.0.ts
@@ -164,6 +164,7 @@ declare function get_old_InterfaceDeclaration_ICodeLoader():
 declare function use_current_InterfaceDeclaration_ICodeLoader(
     use: current.ICodeLoader);
 use_current_InterfaceDeclaration_ICodeLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICodeLoader());
 
 /*
@@ -603,6 +604,7 @@ declare function get_old_InterfaceDeclaration_IFluidModule():
 declare function use_current_InterfaceDeclaration_IFluidModule(
     use: current.IFluidModule);
 use_current_InterfaceDeclaration_IFluidModule(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidModule());
 
 /*

--- a/common/lib/container-definitions/src/test/types/validate0.43.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.43.0.ts
@@ -260,6 +260,7 @@ declare function get_old_InterfaceDeclaration_ICodeDetailsLoader():
 declare function use_current_InterfaceDeclaration_ICodeDetailsLoader(
     use: current.ICodeDetailsLoader);
 use_current_InterfaceDeclaration_ICodeDetailsLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICodeDetailsLoader());
 
 /*
@@ -285,6 +286,7 @@ declare function get_old_InterfaceDeclaration_ICodeLoader():
 declare function use_current_InterfaceDeclaration_ICodeLoader(
     use: current.ICodeLoader);
 use_current_InterfaceDeclaration_ICodeLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICodeLoader());
 
 /*
@@ -818,6 +820,7 @@ declare function get_old_InterfaceDeclaration_IFluidModule():
 declare function use_current_InterfaceDeclaration_IFluidModule(
     use: current.IFluidModule);
 use_current_InterfaceDeclaration_IFluidModule(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidModule());
 
 /*
@@ -843,6 +846,7 @@ declare function get_old_InterfaceDeclaration_IFluidModuleWithDetails():
 declare function use_current_InterfaceDeclaration_IFluidModuleWithDetails(
     use: current.IFluidModuleWithDetails);
 use_current_InterfaceDeclaration_IFluidModuleWithDetails(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidModuleWithDetails());
 
 /*

--- a/common/lib/container-definitions/src/test/types/validate0.44.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.44.0.ts
@@ -260,6 +260,7 @@ declare function get_old_InterfaceDeclaration_ICodeDetailsLoader():
 declare function use_current_InterfaceDeclaration_ICodeDetailsLoader(
     use: current.ICodeDetailsLoader);
 use_current_InterfaceDeclaration_ICodeDetailsLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICodeDetailsLoader());
 
 /*
@@ -285,6 +286,7 @@ declare function get_old_InterfaceDeclaration_ICodeLoader():
 declare function use_current_InterfaceDeclaration_ICodeLoader(
     use: current.ICodeLoader);
 use_current_InterfaceDeclaration_ICodeLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICodeLoader());
 
 /*
@@ -818,6 +820,7 @@ declare function get_old_InterfaceDeclaration_IFluidModule():
 declare function use_current_InterfaceDeclaration_IFluidModule(
     use: current.IFluidModule);
 use_current_InterfaceDeclaration_IFluidModule(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidModule());
 
 /*
@@ -843,6 +846,7 @@ declare function get_old_InterfaceDeclaration_IFluidModuleWithDetails():
 declare function use_current_InterfaceDeclaration_IFluidModuleWithDetails(
     use: current.IFluidModuleWithDetails);
 use_current_InterfaceDeclaration_IFluidModuleWithDetails(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidModuleWithDetails());
 
 /*

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -181,9 +181,9 @@
       "integrity": "sha512-seE/EADKV2cu4YZ9MuueCT/3t8Y4ehtVPow0yJyhy53r/OIB41/8G8tTH/sPVbIq1OhqKBPpvseotK67HrqU6A=="
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
-      "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+      "version": "0.42.0-49742",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+      "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
     },
     "@fluidframework/driver-definitions-0.39.8": {
       "version": "npm:@fluidframework/driver-definitions@0.39.8",
@@ -278,6 +278,14 @@
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        }
       }
     },
     "@fluidframework/driver-definitions-0.43.0": {
@@ -289,6 +297,14 @@
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        }
       }
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Compat tests were failing from anticipated changes to IFluidModule (#8302) which should be fine AFAICT.