### PR TITLE
Container dirty flag docs update.

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -13,6 +13,7 @@ There are a few steps you can take to write a good change note and avoid needing
 ## 0.57 Breaking changes
 - [IFluidConfiguration removed](#IFluidConfiguration-removed)
 - [Driver error constructors' signatures have changed](#driver-error-constructors-signatures-have-changed)
+- [The behavior of containers' isDirty flag has changed](#containers-isdirty-flag-behavior-has-changed)
 
 ### IFluidConfiguration removed
 
@@ -26,6 +27,9 @@ Same for helper functions that return new error objects.
 
 Additionally, `createGenericNetworkError`'s signature was refactored to combine `canRetry` and `retryAfterMs` into a single
 required parameter `retryInfo`.
+
+### Containers isDirty flag behavior has changed
+Container is now considered dirty if it's not attached or it is attached but has pending ops. Check https://fluidframework.com/docs/build/containers/#isdirty for further details.
 
 ## 0.56 Breaking changes
 - [`MessageType.Save` and code that handled it was removed](#messageType-save-and-code-that-handled-it-was-removed)

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -78,18 +78,21 @@ export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
     readonly connected: boolean;
 
      /**
-     * A container is considered **dirty** if it has local changes that have not yet been acknowledged by the service.
-     * acknowledged by the service. Closing the container while `isDirty === true` will result in the loss of these
-     * local changes. You should always check the `isDirty` flag before closing the container or navigating away
-     * from the page.
+     * A container is considered **dirty** if it has local changes that have not yet been acknowledged by the service. 
+     * You should always check the `isDirty` flag before closing the container or navigating away from the page. 
+     * Closing the container while `isDirty === true` may result in the loss of operations that have not yet been 
+     * acknowledged by the service.
      *
      * A container is considered dirty in the following cases:
      *
-     * 1. The container has local changes that have not yet been acknowledged by the service. These unacknowledged
-     * changes will be lost if the container is closed.
+     * 1. The container has been created in the detached state, and either it has not been attached yet or it is 
+     * in the process of being attached (container is in `attaching` state). If container is closed prior to being 
+     * attached, host may never know if the file was created or not.
      *
-     * 1. There is no network connection while making changes to the container. These changes cannot be
-     * acknowledged by the service until the network connection is restored.
+     * 2. The container was attached, but it has local changes that have not yet been saved to service endpoint. 
+     * This occurs as part of normal op flow where pending operation (changes) are awaiting acknowledgement from the 
+     * service. In some cases this can be due to lack of network connection. If the network connection is down, 
+     * it needs to be restored for the pending changes to be acknowledged.
      */
      readonly isDirty: boolean;
 


### PR DESCRIPTION
This PR includes doc changes that should accompany earlier PR:  https://github.com/microsoft/FluidFramework/pull/8596
1. Breaking doc update.
2. Fluid container interface doc update.