### PR TITLE
Integrate new prereleases of core-interfaces, driver-definitions, and container-definitions into client

### DIFF
--- a/examples/agents/intelligence-runner-agent/package.json
+++ b/examples/agents/intelligence-runner-agent/package.json
@@ -24,7 +24,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/sequence": "^0.56.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -37,7 +37,7 @@
     "@fluid-experimental/react-inputs": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/sequence": "^0.56.0",
     "@fluidframework/view-interfaces": "^0.56.0",
     "css-loader": "^1.0.0",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/runtime-utils": "^0.56.0",
     "css-loader": "^1.0.0",
     "react": "^16.10.2",

--- a/examples/apps/spaces/package.json
+++ b/examples/apps/spaces/package.json
@@ -44,7 +44,7 @@
     "@fluid-experimental/get-container": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/runtime-definitions": "^0.56.0",
     "@fluidframework/runtime-utils": "^0.56.0",

--- a/examples/data-objects/badge/package.json
+++ b/examples/data-objects/badge/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/cell": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "@uifabric/fluent-theme": "^7.1.3",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/example-utils": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/ink": "^0.56.0",
     "react": "^16.10.2"
   },

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/task-manager": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/runtime-definitions": "^0.56.0",
     "react": "^16.10.2"

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -52,7 +52,7 @@
     "@fluid-example/search-menu": "^0.56.0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/ink": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -38,7 +38,7 @@
     "@fluid-example/client-ui-lib": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/merge-tree": "^0.56.0",
     "@fluidframework/runtime-definitions": "^0.56.0",
     "@fluidframework/sequence": "^0.56.0",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/multiview-coordinate-model": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/map": "^0.56.0"
   },
   "devDependencies": {

--- a/examples/data-objects/pond/package.json
+++ b/examples/data-objects/pond/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/examples/data-objects/primitives/package.json
+++ b/examples/data-objects/primitives/package.json
@@ -37,7 +37,7 @@
     "@fluid-example/example-utils": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/map": "^0.56.0",
     "react": "^16.10.2"
   },

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -39,7 +39,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -37,7 +37,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/examples/data-objects/search-menu/package.json
+++ b/examples/data-objects/search-menu/package.json
@@ -25,7 +25,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/merge-tree": "^0.56.0",
     "@types/node": "^14.18.0"
   },

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/ink": "^0.56.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/merge-tree": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/matrix": "^0.56.0",
     "@fluidframework/runtime-utils": "^0.56.0",
     "@fluidframework/sequence": "^0.56.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/request-handler": "^0.56.0",
     "@fluidframework/runtime-utils": "^0.56.0",
     "css-loader": "^1.0.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/cell": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/runtime-definitions": "^0.56.0",
     "@fluidframework/sequence": "^0.56.0",

--- a/examples/data-objects/vltava/package.json
+++ b/examples/data-objects/vltava/package.json
@@ -44,7 +44,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/data-object-base": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/merge-tree": "^0.56.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/runtime-utils": "^0.56.0",
     "@fluidframework/view-adapters": "^0.56.0",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0"
+    "@fluidframework/core-interfaces": "^0.42.0-0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -30,7 +30,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/routerlicious-driver": "^0.56.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/iframe-driver": "^0.56.0",

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -26,7 +26,7 @@
     "@fluid-example/key-value-cache": "^0.56.0",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/routerlicious-driver": "^0.56.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/data-object-base": "^0.56.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/data-object-base": "^0.56.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -35,7 +35,7 @@
     "@fluid-experimental/property-properties": "^0.56.0",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluid-experimental/ot": "^0.56.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/shared-object-base": "^0.56.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",

--- a/experimental/dds/xtree/package.json
+++ b/experimental/dds/xtree/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -42,7 +42,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "react": "^16.10.2"

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -52,7 +52,7 @@
     "@fluid-experimental/tree": "^0.56.0",
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "@fluidframework/view-interfaces": "^0.56.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "ot-json1": "^1.0.1",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",
     "react": "^16.10.2"

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/local-driver": "^0.56.0",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-runtime": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-utils": "^0.56.0",
     "@fluidframework/shared-summary-block": "^0.56.0"

--- a/experimental/framework/react/package.json
+++ b/experimental/framework/react/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.56.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2029,12 +2029,12 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.45.0-49378",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0-49378.tgz",
-			"integrity": "sha512-IzKCtFGWHwyiXx+W695nyMvRtXMfG5znd6IJWo1vHpHmVyCrDr9vP++yGN+n6+V6oa84HXvLaXgIJmHYwhDfoA==",
+			"version": "0.45.0-49784",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0-49784.tgz",
+			"integrity": "sha512-vjBN0UecJYUhp9MS6oSitNB6orfOf4QQKNjPuHjSVNmqPU7i3iEYNQ1fg8IN6lqfq4HhtRIovEQlFjgB36JKRg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
-				"@fluidframework/core-interfaces": "^0.41.0",
+				"@fluidframework/core-interfaces": "^0.42.0-0",
 				"@fluidframework/driver-definitions": "^0.44.0-0",
 				"@fluidframework/protocol-definitions": "^0.1026.0"
 			}
@@ -2119,6 +2119,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.42.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -2174,6 +2179,11 @@
 						"@fluidframework/driver-definitions": "^0.43.0",
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
+				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
 				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
@@ -2231,6 +2241,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -2282,6 +2297,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -2309,9 +2329,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
-			"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+			"version": "0.42.0-49742",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+			"integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
 		},
 		"@fluidframework/datastore-definitions-0.51.1": {
 			"version": "npm:@fluidframework/datastore-definitions@0.51.1",
@@ -2393,6 +2413,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.42.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -2448,6 +2473,11 @@
 						"@fluidframework/driver-definitions": "^0.43.0",
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
+				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
 				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
@@ -2505,6 +2535,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -2556,6 +2591,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -2583,12 +2623,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "0.44.0-49064",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49064.tgz",
-			"integrity": "sha512-d+nV+ba46wNlCqBbHcwRRGKJQawp5NMnHBrtFs5uYc3vqHhlB+HmgQFgK5SFetnJGipooMR2FFElXTVTbM+5fw==",
+			"version": "0.44.0-49753",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49753.tgz",
+			"integrity": "sha512-CVaKIeIbStDwhs3KHqoIVsu9Qx3ftj4Ds8soG1D8aIKS302N8Jo4LYRCBvLSbxQ3z9sn0mPv46GZUcjZ9d9Uaw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
-				"@fluidframework/core-interfaces": "^0.41.0",
+				"@fluidframework/core-interfaces": "^0.42.0-0",
 				"@fluidframework/protocol-definitions": "^0.1026.0"
 			}
 		},
@@ -2769,6 +2809,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.42.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -2810,6 +2855,11 @@
 						"@fluidframework/driver-definitions": "^0.43.0",
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
+				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
 				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
@@ -2853,6 +2903,11 @@
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
 				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",
 					"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -2889,6 +2944,11 @@
 						"@fluidframework/driver-definitions": "^0.43.0",
 						"@fluidframework/protocol-definitions": "^0.1026.0"
 					}
+				},
+				"@fluidframework/core-interfaces": {
+					"version": "0.41.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+					"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
 				},
 				"@fluidframework/driver-definitions": {
 					"version": "0.43.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/merge-tree": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/merge-tree": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-utils": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/odsp-driver": "^0.56.0",
     "@fluidframework/odsp-driver-definitions": "^0.56.0"

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-base": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-base": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",

--- a/packages/drivers/odsp-driver/src/checkUrl.ts
+++ b/packages/drivers/odsp-driver/src/checkUrl.ts
@@ -27,7 +27,6 @@ export function checkUrl(documentUrl: URL): DriverPreCheckInfo | undefined {
   } catch {}
 
   return {
-    containerPath: locator.dataStorePath,
     codeDetailsHint: locator?.containerPackageName,
     // Add the snapshot endpoint, which has the same domain as the site URL
     criticalBootDomains: siteOrigin ? [siteOrigin] : undefined,

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -32,7 +32,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/odsp-driver": "^0.56.0",
     "@fluidframework/odsp-driver-definitions": "^0.56.0"

--- a/packages/drivers/routerlicious-host/package.json
+++ b/packages/drivers/routerlicious-host/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "axios": "^0.21.2"
   },

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "nconf": "^0.11.0"

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -27,7 +27,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -40,7 +40,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/fluid-static": "^0.56.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/request-handler": "^0.56.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -35,7 +35,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/request-handler": "^0.56.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/runtime-definitions": "^0.56.0",
     "@fluidframework/runtime-utils": "^0.56.0"
   },

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/eslint-config-fluid": "^0.25.0",
     "@fluidframework/mocha-test-setup": "^0.56.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/view-interfaces": "^0.56.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/core-interfaces": "^0.41.0"
+    "@fluidframework/core-interfaces": "^0.42.0-0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-utils": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/gitresources": "^0.1034.0",
     "@fluidframework/protocol-base": "^0.1034.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/map": "^0.56.0",

--- a/packages/runtime/container-runtime-definitions/package-lock.json
+++ b/packages/runtime/container-runtime-definitions/package-lock.json
@@ -150,26 +150,14 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
-      "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+      "version": "0.45.0-49784",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0-49784.tgz",
+      "integrity": "sha512-vjBN0UecJYUhp9MS6oSitNB6orfOf4QQKNjPuHjSVNmqPU7i3iEYNQ1fg8IN6lqfq4HhtRIovEQlFjgB36JKRg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.42.0-0",
+        "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
-      },
-      "dependencies": {
-        "@fluidframework/driver-definitions": {
-          "version": "0.43.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.0",
-            "@fluidframework/core-interfaces": "^0.41.0",
-            "@fluidframework/protocol-definitions": "^0.1026.0"
-          }
-        }
       }
     },
     "@fluidframework/container-runtime-definitions-0.51.1": {
@@ -275,6 +263,12 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.42.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -336,6 +330,12 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -385,6 +385,24 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -428,6 +446,24 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -457,9 +493,9 @@
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
-      "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+      "version": "0.42.0-49742",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+      "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
     },
     "@fluidframework/driver-definitions": {
       "version": "0.44.0-49064",
@@ -469,6 +505,13 @@
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+        }
       }
     },
     "@fluidframework/eslint-config-fluid": {
@@ -503,8 +546,8 @@
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^0.44.0",
-        "@fluidframework/core-interfaces": "^0.41.0",
+        "@fluidframework/container-definitions": "^0.45.0-0",
+        "@fluidframework/core-interfaces": "^0.42.0-0",
         "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0",
         "@types/node": "^14.18.0"
@@ -621,6 +664,18 @@
             "@fluidframework/core-interfaces": "^0.41.0",
             "@fluidframework/driver-definitions": "^0.43.0",
             "@fluidframework/protocol-definitions": "^0.1026.0"
+          },
+          "dependencies": {
+            "@fluidframework/driver-definitions": {
+              "version": "0.43.0",
+              "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+              "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+              "requires": {
+                "@fluidframework/common-definitions": "^0.20.0",
+                "@fluidframework/core-interfaces": "^0.41.0",
+                "@fluidframework/protocol-definitions": "^0.1026.0"
+              }
+            }
           }
         },
         "@fluidframework/core-interfaces": {
@@ -629,13 +684,20 @@
           "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
         },
         "@fluidframework/driver-definitions": {
-          "version": "0.43.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "version": "0.44.0-49753",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49753.tgz",
+          "integrity": "sha512-CVaKIeIbStDwhs3KHqoIVsu9Qx3ftj4Ds8soG1D8aIKS302N8Jo4LYRCBvLSbxQ3z9sn0mPv46GZUcjZ9d9Uaw==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.0",
-            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/core-interfaces": "^0.42.0-0",
             "@fluidframework/protocol-definitions": "^0.1026.0"
+          },
+          "dependencies": {
+            "@fluidframework/core-interfaces": {
+              "version": "0.42.0-49742",
+              "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+              "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
+            }
           }
         },
         "@fluidframework/protocol-definitions": {

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -84,40 +84,58 @@
       },
       "0.52.0": {
         "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IProvideContainerRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IContainerRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.53.0": {
-        "InterfaceDeclaration_IContainerRuntime": {
-          "backCompat": false
-        },
         "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IProvideContainerRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.54.0": {
-        "InterfaceDeclaration_IContainerRuntime": {
-          "backCompat": false
+        "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IProvideContainerRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.55.0": {
-        "InterfaceDeclaration_IContainerRuntime": {
-          "backCompat": false
+        "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IProvideContainerRuntime": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": false,
+          "forwardCompat": false
         }
       }
     }

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.52.0.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.52.0.ts
@@ -43,6 +43,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -68,6 +69,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -117,6 +119,7 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.53.0.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.53.0.ts
@@ -43,6 +43,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -68,6 +69,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -117,6 +119,7 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.54.0.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.54.0.ts
@@ -43,6 +43,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -68,6 +69,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -80,6 +82,7 @@ declare function get_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombi
 declare function use_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: old.IContainerRuntimeBaseWithCombinedEvents);
 use_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -116,6 +119,7 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.55.0.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.55.0.ts
@@ -43,6 +43,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -68,6 +69,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -80,6 +82,7 @@ declare function get_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombi
 declare function use_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: old.IContainerRuntimeBaseWithCombinedEvents);
 use_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -116,6 +119,7 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
     "@fluidframework/container-utils": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",

--- a/packages/runtime/datastore-definitions/package-lock.json
+++ b/packages/runtime/datastore-definitions/package-lock.json
@@ -149,20 +149,20 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
-      "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+      "version": "0.45.0-49784",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0-49784.tgz",
+      "integrity": "sha512-vjBN0UecJYUhp9MS6oSitNB6orfOf4QQKNjPuHjSVNmqPU7i3iEYNQ1fg8IN6lqfq4HhtRIovEQlFjgB36JKRg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.42.0-0",
+        "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
-      "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+      "version": "0.42.0-49742",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+      "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
     },
     "@fluidframework/datastore-definitions-0.51.1": {
       "version": "npm:@fluidframework/datastore-definitions@0.51.1",
@@ -267,6 +267,12 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.42.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -328,6 +334,23 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/runtime-definitions": {
           "version": "0.53.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.53.0.tgz",
@@ -366,6 +389,35 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/runtime-definitions": {
           "version": "0.54.2",
           "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.54.2.tgz",
@@ -398,6 +450,35 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
         "@fluidframework/runtime-definitions": {
           "version": "0.55.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.55.0.tgz",
@@ -416,12 +497,12 @@
       }
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-      "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+      "version": "0.44.0-49753",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49753.tgz",
+      "integrity": "sha512-CVaKIeIbStDwhs3KHqoIVsu9Qx3ftj4Ds8soG1D8aIKS302N8Jo4LYRCBvLSbxQ3z9sn0mPv46GZUcjZ9d9Uaw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.41.0",
+        "@fluidframework/core-interfaces": "^0.42.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
       }
     },
@@ -457,8 +538,8 @@
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^0.44.0",
-        "@fluidframework/core-interfaces": "^0.41.0",
+        "@fluidframework/container-definitions": "^0.45.0-0",
+        "@fluidframework/core-interfaces": "^0.42.0-0",
         "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0",
         "@types/node": "^14.18.0"
@@ -575,6 +656,18 @@
             "@fluidframework/core-interfaces": "^0.41.0",
             "@fluidframework/driver-definitions": "^0.43.0",
             "@fluidframework/protocol-definitions": "^0.1026.0"
+          },
+          "dependencies": {
+            "@fluidframework/driver-definitions": {
+              "version": "0.43.0",
+              "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
+              "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+              "requires": {
+                "@fluidframework/common-definitions": "^0.20.0",
+                "@fluidframework/core-interfaces": "^0.41.0",
+                "@fluidframework/protocol-definitions": "^0.1026.0"
+              }
+            }
           }
         },
         "@fluidframework/core-interfaces": {
@@ -583,13 +676,20 @@
           "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
         },
         "@fluidframework/driver-definitions": {
-          "version": "0.43.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
+          "version": "0.44.0-49753",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.44.0-49753.tgz",
+          "integrity": "sha512-CVaKIeIbStDwhs3KHqoIVsu9Qx3ftj4Ds8soG1D8aIKS302N8Jo4LYRCBvLSbxQ3z9sn0mPv46GZUcjZ9d9Uaw==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.0",
-            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/core-interfaces": "^0.42.0-0",
             "@fluidframework/protocol-definitions": "^0.1026.0"
+          },
+          "dependencies": {
+            "@fluidframework/core-interfaces": {
+              "version": "0.42.0-49742",
+              "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+              "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
+            }
           }
         },
         "@fluidframework/protocol-definitions": {

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.56.0",
     "@types/node": "^14.18.0"

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -119,6 +119,36 @@
           "backCompat": false,
           "forwardCompat": false
         },
+        "InterfaceDeclaration_IChannelServices": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IDeltaConnection": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRuntime": {
+          "backCompat": false,
+          "forwardCompat": false
+        }
+      },
+      "0.55.0": {
+        "InterfaceDeclaration_IChannel": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IChannelFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IChannelServices": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IDeltaConnection": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
         "InterfaceDeclaration_IFluidDataStoreRuntime": {
           "backCompat": false,
           "forwardCompat": false

--- a/packages/runtime/datastore-definitions/src/test/types/validate0.54.0.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validate0.54.0.ts
@@ -95,6 +95,7 @@ declare function get_old_InterfaceDeclaration_IChannelServices():
 declare function use_current_InterfaceDeclaration_IChannelServices(
     use: current.IChannelServices);
 use_current_InterfaceDeclaration_IChannelServices(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IChannelServices());
 
 /*
@@ -107,6 +108,7 @@ declare function get_current_InterfaceDeclaration_IChannelServices():
 declare function use_old_InterfaceDeclaration_IChannelServices(
     use: old.IChannelServices);
 use_old_InterfaceDeclaration_IChannelServices(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IChannelServices());
 
 /*
@@ -143,6 +145,7 @@ declare function get_old_InterfaceDeclaration_IDeltaConnection():
 declare function use_current_InterfaceDeclaration_IDeltaConnection(
     use: current.IDeltaConnection);
 use_current_InterfaceDeclaration_IDeltaConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDeltaConnection());
 
 /*
@@ -155,6 +158,7 @@ declare function get_current_InterfaceDeclaration_IDeltaConnection():
 declare function use_old_InterfaceDeclaration_IDeltaConnection(
     use: old.IDeltaConnection);
 use_old_InterfaceDeclaration_IDeltaConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaConnection());
 
 /*

--- a/packages/runtime/datastore-definitions/src/test/types/validate0.55.0.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validate0.55.0.ts
@@ -19,6 +19,7 @@ declare function get_old_InterfaceDeclaration_IChannel():
 declare function use_current_InterfaceDeclaration_IChannel(
     use: current.IChannel);
 use_current_InterfaceDeclaration_IChannel(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IChannel());
 
 /*
@@ -31,6 +32,7 @@ declare function get_current_InterfaceDeclaration_IChannel():
 declare function use_old_InterfaceDeclaration_IChannel(
     use: old.IChannel);
 use_old_InterfaceDeclaration_IChannel(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IChannel());
 
 /*
@@ -67,6 +69,7 @@ declare function get_old_InterfaceDeclaration_IChannelFactory():
 declare function use_current_InterfaceDeclaration_IChannelFactory(
     use: current.IChannelFactory);
 use_current_InterfaceDeclaration_IChannelFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IChannelFactory());
 
 /*
@@ -79,6 +82,7 @@ declare function get_current_InterfaceDeclaration_IChannelFactory():
 declare function use_old_InterfaceDeclaration_IChannelFactory(
     use: old.IChannelFactory);
 use_old_InterfaceDeclaration_IChannelFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IChannelFactory());
 
 /*
@@ -91,6 +95,7 @@ declare function get_old_InterfaceDeclaration_IChannelServices():
 declare function use_current_InterfaceDeclaration_IChannelServices(
     use: current.IChannelServices);
 use_current_InterfaceDeclaration_IChannelServices(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IChannelServices());
 
 /*
@@ -103,6 +108,7 @@ declare function get_current_InterfaceDeclaration_IChannelServices():
 declare function use_old_InterfaceDeclaration_IChannelServices(
     use: old.IChannelServices);
 use_old_InterfaceDeclaration_IChannelServices(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IChannelServices());
 
 /*
@@ -139,6 +145,7 @@ declare function get_old_InterfaceDeclaration_IDeltaConnection():
 declare function use_current_InterfaceDeclaration_IDeltaConnection(
     use: current.IDeltaConnection);
 use_current_InterfaceDeclaration_IDeltaConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDeltaConnection());
 
 /*
@@ -151,6 +158,7 @@ declare function get_current_InterfaceDeclaration_IDeltaConnection():
 declare function use_old_InterfaceDeclaration_IDeltaConnection(
     use: old.IDeltaConnection);
 use_old_InterfaceDeclaration_IDeltaConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeltaConnection());
 
 /*
@@ -187,6 +195,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: current.IFluidDataStoreRuntime);
 use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*
@@ -199,6 +208,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: old.IFluidDataStoreRuntime);
 use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -60,7 +60,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-utils": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",

--- a/packages/runtime/runtime-definitions/package-lock.json
+++ b/packages/runtime/runtime-definitions/package-lock.json
@@ -149,32 +149,20 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
-      "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+      "version": "0.45.0-49784",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0-49784.tgz",
+      "integrity": "sha512-vjBN0UecJYUhp9MS6oSitNB6orfOf4QQKNjPuHjSVNmqPU7i3iEYNQ1fg8IN6lqfq4HhtRIovEQlFjgB36JKRg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.42.0-0",
+        "@fluidframework/driver-definitions": "^0.44.0-0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
-      },
-      "dependencies": {
-        "@fluidframework/driver-definitions": {
-          "version": "0.43.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
-          "integrity": "sha512-71RblJOfO1oDBEV0U6eiKRdSu4sqECRzoNgfEG336o0qkW/Z7jCymb7R7BO6CxNfrSD2JRjAZFcPLxV6i4/brA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.0",
-            "@fluidframework/core-interfaces": "^0.41.0",
-            "@fluidframework/protocol-definitions": "^0.1026.0"
-          }
-        }
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
-      "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+      "version": "0.42.0-49742",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0-49742.tgz",
+      "integrity": "sha512-o404OxaX9lNM6nMu+vcNMwm31YvxJ3H0LOsDIr4Ndf/zqjXyiGJTj9TdjzSZndIl30F3/HmWf1PU5Wc0eRjXNA=="
     },
     "@fluidframework/driver-definitions": {
       "version": "0.44.0-49064",
@@ -184,6 +172,13 @@
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.41.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+        }
       }
     },
     "@fluidframework/eslint-config-fluid": {
@@ -301,6 +296,12 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.42.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.42.0.tgz",
@@ -347,6 +348,12 @@
             "@fluidframework/protocol-definitions": "^0.1026.0"
           }
         },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -381,6 +388,24 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",
@@ -409,6 +434,24 @@
         "@types/node": "^14.18.0"
       },
       "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "0.44.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.44.0.tgz",
+          "integrity": "sha512-aoKjRwEeIQ1IH38QfAYAO7pqA5vknUItl2mF2/EWhCVZaWoyBsMXU5SkC3u2d7OmtkyjSvqFzMmR+BVunehhsw==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.0",
+            "@fluidframework/core-interfaces": "^0.41.0",
+            "@fluidframework/driver-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1026.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+          "integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw==",
+          "dev": true
+        },
         "@fluidframework/driver-definitions": {
           "version": "0.43.0",
           "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.43.0.tgz",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@types/node": "^14.18.0"

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -125,24 +125,170 @@
       },
       "0.52.0": {
         "InterfaceDeclaration_IContainerRuntimeBase": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidDataStoreContext": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidDataStoreContextDetached": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_FluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.53.0": {
         "InterfaceDeclaration_IContainerRuntimeBase": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidDataStoreContext": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
         },
         "InterfaceDeclaration_IFluidDataStoreContextDetached": {
-          "backCompat": false
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_FluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        }
+      },
+      "0.54.0": {
+        "TypeAliasDeclaration_FluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntimeBase": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContext": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContextDetached": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        }
+      },
+      "0.55.0": {
+        "TypeAliasDeclaration_FluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntimeBase": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContext": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContextDetached": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreFactory": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideFluidDataStoreRegistry": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry": {
+          "backCompat": false,
+          "forwardCompat": false
         }
       }
     }

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.52.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.52.0.ts
@@ -115,6 +115,7 @@ declare function get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: current.FluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -127,6 +128,7 @@ declare function get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: old.FluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -211,6 +213,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: current.IContainerRuntimeBase);
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -308,6 +311,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: current.IFluidDataStoreContext);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -333,6 +337,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: current.IFluidDataStoreContextDetached);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -406,6 +411,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreFactory(
     use: current.IFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -418,6 +424,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreFactory(
     use: old.IFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -454,6 +461,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: current.IFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -466,6 +474,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: old.IFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -574,6 +583,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: current.IProvideFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -586,6 +596,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: old.IProvideFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -598,6 +609,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: current.IProvideFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -610,6 +622,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: old.IProvideFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -838,6 +851,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: current.NamedFluidDataStoreRegistryEntries);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -850,6 +864,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: old.NamedFluidDataStoreRegistryEntries);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -862,6 +877,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry()
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: current.NamedFluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*
@@ -874,6 +890,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: old.NamedFluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.53.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.53.0.ts
@@ -115,6 +115,7 @@ declare function get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: current.FluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -127,6 +128,7 @@ declare function get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: old.FluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -211,6 +213,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: current.IContainerRuntimeBase);
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -308,6 +311,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: current.IFluidDataStoreContext);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -333,6 +337,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: current.IFluidDataStoreContextDetached);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -406,6 +411,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreFactory(
     use: current.IFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -418,6 +424,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreFactory(
     use: old.IFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -454,6 +461,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: current.IFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -466,6 +474,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: old.IFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -622,6 +631,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: current.IProvideFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -634,6 +644,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: old.IProvideFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -646,6 +657,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: current.IProvideFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -658,6 +670,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: old.IProvideFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -886,6 +899,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: current.NamedFluidDataStoreRegistryEntries);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -898,6 +912,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: old.NamedFluidDataStoreRegistryEntries);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -910,6 +925,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry()
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: current.NamedFluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*
@@ -922,6 +938,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: old.NamedFluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.54.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.54.0.ts
@@ -115,6 +115,7 @@ declare function get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: current.FluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -127,6 +128,7 @@ declare function get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: old.FluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -211,6 +213,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: current.IContainerRuntimeBase);
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -223,6 +226,7 @@ declare function get_current_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_old_InterfaceDeclaration_IContainerRuntimeBase(
     use: old.IContainerRuntimeBase);
 use_old_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -307,6 +311,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: current.IFluidDataStoreContext);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -319,6 +324,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContext(
     use: old.IFluidDataStoreContext);
 use_old_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -331,6 +337,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: current.IFluidDataStoreContextDetached);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -343,6 +350,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContextDetached
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: old.IFluidDataStoreContextDetached);
 use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -403,6 +411,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreFactory(
     use: current.IFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -415,6 +424,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreFactory(
     use: old.IFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -451,6 +461,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: current.IFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -463,6 +474,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: old.IFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -619,6 +631,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: current.IProvideFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -631,6 +644,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: old.IProvideFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -643,6 +657,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: current.IProvideFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -655,6 +670,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: old.IProvideFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -883,6 +899,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: current.NamedFluidDataStoreRegistryEntries);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -895,6 +912,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: old.NamedFluidDataStoreRegistryEntries);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -907,6 +925,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry()
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: current.NamedFluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*
@@ -919,6 +938,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: old.NamedFluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.55.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.55.0.ts
@@ -115,6 +115,7 @@ declare function get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: current.FluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -127,6 +128,7 @@ declare function get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry():
 declare function use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
     use: old.FluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_FluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_FluidDataStoreRegistryEntry());
 
 /*
@@ -211,6 +213,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: current.IContainerRuntimeBase);
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -223,6 +226,7 @@ declare function get_current_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_old_InterfaceDeclaration_IContainerRuntimeBase(
     use: old.IContainerRuntimeBase);
 use_old_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -307,6 +311,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: current.IFluidDataStoreContext);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -319,6 +324,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContext(
     use: old.IFluidDataStoreContext);
 use_old_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -331,6 +337,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: current.IFluidDataStoreContextDetached);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -343,6 +350,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreContextDetached
 declare function use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: old.IFluidDataStoreContextDetached);
 use_old_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -403,6 +411,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreFactory(
     use: current.IFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -415,6 +424,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreFactory():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreFactory(
     use: old.IFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreFactory());
 
 /*
@@ -451,6 +461,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: current.IFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -463,6 +474,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRegistry():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
     use: old.IFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRegistry());
 
 /*
@@ -643,6 +655,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: current.IProvideFluidDataStoreFactory);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -655,6 +668,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory(
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
     use: old.IProvideFluidDataStoreFactory);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreFactory());
 
 /*
@@ -667,6 +681,7 @@ declare function get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry():
 declare function use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: current.IProvideFluidDataStoreRegistry);
 use_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -679,6 +694,7 @@ declare function get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry
 declare function use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
     use: old.IProvideFluidDataStoreRegistry);
 use_old_InterfaceDeclaration_IProvideFluidDataStoreRegistry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideFluidDataStoreRegistry());
 
 /*
@@ -907,6 +923,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: current.NamedFluidDataStoreRegistryEntries);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -919,6 +936,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
     use: old.NamedFluidDataStoreRegistryEntries);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntries());
 
 /*
@@ -931,6 +949,7 @@ declare function get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry()
 declare function use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: current.NamedFluidDataStoreRegistryEntry);
 use_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*
@@ -943,6 +962,7 @@ declare function get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEnt
 declare function use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
     use: old.NamedFluidDataStoreRegistryEntry);
 use_old_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_NamedFluidDataStoreRegistryEntry());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/garbage-collector": "^0.56.0",
     "@fluidframework/protocol-base": "^0.1034.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -57,7 +57,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -59,7 +59,7 @@
     "@fluidframework/container-runtime": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
     "@fluidframework/container-utils": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -58,7 +58,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "uuid": "^8.3.1"

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/local-driver": "^0.56.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/container-runtime": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
     "@fluidframework/container-utils": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -69,7 +69,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime": "^0.56.0",
     "@fluidframework/container-runtime-definitions": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/counter": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -36,7 +36,7 @@
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
     "@fluidframework/container-runtime": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/datastore": "^0.56.0",
     "@fluidframework/datastore-definitions": "^0.56.0",
     "@fluidframework/driver-definitions": "^0.44.0-0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.45.0-0",
     "@fluidframework/container-loader": "^0.56.0",
-    "@fluidframework/core-interfaces": "^0.41.0",
+    "@fluidframework/core-interfaces": "^0.42.0-0",
     "@fluidframework/driver-definitions": "^0.44.0-0",
     "@fluidframework/driver-utils": "^0.56.0",
     "@fluidframework/local-driver": "^0.56.0",


### PR DESCRIPTION
Also disables a bunch of compat tests that were failing with the integrate (probably needs some scrutiny) and removes containerPath from checkUrl per the new definition