### PR TITLE
Let OrderedClientCollection track the summarizer client separately

### DIFF
--- a/packages/runtime/container-runtime/src/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/orderedClientElection.ts
@@ -208,7 +208,10 @@ export interface IOrderedClientElectionEvents extends IEvent {
 export interface ISerializedElection {
     /** Sequence number at the time of the latest election. */
     readonly electionSequenceNumber: number;
-    /** Most recently elected client id. May be interactive client or summarizer client. */
+    /** Most recently elected client id. This is either:
+     * 1. the interactive elected parent client, in which case electedClientId === electedParentId,
+     *  and the SummaryManager on the elected client will spawn a summarizer client, or
+     * 2. the non-interactive summarizer client itself. */
     readonly electedClientId: string | undefined;
     /** Most recently elected parent client id. This is always an interactive client. */
     readonly electedParentId: string | undefined;
@@ -218,9 +221,12 @@ export interface ISerializedElection {
 export interface IOrderedClientElection extends IEventProvider<IOrderedClientElectionEvents> {
     /** Count of eligible clients in the collection. */
     readonly eligibleCount: number;
-    /** Currently elected client. */
+    /** Currently elected client id. This is either:
+     * 1. the interactive elected parent client, in which case electedClientId === electedParentId,
+     *  and the SummaryManager on the elected client will spawn a summarizer client, or
+     * 2. the non-interactive summarizer client itself. */
     readonly electedClient: ITrackedClient | undefined;
-    /** Currently elected parent, may be equal to electedClient */
+    /** Currently elected parent client id. This is always an interactive client. */
     readonly electedParent: ITrackedClient | undefined;
     /** Sequence number of most recent election. */
     readonly electionSequenceNumber: number;

--- a/packages/runtime/container-runtime/src/summarizerClientElection.ts
+++ b/packages/runtime/container-runtime/src/summarizerClientElection.ts
@@ -17,6 +17,7 @@ export interface ISummarizerClientElectionEvents extends IEvent {
 
 export interface ISummarizerClientElection extends IEventProvider<ISummarizerClientElectionEvents> {
     readonly electedClientId: string | undefined;
+    readonly electedParentId: string | undefined;
 }
 
 /**
@@ -43,6 +44,9 @@ export class SummarizerClientElection
 
     public get electedClientId() {
         return this.clientElection.electedClient?.clientId;
+    }
+    public get electedParentId() {
+        return this.clientElection.electedParent?.clientId;
     }
 
     constructor(
@@ -127,9 +131,10 @@ export class SummarizerClientElection
     }
 
     public serialize(): ISerializedElection {
-        const { electedClientId, electionSequenceNumber } = this.clientElection.serialize();
+        const { electedClientId, electedParentId, electionSequenceNumber } = this.clientElection.serialize();
         return {
             electedClientId,
+            electedParentId,
             electionSequenceNumber: this.lastSummaryAckSeqForClient ?? electionSequenceNumber,
         };
     }
@@ -144,5 +149,5 @@ export class SummarizerClientElection
     }
 
     public static readonly clientDetailsPermitElection = (details: IClientDetails): boolean =>
-        details.capabilities.interactive && details.type !== summarizerClientType;
+        details.capabilities.interactive || details.type === summarizerClientType;
 }

--- a/packages/runtime/container-runtime/src/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summaryManager.ts
@@ -139,7 +139,7 @@ export class SummaryManager implements IDisposable {
     private getShouldSummarizeState(): ShouldSummarizeState {
         if (!this.connectedState.connected) {
             return { shouldSummarize: false, stopReason: "parentNotConnected" };
-        } else if (this.connectedState.clientId !== this.clientElection.electedClientId) {
+        } else if (this.connectedState.clientId !== this.clientElection.electedParentId) {
             return { shouldSummarize: false, stopReason: "parentShouldNotSummarize" };
         } else if (this.disposed) {
             assert(false, 0x260 /* "Disposed should mean disconnected!" */);

--- a/packages/runtime/container-runtime/src/test/orderedClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/orderedClientElection.spec.ts
@@ -405,7 +405,7 @@ describe("Ordered Client Collection", () => {
                 assertElectionState(4, 3, "c", 19);
                 assertEvents(2);
                 removeClient("c", 5);
-                assertElectionState(3, 2, undefined, 24);
+                assertElectionState(3, 2, "a", 24);
                 assertEvents(3);
                 assertOrderedEligibleClientIds("a", "b");
             });
@@ -478,7 +478,7 @@ describe("Ordered Client Collection", () => {
                 removeClient("s", 1111);
                 assertElectionState(3, 3, "c", 4321);
                 removeClient("c", 1111);
-                assertElectionState(2, 2, undefined, 6543);
+                assertElectionState(2, 2, "a", 6543);
                 assertEvents(1);
             });
         });
@@ -516,35 +516,6 @@ describe("Ordered Client Collection", () => {
                 assertEvents(2);
             });
 
-            it("Should go to undefined from last", () => {
-                createOrderedClientElection([
-                    ["a", 1, true],
-                    ["b", 2, true],
-                    ["s", 5, false],
-                    ["c", 9, true],
-                ]);
-                incrementElectedClient(12);
-                incrementElectedClient(16);
-                incrementElectedClient(21);
-                assertElectionState(4, 3, undefined, 21);
-                assertEvents(3);
-            });
-
-            it("Should stay unchanged from end", () => {
-                createOrderedClientElection([
-                    ["a", 1, true],
-                    ["b", 2, true],
-                    ["s", 5, false],
-                    ["c", 9, true],
-                ]);
-                incrementElectedClient(12);
-                incrementElectedClient(16);
-                incrementElectedClient(21);
-                incrementElectedClient(27); // no-op, still updates election seq #
-                assertElectionState(4, 3, undefined, 27);
-                assertEvents(3);
-            });
-
             it("Should increment to new nodes", () => {
                 createOrderedClientElection([
                     ["a", 1, true],
@@ -552,11 +523,10 @@ describe("Ordered Client Collection", () => {
                     ["s", 5, false],
                     ["c", 9, true],
                 ]);
-                incrementElectedClient(12);
                 incrementElectedClient(16);
-                incrementElectedClient(21);
                 incrementElectedClient(27); // no-op
                 addClient("d", 100);
+                incrementElectedClient(100);
                 addClient("e", 101);
                 assertElectionState(6, 5, "d", 100);
                 incrementElectedClient(111);
@@ -565,9 +535,9 @@ describe("Ordered Client Collection", () => {
                 incrementElectedClient(205);
                 assertElectionState(7, 6, "f", 205);
                 incrementElectedClient(221);
-                assertElectionState(7, 6, undefined, 221);
+                assertElectionState(7, 6, "a", 221);
                 addClient("g", 229);
-                assertElectionState(8, 7, "g", 229);
+                assertElectionState(8, 7, "a", 221);
             });
 
             it("Should increment when ineligible client is elected", () => {
@@ -585,25 +555,6 @@ describe("Ordered Client Collection", () => {
         });
 
         describe("Reset elected client", () => {
-            it("Should only change election sequence number in empty quorum", () => {
-                createOrderedClientElection();
-                resetElectedClient(11);
-                assertElectionState(0, 0, undefined, 11);
-                assertEvents(0);
-            });
-
-            it("Should not reelect, only change election sequence number when already first", () => {
-                createOrderedClientElection([
-                    ["a", 1, true],
-                    ["b", 2, true],
-                    ["s", 5, false],
-                    ["c", 9, true],
-                ]);
-                resetElectedClient(11);
-                assertElectionState(4, 3, "a", 11);
-                assertEvents(0);
-            });
-
             it("Should reset to first when not first", () => {
                 createOrderedClientElection([
                     ["a", 1, true],
@@ -628,9 +579,9 @@ describe("Ordered Client Collection", () => {
                 incrementElectedClient(12);
                 incrementElectedClient(15);
                 incrementElectedClient(19);
-                resetElectedClient(31);
-                assertElectionState(4, 3, "a", 31);
-                assertEvents(4);
+                resetElectedClient(31); // no-op
+                assertElectionState(4, 3, "a", 19);
+                assertEvents(3);
             });
 
             it("Should reset to first when ineligible client is elected", () => {

--- a/packages/runtime/container-runtime/src/test/orderedClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/orderedClientElection.spec.ts
@@ -169,6 +169,11 @@ describe("Ordered Client Collection", () => {
         });
 
         describe("Initialize", () => {
+            const emptySerializedElection = {
+                electedClientId: undefined,
+                electedParentId: undefined,
+                electionSequenceNumber: 101 };
+
             it("Should initialize with empty quorum", () => {
                 createOrderedClientElection();
                 assertElectionState(0, 0, undefined, 0);
@@ -194,14 +199,14 @@ describe("Ordered Client Collection", () => {
             });
 
             it("Should initialize with empty quorum and initial state", () => {
-                createOrderedClientElection(undefined, { electedClientId: undefined, electionSequenceNumber: 101 });
+                createOrderedClientElection(undefined, emptySerializedElection);
                 assertElectionState(0, 0, undefined, 101);
                 assertOrderedEligibleClientIds();
             });
 
             it("Should log error with empty quorum and initially elected client", () => {
                 const clientId = "x";
-                createOrderedClientElection(undefined, { electedClientId: clientId, electionSequenceNumber: 101 });
+                createOrderedClientElection(undefined, emptySerializedElection);
                 assertElectionState(0, 0, undefined, 101);
                 mockLogger.matchEvents([{ eventName: "InitialElectedClientNotFound", clientId }]);
                 assertOrderedEligibleClientIds();
@@ -213,7 +218,7 @@ describe("Ordered Client Collection", () => {
                     ["b", 2, true],
                     ["s", 5, false],
                     ["c", 9, true],
-                ], { electedClientId: "b", electionSequenceNumber: 4321 });
+                ], { electedClientId: "b", electedParentId: "b", electionSequenceNumber: 4321 });
                 assertElectionState(4, 3, "b", 4321);
                 assertOrderedEligibleClientIds("a", "b", "c");
             });
@@ -225,7 +230,7 @@ describe("Ordered Client Collection", () => {
                     ["s", 5, false],
                     ["s2", 7, false],
                     ["c", 9, true],
-                ], { electedClientId: "s", electionSequenceNumber: 4321 });
+                ], { electedClientId: "s", electedParentId: "s", electionSequenceNumber: 4321 });
                 assertElectionState(5, 3, "c", 4321);
                 mockLogger.matchEvents([{
                     eventName: "InitialElectedClientIneligible",
@@ -241,7 +246,7 @@ describe("Ordered Client Collection", () => {
                     ["b", 2, true],
                     ["s", 5, false],
                     ["s2", 7, false],
-                ], { electedClientId: "s", electionSequenceNumber: 4321 });
+                ], { electedClientId: "s", electedParentId: "s", electionSequenceNumber: 4321 });
                 assertElectionState(4, 2, undefined, 4321);
                 mockLogger.matchEvents([{
                     eventName: "InitialElectedClientIneligible",
@@ -257,7 +262,7 @@ describe("Ordered Client Collection", () => {
                     ["b", 2, true],
                     ["s", 5, false],
                     ["c", 9, true],
-                ], { electedClientId: "x", electionSequenceNumber: 4321 });
+                ], { electedClientId: "x", electedParentId: "x", electionSequenceNumber: 4321 });
                 assertElectionState(4, 3, undefined, 4321);
                 mockLogger.matchEvents([{ eventName: "InitialElectedClientNotFound", clientId: "x" }]);
                 assertOrderedEligibleClientIds("a", "b", "c");
@@ -469,7 +474,7 @@ describe("Ordered Client Collection", () => {
                     ["b", 2, true],
                     ["s", 5, false],
                     ["c", 9, true],
-                ], { electedClientId: "s", electionSequenceNumber: 4321 });
+                ], { electedClientId: "s", electedParentId: "s", electionSequenceNumber: 4321 });
                 removeClient("s", 1111);
                 assertElectionState(3, 3, "c", 4321);
                 removeClient("c", 1111);
@@ -571,7 +576,7 @@ describe("Ordered Client Collection", () => {
                     ["s", 2, false],
                     ["b", 5, true],
                     ["c", 9, true],
-                ], { electedClientId: "s", electionSequenceNumber: 4321 });
+                ], { electedClientId: "s", electedParentId: "s", electionSequenceNumber: 4321 });
                 assertElectionState(4, 3, "b", 4321);
                 incrementElectedClient(7777);
                 assertElectionState(4, 3, "c", 7777);
@@ -634,7 +639,7 @@ describe("Ordered Client Collection", () => {
                     ["s", 2, false],
                     ["b", 5, true],
                     ["c", 9, true],
-                ], { electedClientId: "s", electionSequenceNumber: 4321 });
+                ], { electedClientId: "s", electedParentId: "s", electionSequenceNumber: 4321 });
                 assertElectionState(4, 3, "b", 4321);
                 resetElectedClient(7777);
                 assertElectionState(4, 3, "a", 7777);

--- a/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
@@ -187,7 +187,6 @@ describe("Summarizer Client Election", () => {
         mockLogger.events = [];
         testQuorum.reset();
         summaryCollectionEmitter.removeAllListeners();
-        summaryManager.removeAllListeners();
         summarizer.removeAllListeners();
         election.removeAllListeners();
         currentSequenceNumber = 0;
@@ -213,7 +212,7 @@ describe("Summarizer Client Election", () => {
             assertState("a-summarizer", 679, "summarizer still elected while completing work");
             summarizer.runDeferred.resolve();
             await flushPromises();
-            assertState("b", 679, "revert to parent election");
+            assertState("a", 679, "revert to parent election");
         });
 
         it("Should automatically elect oldest eligible client on op when not found initial client", async () => {
@@ -235,7 +234,7 @@ describe("Summarizer Client Election", () => {
             assertState("a-summarizer", 679, "summarizer still elected while completing work");
             summarizer.runDeferred.resolve();
             await flushPromises();
-            assertState("b", 679, "revert to parent election");
+            assertState("a", 679, "revert to parent election");
         });
 
         it("Should already have elected next eligible client when ineligible initial client", () => {
@@ -317,7 +316,7 @@ describe("Summarizer Client Election", () => {
 
             // Should elect first client at this point
             defaultOp();
-            assertState("a", maxOps + 4801, "should reelect > max ops");
+            assertState("b-summarizer", 4800, "b's summarizer still working");
             summarizer.runDeferred.resolve();
             await flushPromises();
             assertState("a-summarizer", maxOps + 4801, "should elect a's summarizer");
@@ -326,7 +325,9 @@ describe("Summarizer Client Election", () => {
             defaultOp(maxOps);
             assertState("a-summarizer", maxOps + 4801, "should not reelect <= max ops since baseline");
             defaultOp();
-            assertState("b", 2 * maxOps + 4802, "should reelect again");
+            summarizer.runDeferred.resolve();
+            await flushPromises();
+            assertState("b-summarizer", 2 * maxOps + 4802, "should reelect again");
         });
 
         it("Should not reelect when summary ack is found", () => {

--- a/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
@@ -4,13 +4,19 @@
  */
 
 import { strict as assert } from "assert";
-import { TypedEventEmitter } from "@fluidframework/common-utils";
+import { Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import { ISequencedClient, MessageType } from "@fluidframework/protocol-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ISerializedElection, OrderedClientCollection, OrderedClientElection } from "../orderedClientElection";
 import { ISummaryCollectionOpEvents } from "../summaryCollection";
-import { SummarizerClientElection } from "../summarizerClientElection";
+import { SummarizerClientElection, summarizerClientType } from "../summarizerClientElection";
 import { TestQuorum } from "./testQuorum";
+import { IConnectedEvents, IConnectedState, SummaryManager } from "../summaryManager";
+import {
+    ISummarizer,
+    ISummarizerEvents,
+    SummarizerStopReason,
+} from "../summarizerTypes";
 
 describe("Summarizer Client Election", () => {
     const maxOps = 1000;
@@ -21,12 +27,78 @@ describe("Summarizer Client Election", () => {
     let refreshSummarizerCallCount = 0;
     const summaryCollectionEmitter = new TypedEventEmitter<ISummaryCollectionOpEvents>();
     let election: SummarizerClientElection;
+    let summaryManager: SummaryManager;
 
-    function addClient(clientId: string, sequenceNumber: number, interactive = true) {
+    const summaryCollection = {
+        opsSinceLastAck: 0,
+        addOpListener: () => {},
+        removeOpListener: () => {},
+    };
+
+    class TestConnectedState extends TypedEventEmitter<IConnectedEvents> implements IConnectedState {
+        public connected = false;
+        public clientId: string | undefined;
+
+        public connect() {
+            this.connected = true;
+            this.clientId = election.electedParentId;
+            this.emit("connected", this.clientId);
+        }
+
+        public disconnect() {
+            this.connected = false;
+            this.emit("disconnected");
+        }
+    }
+
+    class TestSummarizer extends TypedEventEmitter<ISummarizerEvents> implements ISummarizer {
+        private notImplemented(): never {
+            throw Error("not implemented");
+        }
+        public onBehalfOf: string | undefined;
+        public state: "notStarted" | "running" | "stopped" = "notStarted";
+        public readonly stopDeferred = new Deferred<string | undefined>();
+        public readonly runDeferred = new Deferred<void>();
+        public clientId: string | undefined;
+
+        constructor() { super(); }
+        public async setSummarizer() { this.notImplemented(); }
+        public get cancelled() {
+            // Approximation, as ideally it should become cancelled immediately after stop() call
+            return this.state !== "running";
+        }
+        public stop(reason?: string): void {
+            this.stopDeferred.resolve(reason);
+        }
+        public async run(onBehalfOf: string): Promise<SummarizerStopReason> {
+            this.onBehalfOf = onBehalfOf;
+            this.state = "running";
+            await Promise.all([
+                this.stopDeferred.promise,
+                this.runDeferred.promise,
+            ]);
+            this.state = "stopped";
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            removeClient(this.clientId!, 0);
+            return "summarizerClientDisconnected";
+        }
+
+        public readonly summarizeOnDemand = () => this.notImplemented();
+        public readonly enqueueSummarize = () => this.notImplemented();
+        public get IFluidLoadable() { return this.notImplemented(); }
+        public get handle() { return this.notImplemented(); }
+    }
+
+    let connectedState: TestConnectedState;
+    let summarizer: TestSummarizer;
+
+    const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));
+
+    function addClient(clientId: string, sequenceNumber: number, interactive = true, type?: string) {
         if (sequenceNumber > currentSequenceNumber) {
             currentSequenceNumber = sequenceNumber;
         }
-        const details: ISequencedClient["client"]["details"] = { capabilities: { interactive } };
+        const details: ISequencedClient["client"]["details"] = { type, capabilities: { interactive } };
         const c: Partial<ISequencedClient["client"]> = { details };
         const client: ISequencedClient = { client: c as ISequencedClient["client"], sequenceNumber };
         testQuorum.addClient(clientId, client);
@@ -35,6 +107,25 @@ describe("Summarizer Client Election", () => {
         currentSequenceNumber += opCount;
         testQuorum.removeClient(clientId);
     }
+
+    const requestSummarizer = async (): Promise<ISummarizer> => {
+        summarizer = new TestSummarizer();
+        const parentId = election.electedParentId;
+        const clientId = `${parentId}-summarizer`;
+        summarizer.clientId = clientId;
+        addClient(clientId, currentSequenceNumber, false, summarizerClientType);
+        return summarizer;
+    };
+
+    const throttler = {
+        delayMs: 0,
+        numAttempts: 0,
+        getDelay() { return this.delayMs; },
+        maxDelayMs: 0,
+        delayWindowMs: 0,
+        delayFn: () => 0,
+    };
+
     function createElection(
         initialClients: [id: string, seq: number, int: boolean][] = [],
         initialState?: ISerializedElection,
@@ -55,6 +146,21 @@ describe("Summarizer Client Election", () => {
             maxOps,
             electionEnabled,
         );
+        connectedState = new TestConnectedState();
+        summaryManager = new SummaryManager(
+            election,
+            connectedState,
+            summaryCollection,
+            mockLogger,
+            requestSummarizer,
+            throttler,
+            {
+                initialDelayMs: 0,
+                opsToBypassInitialDelay: 0,
+            },
+        );
+        summaryManager.start();
+        election.on("electedSummarizerChanged", () => { connectedState.clientId = election.electedParentId; });
         election.on("shouldSummarizeStateChanged", () => refreshSummarizerCallCount++);
     }
     function defaultOp(opCount = 1) {
@@ -81,11 +187,14 @@ describe("Summarizer Client Election", () => {
         mockLogger.events = [];
         testQuorum.reset();
         summaryCollectionEmitter.removeAllListeners();
+        summaryManager.removeAllListeners();
+        summarizer.removeAllListeners();
+        election.removeAllListeners();
         currentSequenceNumber = 0;
     });
 
     describe("With initial state", () => {
-        it("Should automatically elect oldest eligible client on op when undefined initial client", () => {
+        it("Should automatically elect oldest eligible client on op when undefined initial client", async () => {
             currentSequenceNumber = 678;
             createElection([
                 ["s1", 1, false],
@@ -96,9 +205,18 @@ describe("Summarizer Client Election", () => {
             assertState(undefined, 432, "no elected client at first");
             defaultOp();
             assertState("a", 679, "auto-elect first eligible client");
+            connectedState.connect();
+            await flushPromises();
+            assertState("a-summarizer", 679, "a's summarizer elected on connect");
+            connectedState.disconnect();
+            await flushPromises();
+            assertState("a-summarizer", 679, "summarizer still elected while completing work");
+            summarizer.runDeferred.resolve();
+            await flushPromises();
+            assertState("b", 679, "revert to parent election");
         });
 
-        it("Should automatically elect oldest eligible client on op when not found initial client", () => {
+        it("Should automatically elect oldest eligible client on op when not found initial client", async () => {
             currentSequenceNumber = 678;
             createElection([
                 ["s1", 1, false],
@@ -109,6 +227,15 @@ describe("Summarizer Client Election", () => {
             assertState(undefined, 432, "no elected client at first");
             defaultOp();
             assertState("a", 679, "auto-elect first eligible client");
+            connectedState.connect();
+            await flushPromises();
+            assertState("a-summarizer", 679, "a's summarizer elected on connect");
+            connectedState.disconnect();
+            await flushPromises();
+            assertState("a-summarizer", 679, "summarizer still elected while completing work");
+            summarizer.runDeferred.resolve();
+            await flushPromises();
+            assertState("b", 679, "revert to parent election");
         });
 
         it("Should already have elected next eligible client when ineligible initial client", () => {
@@ -138,7 +265,7 @@ describe("Summarizer Client Election", () => {
             assertState(undefined, 432, "no client to elect");
         });
 
-        it("Should reelect during add/remove clients", () => {
+        it("Should reelect during add/remove clients", async () => {
             createElection([
             ], { electedClientId: undefined, electedParentId: undefined, electionSequenceNumber: 12 });
             assertState(undefined, 12, "no clients, should initially be undefined");
@@ -150,18 +277,28 @@ describe("Summarizer Client Election", () => {
             // Add interactive client, should elect
             addClient("a", 17, true);
             assertState("a", 17, "only one interactive client in quorum, should elect");
+            connectedState.connect();
+            await flushPromises();
+            assertState("a-summarizer", 17, "a's summarizer elected on connect");
 
             // Add more clients, no effect
             addClient("s2", 19, false);
             addClient("b", 41, true);
-            assertState("a", 17, "additional younger clients should have no effect");
+            assertState("a-summarizer", 17, "additional younger clients should have no effect");
 
             // Remove elected client, should reelect
             removeClient("a", 400);
+            connectedState.disconnect();
+            assertState("a-summarizer", 17, "summarizer still doing work");
+            summarizer.runDeferred.resolve();
+            await flushPromises();
             assertState("b", 441, "elected client leaving should reelect next oldest client");
+            connectedState.connect();
+            await flushPromises();
+            assertState("b-summarizer", 441, "should elect new summarizer");
         });
 
-        it("Should reelect when client not summarizing", () => {
+        it("Should reelect when client not summarizing", async () => {
             currentSequenceNumber = 4800;
             createElection([
                 ["s1", 1, false],
@@ -170,20 +307,26 @@ describe("Summarizer Client Election", () => {
                 ["b", 7, true],
             ], { electedClientId: "b", electedParentId: "b", electionSequenceNumber: 4000 });
             assertState("b", 4000, "elected client based on initial state");
+            connectedState.connect();
+            await flushPromises();
+            assertState("b-summarizer", 4800, "should elect b's summarizer");
 
             // Should stay the same right up until max ops
-            defaultOp(maxOps - 800);
-            assertState("b", 4000, "should not reelect <= max ops");
+            defaultOp(maxOps);
+            assertState("b-summarizer", 4800, "should not reelect <= max ops");
 
             // Should elect first client at this point
             defaultOp();
-            assertState("a", maxOps + 4001, "should reelect > max ops");
+            assertState("a", maxOps + 4801, "should reelect > max ops");
+            summarizer.runDeferred.resolve();
+            await flushPromises();
+            assertState("a-summarizer", maxOps + 4801, "should elect a's summarizer");
 
             // Trigger another reelection
             defaultOp(maxOps);
-            assertState("a", maxOps + 4001, "should not reelect <= max ops since baseline");
+            assertState("a-summarizer", maxOps + 4801, "should not reelect <= max ops since baseline");
             defaultOp();
-            assertState("b", 2 * maxOps + 4002, "should reelect again");
+            assertState("b", 2 * maxOps + 4802, "should reelect again");
         });
 
         it("Should not reelect when summary ack is found", () => {

--- a/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
@@ -92,7 +92,7 @@ describe("Summarizer Client Election", () => {
                 ["a", 2, true],
                 ["s2", 4, false],
                 ["b", 7, true],
-            ], { electedClientId: undefined, electionSequenceNumber: 432 });
+            ], { electedClientId: undefined, electedParentId: undefined, electionSequenceNumber: 432 });
             assertState(undefined, 432, "no elected client at first");
             defaultOp();
             assertState("a", 679, "auto-elect first eligible client");
@@ -105,7 +105,7 @@ describe("Summarizer Client Election", () => {
                 ["a", 2, true],
                 ["s2", 4, false],
                 ["b", 7, true],
-            ], { electedClientId: "x", electionSequenceNumber: 432 });
+            ], { electedClientId: "x", electedParentId: "x", electionSequenceNumber: 432 });
             assertState(undefined, 432, "no elected client at first");
             defaultOp();
             assertState("a", 679, "auto-elect first eligible client");
@@ -118,13 +118,14 @@ describe("Summarizer Client Election", () => {
                 ["a", 2, true],
                 ["s2", 4, false],
                 ["b", 7, true],
-            ], { electedClientId: "s2", electionSequenceNumber: 432 });
+            ], { electedClientId: "s2", electedParentId: "s2", electionSequenceNumber: 432 });
             assertState("b", 432, "auto-elect next eligible client");
         });
 
         it("Should remain unelected with empty quorum", () => {
             currentSequenceNumber = 678;
-            createElection([], { electedClientId: undefined, electionSequenceNumber: 432 });
+            createElection([
+            ], { electedClientId: undefined, electedParentId: undefined, electionSequenceNumber: 432 });
             assertState(undefined, 432, "no elected client at first");
             defaultOp();
             assertState(undefined, 432, "still no client to elect");
@@ -132,12 +133,14 @@ describe("Summarizer Client Election", () => {
 
         it("Should remain unelected with empty quorum and not found client", () => {
             currentSequenceNumber = 678;
-            createElection([], { electedClientId: "x", electionSequenceNumber: 432 });
+            createElection([
+            ], { electedClientId: "x", electedParentId: "x", electionSequenceNumber: 432 });
             assertState(undefined, 432, "no client to elect");
         });
 
         it("Should reelect during add/remove clients", () => {
-            createElection([], { electedClientId: undefined, electionSequenceNumber: 12 });
+            createElection([
+            ], { electedClientId: undefined, electedParentId: undefined, electionSequenceNumber: 12 });
             assertState(undefined, 12, "no clients, should initially be undefined");
 
             // Add non-interactive client, no effect
@@ -165,7 +168,7 @@ describe("Summarizer Client Election", () => {
                 ["a", 2, true],
                 ["s2", 4, false],
                 ["b", 7, true],
-            ], { electedClientId: "b", electionSequenceNumber: 4000 });
+            ], { electedClientId: "b", electedParentId: "b", electionSequenceNumber: 4000 });
             assertState("b", 4000, "elected client based on initial state");
 
             // Should stay the same right up until max ops
@@ -190,7 +193,7 @@ describe("Summarizer Client Election", () => {
                 ["a", 2, true],
                 ["s2", 4, false],
                 ["b", 7, true],
-            ], { electedClientId: "s2", electionSequenceNumber: 4000 });
+            ], { electedClientId: "s2", electedParentId: "s2", electionSequenceNumber: 4000 });
             assertState("b", 4000, "elected based on initial state");
 
             // Should stay the same right up until max ops
@@ -217,7 +220,7 @@ describe("Summarizer Client Election", () => {
                 ["a", 2, true],
                 ["s2", 4, false],
                 ["b", 7, true],
-            ], { electedClientId: "b", electionSequenceNumber: 4000 }, false);
+            ], { electedClientId: "b", electedParentId: "b", electionSequenceNumber: 4000 }, false);
             assertState("b", 4000, "elected client based on initial state");
 
             // Should stay the same right up until max ops

--- a/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerClientElection.spec.ts
@@ -10,13 +10,13 @@ import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ISerializedElection, OrderedClientCollection, OrderedClientElection } from "../orderedClientElection";
 import { ISummaryCollectionOpEvents } from "../summaryCollection";
 import { SummarizerClientElection, summarizerClientType } from "../summarizerClientElection";
-import { TestQuorum } from "./testQuorum";
 import { IConnectedEvents, IConnectedState, SummaryManager } from "../summaryManager";
 import {
     ISummarizer,
     ISummarizerEvents,
     SummarizerStopReason,
 } from "../summarizerTypes";
+import { TestQuorum } from "./testQuorum";
 
 describe("Summarizer Client Election", () => {
     const maxOps = 1000;

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -108,6 +108,7 @@ describe("Summary Manager", () => {
         extends TypedEventEmitter<ISummarizerClientElectionEvents>
         implements ISummarizerClientElection {
         public electedClientId: string | undefined;
+        public get electedParentId() { return this.electedClientId; }
 
         public electClient(clientId: string | undefined) {
             this.electedClientId = clientId;

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -191,7 +191,7 @@ describe("Summary Manager", () => {
         assertState(SummaryManagerState.Off, "connected but other client elected");
         clientElection.electClient(thisClientId);
         await flushPromises();
-        assertState(SummaryManagerState.Starting, "should request summarizer");
+        assertState(SummaryManagerState.Running, "should request summarizer");
         assertRequests(1, "should have requested summarizer");
         completeSummarizerRequest();
         await flushPromises();
@@ -213,7 +213,7 @@ describe("Summary Manager", () => {
         assertState(SummaryManagerState.Off, "elected but not yet connected");
         connectedState.connect();
         await flushPromises();
-        assertState(SummaryManagerState.Starting, "should request summarizer");
+        assertState(SummaryManagerState.Running, "should request summarizer");
         assertRequests(1, "should have requested summarizer");
         completeSummarizerRequest();
         await flushPromises();
@@ -235,7 +235,7 @@ describe("Summary Manager", () => {
         assertState(SummaryManagerState.Off, "connected but not yet elected");
         clientElection.electClient(thisClientId);
         await flushPromises();
-        assertState(SummaryManagerState.Starting, "should request summarizer");
+        assertState(SummaryManagerState.Running, "should request summarizer");
         assertRequests(1, "should have requested summarizer");
         completeSummarizerRequest();
         await flushPromises();
@@ -243,7 +243,7 @@ describe("Summary Manager", () => {
         summarizer.stop(); // Simulate summarizer stopping itself
         summarizer.runDeferred.resolve();
         await flushPromises();
-        assertState(SummaryManagerState.Starting, "should restart itself");
+        assertState(SummaryManagerState.Running, "should restart itself");
         assertRequests(2, "should have requested a new summarizer");
         completeSummarizerRequest();
         await flushPromises();
@@ -281,7 +281,7 @@ describe("Summary Manager", () => {
             });
             clientElection.electClient(thisClientId);
             await flushPromises();
-            assertState(SummaryManagerState.Starting, "should enter starting state immediately");
+            assertState(SummaryManagerState.Running, "should enter starting state immediately");
             assertRequests(1, "should request summarizer immediately, bypassing initial delay");
             completeSummarizerRequest();
             await flushPromises();


### PR DESCRIPTION
That allows us to postpone electing a new client while the existing summarizer is still doing work, e.g., doing a last summary.