### PR TITLE
0.55: Fix Synthezie Regression: Return Promise instead of Undefined

### DIFF
--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -63,7 +63,7 @@ export class DependencyContainer implements IFluidDependencySynthesizer {
      */
     public synthesize<
         O extends IFluidObject,
-        // eslint-disable-next-line @typescript-eslint/ban-types
+         
         R extends IFluidObject = {}>(
             optionalTypes: FluidObjectSymbolProvider<O>,
             requiredTypes: FluidObjectSymbolProvider<R>,
@@ -133,14 +133,12 @@ export class DependencyContainer implements IFluidDependencySynthesizer {
         types: FluidObjectSymbolProvider<T>,
     ) {
         for(const key of Object.keys(types) as unknown as (keyof IFluidObject)[]) {
-            const provider = this.resolveProvider(key);
-            if(provider !== undefined) {
-                Object.defineProperty(
-                    base,
-                    key,
-                    provider,
-                );
-            }
+            const provider = this.resolveProvider(key) ?? {get:()=>Promise.resolve(undefined)};
+            Object.defineProperty(
+                base,
+                key,
+                provider,
+            );
         }
     }
 
@@ -149,9 +147,9 @@ export class DependencyContainer implements IFluidDependencySynthesizer {
         const provider = this.providers.get(t);
         if (provider === undefined) {
             for(const parent of this.parents) {
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                 
                 const sp = { [t]: t } as FluidObjectSymbolProvider<Pick<IFluidObject, T>>;
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const syn = parent.synthesize<Pick<IFluidObject, T>,{}>(
                     sp,
                     {});

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -63,7 +63,7 @@ export class DependencyContainer implements IFluidDependencySynthesizer {
      */
     public synthesize<
         O extends IFluidObject,
-         
+        // eslint-disable-next-line @typescript-eslint/ban-types
         R extends IFluidObject = {}>(
             optionalTypes: FluidObjectSymbolProvider<O>,
             requiredTypes: FluidObjectSymbolProvider<R>,
@@ -147,9 +147,9 @@ export class DependencyContainer implements IFluidDependencySynthesizer {
         const provider = this.providers.get(t);
         if (provider === undefined) {
             for(const parent of this.parents) {
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types 
                 const sp = { [t]: t } as FluidObjectSymbolProvider<Pick<IFluidObject, T>>;
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types 
                 const syn = parent.synthesize<Pick<IFluidObject, T>,{}>(
                     sp,
                     {});

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -147,9 +147,9 @@ export class DependencyContainer implements IFluidDependencySynthesizer {
         const provider = this.providers.get(t);
         if (provider === undefined) {
             for(const parent of this.parents) {
-                // eslint-disable-next-line @typescript-eslint/ban-types 
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 const sp = { [t]: t } as FluidObjectSymbolProvider<Pick<IFluidObject, T>>;
-                // eslint-disable-next-line @typescript-eslint/ban-types 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const syn = parent.synthesize<Pick<IFluidObject, T>,{}>(
                     sp,
                     {});

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -99,7 +99,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IFluidLoadable, mock);
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -112,7 +112,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IFluidLoadable, Promise.resolve(mock));
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -126,7 +126,7 @@ describe("Routerlicious", () => {
                 const factory = () => mock;
                 dc.register(IFluidLoadable, factory);
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -140,7 +140,7 @@ describe("Routerlicious", () => {
                 const factory = async () => mock;
                 dc.register(IFluidLoadable, factory);
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -199,7 +199,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockFluidConfiguration();
                 dc.register(IFluidConfiguration, configMock);
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable & IFluidConfiguration>(
                     {}, { IFluidLoadable, IFluidConfiguration });
                 const loadable = await s.IFluidLoadable;
@@ -214,7 +214,7 @@ describe("Routerlicious", () => {
             it(`Required Provider not registered should throw`, async () => {
                 const dc = new DependencyContainer();
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 assert.throws(() => dc.synthesize<{}, IFluidLoadable>(
                     {},
                     { IFluidLoadable },
@@ -272,7 +272,7 @@ describe("Routerlicious", () => {
                 parentDc.register(IFluidLoadable, mock);
                 const dc = new DependencyContainer(parentDc);
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -288,7 +288,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockFluidConfiguration();
                 dc.register(IFluidConfiguration, configMock);
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable & IFluidConfiguration>(
                     {}, { IFluidLoadable, IFluidConfiguration });
                 const loadable = await s.IFluidLoadable;
@@ -307,7 +307,7 @@ describe("Routerlicious", () => {
                 const loadableMock = new MockLoadable();
                 dc.register(IFluidLoadable, loadableMock);
 
-                 
+                // eslint-disable-next-line @typescript-eslint/ban-types
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -383,7 +383,7 @@ describe("Routerlicious", () => {
                 const parentDc = new DependencyContainer();
                 const loadableToHandle: FluidObjectProvider<"IFluidHandle"> =
                     async (fds: IFluidDependencySynthesizer) => {
-                         
+                        // eslint-disable-next-line @typescript-eslint/ban-types
                         const loadable = fds.synthesize<{},IFluidLoadable>({},{IFluidLoadable});
                         return (await loadable.IFluidLoadable).handle;
                     };
@@ -396,7 +396,6 @@ describe("Routerlicious", () => {
                 const deps = dc.synthesize<IFluidHandle>({IFluidHandle}, {});
                 assert(await deps.IFluidHandle !== undefined, "handle undefined");
             });
-
             
             it(`Undefined Provider is not Undefined`, async () => {
                 const dc = new DependencyContainer();

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -99,7 +99,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IFluidLoadable, mock);
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -112,7 +112,7 @@ describe("Routerlicious", () => {
                 const mock = new MockLoadable();
                 dc.register(IFluidLoadable, Promise.resolve(mock));
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -126,7 +126,7 @@ describe("Routerlicious", () => {
                 const factory = () => mock;
                 dc.register(IFluidLoadable, factory);
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -140,7 +140,7 @@ describe("Routerlicious", () => {
                 const factory = async () => mock;
                 dc.register(IFluidLoadable, factory);
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -199,7 +199,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockFluidConfiguration();
                 dc.register(IFluidConfiguration, configMock);
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable & IFluidConfiguration>(
                     {}, { IFluidLoadable, IFluidConfiguration });
                 const loadable = await s.IFluidLoadable;
@@ -214,7 +214,7 @@ describe("Routerlicious", () => {
             it(`Required Provider not registered should throw`, async () => {
                 const dc = new DependencyContainer();
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 assert.throws(() => dc.synthesize<{}, IFluidLoadable>(
                     {},
                     { IFluidLoadable },
@@ -272,7 +272,7 @@ describe("Routerlicious", () => {
                 parentDc.register(IFluidLoadable, mock);
                 const dc = new DependencyContainer(parentDc);
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -288,7 +288,7 @@ describe("Routerlicious", () => {
                 const configMock = new MockFluidConfiguration();
                 dc.register(IFluidConfiguration, configMock);
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable & IFluidConfiguration>(
                     {}, { IFluidLoadable, IFluidConfiguration });
                 const loadable = await s.IFluidLoadable;
@@ -307,7 +307,7 @@ describe("Routerlicious", () => {
                 const loadableMock = new MockLoadable();
                 dc.register(IFluidLoadable, loadableMock);
 
-                // eslint-disable-next-line @typescript-eslint/ban-types
+                 
                 const s = dc.synthesize<{}, IFluidLoadable>({}, { IFluidLoadable });
                 const loadable = await s.IFluidLoadable;
                 assert(loadable, "Required IFluidLoadable was registered");
@@ -383,7 +383,7 @@ describe("Routerlicious", () => {
                 const parentDc = new DependencyContainer();
                 const loadableToHandle: FluidObjectProvider<"IFluidHandle"> =
                     async (fds: IFluidDependencySynthesizer) => {
-                        // eslint-disable-next-line @typescript-eslint/ban-types
+                         
                         const loadable = fds.synthesize<{},IFluidLoadable>({},{IFluidLoadable});
                         return (await loadable.IFluidLoadable).handle;
                     };
@@ -395,6 +395,14 @@ describe("Routerlicious", () => {
 
                 const deps = dc.synthesize<IFluidHandle>({IFluidHandle}, {});
                 assert(await deps.IFluidHandle !== undefined, "handle undefined");
+            });
+
+            
+            it(`Undefined Provider is not Undefined`, async () => {
+                const dc = new DependencyContainer();
+                const deps = dc.synthesize<IFluidLoadable>({IFluidLoadable}, {});
+                assert(deps.IFluidLoadable !== undefined, "handle undefined");
+                assert(await deps.IFluidLoadable === undefined, "handle undefined");
             });
         });
     });


### PR DESCRIPTION
This fixes a regression in 0.55 where were changed the behavior to return undefined, rather than Promise<undefined> this change reverts back to the previous behavior