### PR TITLE
Respect canRetry from error thrown from token provider

### DIFF
--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -5,7 +5,13 @@
 
 import { ITelemetryProperties, ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { IResolvedUrl, DriverErrorType } from "@fluidframework/driver-definitions";
-import { isOnline, OnlineStatus, RetryableError, NonRetryableError } from "@fluidframework/driver-utils";
+import {
+    isOnline,
+    OnlineStatus,
+    RetryableError,
+    NonRetryableError,
+    NetworkErrorBasic,
+} from "@fluidframework/driver-utils";
 import { assert, performance } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { ChildLogger, PerformanceEvent, wrapError } from "@fluidframework/telemetry-utils";
@@ -307,12 +313,16 @@ export function toInstrumentedOdspTokenFetcher(
                 }
                 return token;
             }, (error) => {
+                // There is an important but unofficial contract here where token providers can set canRetry: true
+                // to hook into the driver's retry logic (e.g. the retry loop when initiating a connection)
+                const rawCanRetry = error?.canRetry;
                 const tokenError = wrapError(
                     error,
-                    (errorMessage) => new NonRetryableError(
+                    (errorMessage) => new NetworkErrorBasic(
                         "tokenFetcherFailed",
                         errorMessage,
                         OdspErrorType.fetchTokenError,
+                        typeof rawCanRetry === "boolean" ? rawCanRetry : false /* canRetry */,
                         { method: name, driverVersion }));
                 throw tokenError;
             }),


### PR DESCRIPTION
This seems to be the root cause of a bad user experience in office.com's use of Fluid, where after a long idle period, we try to connect before the underlying network error is online.  The token provider is the first bit of code to make a network call, it fails, they set `canRetry: true`, but we drop it and close the container thinking it's a fatal error.

See https://dev.azure.com/Office/OC/_workitems/edit/5751901 and https://portal.microsofticm.com/imp/v3/incidents/details/285457594/home