### PR TITLE
Bumping Node Docker image to 14.18.3

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:14.18.2-stretch AS base
+FROM node:14.18.3-stretch AS base
 
 # Add Tini
 ENV TINI_VERSION v0.18.0

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:14.18.2-stretch-slim AS base
+FROM node:14.18.3-stretch-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:14.18.2-stretch-slim AS base
+FROM node:14.18.3-stretch-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/tinylicious/.devcontainer/Dockerfile
+++ b/server/tinylicious/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-FROM node:14.18.2
+FROM node:14.18.3
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Bumping Node.js Docker images used in GitRest, Historian, Routerlicious and Tinylicious according to the most recent Node.js security releases: https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/

Testing strategy: built Routerlicious, Historian and GitRest images. Ran Routerlicious targeting all those images (locally modified my docker-compose.yml to do that). Tested with Clicker, all good. I could not figure out how to test Tinylicious Docker (please let me know if anyone has instructions on how to do that), but I assume there would be no issues since nothing unexpected was observed for historian, r11s and gitrest.