### PR TITLE
Fix package-lock for container-definitions

### DIFF
--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -399,20 +399,13 @@
       "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.44.0-49064",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
-      "integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
+      "version": "0.44.0-49753",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49753.tgz",
+      "integrity": "sha512-CVaKIeIbStDwhs3KHqoIVsu9Qx3ftj4Ds8soG1D8aIKS302N8Jo4LYRCBvLSbxQ3z9sn0mPv46GZUcjZ9d9Uaw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.41.0",
+        "@fluidframework/core-interfaces": "^0.42.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
-      },
-      "dependencies": {
-        "@fluidframework/core-interfaces": {
-          "version": "0.41.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
-          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
-        }
       }
     },
     "@fluidframework/eslint-config-fluid": {


### PR DESCRIPTION
Tried to update the core-interfaces used by container-definitions simultaneously with driver-definitions in #8907, but failed to notice that container-definitions needs the matching prerelease of driver-definitions.  Stale prerelease means a mismatch of core-interfaces.