### PR TITLE
Add no-multi-spaces and no-return-assign to ESLint rules and fix up

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -73,6 +73,7 @@ module.exports = {
                 "code": 120
             }
         ],
+        "no-multi-spaces": ["error", {"ignoreEOLComments": true}],
         "unicorn/better-regex": "error",
         "unicorn/filename-case": [
             "error",
@@ -100,7 +101,6 @@ module.exports = {
         "@typescript-eslint/typedef": "off",
         "func-call-spacing": "off", // Off because it conflicts with typescript-formatter
         "no-empty": "off",
-        "no-return-assign": "off",
         "no-void": "off",
         "require-atomic-updates": "off",
         "dot-notation": "off", // Superseded by @typescript-eslint/dot-notation

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -17,7 +17,6 @@ module.exports = {
         // RECOMMEDED RULES
         "@rushstack/no-new-null": "error",
         "no-empty": "error",
-        "no-return-assign": "error",
         "no-void": "error",
         "require-atomic-updates": "error",
 

--- a/common/lib/common-utils/src/test/mocha/timer.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/timer.spec.ts
@@ -228,7 +228,7 @@ describe("Timers", () => {
 
         function startWithThen(ms?: number, handler?: () => void) {
             timer.start(ms, handler).then(
-                (result) => resolveResult = result.timerResult,
+                (result) => { resolveResult = result.timerResult },
                 (error) => assert.fail(error),
             );
         }

--- a/common/lib/container-definitions/src/browserPackage.ts
+++ b/common/lib/container-definitions/src/browserPackage.ts
@@ -52,7 +52,7 @@ export interface IFluidBrowserPackage extends IFluidPackage {
  * Determines if any object is an IFluidBrowserPackage
  * @param maybePkg - The object to check for compatibility with IFluidBrowserPackage
  */
-export const isFluidBrowserPackage = (maybePkg: any): maybePkg is Readonly<IFluidBrowserPackage>  =>
+export const isFluidBrowserPackage = (maybePkg: any): maybePkg is Readonly<IFluidBrowserPackage> =>
     isFluidPackage(maybePkg)
     && typeof maybePkg?.fluid?.browser?.umd?.library === "string"
     && Array.isArray(maybePkg?.fluid?.browser?.umd?.files);

--- a/common/lib/container-definitions/src/deltas.ts
+++ b/common/lib/container-definitions/src/deltas.ts
@@ -52,7 +52,7 @@ export interface IDeltaHandlerStrategy {
 }
 
 declare module "@fluidframework/core-interfaces" {
-    interface IFluidObject  {
+    interface IFluidObject {
         /** @deprecated - use `FluidObject<IDeltaSender>` instead */
         readonly IDeltaSender?: IDeltaSender
      }

--- a/common/lib/container-definitions/src/fluidPackage.ts
+++ b/common/lib/container-definitions/src/fluidPackage.ts
@@ -48,7 +48,7 @@ export interface IFluidPackage {
          * The name of the of the environment. This should be something like browser, or node
          * and contain the necessary targets for loading this code in that environment.
          */
-        [environment: string]:  undefined | IFluidPackageEnvironment;
+        [environment: string]: undefined | IFluidPackageEnvironment;
     };
     /**
      * General access for extended fields as specific usages will

--- a/common/lib/container-definitions/src/legacy/chaincode.ts
+++ b/common/lib/container-definitions/src/legacy/chaincode.ts
@@ -25,7 +25,7 @@ export interface IFluidTokenProvider extends IProvideFluidTokenProvider {
 }
 
 declare module "@fluidframework/core-interfaces" {
-    export interface IFluidObject  {
+    export interface IFluidObject {
         /** @deprecated - use `FluidObject<IRuntimeFactory>` instead */
         readonly IRuntimeFactory?: IRuntimeFactory;
         /** @deprecated - use `FluidObject<IFluidTokenProvider>` instead */

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -464,7 +464,7 @@ export interface IProvideLoader {
 declare module "@fluidframework/core-interfaces" {
     export interface IRequestHeader extends Partial<ILoaderHeader> { }
 
-    export interface IFluidObject  {
+    export interface IFluidObject {
         /**
          * @deprecated - use `FluidObject<ILoader>` instead
          */

--- a/common/lib/core-interfaces/src/fluidPackage.ts
+++ b/common/lib/core-interfaces/src/fluidPackage.ts
@@ -9,7 +9,6 @@
   * Specifies an environment on Fluid property of a IFluidPackage
   */
 export interface IFluidPackageEnvironment {
-
     /**
      * The name of the target. For a browser environment, this could be umd for scripts
      * or css for styles.
@@ -52,7 +51,7 @@ export interface IFluidPackage {
          * The name of the of the environment. This should be something like browser, or node
          * and contain the necessary targets for loading this code in that environment.
          */
-        [environment: string]:  undefined | IFluidPackageEnvironment;
+        [environment: string]: undefined | IFluidPackageEnvironment;
     };
     /**
      * General access for extended fields as specific usages will

--- a/examples/data-objects/multiview/slider-coordinate-view/src/view.tsx
+++ b/examples/data-objects/multiview/slider-coordinate-view/src/view.tsx
@@ -37,7 +37,7 @@ export const SliderCoordinateView: React.FC<ISliderCoordinateViewProps> = (props
                 X:
                 <input
                     type="range"
-                    onChange={(e) => props.model.x = parseInt((e.target as HTMLInputElement).value, 10)}
+                    onChange={(e) => { props.model.x = parseInt((e.target as HTMLInputElement).value, 10) }}
                     value={x}
                 />
                 {Math.trunc(x)}
@@ -46,7 +46,7 @@ export const SliderCoordinateView: React.FC<ISliderCoordinateViewProps> = (props
                 Y:
                 <input
                     type="range"
-                    onChange={(e) => props.model.y = parseInt((e.target as HTMLInputElement).value, 10)}
+                    onChange={(e) => { props.model.y = parseInt((e.target as HTMLInputElement).value, 10) }}
                     value={y}
                 />
                 {Math.trunc(y)}

--- a/examples/data-objects/table-view/src/grid.ts
+++ b/examples/data-objects/table-view/src/grid.ts
@@ -361,12 +361,12 @@ export class GridView {
         /* eslint-disable no-fallthrough */
         switch (e.code) {
             case KeyCode.escape: { this.cancelInput(); break; }
-            case KeyCode.arrowUp: { this.moveInputByOffset(e, /* rowOffset: */ -1, /* colOffset */  0); break; }
+            case KeyCode.arrowUp: { this.moveInputByOffset(e, /* rowOffset: */ -1, /* colOffset */ 0); break; }
             case KeyCode.enter: { this.commitInput(); /* fall-through */ }
-            case KeyCode.arrowDown: { this.moveInputByOffset(e, /* rowOffset: */  1, /* colOffset */  0); break; }
-            case KeyCode.arrowLeft: { this.moveInputByOffset(e, /* rowOffset: */  0, /* colOffset */ -1); break; }
+            case KeyCode.arrowDown: { this.moveInputByOffset(e, /* rowOffset: */ 1, /* colOffset */ 0); break; }
+            case KeyCode.arrowLeft: { this.moveInputByOffset(e, /* rowOffset: */ 0, /* colOffset */ -1); break; }
             case KeyCode.tab: { e.preventDefault(); /* fall-through */ }
-            case KeyCode.arrowRight: { this.moveInputByOffset(e, /* rowOffset: */  0, /* colOffset */  1); }
+            case KeyCode.arrowRight: { this.moveInputByOffset(e, /* rowOffset: */ 0, /* colOffset */ 1); }
         }
         /* eslint-enable no-fallthrough */
     };

--- a/examples/data-objects/vltava/src/fluidObjects/tabs/view.tsx
+++ b/examples/data-objects/vltava/src/fluidObjects/tabs/view.tsx
@@ -57,7 +57,7 @@ export class TabsView extends React.Component<ITabsViewProps, ITabsViewState> {
                     {id.substring(0, 3)}
                 </Tab>);
             tabPanel.push(
-                <TabPanel key={id}  >
+                <TabPanel key={id}>
                     <EmbeddedFluidObjectWrapper
                         id={id}
                         requestFluidObject={async (compId: string) => this.props.dataModel.getFluidObjectTab(compId)}

--- a/examples/data-objects/webflow/src/test/direction.spec.ts
+++ b/examples/data-objects/webflow/src/test/direction.spec.ts
@@ -7,6 +7,8 @@
 import { strict as assert } from "assert";
 import { Direction, getDeltaX, getDeltaY } from "../util";
 
+/* eslint-disable no-multi-spaces */
+
 const cases = [
     { name: "none",       direction: Direction.none,                      expectedX:  0,    expectedY:  0 },
     { name: "left",       direction: Direction.left,                      expectedX: -1,    expectedY:  0 },
@@ -18,6 +20,8 @@ const cases = [
     { name: "left down",  direction: Direction.left  | Direction.down,    expectedX: -1,    expectedY:  1 },
     { name: "right down", direction: Direction.right | Direction.down,    expectedX:  1,    expectedY:  1 },
 ];
+
+/* eslint-enable no-multi-spaces */
 
 describe("direction", () => {
     describe("getDeltaX", () => {

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -137,7 +137,7 @@ export class IFrameOuterHost {
         // them all in one (otherwise there are mysterious runtime errors)
         const combinedProxy = {};
 
-        const outerDocumentServiceProxy =  new DocumentServiceFactoryProxy(
+        const outerDocumentServiceProxy = new DocumentServiceFactoryProxy(
             MultiDocumentServiceFactory.create(this.hostConfig.documentServiceFactory),
             this.hostConfig.options,
         );

--- a/examples/hosts/iframe-host/src/outer.ts
+++ b/examples/hosts/iframe-host/src/outer.ts
@@ -108,7 +108,7 @@ async function loadOuterLogDiv(
         };
 
     const quorum = container.getQuorum();
-    quorum.getMembers().forEach((client) => logDiv.innerHTML += `Quorum: client: ${JSON.stringify(client)}<br/>`);
+    quorum.getMembers().forEach((client) => { logDiv.innerHTML += `Quorum: client: ${JSON.stringify(client)}<br/>` });
     log(quorum, "Quorum", "error", "addMember", "removeMember");
     log(container, "Container", "error", "connected", "disconnected");
 }

--- a/experimental/PropertyDDS/examples/partial-checkout/src/checkout_view.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/checkout_view.ts
@@ -40,7 +40,7 @@ export async function renderCheckoutView(div: HTMLDivElement): Promise<string[] 
             div.removeChild(wrapperDiv);
             const paths = getPaths(list);
             params.set("paths", paths.toString());
-            window.history.replaceState({}, "", `?${ params.toString()  }${window.location.hash}`);
+            window.history.replaceState({}, "", `?${ params.toString() }${window.location.hash}`);
             resolve(paths.length > 0 ? paths : undefined);
         };
     });

--- a/experimental/PropertyDDS/examples/partial-checkout/src/demo/squaresApp.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/demo/squaresApp.ts
@@ -47,7 +47,7 @@ export function randomSquaresBoardGenerator(
                 x: _.random(SquaresBoard.WIDTH - Square.DEFAULT_LENGTH),
                 y: _.random(SquaresBoard.HEIGHT - Square.DEFAULT_LENGTH),
             },
-            color: `#${  Math.floor(Math.random() * 16777215).toString(16)}`,
+            color: `#${ Math.floor(Math.random() * 16777215).toString(16) }`,
         };
     }
     propertyNode.insert(PropertyFactory.create("autofluid:squaresBoard-1.0.0", undefined, {
@@ -63,7 +63,7 @@ export class SquaresApp {
     init() {
         // Define a runtime representation for squaresBoard & square typeids.
         this.dataBinder.defineRepresentation("view", "autofluid:squaresBoard-1.0.0", (property) => {
-            const board =  new SquaresBoard([], this.container);
+            const board = new SquaresBoard([], this.container);
             // Rendering move button to move board's squares randomly
             renderMoveButton(
                 this.dataBinder.getPropertyTree()!,

--- a/experimental/PropertyDDS/examples/partial-checkout/src/view.tsx
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/view.tsx
@@ -46,7 +46,7 @@ export function renderButtons(propertyTree: IPropertyTree, div: HTMLDivElement) 
     buttons.append(randomButton);
 
     const commitButton = document.createElement("button");
-    commitButton.id  = "commit";
+    commitButton.id = "commit";
     commitButton.style.fontSize = "15px";
     commitButton.textContent = "Commit";
     commitButton.addEventListener("click", () => {

--- a/experimental/PropertyDDS/examples/property-inspector/src/theme.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/src/theme.ts
@@ -33,7 +33,7 @@ export const theme = createTheme({
   palette: {
     primary: {
       contrastText: "#fff",
-      main:  "#0696d7",
+      main: "#0696d7",
     },
   },
 

--- a/experimental/PropertyDDS/examples/schemas/src/schemasRegisterer.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/schemasRegisterer.ts
@@ -5,7 +5,7 @@
 import { ALL_SCHEMAS } from "./";
 
 export const registerSchemas = function(propertyFactory: any) {
-    Object.values(ALL_SCHEMAS).forEach((schemas)  => {
+    Object.values(ALL_SCHEMAS).forEach((schemas) => {
         propertyFactory.register(Object.values(schemas));
     });
 };

--- a/experimental/PropertyDDS/examples/schemas/src/squares_demo/2DPoint-1.0.0.ts
+++ b/experimental/PropertyDDS/examples/schemas/src/squares_demo/2DPoint-1.0.0.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-export default  {
+export default {
     typeid: "autofluid:2DPoint-1.0.0",
     properties: [
         { id: "x", typeid: "Float32" },

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBindingTree.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/dataBindingTree.ts
@@ -614,7 +614,7 @@ export class DataBindingTree {
         let maxIndex = -1;
         for (let i = 0; i < keys.length; ++i) {
             console.assert(isNormalInteger(keys[i]));
-            const key =  Number.parseInt(keys[i], 10) ;
+            const key = Number.parseInt(keys[i], 10) ;
             maxIndex = key > maxIndex ? key : maxIndex;
             replacementNode._childNodes[keys[i]] =
                 oldDataBindingTreeNode._childNodes[keys[i]];

--- a/experimental/PropertyDDS/packages/property-binder/src/data_binder/internalUtils.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/data_binder/internalUtils.ts
@@ -478,7 +478,7 @@ const invokeCallbacks = function(
     }
 };
 
-const isSubPath = function(a: string,  b: string) {
+const isSubPath = function(a: string, b: string) {
     return b.indexOf(a as string) === 0 && ((b[a.length] === '.' || b[a.length] === '[') || a.length === b.length);
 };
 

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/arrayChangesetIterator.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset_operations/arrayChangesetIterator.ts
@@ -23,7 +23,7 @@ const { MSG } = constants;
 
 type genericArray = Array<number | string | (SerializedChangeSet & {typeid:string})>;
 export type arrayInsertList = [number, string | genericArray]
-export type arrayModifyList = [number, string | genericArray] | [number,  string, string] | [number,  genericArray, genericArray]
+export type arrayModifyList = [number, string | genericArray] | [number, string, string] | [number, genericArray, genericArray]
 export type arrayRemoveList = [number, number | string | genericArray]
 
 

--- a/experimental/PropertyDDS/packages/property-common/src/error_objects/flaggedError.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/error_objects/flaggedError.ts
@@ -9,7 +9,7 @@
  * @param  flag - A flag to be checked
  * @returns   True if the flag is set in passed flags, false otherwise.
  */
- const _isFlagSet = (flags: number, flag: number) =>   {
+ const _isFlagSet = (flags: number, flag: number) => {
     // eslint-disable-next-line no-bitwise
     return (flags & flag) === flag;
 };
@@ -35,13 +35,13 @@ export class FlaggedError {
      * @returns True if the quiet flag is set.
      */
     isQuiet(): boolean {
-        return  _isFlagSet(this.flags,FlaggedError.FLAGS.QUIET);
+        return _isFlagSet(this.flags,FlaggedError.FLAGS.QUIET);
     }
 
     /**
      * @returns True if the transient flag is set.
      */
     isTransient(): boolean {
-        return  _isFlagSet(this.flags, FlaggedError.FLAGS.TRANSIENT);
+        return _isFlagSet(this.flags, FlaggedError.FLAGS.TRANSIENT);
     }
 }

--- a/experimental/PropertyDDS/packages/property-common/src/test/chronometer.spec.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/test/chronometer.spec.ts
@@ -64,7 +64,7 @@ describe("property-common.Chronometer", function() {
                 resolve(expectedResult);
             }, expectedElapsedMilliSec);
 
-            const expectations: Promise<void>  = Chronometer.timePromise(async () => promise)
+            const expectations: Promise<void> = Chronometer.timePromise(async () => promise)
                 .then(function(timedResult) {
                     expect(timedResult.chrono.elapsedMilliSec()).to.be.at.least(expectedElapsedMilliSec - 5);
                     expect(timedResult.chrono.elapsedMilliSec()).to.be.at.most(expectedElapsedMilliSec + 50);

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -200,7 +200,7 @@ export class SharedPropertyTree extends SharedObject {
 
 		// if no override provided dont submit unless metadata are provided
 		if (submitEmptyChange === undefined) {
-			doSubmit =  metadata !== undefined;
+			doSubmit = metadata !== undefined;
 		}
 
 		if (doSubmit || !isEmpty(changes)) {

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/InspectorTable.tsx
@@ -457,7 +457,7 @@ class InspectorTable extends React.Component<WithStyles<typeof styles> & IInspec
       const rowsData = this.props.checkoutInProgress ? fakeRows : rows;
       this.columns = this.generateColumns(width);
       const getHeader = ({cells, headerIndex}) => {
-        if ( headerIndex === 1)  {
+        if (headerIndex === 1) {
           return cells;
         }
         return (

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/NameCell.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/NameCell.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {  PropertyProxy } from '@fluid-experimental/property-proxy';
+import { PropertyProxy } from '@fluid-experimental/property-proxy';
 import { ItemMenu } from './ItemMenu';
 import { BaseProperty, ArrayProperty, NodeProperty, MapProperty } from '@fluid-experimental/property-properties';
 import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/Theme.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/Theme.tsx
@@ -34,7 +34,7 @@ export const theme = createTheme({
   palette: {
     primary: {
       contrastText: '#fff',
-      main:  '#0696d7',
+      main: '#0696d7',
     },
   },
 

--- a/experimental/PropertyDDS/packages/property-inspector-table/src/utils.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/src/utils.tsx
@@ -102,7 +102,7 @@ function findMatchingElementIndexInDataSet(data: IInspectorRow[], currentlyExpan
       }
     }
   }
-  return  {idx: rowCounter, found: false};
+  return { idx: rowCounter, found: false };
 }
 
 interface ISearchLevelState {

--- a/experimental/PropertyDDS/packages/property-inspector-table/test/InspectorTable.spec.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/test/InspectorTable.spec.tsx
@@ -17,7 +17,7 @@ import { BooleanView } from '../src/PropertyViews/Boolean';
 import { EnumView } from '../src/PropertyViews/Enum';
 import { NumberView } from '../src/PropertyViews/Number';
 import { StringView } from '../src/PropertyViews/String';
-import {  useFakeTimers } from 'sinon';
+import { useFakeTimers } from 'sinon';
 import {
   coordinateSystem3DSchema,
   enumUnoDosTresSchema,

--- a/experimental/PropertyDDS/packages/property-inspector-table/test/Utils.spec.tsx
+++ b/experimental/PropertyDDS/packages/property-inspector-table/test/Utils.spec.tsx
@@ -418,7 +418,7 @@ describe('InspectorTable', () => {
     let expanded;
     beforeAll(async () => {
       ({ workspace } = await initializeWorkspace());
-      expanded =  Object.keys(expandAll(workspace));
+      expanded = Object.keys(expandAll(workspace));
     });
 
     it('should expand nonprimitives', () => {

--- a/experimental/PropertyDDS/packages/property-inspector-table/test/schemas.ts
+++ b/experimental/PropertyDDS/packages/property-inspector-table/test/schemas.ts
@@ -260,7 +260,7 @@ export const uint64CasesSchema = {
   typeid: 'autodesk.uint64:uint64-1.0.0',
 };
 
-export const inheritNodeProp  =  {
+export const inheritNodeProp = {
   inherits: 'NodeProperty',
   properties: [
     { id: 'something', typeid: 'String' },

--- a/experimental/dds/xtree/src/tree.ts
+++ b/experimental/dds/xtree/src/tree.ts
@@ -35,9 +35,9 @@ export class SharedXTree extends SharedObject
         throw new Error("not implemented");
     }
 
-    protected didAttach() {  }
+    protected didAttach() { }
 
-    protected onConnect() {  }
+    protected onConnect() { }
 
     protected reSubmitCore(content: any, localOpMetadata: unknown) { throw new Error("not implemented"); }
 

--- a/experimental/examples/bubblebench/baseline/src/state.ts
+++ b/experimental/examples/bubblebench/baseline/src/state.ts
@@ -28,7 +28,7 @@ export class AppState implements IAppState {
     public get height() { return this._height; }
 
     private makeBubble() {
-        return makeBubble(this.width,  this.height);
+        return makeBubble(this.width, this.height);
     }
 
     public increaseBubbles() {

--- a/experimental/examples/bubblebench/ot/src/state.ts
+++ b/experimental/examples/bubblebench/ot/src/state.ts
@@ -47,7 +47,7 @@ export class AppState implements IAppState {
     }
 
     private makeBubble() {
-        return makeBubble(this.width,  this.height);
+        return makeBubble(this.width, this.height);
     }
 
     public increaseBubbles() {

--- a/experimental/examples/bubblebench/sharedtree/src/state.ts
+++ b/experimental/examples/bubblebench/sharedtree/src/state.ts
@@ -59,7 +59,7 @@ export class AppState implements IAppState {
     }
 
     private makeBubble() {
-        return makeBubble(this.width,  this.height);
+        return makeBubble(this.width, this.height);
     }
 
     public increaseBubbles() {

--- a/experimental/framework/data-objects/src/signalManager/signalManager.ts
+++ b/experimental/framework/data-objects/src/signalManager/signalManager.ts
@@ -91,7 +91,7 @@ export interface IRuntimeSignaler {
  * deregistration.
  */
 export class Signaler extends TypedEventEmitter<IErrorEvent> implements ISignaler {
-    private readonly emitter  = new EventEmitter();
+    private readonly emitter = new EventEmitter();
 
     private readonly managerId: string | undefined;
 

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2047,6 +2047,13 @@
 						"@fluidframework/common-definitions": "^0.20.0",
 						"@fluidframework/core-interfaces": "^0.41.0",
 						"@fluidframework/protocol-definitions": "^0.1026.0"
+					},
+					"dependencies": {
+						"@fluidframework/core-interfaces": {
+							"version": "0.41.0",
+							"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.41.0.tgz",
+							"integrity": "sha512-1mA1W6brtWbBelQLFHIhcPQBW1GCHRQd+MnnhONV9v8ThF0yfK2lSQGTCEncGdSq0tkgEJKCP2gI9+jWrClNHw=="
+						}
 					}
 				}
 			}
@@ -2100,9 +2107,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2161,9 +2168,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2222,9 +2229,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2450,9 +2457,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2511,9 +2518,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2572,9 +2579,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2847,9 +2854,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2902,9 +2909,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2949,9 +2956,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},
@@ -2996,9 +3003,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
-					"integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
+					"version": "12.20.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
+					"integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
 				}
 			}
 		},

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ISequencedDocumentMessage,  MessageType } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import {
     IFluidDataStoreRuntime,
     IChannelStorageService,

--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -125,7 +125,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 
         const index = this.getIndex(start);
         if (index < this.handles.length) {
-            this.handles.length =  index;
+            this.handles.length = index;
         }
     }
 

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -19,6 +19,8 @@ import { MatrixItem, SharedMatrix, SharedMatrixFactory } from "..";
 import { fill, check, insertFragmented, extract, expectSize } from "./utils";
 import { TestConsumer } from "./testconsumer";
 
+/* eslint-disable no-multi-spaces */
+
 function createConnectedMatrix(id: string, runtimeFactory: MockContainerRuntimeFactory) {
     const dataStoreRuntime = new MockFluidDataStoreRuntime();
     const matrix = new SharedMatrix(dataStoreRuntime, id, SharedMatrixFactory.Attributes);
@@ -974,3 +976,5 @@ describe("Matrix", () => {
         runGCTests(GCSharedMatrixProvider);
     });
 });
+
+/* eslint-enable no-multi-spaces */

--- a/packages/dds/matrix/src/test/sparsearray2d.spec.ts
+++ b/packages/dds/matrix/src/test/sparsearray2d.spec.ts
@@ -33,7 +33,7 @@ describe("SparseArray2D", () => {
         fill(a, /* rowStart: */ 0, /* colStart: */ 0, /* rowCount: */ 256, /* colCount: */ 256);
         check(a, /* rowStart: */ 0, /* colStart: */ 0, /* rowCount: */ 256, /* colCount: */ 256);
 
-        fill(a,  /* rowStart: */ 0xffffff00, /* colStart: */ 0xffffff00, /* rowCount: */ 256, /* colCount: */ 256);
+        fill(a, /* rowStart: */ 0xffffff00, /* colStart: */ 0xffffff00, /* rowCount: */ 256, /* colCount: */ 256);
         check(a, /* rowStart: */ 0xffffff00, /* colStart: */ 0xffffff00, /* rowCount: */ 256, /* colCount: */ 256);
     });
 

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2265,7 +2265,7 @@ export class MergeTree {
     }
 
     // Assume called only when pos == len
-    private breakTie(pos: number, node: IMergeNode,  seq: number) {
+    private breakTie(pos: number, node: IMergeNode, seq: number) {
         if (node.isLeaf()) {
             if (pos === 0) {
                 // normalize the seq numbers

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -17,8 +17,8 @@ export type MergeTreeDeltaOperationType =
 
 // Note: Assigned negative integers to avoid clashing with MergeTreeDeltaType
 export const enum MergeTreeMaintenanceType {
-    APPEND  = -1,
-    SPLIT   = -2,
+    APPEND = -1,
+    SPLIT = -2,
     /**
      * Notification that a segment has been unlinked from the MergeTree.  This occurs during
      * Zamboni when:
@@ -28,7 +28,7 @@ export const enum MergeTreeMaintenanceType {
      *
      *    b) The segment's tracking collection is empty (e.g., not being tracked for undo/redo).
      */
-    UNLINK  = -3,
+    UNLINK = -3,
     /**
      * Notification that a local change has been acknowledged by the server.
      * This means that it has made the round trip to the server and has had a sequence number assigned.

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -108,7 +108,7 @@ export function runMergeTreeOperationRunner(
                 minLength,
                 config.operations,
             );
-            const msgs =  messageData.map((md)=>md[0]);
+            const msgs = messageData.map((md)=>md[0]);
             seq = apply(seq, messageData, clients, logger);
             const resultText = logger.validate();
             results.push({
@@ -123,7 +123,7 @@ export function runMergeTreeOperationRunner(
     if(config.resultsFilePostfix !== undefined) {
         const resultsFilePath =
             `${replayResultsPath}/len_${minLength}-clients_${clients.length}-${config.resultsFilePostfix}`;
-        fs.writeFileSync(resultsFilePath, JSON.stringify(results, undefined,  4));
+        fs.writeFileSync(resultsFilePath, JSON.stringify(results, undefined, 4));
     }
 
     return seq;

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -585,7 +585,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 
         this.processMinSequenceNumberChanged(minSeq);
 
-        this.messagesSinceMSNChange.forEach((m) => m.minimumSequenceNumber = minSeq);
+        this.messagesSinceMSNChange.forEach((m) => { m.minimumSequenceNumber = minSeq });
 
         return this.client.summarize(this.runtime, this.handle, serializer, this.messagesSinceMSNChange);
     }

--- a/packages/dds/shared-object-base/bench/src/index.ts
+++ b/packages/dds/shared-object-base/bench/src/index.ts
@@ -26,7 +26,7 @@ const shallowNoHandles = makeJson(/* breadth: */ 2, /* depth: */ 2, () => ({}));
 const deepWithHandles = makeJson(/* breadth: */ 8, /* depth: */ 8, () => handle);
 
 const shallowNoHandlesString = serializer.stringify(shallowNoHandles, handle);
-const deepWithHandlesString =  serializer.stringify(deepWithHandles, handle);
+const deepWithHandlesString = serializer.stringify(deepWithHandles, handle);
 
 const measureReplaceHandles = (name: string, value: any) => new Suite(`encode Handles: ${name}`)
     .add("encode(...)", () => {

--- a/packages/drivers/debugger/src/fluidDebuggerController.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerController.ts
@@ -344,7 +344,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
     }
 }
 
-async function* generateSequencedMessagesFromDeltaStorage(deltaStorage: IDocumentDeltaStorageService)  {
+async function* generateSequencedMessagesFromDeltaStorage(deltaStorage: IDocumentDeltaStorageService) {
     const stream = deltaStorage.fetchMessages(1, undefined);
     while (true) {
         const result = await stream.read();

--- a/packages/drivers/debugger/src/fluidDebuggerUi.ts
+++ b/packages/drivers/debugger/src/fluidDebuggerUi.ts
@@ -328,7 +328,7 @@ export class DebuggerUI {
 
     private download(filename: string, data: string): void {
         const element = document.createElement("a");
-        element.setAttribute("href", `data:text/plain;charset=utf-8,${  encodeURIComponent(data)}`);
+        element.setAttribute("href", `data:text/plain;charset=utf-8,${ encodeURIComponent(data) }`);
         element.setAttribute("download", filename);
 
         element.style.display = "none";

--- a/packages/drivers/debugger/src/sanitizer.ts
+++ b/packages/drivers/debugger/src/sanitizer.ts
@@ -214,7 +214,7 @@ export class Sanitizer {
      * information is being sufficiently sanitized.
      */
     objectMatchesSchema = (object: any, schema: any): boolean => {
-        const result =  schema === false ? falseResult : this.validator.validate(object, schema);
+        const result = schema === false ? falseResult : this.validator.validate(object, schema);
         if (!result.valid) {
             const errorMsg = `Bad msg fmt:\n${result.toString()}\n${JSON.stringify(object, undefined, 2)}`;
 

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import  { DriverError } from "@fluidframework/driver-definitions";
+import { DriverError } from "@fluidframework/driver-definitions";
 
 export enum OdspErrorType {
     /**

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {  OdspFluidDataStoreLocator } from "./contractsPublic";
+import { OdspFluidDataStoreLocator } from "./contractsPublic";
 
 /*
  * Per https://github.com/microsoft/FluidFramework/issues/1556, isolating createOdspUrl() in its own file.

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -370,7 +370,7 @@ async function fetchSnapshotContentsCoreV1(
         fetchAndParseAsJSONHelper<IOdspSnapshot>(url, fetchOptions));
     const snapshotContents: ISnapshotContents = convertOdspSnapshotToSnapsohtTreeAndBlobs(response.content);
     const finalSnapshotContents: IOdspResponse<ISnapshotContents> = { ...response, content: snapshotContents };
-    return  {
+    return {
         odspSnapshotResponse: finalSnapshotContents,
         requestHeaders: headers,
         requestUrl: url,
@@ -410,7 +410,7 @@ async function fetchSnapshotContentsCoreV2(
     const snapshotContents: ISnapshotContents = parseCompactSnapshotResponse(
         new ReadBuffer(new Uint8Array(response.content)));
     const finalSnapshotContents: IOdspResponse<ISnapshotContents> = { ...response, content: snapshotContents };
-    return  {
+    return {
         odspSnapshotResponse: finalSnapshotContents,
         requestHeaders: headers,
         requestUrl: fullUrl,

--- a/packages/drivers/odsp-driver/src/getQueryString.ts
+++ b/packages/drivers/odsp-driver/src/getQueryString.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ISnapshotOptions }  from "@fluidframework/odsp-driver-definitions";
+import { ISnapshotOptions } from "@fluidframework/odsp-driver-definitions";
 
 /**
  * Generates query string from the given query parameters.

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -68,7 +68,7 @@ export async function runWithRetry<T>(
 
             assert(canRetry, 0x24d /* "can retry" */);
             await delay(Math.floor(retryAfter));
-            retryAfter += retryAfter / 4  * (1 + Math.random());
+            retryAfter += retryAfter / 4 * (1 + Math.random());
             lastError = error;
         }
     }

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -74,7 +74,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
                 assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
                 assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");
                 assert.strictEqual(resolvedUrl2.itemId, itemId, "Item id should be equal");
-                assert.strictEqual(resolvedUrl2.fileVersion, urlWithNav.hasVersion  ? fileVersion : undefined);
+                assert.strictEqual(resolvedUrl2.fileVersion, urlWithNav.hasVersion ? fileVersion : undefined);
                 assert.strictEqual(resolvedUrl2.hashedDocumentId, await getHashedDocumentId(driveId, itemId), "Doc id should be equal");
                 assert(resolvedUrl2.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
             };

--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -81,7 +81,7 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
                 versionId: id,
                 count,
             },
-            async () =>  this.manager.getCommits(id, count),
+            async () => this.manager.getCommits(id, count),
         );
         return commits.map((commit) => ({
             date: commit.commit.author.date,

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -78,7 +78,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
                 versionId: id,
                 count,
             },
-            async () =>  this.manager.getCommits(id, count),
+            async () => this.manager.getCommits(id, count),
         );
         return commits.map((commit) => ({
             date: commit.commit.author.date,

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -16,7 +16,7 @@ import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { FluidObjectSymbolProvider } from "@fluidframework/synthesize";
 import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 
-import { DataObject, DataObjectTypes, DataObjectType, IDataObjectProps  } from "../data-objects";
+import { DataObject, DataObjectTypes, DataObjectType, IDataObjectProps } from "../data-objects";
 import { PureDataObjectFactory } from "./pureDataObjectFactory";
 
 /**

--- a/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
+++ b/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
@@ -29,7 +29,7 @@ export interface IFluidDependencySynthesizer extends IProvideFluidDependencySynt
      * @param optionalTypes - optional types to be in the Scope object
      * @param requiredTypes - required types that need to be in the Scope object
      */
-    synthesize<O, R = undefined  | Record<string, never>>(
+    synthesize<O, R = undefined | Record<string, never>>(
             optionalTypes: FluidObjectSymbolProvider<O>,
             requiredTypes: Required<FluidObjectSymbolProvider<R>>,
     ): AsyncFluidObjectProvider<O, R>;

--- a/packages/framework/synthesize/src/types.ts
+++ b/packages/framework/synthesize/src/types.ts
@@ -19,7 +19,7 @@ export type FluidObjectSymbolProvider<T> = {
  * the IFluidObject properties as its type mapped to an object that implements
  * the property.
  */
-export type AsyncRequiredFluidObjectProvider<T> =  T extends undefined ? Record<string, never> : {
+export type AsyncRequiredFluidObjectProvider<T> = T extends undefined ? Record<string, never> : {
     [P in keyof T]: Promise<NonNullable<Exclude<T[P], undefined | null>>>
 };
 

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -82,7 +82,7 @@ const createReconnectError = (fluidErrorCode: string, err: any) =>
     wrapError(
         err,
         (errorMessage: string) =>
-            new GenericNetworkError(fluidErrorCode, errorMessage, true /* canRetry */,  { driverVersion: undefined }),
+            new GenericNetworkError(fluidErrorCode, errorMessage, true /* canRetry */, { driverVersion: undefined }),
     );
 
 /**
@@ -863,7 +863,7 @@ export class ConnectionManager implements IConnectionManager {
         // TODO: we should remove this check when service updates?
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (this._readonlyPermissions) {
-            this.props.closeHandler(createWriteError("writeOnReadOnlyDocument",  { driverVersion: undefined }));
+            this.props.closeHandler(createWriteError("writeOnReadOnlyDocument", { driverVersion: undefined }));
         }
 
         // check message.content for Back-compat with old service.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -370,7 +370,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     private _storageService: IDocumentStorageService & IDisposable | undefined;
-    private get storageService(): IDocumentStorageService  {
+    private get storageService(): IDocumentStorageService {
         if (this._storageService === undefined) {
             throw new Error("Attempted to access storageService before it was defined");
         }
@@ -647,7 +647,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     this.lastVisible = performance.now();
                 } else {
                     // settimeout so this will hopefully fire after disconnect event if being hidden caused it
-                    setTimeout(() => this.lastVisible = undefined, 0);
+                    setTimeout(() => { this.lastVisible = undefined }, 0);
                 }
             };
             document.addEventListener("visibilitychange", this.visibilityEventHandler);
@@ -683,7 +683,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                         break;
                     default:
                 }
-            }).catch((error) =>  {
+            }).catch((error) => {
                 this.mc.logger.sendErrorEvent({ eventName: "RaiseConnectedEventError" }, error);
             });
         });

--- a/packages/loader/driver-utils/src/blobAggregationStorage.ts
+++ b/packages/loader/driver-utils/src/blobAggregationStorage.ts
@@ -172,7 +172,7 @@ export class BlobAggregationStorage extends SnapshotExtractor implements IDocume
             return storage;
         }
         const mc = loggerToMonitoringContext(logger);
-        const realAllowPackaging = mc.config.getBoolean("FluidAggregateBlobs") ??  allowPacking ?? false;
+        const realAllowPackaging = mc.config.getBoolean("FluidAggregateBlobs") ?? allowPacking ?? false;
 
         // Always create BlobAggregationStorage even if storage is not asking for packing.
         // This is mostly to avoid cases where future changes in policy would result in inability to

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -29,7 +29,7 @@ export function isOnline(): OnlineStatus {
     return OnlineStatus.Unknown;
 }
 
-export type DriverErrorTelemetryProps = ITelemetryProperties & { driverVersion: string  | undefined };
+export type DriverErrorTelemetryProps = ITelemetryProperties & { driverVersion: string | undefined };
 
 /**
  * Generic network error class.

--- a/packages/loader/driver-utils/src/test/blobAggregation.spec.ts
+++ b/packages/loader/driver-utils/src/test/blobAggregation.spec.ts
@@ -35,7 +35,7 @@ export class FlattenedStorageService {
 
     public async readBlob(path: string): Promise<ArrayBufferLike> {
         const id = this.flattenedTree[path];
-        return  this.storage.readBlob(id);
+        return this.storage.readBlob(id);
     }
 }
 

--- a/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
+++ b/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
@@ -11,7 +11,7 @@ import { runWithRetry } from "../runWithRetry";
 const _setTimeout = global.setTimeout;
 const fastSetTimeout: any =
     (callback: (...cbArgs: any[]) => void, ms: number, ...args: any[]) => _setTimeout(callback, ms / 1000.0, ...args);
-async function  runWithFastSetTimeout<T>(callback: () => Promise<T>): Promise<T> {
+async function runWithFastSetTimeout<T>(callback: () => Promise<T>): Promise<T> {
     global.setTimeout = fastSetTimeout;
     return callback().finally(()=>{
         global.setTimeout = _setTimeout;

--- a/packages/loader/web-code-loader/src/webLoader.ts
+++ b/packages/loader/web-code-loader/src/webLoader.ts
@@ -74,7 +74,7 @@ export class WebCodeLoader implements ICodeLoader {
             throw new Error(`Package ${resolved.resolvedPackage.name} not a Fluid module.`);
         }
 
-        const loadedScriptsP =  this.scriptManager.loadLibrary(
+        const loadedScriptsP = this.scriptManager.loadLibrary(
             resolved.resolvedPackage.fluid.browser.umd);
 
         let fluidModule: IFluidModule | undefined;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -652,7 +652,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     ): Promise<ContainerRuntime> {
         // If taggedLogger exists, use it. Otherwise, wrap the vanilla logger:
         // back-compat: Remove the TaggedLoggerAdapter fallback once all the host are using loader > 0.45
-        const passLogger = context.taggedLogger  ?? new TaggedLoggerAdapter((context as
+        const passLogger = context.taggedLogger ?? new TaggedLoggerAdapter((context as
             OldContainerContextWithLogger).logger);
         const logger = ChildLogger.create(passLogger, undefined, {
             all: {
@@ -874,14 +874,14 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     private get summaryConfiguration() {
-        return  {
+        return {
             // the defaults
             ... DefaultSummaryConfiguration,
             // the server provided values
             ... this.context?.serviceConfiguration?.summary,
             // the runtime configuration overrides
             ... this.runtimeOptions.summaryOptions?.summaryConfigOverrides,
-         };
+        };
     }
 
     private _disposed = false;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -750,7 +750,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
         });
     }
 
-    private readonly initialSnapshotDetailsP =  new LazyPromise<ISnapshotDetails>(async () => {
+    private readonly initialSnapshotDetailsP = new LazyPromise<ISnapshotDetails>(async () => {
         let tree: ISnapshotTree | undefined;
         let isRootDataStore = true;
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -111,7 +111,7 @@ export class DataStores implements IDisposable {
         private readonly runtime: ContainerRuntime,
         private readonly submitAttachFn: (attachContent: any) => void,
         private readonly getCreateChildSummarizerNodeFn:
-            (id: string, createParam: CreateChildSummarizerNodeParam)  => CreateChildSummarizerNodeFn,
+            (id: string, createParam: CreateChildSummarizerNodeParam) => CreateChildSummarizerNodeFn,
         private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
         getBaseGCDetails: () => Promise<Map<string, IGarbageCollectionDetailsBase>>,

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -429,7 +429,7 @@ export class GarbageCollector implements IGarbageCollector {
         // we only do this once - the very first time we run GC.
         this.initializeBaseStateP = new LazyPromise<void>(async () => {
             const currentTimestampMs = this.getCurrentTimestampMs();
-            const baseState =  await baseSummaryStateP;
+            const baseState = await baseSummaryStateP;
             if (baseState === undefined) {
                 return;
             }

--- a/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
@@ -14,7 +14,7 @@ function setNavigator(navigator: Partial<Navigator & {deviceMemory?: number}> | 
     global.navigator = navigator as Navigator;
 }
 
-describe("Hardware Stats",  () => {
+describe("Hardware Stats", () => {
     let mockLogger = new MockLogger();
     let mockContext: Partial<IContainerContext> = {
         deltaManager: new MockDeltaManager(),

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
-import { neverCancelledSummaryToken } from  "../runWhileConnectedCoordinator";
+import { neverCancelledSummaryToken } from "../runWhileConnectedCoordinator";
 import { RunningSummarizer } from "../runningSummarizer";
 import { ISummarizerOptions } from "../summarizerTypes";
 import { SummaryCollection } from "../summaryCollection";
@@ -935,7 +935,7 @@ describe("Runtime", () => {
                     emitBroadcast(summaryTimestamp);
 
                     let startStatus: "starting" | "started" | "failed" = "starting";
-                    startRunningSummarizer().then(() => startStatus = "started", () => startStatus = "failed");
+                    startRunningSummarizer().then(() => { startStatus = "started" }, () => { startStatus = "failed" });
                     await flushPromises();
                     assert.strictEqual(startStatus, "starting",
                         "RunningSummarizer should still be starting since outstanding summary op");
@@ -1012,7 +1012,7 @@ describe("Runtime", () => {
 
                     let startStatus: "starting" | "started" | "failed" = "starting";
                     startRunningSummarizer({ disableHeuristics: true }).then(
-                        () => startStatus = "started", () => startStatus = "failed");
+                        () => { startStatus = "started" }, () => { startStatus = "failed" });
                     await flushPromises();
                     assert.strictEqual(startStatus, "starting",
                         "RunningSummarizer should still be starting since outstanding summary op");

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -25,7 +25,7 @@ import { ISummarizerClientElection, ISummarizerClientElectionEvents } from "../s
 
 describe("Summary Manager", () => {
     let clock: sinon.SinonFakeTimers;
-    before(() => clock = sinon.useFakeTimers());
+    before(() => { clock = sinon.useFakeTimers() });
     after(() => clock.restore());
     const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));
     const thisClientId = "this";

--- a/packages/runtime/container-runtime/src/test/throttler.spec.ts
+++ b/packages/runtime/container-runtime/src/test/throttler.spec.ts
@@ -14,7 +14,7 @@ import {
 describe("Throttler", () => {
     let throttler: Throttler;
     let clock: sinon.SinonFakeTimers;
-    before(() => clock = sinon.useFakeTimers());
+    before(() => { clock = sinon.useFakeTimers() });
     after(() => clock.restore());
     afterEach(() => clock.reset());
 
@@ -52,7 +52,7 @@ describe("Throttler", () => {
         expectedDelays: number[],
     }) {
         describe(message, () => {
-            beforeEach(() => throttler = new Throttler(delayWindowMs, maxDelayMs, delayFn));
+            beforeEach(() => { throttler = new Throttler(delayWindowMs, maxDelayMs, delayFn) });
             const expectedMaxAttempts = expectedDelays.length;
             const expectedDelayAt = (attempt: number) => attempt >= expectedMaxAttempts
                 ? maxDelayMs

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -882,7 +882,7 @@ export const mixinRequestHandler = (
     Base: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
 ) => class RuntimeWithRequestHandler extends Base {
         public async request(request: IRequest) {
-            const response  = await super.request(request);
+            const response = await super.request(request);
             if (response.status === 404) {
                 return requestHandler(request, this);
             }

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -61,7 +61,7 @@ export class RemoteChannelContext implements IChannelContext {
         dirtyFn: (address: string) => void,
         addedGCOutboundReferenceFn: (srcHandle: IFluidHandle, outboundHandle: IFluidHandle) => void,
         private readonly id: string,
-        baseSnapshot:  ISnapshotTree,
+        baseSnapshot: ISnapshotTree,
         private readonly registry: ISharedObjectRegistry,
         extraBlobs: Map<string, ArrayBufferLike> | undefined,
         createSummarizerNode: CreateChildSummarizerNodeFn,

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -6,7 +6,7 @@
 import { IFluidDataStoreContext, IFluidDataStoreChannel } from "./dataStoreContext";
 
 declare module "@fluidframework/core-interfaces" {
-    export interface IFluidObject  {
+    export interface IFluidObject {
         /**
          * @deprecated - use `FluidObject<IFluidDataStoreFactory>` instead
          */

--- a/packages/runtime/runtime-utils/src/test/dataStoreHelpers.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/dataStoreHelpers.spec.ts
@@ -19,7 +19,7 @@ describe("createResponseError", () => {
     it("request / response / error handling ", () => {
         const request = { url: "/foo/bar?something"};
         const response = createResponseError(401, "some value", request);
-        const value  = "some value: /foo/bar";
+        const value = "some value: /foo/bar";
         assert.strict.equal(response.status, 401, "status code");
         assert.strict.equal(response.value, value, "value");
         const stack = response.stack;

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -22,7 +22,7 @@ export class InsecureTokenProvider implements ITokenProvider {
     public async fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
         return {
             fromCache: true,
-            jwt:  generateToken(
+            jwt: generateToken(
                 tenantId,
                 this.tenantKey,
                 [

--- a/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLifecycle.spec.ts
@@ -41,7 +41,7 @@ const testConfigs =
 
 describeFullCompat("Validate Attach lifecycle", (getTestObjectProvider) => {
     before(function (){
-        const provider  = getTestObjectProvider();
+        const provider = getTestObjectProvider();
         switch(provider.driver.type){
             case "local":
             case "tinylicious":
@@ -53,7 +53,7 @@ describeFullCompat("Validate Attach lifecycle", (getTestObjectProvider) => {
     for(const testConfig of testConfigs) {
         it(`Validate attach orders: ${JSON.stringify(testConfig ?? "undefined")}`, async function() {
             // setup shared states
-            const provider  = getTestObjectProvider();
+            const provider = getTestObjectProvider();
             const timeoutDurationMs = this.timeout() / 2;
             let containerUrl: IResolvedUrl | undefined;
             const oldRegistry: [string | undefined, IChannelFactory][] =
@@ -70,7 +70,7 @@ describeFullCompat("Validate Attach lifecycle", (getTestObjectProvider) => {
 
                 const initContainer = await initLoader.createDetachedContainer(provider.defaultCodeDetails);
                 const attachContainer = async ()=>{
-                    const attachP =  initContainer.attach(provider.driver.createCreateNewRequest(provider.documentId))
+                    const attachP = initContainer.attach(provider.driver.createCreateNewRequest(provider.documentId))
                     if(testConfig.containerSaveAfterAttach){
                         await attachP;
                     }

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -366,7 +366,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             assert(defaultDataStore.context.storage !== undefined,
                 "Storage should be present in detached data store");
             let success1: boolean | undefined;
-            await defaultDataStore.context.storage.getSnapshotTree(undefined).catch((err) => success1 = false);
+            await defaultDataStore.context.storage.getSnapshotTree(undefined).catch((err) => { success1 = false });
             assert(success1 === false, "Snapshot fetch should not be allowed in detached data store");
 
             const container2: IContainer = await loader.rehydrateDetachedContainerFromSnapshot(snapshotTree);
@@ -379,7 +379,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             assert(defaultDataStore2.context.storage !== undefined,
                 "Storage should be present in rehydrated data store");
             let success2: boolean | undefined;
-            await defaultDataStore2.context.storage.getSnapshotTree(undefined).catch((err) => success2 = false);
+            await defaultDataStore2.context.storage.getSnapshotTree(undefined).catch((err) => { success2 = false });
             assert(success2 === false, "Snapshot fetch should not be allowed in rehydrated data store");
         });
 

--- a/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
@@ -47,7 +47,7 @@ const testContainerConfig: ITestContainerConfig = {
 describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvider) => {
     for(const testConfig of testConfigs) {
         it.skip(`Validate Load Modes: ${JSON.stringify(testConfig ?? "undefined")}`, async function() {
-            const provider  = getTestObjectProvider();
+            const provider = getTestObjectProvider();
             let containerUrl: IResolvedUrl | undefined;
             // initialize the container and its data
             {

--- a/packages/test/test-pairwise-generator/src/index.ts
+++ b/packages/test/test-pairwise-generator/src/index.ts
@@ -70,7 +70,7 @@ export function generatePairwiseOptions<T extends Record<string, any>>(
     const matrixKeys: (keyof T)[] =
         Object.keys(optionsMatrix)
         .filter((k)=>optionsMatrix[k].length > 1 || optionsMatrix[k][0] !== undefined)
-        .sort((a,b)=>optionsMatrix[b].length  - optionsMatrix[a].length);
+        .sort((a,b)=>optionsMatrix[b].length - optionsMatrix[a].length);
 
     if(matrixKeys.length === 0) {
         return [];
@@ -90,7 +90,7 @@ export function generatePairwiseOptions<T extends Record<string, any>>(
         const iKey = matrixKeys[i];
         for(let j = i + 1; j < matrixKeys.length; j++) {
             const jKey = matrixKeys[j];
-            for(const iVal of  optionsMatrix[iKey]) {
+            for(const iVal of optionsMatrix[iKey]) {
                 for(const jVal of optionsMatrix[jKey]) {
                     applyPairToPartial(
                         randEng,

--- a/packages/test/test-pairwise-generator/src/test/examples.spec.ts
+++ b/packages/test/test-pairwise-generator/src/test/examples.spec.ts
@@ -17,7 +17,7 @@ describe("generatePairwiseOptions.examples",()=>{
             p3: [undefined, 0, 10, 100],
         });
 
-        for(const option  of options) {
+        for(const option of options) {
             myFunction(option.p1, option.p2, option.p3);
         }
     });

--- a/packages/test/test-pairwise-generator/src/test/generatePairwiseOptions.spec.ts
+++ b/packages/test/test-pairwise-generator/src/test/generatePairwiseOptions.spec.ts
@@ -26,7 +26,7 @@ const simpleOptionsMatrix: OptionsMatrix<SimpleOptions> = {
     array:[undefined, [0]],
 };
 
-function  validateSimpleOption(option: SimpleOptions) {
+function validateSimpleOption(option: SimpleOptions) {
     assert("number" in option, `number not defined:${optionsToString(option)}`);
     assert(option.number === undefined || option.number === 7,
          `number not expected value:${optionsToString(option)}`);
@@ -79,7 +79,7 @@ function validateComplexOption(option: ComplexOptions) {
 /**
  * No pruning or optimizations, just calculate and validate all pairs
  */
-function  validatePairsExhaustively<T>(
+function validatePairsExhaustively<T>(
     matrix: OptionsMatrix<T>, values: T[]) {
     const keys = Object.keys(matrix);
     for(const i of keys) {

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -24,7 +24,7 @@ import {
 import { LoggingError } from "@fluidframework/telemetry-utils";
 
 export class FaultInjectionDocumentServiceFactory implements IDocumentServiceFactory {
-    private  readonly _documentServices = new Map<IResolvedUrl, FaultInjectionDocumentService>();
+    private readonly _documentServices = new Map<IResolvedUrl, FaultInjectionDocumentService>();
 
     public get protocolName() { return this.internal.protocolName; }
     public get documentServices() { return this._documentServices; }
@@ -53,7 +53,7 @@ export class FaultInjectionDocumentServiceFactory implements IDocumentServiceFac
 }
 
 export class FaultInjectionDocumentService implements IDocumentService {
-    private  _currentDeltaStream: FaultInjectionDocumentDeltaConnection | undefined;
+    private _currentDeltaStream: FaultInjectionDocumentDeltaConnection | undefined;
 
     constructor(private readonly internal: IDocumentService) {
     }

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -32,7 +32,7 @@ export function applyOverrides<T>(options: OptionsMatrix<T>, optionsOverrides: P
             const override = optionsOverrides[key];
             if(override !== undefined) {
                 if(Array.isArray(override)) {
-                    realOptions[key] =  override;
+                    realOptions[key] = override;
                 }else{
                     throw new Error(`Override for ${key} is not array: ${JSON.stringify(optionsOverrides)}`);
                 }
@@ -43,7 +43,7 @@ export function applyOverrides<T>(options: OptionsMatrix<T>, optionsOverrides: P
 }
 
 export const generateLoaderOptions =
-    (seed: number,  overrides: Partial<OptionsMatrix<ILoaderOptions>> | undefined): ILoaderOptions[] => {
+    (seed: number, overrides: Partial<OptionsMatrix<ILoaderOptions>> | undefined): ILoaderOptions[] => {
     return generatePairwiseOptions<ILoaderOptions>(
         applyOverrides(loaderOptionsMatrix, overrides),
         seed);

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -13,7 +13,7 @@
             "optionOverrides":{
                 "odsp":{
                     "loader":{
-                        "summarizeProtocolTree":  [true,false]
+                        "summarizeProtocolTree": [true,false]
                     }
                 }
             }

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -107,7 +107,7 @@ function getDocumentIdStrategy(type?: TestDriverTypes): IDocumentIdStrategy {
             return {
                 get: () => documentId,
                 update: () => { }, // do not update the document ID in odsp test cases
-                reset: () => documentId = createDocumentId(),
+                reset: () => { documentId = createDocumentId() },
             };
         default:
             return {
@@ -117,7 +117,7 @@ function getDocumentIdStrategy(type?: TestDriverTypes): IDocumentIdStrategy {
                     ensureFluidResolvedUrl(resolvedUrl);
                     documentId = resolvedUrl.id ?? documentId;
                 },
-                reset: () => documentId = createDocumentId(),
+                reset: () => { documentId = createDocumentId() },
             };
     }
 }

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -31,7 +31,7 @@ export async function timeoutPromise<T = void>(
         timeoutOptions.durationMs !== undefined
         && Number.isFinite(timeoutOptions.durationMs)
         && timeoutOptions.durationMs > 0
-            ?  timeoutOptions.durationMs : defaultTimeoutDurationMs;
+            ? timeoutOptions.durationMs : defaultTimeoutDurationMs;
     // create the timeout error outside the async task, so it's callstack includes
     // the original call site, this makes it easier to debug
     const err = timeoutOptions.reject === false

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -222,7 +222,7 @@ export function enrichOdspError(
         props.responseType = response.type;
         if (response.headers) {
             const headers = getSPOAndGraphRequestIdsFromResponse(response.headers);
-            for (const key of Object.keys(headers))  {
+            for (const key of Object.keys(headers)) {
                 props[key] = headers[key];
             }
             (error as IOdspError).serverEpoch = response.headers.get("x-fluid-epoch") ?? undefined;

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -323,7 +323,7 @@ export class LoggingError extends Error implements ILoggingError, Pick<IFluidErr
     public getTelemetryProperties(): ITelemetryProperties {
         const taggableProps = getValidTelemetryProps(this, this.omitPropsFromLogging);
         // Include non-enumerable props inherited from Error that are not returned by getValidTelemetryProps
-        return  {
+        return {
             ...taggableProps,
             stack: this.stack,
             message: this.message,

--- a/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
+++ b/packages/utils/telemetry-utils/src/eventEmitterWithErrorHandling.ts
@@ -11,7 +11,7 @@ import { TypedEventEmitter, EventEmitterEventType } from "@fluidframework/common
  * Any exception thrown by "error" listeners will propagate to the caller.
  */
 export class EventEmitterWithErrorHandling<TEvent extends IEvent = IEvent> extends TypedEventEmitter<TEvent> {
-    constructor(private readonly  errorHandler: (eventName: EventEmitterEventType, error: any) => void) {
+    constructor(private readonly errorHandler: (eventName: EventEmitterEventType, error: any) => void) {
         super();
     }
 

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -7,7 +7,7 @@ import assert from "assert";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { ITelemetryLoggerPropertyBags, ITelemetryLoggerPropertyBag, TelemetryLogger } from "../logger";
 
-class TestTelemetryLogger  extends TelemetryLogger {
+class TestTelemetryLogger extends TelemetryLogger {
     public events: ITelemetryBaseEvent[]=[];
     public send(event: ITelemetryBaseEvent): void {
         this.events.push(this.prepareEvent(event));

--- a/server/gitrest/src/runner.ts
+++ b/server/gitrest/src/runner.ts
@@ -63,17 +63,17 @@ export class GitrestRunner implements IRunner {
         }
 
         const bind = typeof this.port === "string"
-            ? `Pipe ${  this.port}`
-            : `Port ${  this.port}`;
+            ? `Pipe ${ this.port }`
+            : `Port ${ this.port }`;
 
         // handle specific listen errors with friendly messages
         switch (error.code) {
             case "EACCES":
-                winston.error(`${bind  } requires elevated privileges`);
+                winston.error(`${ bind } requires elevated privileges`);
                 process.exit(1);
                 break;
             case "EADDRINUSE":
-                winston.error(`${bind  } is already in use`);
+                winston.error(`${ bind } is already in use`);
                 process.exit(1);
                 break;
             default:
@@ -88,8 +88,8 @@ export class GitrestRunner implements IRunner {
     private onListening() {
         const addr = this.server.httpServer.address();
         const bind = typeof addr === "string"
-            ? `pipe ${  addr}`
-            : `port ${  addr.port}`;
-        winston.info(`Listening on ${  bind}`);
+            ? `pipe ${ addr }`
+            : `port ${ addr.port }`;
+        winston.info(`Listening on ${ bind }`);
     }
 }

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -199,7 +199,7 @@ describe("GitRest", () => {
             describe("Blobs", () => {
                 it("Can create and retrieve a blob", async () => {
                     await createRepo(supertest, testOwnerName, testRepoName);
-                    const result = await createBlob(supertest,  testOwnerName, testRepoName, testBlob);
+                    const result = await createBlob(supertest, testOwnerName, testRepoName, testBlob);
                     assert.equal(result.body.sha, "b45ef6fec89518d314f546fd6c3025367b721684");
 
                     return supertest
@@ -221,7 +221,7 @@ describe("GitRest", () => {
                 it("Can create and retrieve a tree", async () => {
                     await createRepo(supertest, testOwnerName, testRepoName);
                     await createBlob(supertest, testOwnerName, testRepoName, testBlob);
-                    const tree = await createTree(supertest,  testOwnerName, testRepoName, testTree);
+                    const tree = await createTree(supertest, testOwnerName, testRepoName, testTree);
                     assert.equal(tree.body.sha, "bf4db183cbd07f48546a5dde098b4510745d79a1");
 
                     return supertest

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -68,19 +68,19 @@ export class HistorianRunner implements IRunner {
         }
 
         const bind = typeof this.port === "string"
-            ? `Pipe ${  this.port}`
-            : `Port ${  this.port}`;
+            ? `Pipe ${ this.port }`
+            : `Port ${ this.port }`;
 
         // handle specific listen errors with friendly messages
         switch (error.code) {
             case "EACCES":
-                winston.error(`${bind  } requires elevated privileges`);
-                Lumberjack.error(`${bind  } requires elevated privileges`);
+                winston.error(`${ bind } requires elevated privileges`);
+                Lumberjack.error(`${ bind } requires elevated privileges`);
                 process.exit(1);
                 break;
             case "EADDRINUSE":
-                winston.error(`${bind  } is already in use`);
-                Lumberjack.error(`${bind  } is already in use`);
+                winston.error(`${ bind } is already in use`);
+                Lumberjack.error(`${ bind } is already in use`);
                 process.exit(1);
                 break;
             default:
@@ -95,9 +95,9 @@ export class HistorianRunner implements IRunner {
     private onListening() {
         const addr = this.server.httpServer.address();
         const bind = typeof addr === "string"
-            ? `pipe ${  addr}`
-            : `port ${  addr.port}`;
-        winston.info(`Listening on ${  bind}`);
-        Lumberjack.info(`Listening on ${  bind}`);
+            ? `pipe ${ addr }`
+            : `port ${ addr.port }`;
+        winston.info(`Listening on ${ bind }`);
+        Lumberjack.info(`Listening on ${ bind }`);
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -40,7 +40,7 @@ export function create(
     router.post("/tenants/:id/validate", (request, response) => {
         const tenantId = getParam(request.params, "id");
         const includeDisabledTenant = getIncludeDisabledFlag(request);
-        const validP = manager.validateToken(tenantId, request.body.token,  includeDisabledTenant);
+        const validP = manager.validateToken(tenantId, request.body.token, includeDisabledTenant);
         handleResponse(validP, response);
     });
 

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -8,7 +8,7 @@ import safeStringify from "json-stringify-safe";
 import { AxiosError, AxiosInstance, AxiosRequestConfig, default as Axios } from "axios";
 import { v4 as uuid } from "uuid";
 import { debug } from "./debug";
-import { createFluidServiceNetworkError, INetworkErrorDetails }  from "./error";
+import { createFluidServiceNetworkError, INetworkErrorDetails } from "./error";
 
 export abstract class RestWrapper {
     constructor(

--- a/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
@@ -133,7 +133,7 @@ describe("BasicRestWrapper", () => {
             ),
         };
 
-        axiosMockAdapterTooManyRequestsErrorPositiveRetryAfter  = new AxiosMockAdapter(axiosInstance);
+        axiosMockAdapterTooManyRequestsErrorPositiveRetryAfter = new AxiosMockAdapter(axiosInstance);
 
         // For axios mock for testing 429 throttled requests with a valid retryAfter value,
         // first request should return 429 and then a 200 should be returned

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -35,7 +35,7 @@ export async function runWithRetry<T>(
     let result: T | undefined;
     let retryCount = 0;
     let success = false;
-    do  {
+    do {
         try {
             result = await api();
             success = true;
@@ -108,7 +108,7 @@ export async function runWithRetry<T>(
     let result: T;
     let retryCount = 0;
     let success = false;
-    do  {
+    do {
         try {
             result = await request();
             success = true;

--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -22,7 +22,7 @@ import {
 // or error() on Lumber to emit the data.
 export class Lumber<T extends string = LumberEventName> {
     private readonly _startTime = performance.now();
-    private  _properties = new Map<string, any>();
+    private _properties = new Map<string, any>();
     private _durationInMs?: number;
     private _successful?: boolean;
     private _message?: string;
@@ -149,7 +149,7 @@ export class Lumber<T extends string = LumberEventName> {
         }
 
         const durationOverwrite = parseFloat(this.properties.get("durationInMs"));
-        this._durationInMs = isNaN(durationOverwrite) ?  performance.now() - this._startTime : durationOverwrite;
+        this._durationInMs = isNaN(durationOverwrite) ? performance.now() - this._startTime : durationOverwrite;
 
         this._engineList.forEach((engine) => engine.emit(this));
         this._completed = true;

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -26,7 +26,7 @@ export async function deleteSummarizedOps(
         ).toArray();
 
         const currentEpochTime = new Date().getTime();
-        const epochTimeBeforeOfflineWindow =  currentEpochTime - offlineWindowMs;
+        const epochTimeBeforeOfflineWindow = currentEpochTime - offlineWindowMs;
         const scheduledDeletionEpochTime = currentEpochTime + softDeleteRetentionPeriodMs;
 
         for (const doc of uniqueDocuments) {

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -42,7 +42,7 @@ export function createProducer(
             }
         });
     } else {
-        producer =  new KafkaNodeProducer(
+        producer = new KafkaNodeProducer(
             { kafkaHost: kafkaEndPoint },
             clientId,
             topic,

--- a/server/routerlicious/packages/services/src/secretManager.ts
+++ b/server/routerlicious/packages/services/src/secretManager.ts
@@ -9,7 +9,7 @@ import * as core from "@fluidframework/server-services-core";
  * This is a dummy implementation that returns the secret as is after encryption/decryption.
  * Users requiring encryption of secrets are expected to have their own implementation of ISecretManager.
  */
-export class SecretManager  implements core.ISecretManager {
+export class SecretManager implements core.ISecretManager {
     public decryptSecret(encryptedSecret: string): string {
         return encryptedSecret;
     }

--- a/server/routerlicious/packages/test-utils/src/test/testsForThrottlerHelper.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForThrottlerHelper.spec.ts
@@ -27,10 +27,10 @@ describe("Test for Test Utils", () => {
 
             let response: IThrottlerResponse;
             for (let i = 0; i < rate; i++) {
-                response =  await throttlerHelper.updateCount(id, 1);
+                response = await throttlerHelper.updateCount(id, 1);
                 assert.strictEqual(response.throttleStatus, false);
             }
-            response =  await throttlerHelper.updateCount(id, 1);
+            response = await throttlerHelper.updateCount(id, 1);
             assert.strictEqual(response.throttleStatus, true);
         });
 
@@ -40,7 +40,7 @@ describe("Test for Test Utils", () => {
 
             const id = "test-id";
 
-            const response =  await throttlerHelper.updateCount(id, rate + 1);
+            const response = await throttlerHelper.updateCount(id, rate + 1);
             assert.strictEqual(response.throttleStatus, true);
         });
 
@@ -50,19 +50,19 @@ describe("Test for Test Utils", () => {
 
             const id = "test-id";
 
-            let response =  await throttlerHelper.updateCount(id, rate + 1);
+            let response = await throttlerHelper.updateCount(id, rate + 1);
             assert.strictEqual(response.throttleStatus, true);
 
             Sinon.clock.tick(response.retryAfterInMs);
-            response =  await throttlerHelper.updateCount(id, 0);
+            response = await throttlerHelper.updateCount(id, 0);
             assert.strictEqual(response.throttleStatus, false);
 
             // for longer
-            response =  await throttlerHelper.updateCount(id, rate + 10);
+            response = await throttlerHelper.updateCount(id, rate + 10);
             assert.strictEqual(response.throttleStatus, true);
 
             Sinon.clock.tick(response.retryAfterInMs);
-            response =  await throttlerHelper.updateCount(id, 0);
+            response = await throttlerHelper.updateCount(id, 0);
             assert.strictEqual(response.throttleStatus, false);
         });
 
@@ -74,11 +74,11 @@ describe("Test for Test Utils", () => {
 
             let response: IThrottlerResponse;
             for (let i = 0; i < rate; i++) {
-                response =  await throttlerHelper.updateCount(id, 1);
+                response = await throttlerHelper.updateCount(id, 1);
                 assert.strictEqual(response.throttleStatus, false);
                 Sinon.clock.tick(1);
             }
-            response =  await throttlerHelper.updateCount(id, 1);
+            response = await throttlerHelper.updateCount(id, 1);
             assert.strictEqual(response.throttleStatus, false);
         });
 
@@ -91,12 +91,12 @@ describe("Test for Test Utils", () => {
             let response: IThrottlerResponse;
             let cachedResponse: IThrottlerResponse;
 
-            response =  await throttlerHelper.updateCount(id, 1);
+            response = await throttlerHelper.updateCount(id, 1);
             assert.strictEqual(response.throttleStatus, false);
             cachedResponse = await throttlerHelper.getThrottleStatus(id);
             assert.deepStrictEqual(cachedResponse, response);
 
-            response =  await throttlerHelper.updateCount(id, 1);
+            response = await throttlerHelper.updateCount(id, 1);
             assert.strictEqual(response.throttleStatus, true);
             cachedResponse = await throttlerHelper.getThrottleStatus(id);
             assert.deepStrictEqual(cachedResponse, response);

--- a/tools/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
+++ b/tools/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
@@ -124,7 +124,7 @@ export const handler: Handler = {
                 s.saveSync();
             }
         }
-        const result =  errors.length > 0 ? {error: errors.join("\n")} : undefined;
+        const result = errors.length > 0 ? {error: errors.join("\n")} : undefined;
         return result;
     }
 };


### PR DESCRIPTION
This change does the following:

1. Adds the rule `"no-multi-spaces": ["error", {"ignoreEOLComments": true}],` - I've found myself adding lots of nits in PRs lately, this should save everyone a little time.
2. Upgrades `no-return-assign` from recommended to minimal - All instances I found were unintentional (arrow functions without braces), and seems likely it could help catch some errors.
3. Preemptively fixes up the existing instances to make integration easier on the prerelease.