### PR TITLE
Remove deprecation tag for `DriverErrorType.genericError`

### DIFF
--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -36,7 +36,6 @@ export enum DriverErrorType {
     fetchFailure = "fetchFailure",
     fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
     fileOverwrittenInStorage = "fileOverwrittenInStorage",
-    // @deprecated (undocumented)
     genericError = "genericError",
     genericNetworkError = "genericNetworkError",
     incorrectServerResponse = "incorrectServerResponse",

--- a/common/lib/driver-definitions/src/driverError.ts
+++ b/common/lib/driver-definitions/src/driverError.ts
@@ -9,7 +9,7 @@
  */
 export enum DriverErrorType {
     /**
-     * Some error, most likely an exception caught by runtime and propagated to container as critical error
+     * A fatal error with no specific interpretation covered by other DriverErrorType values
      */
     genericError = "genericError",
 

--- a/common/lib/driver-definitions/src/driverError.ts
+++ b/common/lib/driver-definitions/src/driverError.ts
@@ -9,7 +9,7 @@
  */
 export enum DriverErrorType {
     /**
-     * @deprecated - use genericNetworkError or add a new specific errorType if needed
+     * Some error, most likely an exception caught by runtime and propagated to container as critical error
      */
     genericError = "genericError",
 


### PR DESCRIPTION
The enum member `DriverErrorType.genericError` from `driver-definitions` was deprecated, but we have decided to keep this property and remove the deprecation tag.

Context: https://github.com/microsoft/FluidFramework/pull/8803#issuecomment-1024640085