### PR TITLE
ICodeDetailsLoader imported from container-definitions

### DIFF
--- a/examples/hosts/hosts-sample/src/codeDetailsLoader.ts
+++ b/examples/hosts/hosts-sample/src/codeDetailsLoader.ts
@@ -10,7 +10,7 @@ import {
 import {
     ICodeDetailsLoader,
     IFluidModuleWithDetails,
-} from "@fluidframework/container-loader";
+} from "@fluidframework/container-definitions";
 import { fluidExport } from "./fauxComponent";
 import { parsePackageDetails } from "./utils";
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -27,6 +27,8 @@ import {
     IRuntimeFactory,
     ICodeLoader,
     IProvideRuntimeFactory,
+    ICodeDetailsLoader,
+    IFluidModuleWithDetails,
 } from "@fluidframework/container-definitions";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
@@ -45,7 +47,6 @@ import {
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { assert, LazyPromise } from "@fluidframework/common-utils";
 import { Container } from "./container";
-import { ICodeDetailsLoader, IFluidModuleWithDetails } from "./loader";
 
 const PackageNotFactoryError = "Code package does not implement IRuntimeFactory";
 

--- a/packages/loader/container-loader/src/test/containerContext.spec.ts
+++ b/packages/loader/container-loader/src/test/containerContext.spec.ts
@@ -9,6 +9,7 @@ import {
     ILoader,
     IRuntime,
     IRuntimeFactory,
+    ICodeDetailsLoader,
 } from "@fluidframework/container-definitions";
 import {
     FluidObject,
@@ -23,7 +24,6 @@ import {
 } from "@fluidframework/telemetry-utils";
 import { Container } from "../container";
 import { ContainerContext } from "../containerContext";
-import { ICodeDetailsLoader } from "../loader";
 
 describe("ContainerContext Tests", () => {
     let sandbox: Sinon.SinonSandbox;


### PR DESCRIPTION
In this PR, `ICodeDetailsLoader` is being imported from `@fluidframework/container-definitions` instead of `@fluidframework/container-loader`. The interfaces `ICodeLoader` and `ICodeDetailsLoader` are not removed yet, the imports are modified.