### PR TITLE
Encoding git blobs correctly in tinylicious

### DIFF
--- a/server/tinylicious/src/routes/storage/git/blobs.ts
+++ b/server/tinylicious/src/routes/storage/git/blobs.ts
@@ -5,6 +5,7 @@
 
 import fs from "fs";
 import { IBlob, ICreateBlobParams, ICreateBlobResponse } from "@fluidframework/gitresources";
+import { Uint8ArrayToString } from "@fluidframework/common-utils";
 import { Router } from "express";
 import * as git from "isomorphic-git";
 import nconf from "nconf";
@@ -44,7 +45,7 @@ export async function getBlob(
         url: "",
         sha,
         size: buffer.length,
-        content: buffer.toString("base64"),
+        content: Uint8ArrayToString(buffer, "base64"),
         encoding: "base64",
     };
 


### PR DESCRIPTION
isomorphic-git introduced recently a [breaking change](https://github.com/isomorphic-git/isomorphic-git/pull/1009), where all functions returns Uint8Array instead of Buffer, this introduced a breaking change to tinylcious code when loading the blob, because it still expects Buffer to be returned.