### PR TITLE
Updated data store creation properties to be an object

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -120,6 +120,36 @@ interface FluidDataStoreMessage {
     type: string;
 }
 
+/** Properties necessary for creating a FluidDataStoreContext */
+export interface IFluidDataStoreContextProps {
+    readonly id: string;
+    readonly runtime: ContainerRuntime;
+    readonly storage: IDocumentStorageService;
+    readonly scope: FluidObject;
+    readonly createSummarizerNodeFn: CreateChildSummarizerNodeFn;
+    readonly writeGCDataAtRoot: boolean;
+    readonly disableIsolatedChannels: boolean;
+    readonly pkg?: Readonly<string[]>;
+}
+
+/** Properties necessary for creating a local FluidDataStoreContext */
+export interface ILocalFluidDataStoreContextProps extends IFluidDataStoreContextProps {
+    readonly pkg: Readonly<string[]> | undefined;
+    readonly snapshotTree: ISnapshotTree | undefined;
+    readonly isRootDataStore: boolean | undefined;
+    readonly bindChannelFn: (channel: IFluidDataStoreChannel) => void;
+    /**
+     * @deprecated 0.16 Issue #1635, #3631
+     */
+    readonly createProps?: any;
+}
+
+/** Properties necessary for creating a remote FluidDataStoreContext */
+export interface IRemoteFluidDataStoreContextProps extends IFluidDataStoreContextProps {
+    readonly snapshotTree: ISnapshotTree | string | undefined;
+    readonly getBaseGCDetails: () => Promise<IGarbageCollectionDetailsBase | undefined>;
+}
+
 /**
  * Represents the context for the store. This context is passed to the store runtime.
  */
@@ -186,10 +216,6 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         return (await this.getInitialSnapshotDetails()).isRootDataStore;
     }
 
-    protected get disableIsolatedChannels(): boolean {
-        return this._containerRuntime.disableIsolatedChannels;
-    }
-
     protected registry: IFluidDataStoreRegistry | undefined;
 
     protected detachedRuntimeCreation = false;
@@ -209,24 +235,34 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     // if it realizes after GC is run.
     private lastUsedState: { usedRoutes: string[], gcTimestamp?: number } | undefined;
 
+    public readonly id: string;
+    private readonly _containerRuntime: ContainerRuntime;
+    public readonly storage: IDocumentStorageService;
+    public readonly scope: FluidObject;
+    private readonly writeGCDataAtRoot: boolean;
+    protected readonly disableIsolatedChannels: boolean;
+    protected pkg?: readonly string[];
+
     constructor(
-        private readonly _containerRuntime: ContainerRuntime,
-        public readonly id: string,
+        props: IFluidDataStoreContextProps,
         private readonly existing: boolean,
-        public readonly storage: IDocumentStorageService,
-        public readonly scope: FluidObject | FluidObject,
-        createSummarizerNode: CreateChildSummarizerNodeFn,
         private bindState: BindState,
         public readonly isLocalDataStore: boolean,
-        bindChannel: (channel: IFluidDataStoreChannel) => void,
-        private writeGCDataAtRoot: boolean,
-        protected pkg?: readonly string[],
+        bindChannelFn: (channel: IFluidDataStoreChannel) => void,
     ) {
         super();
 
+        this._containerRuntime = props.runtime;
+        this.id = props.id;
+        this.storage = props.storage;
+        this.scope = props.scope;
+        this.writeGCDataAtRoot = props.writeGCDataAtRoot;
+        this.disableIsolatedChannels = props.disableIsolatedChannels;
+        this.pkg = props.pkg;
+
         // URIs use slashes as delimiters. Handles use URIs.
         // Thus having slashes in types almost guarantees trouble down the road!
-        assert(id.indexOf("/") === -1, 0x13a /* `Data store ID contains slash: ${id}` */);
+        assert(this.id.indexOf("/") === -1, 0x13a /* `Data store ID contains slash: ${id}` */);
 
         this._attachState = this.containerRuntime.attachState !== AttachState.Detached && this.existing ?
             this.containerRuntime.attachState : AttachState.Detached;
@@ -235,14 +271,14 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
             assert(this.bindState === BindState.NotBound, 0x13b /* "datastore context is already in bound state" */);
             this.bindState = BindState.Binding;
             assert(this.channel !== undefined, 0x13c /* "undefined channel on datastore context" */);
-            bindChannel(this.channel);
+            bindChannelFn(this.channel);
             this.bindState = BindState.Bound;
         };
 
         const thisSummarizeInternal =
             async (fullTree: boolean, trackState: boolean) => this.summarizeInternal(fullTree, trackState);
 
-        this.summarizerNode = createSummarizerNode(
+        this.summarizerNode = props.createSummarizerNodeFn(
             thisSummarizeInternal,
             async (fullGC?: boolean) => this.getGCDataInternal(fullGC),
             async () => this.getBaseGCDetails(),
@@ -698,39 +734,25 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     }
 }
 
-export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
+export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
     private isRootDataStore: boolean | undefined;
+    private readonly initSnapshotValue: ISnapshotTree | string | undefined;
     private readonly baseGCDetailsP: Promise<IGarbageCollectionDetailsBase>;
 
-    constructor(
-        id: string,
-        private readonly initSnapshotValue: ISnapshotTree | string | undefined,
-        getBaseGCDetails: () => Promise<IGarbageCollectionDetailsBase | undefined>,
-        runtime: ContainerRuntime,
-        storage: IDocumentStorageService,
-        scope: FluidObject,
-        createSummarizerNode: CreateChildSummarizerNodeFn,
-        writeGCDataAtRoot: boolean,
-        pkg?: string[],
-    ) {
+    constructor(props: IRemoteFluidDataStoreContextProps) {
         super(
-            runtime,
-            id,
-            true,
-            storage,
-            scope,
-            createSummarizerNode,
+            props,
+            true /* existing */,
             BindState.Bound,
-            false,
+            false /* isLocalDataStore */,
             () => {
                 throw new Error("Already attached");
             },
-            writeGCDataAtRoot,
-            pkg,
         );
 
+        this.initSnapshotValue = props.snapshotTree;
         this.baseGCDetailsP = new LazyPromise<IGarbageCollectionDetailsBase>(async () => {
-            return (await getBaseGCDetails()) ?? {};
+            return (await props.getBaseGCDetails()) ?? {};
         });
     }
 
@@ -829,34 +851,20 @@ export class RemotedFluidDataStoreContext extends FluidDataStoreContext {
  * Base class for detached & attached context classes
  */
 export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
-    constructor(
-        id: string,
-        pkg: Readonly<string[]> | undefined,
-        runtime: ContainerRuntime,
-        storage: IDocumentStorageService,
-        scope: FluidObject,
-        createSummarizerNode: CreateChildSummarizerNodeFn,
-        bindChannel: (channel: IFluidDataStoreChannel) => void,
-        private readonly snapshotTree: ISnapshotTree | undefined,
-        protected isRootDataStore: boolean | undefined,
-        writeGCDataAtRoot: boolean,
-        /**
-         * @deprecated 0.16 Issue #1635, #3631
-         */
-        public readonly createProps?: any,
-    ) {
+    private readonly snapshotTree: ISnapshotTree | undefined;
+    protected isRootDataStore: boolean | undefined;
+
+    constructor(props: ILocalFluidDataStoreContextProps) {
         super(
-            runtime,
-            id,
-            snapshotTree !== undefined ? true : false,
-            storage,
-            scope,
-            createSummarizerNode,
-            snapshotTree ? BindState.Bound : BindState.NotBound,
-            true,
-            bindChannel,
-            writeGCDataAtRoot,
-            pkg);
+            props,
+            props.snapshotTree !== undefined ? true : false /* existing */,
+            props.snapshotTree ? BindState.Bound : BindState.NotBound,
+            true /* isLocalDataStore */,
+            props.bindChannelFn,
+        );
+
+        this.snapshotTree = props.snapshotTree;
+        this.isRootDataStore = props.isRootDataStore;
         this.attachListeners();
     }
 
@@ -965,34 +973,8 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
  * Runtime is created using data store factory that is associated with this context.
  */
 export class LocalFluidDataStoreContext extends LocalFluidDataStoreContextBase {
-    constructor(
-        id: string,
-        pkg: string[] | undefined,
-        runtime: ContainerRuntime,
-        storage: IDocumentStorageService,
-        scope: FluidObject & FluidObject,
-        createSummarizerNode: CreateChildSummarizerNodeFn,
-        bindChannel: (channel: IFluidDataStoreChannel) => void,
-        snapshotTree: ISnapshotTree | undefined,
-        isRootDataStore: boolean | undefined,
-        writeGCDataAtRoot: boolean,
-        /**
-         * @deprecated 0.16 Issue #1635, #3631
-         */
-        createProps?: any,
-    ) {
-        super(
-            id,
-            pkg,
-            runtime,
-            storage,
-            scope,
-            createSummarizerNode,
-            bindChannel,
-            snapshotTree,
-            isRootDataStore,
-            writeGCDataAtRoot,
-            createProps);
+    constructor(props: ILocalFluidDataStoreContextProps) {
+        super(props);
     }
 }
 
@@ -1006,29 +988,8 @@ export class LocalDetachedFluidDataStoreContext
     extends LocalFluidDataStoreContextBase
     implements IFluidDataStoreContextDetached
 {
-    constructor(
-        id: string,
-        pkg: Readonly<string[]>,
-        runtime: ContainerRuntime,
-        storage: IDocumentStorageService,
-        scope: FluidObject & FluidObject,
-        createSummarizerNode: CreateChildSummarizerNodeFn,
-        bindChannel: (channel: IFluidDataStoreChannel) => void,
-        isRootDataStore: boolean,
-        writeGCDataAtRoot: boolean,
-    ) {
-        super(
-            id,
-            pkg,
-            runtime,
-            storage,
-            scope,
-            createSummarizerNode,
-            bindChannel,
-            undefined,
-            isRootDataStore,
-            writeGCDataAtRoot,
-        );
+    constructor(props: ILocalFluidDataStoreContextProps) {
+        super(props);
         this.detachedRuntimeCreation = true;
     }
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -44,7 +44,7 @@ import { DataStoreContexts } from "./dataStoreContexts";
 import { ContainerRuntime } from "./containerRuntime";
 import {
     FluidDataStoreContext,
-    RemotedFluidDataStoreContext,
+    RemoteFluidDataStoreContext,
     LocalFluidDataStoreContext,
     createAttributesBlob,
     LocalDetachedFluidDataStoreContext,
@@ -151,33 +151,41 @@ export class DataStores implements IDisposable {
             }
             // If we have a detached container, then create local data store contexts.
             if (this.runtime.attachState !== AttachState.Detached) {
-                dataStoreContext = new RemotedFluidDataStoreContext(
-                    key,
-                    value,
-                    async () => dataStoreBaseGCDetails(key),
-                    this.runtime,
-                    this.runtime.storage,
-                    this.runtime.scope,
-                    this.getCreateChildSummarizerNodeFn(key, { type: CreateSummarizerNodeSource.FromSummary }),
-                    this.writeGCDataAtRoot,
-                );
+                dataStoreContext = new RemoteFluidDataStoreContext({
+                    id: key,
+                    snapshotTree: value,
+                    getBaseGCDetails: async () => dataStoreBaseGCDetails(key),
+                    runtime: this.runtime,
+                    storage: this.runtime.storage,
+                    scope: this.runtime.scope,
+                    createSummarizerNodeFn: this.getCreateChildSummarizerNodeFn(
+                        key,
+                        { type: CreateSummarizerNodeSource.FromSummary },
+                    ),
+                    writeGCDataAtRoot: this.writeGCDataAtRoot,
+                    disableIsolatedChannels: this.runtime.disableIsolatedChannels,
+                });
             } else {
                 if (typeof value !== "object") {
                     throw new Error("Snapshot should be there to load from!!");
                 }
                 const snapshotTree = value;
-                dataStoreContext = new LocalFluidDataStoreContext(
-                    key,
-                    undefined,
-                    this.runtime,
-                    this.runtime.storage,
-                    this.runtime.scope,
-                    this.getCreateChildSummarizerNodeFn(key, { type: CreateSummarizerNodeSource.FromSummary }),
-                    (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
+                dataStoreContext = new LocalFluidDataStoreContext({
+                    id: key,
+                    pkg: undefined,
+                    runtime: this.runtime,
+                    storage: this.runtime.storage,
+                    scope: this.runtime.scope,
+                    createSummarizerNodeFn: this.getCreateChildSummarizerNodeFn(
+                        key,
+                        { type: CreateSummarizerNodeSource.FromSummary },
+                    ),
+                    bindChannelFn: (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
                     snapshotTree,
-                    undefined,
-                    this.writeGCDataAtRoot,
-                );
+                    isRootDataStore: undefined,
+                    writeGCDataAtRoot: this.writeGCDataAtRoot,
+                    disableIsolatedChannels: this.runtime.disableIsolatedChannels,
+                });
             }
             this.contexts.addBoundOrRemoted(dataStoreContext);
         }
@@ -228,17 +236,17 @@ export class DataStores implements IDisposable {
         }
 
         // Include the type of attach message which is the pkg of the store to be
-        // used by RemotedFluidDataStoreContext in case it is not in the snapshot.
+        // used by RemoteFluidDataStoreContext in case it is not in the snapshot.
         const pkg = [attachMessage.type];
-        const remotedFluidDataStoreContext = new RemotedFluidDataStoreContext(
-            attachMessage.id,
+        const remoteFluidDataStoreContext = new RemoteFluidDataStoreContext({
+            id: attachMessage.id,
             snapshotTree,
             // New data stores begin with empty GC details since GC hasn't run on them yet.
-            async () => { return {}; },
-            this.runtime,
-            new BlobCacheStorageService(this.runtime.storage, flatBlobs),
-            this.runtime.scope,
-            this.getCreateChildSummarizerNodeFn(
+            getBaseGCDetails: async () => { return {}; },
+            runtime: this.runtime,
+            storage: new BlobCacheStorageService(this.runtime.storage, flatBlobs),
+            scope: this.runtime.scope,
+            createSummarizerNodeFn: this.getCreateChildSummarizerNodeFn(
                 attachMessage.id,
                 {
                     type: CreateSummarizerNodeSource.FromAttach,
@@ -250,12 +258,14 @@ export class DataStores implements IDisposable {
                             this.runtime.disableIsolatedChannels,
                         )],
                     },
-                }),
-            this.writeGCDataAtRoot,
+                },
+            ),
+            writeGCDataAtRoot: this.writeGCDataAtRoot,
+            disableIsolatedChannels: this.runtime.disableIsolatedChannels,
             pkg,
-        );
+        });
 
-        this.contexts.addBoundOrRemoted(remotedFluidDataStoreContext);
+        this.contexts.addBoundOrRemoted(remoteFluidDataStoreContext);
     }
 
     public processAliasMessage(
@@ -328,35 +338,44 @@ export class DataStores implements IDisposable {
         isRoot: boolean,
         id = uuid()): IFluidDataStoreContextDetached
     {
-        const context = new LocalDetachedFluidDataStoreContext(
+        const context = new LocalDetachedFluidDataStoreContext({
             id,
             pkg,
-            this.runtime,
-            this.runtime.storage,
-            this.runtime.scope,
-            this.getCreateChildSummarizerNodeFn(id, { type: CreateSummarizerNodeSource.Local }),
-            (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
-            isRoot,
-            this.writeGCDataAtRoot,
-        );
+            runtime: this.runtime,
+            storage: this.runtime.storage,
+            scope: this.runtime.scope,
+            createSummarizerNodeFn: this.getCreateChildSummarizerNodeFn(
+                id,
+                { type: CreateSummarizerNodeSource.Local },
+            ),
+            bindChannelFn: (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
+            snapshotTree: undefined,
+            isRootDataStore: isRoot,
+            writeGCDataAtRoot: this.writeGCDataAtRoot,
+            disableIsolatedChannels: this.runtime.disableIsolatedChannels,
+        });
         this.contexts.addUnbound(context);
         return context;
     }
 
     public _createFluidDataStoreContext(pkg: string[], id: string, isRoot: boolean, props?: any) {
-        const context = new LocalFluidDataStoreContext(
+        const context = new LocalFluidDataStoreContext({
             id,
             pkg,
-            this.runtime,
-            this.runtime.storage,
-            this.runtime.scope,
-            this.getCreateChildSummarizerNodeFn(id, { type: CreateSummarizerNodeSource.Local }),
-            (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
-            undefined,
-            isRoot,
-            this.writeGCDataAtRoot,
-            props,
-        );
+            runtime: this.runtime,
+            storage: this.runtime.storage,
+            scope: this.runtime.scope,
+            createSummarizerNodeFn: this.getCreateChildSummarizerNodeFn(
+                id,
+                { type: CreateSummarizerNodeSource.Local },
+            ),
+            bindChannelFn: (cr: IFluidDataStoreChannel) => this.bindFluidDataStore(cr),
+            snapshotTree: undefined,
+            isRootDataStore: isRoot,
+            writeGCDataAtRoot: this.writeGCDataAtRoot,
+            disableIsolatedChannels: this.runtime.disableIsolatedChannels,
+            createProps: props,
+        });
         this.contexts.addUnbound(context);
         return context;
     }

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -30,7 +30,7 @@ import { createRootSummarizerNodeWithGC, IRootSummarizerNodeWithGC } from "@flui
 import { stringToBuffer, TelemetryNullLogger } from "@fluidframework/common-utils";
 import {
     LocalFluidDataStoreContext,
-    RemotedFluidDataStoreContext,
+    RemoteFluidDataStoreContext,
 } from "../dataStoreContext";
 import { ContainerRuntime } from "../containerRuntime";
 import {
@@ -83,7 +83,6 @@ describe("Data Store Context Tests", () => {
                 get IFluidDataStoreRegistry() { return registry; },
                 get: async (pkg) => Promise.resolve(factory),
             };
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             containerRuntime = {
                 IFluidDataStoreRegistry: registry,
                 on: (event, listener) => { },
@@ -93,18 +92,19 @@ describe("Data Store Context Tests", () => {
 
         describe("Initialization", () => {
             it("can initialize correctly and generate attributes", async () => {
-                localDataStoreContext = new LocalFluidDataStoreContext(
-                    dataStoreId,
-                    ["TestDataStore1"],
-                    containerRuntime,
+                localDataStoreContext = new LocalFluidDataStoreContext({
+                    id: dataStoreId,
+                    pkg: ["TestDataStore1"],
+                    runtime: containerRuntime,
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    attachCb,
-                    undefined,
-                    true /* isRootDataStore */,
-                    true /* writeGCDataAtRoot */,
-                );
+                    bindChannelFn: attachCb,
+                    snapshotTree: undefined,
+                    isRootDataStore: true,
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 await localDataStoreContext.realize();
                 const attachMessage = localDataStoreContext.generateAttachMessage();
@@ -134,17 +134,19 @@ describe("Data Store Context Tests", () => {
 
             it("should generate exception when incorrectly created with array of packages", async () => {
                 let exception = false;
-                localDataStoreContext = new LocalFluidDataStoreContext(
-                    dataStoreId,
-                    ["TestComp", "SubComp"],
-                    containerRuntime,
-                    storage,
-                    scope,
-                    createSummarizerNodeFn,
-                    attachCb,
-                    undefined,
-                    false /* isRootDataStore */,
-                    true /* writeGCDataAtRoot */,
+                localDataStoreContext = new LocalFluidDataStoreContext({
+                        id: dataStoreId,
+                        pkg: ["TestComp", "SubComp"],
+                        runtime: containerRuntime,
+                        storage,
+                        scope,
+                        createSummarizerNodeFn,
+                        bindChannelFn: attachCb,
+                        snapshotTree: undefined,
+                        isRootDataStore: false,
+                        writeGCDataAtRoot: true,
+                        disableIsolatedChannels: false,
+                    }
                 );
 
                 await localDataStoreContext.realize()
@@ -162,23 +164,23 @@ describe("Data Store Context Tests", () => {
                 registryWithSubRegistries.instantiateDataStore =
                     async (context: IFluidDataStoreContext) => new MockFluidDataStoreRuntime();
 
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 containerRuntime = {
                     IFluidDataStoreRegistry: registryWithSubRegistries,
                     on: (event, listener) => { },
                 } as ContainerRuntime;
-                localDataStoreContext = new LocalFluidDataStoreContext(
-                    dataStoreId,
-                    ["TestComp", "SubComp"],
-                    containerRuntime,
+                localDataStoreContext = new LocalFluidDataStoreContext({
+                    id: dataStoreId,
+                    pkg: ["TestComp", "SubComp"],
+                    runtime: containerRuntime,
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    attachCb,
-                    undefined,
-                    false /* isRootDataStore */,
-                    true /* writeGCDataAtRoot */,
-                );
+                    bindChannelFn: attachCb,
+                    snapshotTree: undefined,
+                    isRootDataStore: false,
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 await localDataStoreContext.realize();
 
@@ -206,36 +208,38 @@ describe("Data Store Context Tests", () => {
             });
 
             it("can correctly initialize root context", async () => {
-                localDataStoreContext = new LocalFluidDataStoreContext(
-                    dataStoreId,
-                    ["TestDataStore1"],
-                    containerRuntime,
+                localDataStoreContext = new LocalFluidDataStoreContext({
+                    id: dataStoreId,
+                    pkg: ["TestDataStore1"],
+                    runtime: containerRuntime,
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    attachCb,
-                    undefined,
-                    true /* isRootDataStore */,
-                    true /* writeGCDataAtRoot */,
-                );
+                    bindChannelFn: attachCb,
+                    snapshotTree: undefined,
+                    isRootDataStore: true,
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 const isRootNode = await localDataStoreContext.isRoot();
                 assert.strictEqual(isRootNode, true, "The data store should be root.");
             });
 
             it("can correctly initialize non-root context", async () => {
-                localDataStoreContext = new LocalFluidDataStoreContext(
-                    dataStoreId,
-                    ["TestDataStore1"],
-                    containerRuntime,
+                localDataStoreContext = new LocalFluidDataStoreContext({
+                    id: dataStoreId,
+                    pkg: ["TestDataStore1"],
+                    runtime: containerRuntime,
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    attachCb,
-                    undefined,
-                    false /* isRootDataStore */,
-                    true /* writeGCDataAtRoot */,
-                );
+                    bindChannelFn: attachCb,
+                    snapshotTree: undefined,
+                    isRootDataStore: false,
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 const isRootNode = await localDataStoreContext.isRoot();
                 assert.strictEqual(isRootNode, false, "The data store should not be root.");
@@ -244,36 +248,38 @@ describe("Data Store Context Tests", () => {
 
         describe("Garbage Collection", () => {
             it("can generate correct GC data", async () => {
-                localDataStoreContext = new LocalFluidDataStoreContext(
-                    dataStoreId,
-                    ["TestDataStore1"],
-                    containerRuntime,
+                localDataStoreContext = new LocalFluidDataStoreContext({
+                    id: dataStoreId,
+                    pkg: ["TestDataStore1"],
+                    runtime: containerRuntime,
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    attachCb,
-                    undefined,
-                    true /* isRootDataStore */,
-                    true /* writeGCDataAtRoot */,
-                );
+                    bindChannelFn: attachCb,
+                    snapshotTree: undefined,
+                    isRootDataStore: true,
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 const gcData = await localDataStoreContext.getGCData();
                 assert.deepStrictEqual(gcData, emptyGCData, "GC data from getGCData should be empty.");
             });
 
             it("can successfully update referenced state", () => {
-                localDataStoreContext = new LocalFluidDataStoreContext(
-                    dataStoreId,
-                    ["TestComp", "SubComp"],
-                    containerRuntime,
+                localDataStoreContext = new LocalFluidDataStoreContext({
+                    id: dataStoreId,
+                    pkg: ["TestComp", "SubComp"],
+                    runtime: containerRuntime,
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    attachCb,
-                    undefined,
-                    false /* isRootDataStore */,
-                    true /* writeGCDataAtRoot */,
-                );
+                    bindChannelFn: attachCb,
+                    snapshotTree: undefined,
+                    isRootDataStore: false,
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 // Get the summarizer node for this data store which tracks its referenced state.
                 const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
@@ -294,28 +300,12 @@ describe("Data Store Context Tests", () => {
     });
 
     describe("RemoteDataStoreContext", () => {
-        let remotedDataStoreContext: RemotedFluidDataStoreContext;
+        let remoteDataStoreContext: RemoteFluidDataStoreContext;
         let dataStoreAttributes: ReadFluidDataStoreAttributes;
         const storage: Partial<IDocumentStorageService> = {};
         let scope: FluidObject;
         let summarizerNode: IRootSummarizerNodeWithGC;
-
-        function mockContainerRuntime(disableIsolatedChannels = true): ContainerRuntime {
-            const factory: { [key: string]: any } = {};
-            factory.IFluidDataStoreFactory = factory;
-            factory.instantiateDataStore =
-                (context: IFluidDataStoreContext) => new MockFluidDataStoreRuntime();
-            const registry: { [key: string]: any } = {};
-            registry.IFluidDataStoreRegistry = registry;
-            registry.get = async (pkg) => Promise.resolve(factory);
-
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            return {
-                disableIsolatedChannels,
-                IFluidDataStoreRegistry: registry,
-                on: (event, listener) => { },
-            } as ContainerRuntime;
-        }
+        let containerRuntime: ContainerRuntime;
 
         beforeEach(async () => {
             summarizerNode = createRootSummarizerNodeWithGC(
@@ -324,6 +314,19 @@ describe("Data Store Context Tests", () => {
                 0,
                 0);
             summarizerNode.startSummary(0, new TelemetryNullLogger());
+
+            const factory: { [key: string]: any } = {};
+            factory.IFluidDataStoreFactory = factory;
+            factory.instantiateDataStore =
+                (context: IFluidDataStoreContext) => new MockFluidDataStoreRuntime();
+            const registry: { [key: string]: any } = {};
+            registry.IFluidDataStoreRegistry = registry;
+            registry.get = async (pkg) => Promise.resolve(factory);
+
+            containerRuntime = {
+                IFluidDataStoreRegistry: registry,
+                on: (event, listener) => { },
+            } as ContainerRuntime;
         });
 
         describe("Initialization - can correctly initialize and generate attributes", () => {
@@ -382,21 +385,22 @@ describe("Data Store Context Tests", () => {
                         };
                     }
 
-                    remotedDataStoreContext = new RemotedFluidDataStoreContext(
-                        dataStoreId,
+                    remoteDataStoreContext = new RemoteFluidDataStoreContext({
+                        id: dataStoreId,
                         snapshotTree,
-                        async () => undefined,
-                        mockContainerRuntime(!writeIsolatedChannels),
-                        new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                        getBaseGCDetails: async () => undefined,
+                        runtime: containerRuntime,
+                        storage: new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                         scope,
                         createSummarizerNodeFn,
-                        true /* writeGCDataAtRoot */,
-                    );
+                        writeGCDataAtRoot: true,
+                        disableIsolatedChannels: !writeIsolatedChannels,
+                    });
 
-                    const isRootNode = await remotedDataStoreContext.isRoot();
+                    const isRootNode = await remoteDataStoreContext.isRoot();
                     assert.strictEqual(isRootNode, true, "The data store should be root.");
 
-                    const summarizeResult = await remotedDataStoreContext.summarize(true /* fullTree */);
+                    const summarizeResult = await remoteDataStoreContext.summarize(true /* fullTree */);
                     assert(summarizeResult.summary.type === SummaryType.Tree,
                         "summarize should always return a tree when fullTree is true");
                     const blob = summarizeResult.summary.tree[dataStoreAttributesBlobName] as ISummaryBlob;
@@ -481,18 +485,19 @@ describe("Data Store Context Tests", () => {
                     trees: {},
                 };
 
-                remotedDataStoreContext = new RemotedFluidDataStoreContext(
-                    dataStoreId,
+                remoteDataStoreContext = new RemoteFluidDataStoreContext({
+                    id: dataStoreId,
                     snapshotTree,
-                    async () => undefined,
-                    mockContainerRuntime(),
-                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    getBaseGCDetails: async () => undefined,
+                    runtime: containerRuntime,
+                    storage: new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
-                    true /* writeGCDataAtRoot */,
-                );
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
-                const gcData = await remotedDataStoreContext.getGCData();
+                const gcData = await remoteDataStoreContext.getGCData();
                 assert.deepStrictEqual(gcData, emptyGCData, "GC data from getGCData should be empty.");
             });
 
@@ -517,18 +522,19 @@ describe("Data Store Context Tests", () => {
                     gcData: emptyGCData,
                 };
 
-                remotedDataStoreContext = new RemotedFluidDataStoreContext(
-                    dataStoreId,
+                remoteDataStoreContext = new RemoteFluidDataStoreContext({
+                    id: dataStoreId,
                     snapshotTree,
-                    async () => gcDetails,
-                    mockContainerRuntime(),
-                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    getBaseGCDetails: async () => gcDetails,
+                    runtime: containerRuntime,
+                    storage: new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
-                    true /* writeGCDataAtRoot */,
-                );
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
-                const gcData = await remotedDataStoreContext.getGCData();
+                const gcData = await remoteDataStoreContext.getGCData();
                 assert.deepStrictEqual(gcData, gcDetails.gcData, "GC data from getGCData is incorrect.");
             });
 
@@ -558,18 +564,19 @@ describe("Data Store Context Tests", () => {
                     },
                 };
 
-                remotedDataStoreContext = new RemotedFluidDataStoreContext(
-                    dataStoreId,
+                remoteDataStoreContext = new RemoteFluidDataStoreContext({
+                    id: dataStoreId,
                     snapshotTree,
-                    async () => gcDetails,
-                    mockContainerRuntime(),
-                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    getBaseGCDetails: async () => gcDetails,
+                    runtime: containerRuntime,
+                    storage: new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
-                    true /* writeGCDataAtRoot */,
-                );
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
-                const gcData = await remotedDataStoreContext.getGCData();
+                const gcData = await remoteDataStoreContext.getGCData();
                 assert.deepStrictEqual(gcData, gcDetails.gcData, "GC data from getGCData is incorrect.");
             });
 
@@ -594,36 +601,37 @@ describe("Data Store Context Tests", () => {
                     usedRoutes: [""], // Set initial used routes to be same as the default used routes.
                 };
 
-                remotedDataStoreContext = new RemotedFluidDataStoreContext(
-                    dataStoreId,
+                remoteDataStoreContext = new RemoteFluidDataStoreContext({
+                    id: dataStoreId,
                     snapshotTree,
-                    async () => gcDetails,
-                    mockContainerRuntime(),
-                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    getBaseGCDetails: async () => gcDetails,
+                    runtime: containerRuntime,
+                    storage: new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
-                    true /* writeGCDataAtRoot */,
-                );
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 // Since GC is enabled, GC must run before summarize. Get the GC data and update used routes to
                 // emulate the GC process.
-                const gcData = await remotedDataStoreContext.getGCData();
+                const gcData = await remoteDataStoreContext.getGCData();
                 assert.deepStrictEqual(gcData, emptyGCData, "GC data from getGCData should be empty.");
                 // Update used routes to the same as in initial GC details. This will ensure that the used state
                 // matches the initial used state.
-                remotedDataStoreContext.updateUsedRoutes([""]);
+                remoteDataStoreContext.updateUsedRoutes([""]);
 
                 // The data in the store has not changed since last summary and the reference used routes (from initial
                 // used routes) and current used routes (default) are both empty. So, summarize should return a handle.
-                let summarizeResult = await remotedDataStoreContext.summarize(false /* fullTree */);
+                let summarizeResult = await remoteDataStoreContext.summarize(false /* fullTree */);
                 assert(summarizeResult.summary.type === SummaryType.Handle,
                     "summarize should return a handle since nothing changed");
 
                 // Update the used routes of the data store to a different value than current.
-                remotedDataStoreContext.updateUsedRoutes([]);
+                remoteDataStoreContext.updateUsedRoutes([]);
 
                 // Since the used state has changed, it should generate a full summary tree.
-                summarizeResult = await remotedDataStoreContext.summarize(false /* fullTree */);
+                summarizeResult = await remoteDataStoreContext.summarize(false /* fullTree */);
                 assert(summarizeResult.summary.type === SummaryType.Tree,
                     "summarize should return a tree since used state changed");
             });
@@ -638,16 +646,17 @@ describe("Data Store Context Tests", () => {
                     trees: {},
                 };
 
-                remotedDataStoreContext = new RemotedFluidDataStoreContext(
-                    dataStoreId,
+                remoteDataStoreContext = new RemoteFluidDataStoreContext({
+                    id: dataStoreId,
                     snapshotTree,
-                    async () => undefined,
-                    mockContainerRuntime(),
-                    new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
+                    getBaseGCDetails: async () => undefined,
+                    runtime: containerRuntime,
+                    storage: new BlobCacheStorageService(storage as IDocumentStorageService, blobCache),
                     scope,
                     createSummarizerNodeFn,
-                    true /* writeGCDataAtRoot */,
-                );
+                    writeGCDataAtRoot: true,
+                    disableIsolatedChannels: false,
+                });
 
                 // Get the summarizer node for this data store which tracks its referenced state.
                 const dataStoreSummarizerNode = summarizerNode.getChild(dataStoreId);
@@ -655,12 +664,12 @@ describe("Data Store Context Tests", () => {
                     dataStoreSummarizerNode?.isReferenced(), true, "Data store should be referenced by default");
 
                 // Update the used routes to not include route to the data store.
-                remotedDataStoreContext.updateUsedRoutes([]);
+                remoteDataStoreContext.updateUsedRoutes([]);
                 assert.strictEqual(
                     dataStoreSummarizerNode?.isReferenced(), false, "Data store should now be unreferenced");
 
                 // Add the data store's route (empty string) to its used routes.
-                remotedDataStoreContext.updateUsedRoutes([""]);
+                remoteDataStoreContext.updateUsedRoutes([""]);
                 assert.strictEqual(
                     dataStoreSummarizerNode?.isReferenced(), true, "Data store should now be referenced");
             }

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -90,7 +90,6 @@ describe("Data Store Creation Tests", () => {
                 get IFluidDataStoreRegistry() { return globalRegistry; },
                 get: async (pkg) => globalRegistryEntries.get(pkg),
             };
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             containerRuntime = {
                 IFluidDataStoreRegistry: globalRegistry,
                 on: (event, listener) => { },
@@ -112,18 +111,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreId = "default-Id";
             // Create the default dataStore that is in the global registry.
-            const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                [defaultName],
-                containerRuntime,
+            const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreId,
+                pkg: [defaultName],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await context.realize();
@@ -138,18 +138,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreId = "A-Id";
             // Create dataStore A that is not in the global registry.
-            const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                [dataStoreAName],
-                containerRuntime,
+            const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreId,
+                pkg: [dataStoreAName],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await context.realize();
@@ -164,18 +165,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreId = "A-Id";
             // Create dataStore A that is in the registry of the default dataStore.
-            const contextA: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                [defaultName, dataStoreAName],
-                containerRuntime,
+            const contextA: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreId,
+                pkg: [defaultName, dataStoreAName],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await contextA.realize();
@@ -190,18 +192,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreId = "B-Id";
             // Create dataStore B that is in not the registry of the default dataStore.
-            const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                [defaultName, dataStoreBName],
-                containerRuntime,
+            const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreId,
+                pkg: [defaultName, dataStoreBName],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await contextB.realize();
@@ -216,18 +219,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreBId = "B-Id";
             // Create dataStore B that is in the registry of dataStore A (which is at depth 2).
-            const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreBId,
-                [defaultName, dataStoreAName, dataStoreBName],
-                containerRuntime,
+            const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreBId,
+                pkg: [defaultName, dataStoreAName, dataStoreBName],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreBId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreBId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await contextB.realize();
@@ -239,18 +243,19 @@ describe("Data Store Creation Tests", () => {
 
             const dataStoreCId = "C-Id";
             // Create dataStore C that is in the registry of dataStore A (which is at depth 2).
-            const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreCId,
-                [defaultName, dataStoreAName, dataStoreCName],
-                containerRuntime,
+            const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreCId,
+                pkg: [defaultName, dataStoreAName, dataStoreCName],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreCId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreCId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await contextC.realize();
@@ -265,18 +270,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreId = "fake-Id";
             // Create a fake dataStore that is not in the registry of dataStore A (which is at depth 2).
-            const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                [defaultName, dataStoreAName, "fake"],
-                containerRuntime,
+            const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreId,
+                pkg: [defaultName, dataStoreAName, "fake"],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await contextFake.realize();
@@ -291,18 +297,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreId = "fake-Id";
             // Create a fake dataStore that is not in the registry of dataStore B (which is at depth 3).
-            const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                [defaultName, dataStoreAName, dataStoreBName, "fake"],
-                containerRuntime,
+            const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreId,
+                pkg: [defaultName, dataStoreAName, "fake"],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await contextFake.realize();
@@ -317,18 +324,19 @@ describe("Data Store Creation Tests", () => {
             let success: boolean = true;
             const dataStoreId = "C-Id";
             // Create dataStore C that is in parent's registry but not in the registry of dataStore B.
-            const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext(
-                dataStoreId,
-                [defaultName, dataStoreAName, dataStoreBName, dataStoreCName],
-                containerRuntime,
+            const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
+                id: dataStoreId,
+                pkg: [defaultName, dataStoreAName, dataStoreBName, dataStoreCName],
+                runtime: containerRuntime,
                 storage,
                 scope,
-                getCreateSummarizerNodeFn(dataStoreId),
-                attachCb,
-                undefined,
-                false /* isRootDataStore */,
-                true /* writeGCDataAtRoot */,
-            );
+                createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
+                bindChannelFn: attachCb,
+                snapshotTree: undefined,
+                isRootDataStore: false,
+                writeGCDataAtRoot: true,
+                disableIsolatedChannels: false,
+            });
 
             try {
                 await contextC.realize();


### PR DESCRIPTION
Follow up to this comment - https://github.com/microsoft/FluidFramework/pull/8876#discussion_r792997611.

- The properties to create a data store context are now an object. This will help reduce churn when properties are added / modified.
- Renamed `RemotedFluidDataStoreContext` -> `RemoteFluidDataStoreContext`. Not sure if there was any specific reason for that name but the term `Remoted` always bothered me. 