### PR TITLE
Track total summarization attempts made by a given Summarizer

### DIFF
--- a/docs/content/docs/deep/summaryTelemetry.md
+++ b/docs/content/docs/deep/summaryTelemetry.md
@@ -174,7 +174,7 @@ This should not even be possible, but it means that an unhandled error was raise
 
 > Event Prefix: `Summarizer:Running:`
 
-- `summaryGenTag` - the number of summarize attempts this client has made. This can be used to correlate events for individual summary attempts.
+- `summarizeCount` - the number of summarize attempts this client has made. This can be used to correlate events for individual summary attempts.
 
 ### SummaryAckWaitTimeout
 
@@ -214,7 +214,7 @@ This should not be possible, but it indicates an error was thrown in the code th
 
 > Event Prefix: `Summarizer:Running:`
 
-- `summaryGenTag` - the number of summarize attempts this client has made. This can be used to correlate events for individual summary attempts.
+- `summarizeCount` - the number of summarize attempts this client has made. This can be used to correlate events for individual summary attempts.
 
 ### ConcurrentSummarizeAttempt
 

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -93,6 +93,7 @@ export class RunningSummarizer implements IDisposable {
         readonly resultsBuilder: SummarizeResultBuilder;
     } | undefined;
     private summarizeCount = 0;
+    private totalSuccessfulAttempts = 0;
 
     private constructor(
         baseLogger: ITelemetryLogger,
@@ -107,7 +108,14 @@ export class RunningSummarizer implements IDisposable {
         { disableHeuristics = false }: Readonly<Partial<ISummarizerOptions>> = {},
     ) {
         this.logger = ChildLogger.create(
-            baseLogger, "Running", { all: { summaryGenTag: () => this.summarizeCount } });
+            baseLogger, "Running",
+            {
+                all: {
+                    summarizeCount: () => this.summarizeCount,
+                    summarizerSuccessfulAttempts: () => this.totalSuccessfulAttempts,
+                },
+            }
+        );
 
         if (!disableHeuristics) {
             this.heuristicRunner = new SummarizeHeuristicRunner(
@@ -124,7 +132,7 @@ export class RunningSummarizer implements IDisposable {
             maxAckWaitTime,
             () => {
                 this.raiseSummarizingError("summaryAckWaitTimeout");
-                // Note: summaryGenTag (from ChildLogger definition) may be 0,
+                // Note: summarizeCount (from ChildLogger definition) may be 0,
                 // since this code path is hit when RunningSummarizer first starts up,
                 // before this instance has kicked off a new summarize run.
                 this.logger.sendErrorEvent({
@@ -152,6 +160,7 @@ export class RunningSummarizer implements IDisposable {
             this.heuristicData,
             this.submitSummaryCallback,
             this.raiseSummarizingError,
+            () => { this.totalSuccessfulAttempts++ },
             this.summaryWatcher,
             this.logger,
         );
@@ -338,27 +347,27 @@ export class RunningSummarizer implements IDisposable {
                 { refreshLatestAck: true, fullTree: true, delaySeconds: 10 * 60 },
             ];
             let overrideDelaySeconds: number | undefined;
-            let totalAttempts = 0;
-            let attemptPerPhase = 0;
+            let summaryAttempts = 0;
+            let summaryAttemptsPerPhase = 0;
 
             let lastResult: { message: string; error: any; } | undefined;
 
-            for (let attemptPhase = 0; attemptPhase < attempts.length;) {
+            for (let summaryAttemptPhase = 0; summaryAttemptPhase < attempts.length;) {
                 if (this.cancellationToken.cancelled) {
                     return;
                 }
 
-                totalAttempts++;
-                attemptPerPhase++;
+                summaryAttempts++;
+                summaryAttemptsPerPhase++;
 
-                const { delaySeconds: regularDelaySeconds = 0, ...options } = attempts[attemptPhase];
+                const { delaySeconds: regularDelaySeconds = 0, ...options } = attempts[summaryAttemptPhase];
                 const delaySeconds = overrideDelaySeconds ?? regularDelaySeconds;
 
                 const summarizeProps: ITelemetryProperties = {
                     summarizeReason,
-                    summarizeTotalAttempts: totalAttempts,
-                    summarizeAttemptsPerPhase: attemptPerPhase,
-                    summarizeAttemptPhase: attemptPhase + 1, // make everything 1-based
+                    summaryAttempts,
+                    summaryAttemptsPerPhase,
+                    summaryAttemptPhase: summaryAttemptPhase + 1, // make everything 1-based
                     ...options,
                 };
 
@@ -377,14 +386,15 @@ export class RunningSummarizer implements IDisposable {
                 const result = await resultSummarize.receivedSummaryAckOrNack;
 
                 if (result.success) {
+                    this.totalSuccessfulAttempts++;
                     return;
                 }
                 // Check for retryDelay that can come from summaryNack or upload summary flow.
                 // Retry the same step only once per retryAfter response.
                 overrideDelaySeconds = result.retryAfterSeconds;
-                if (overrideDelaySeconds === undefined || attemptPerPhase > 1) {
-                    attemptPhase++;
-                    attemptPerPhase = 0;
+                if (overrideDelaySeconds === undefined || summaryAttemptsPerPhase > 1) {
+                    summaryAttemptPhase++;
+                    summaryAttemptsPerPhase = 0;
                 }
                 lastResult = result;
             }

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -153,6 +153,7 @@ export class SummaryGenerator {
         private readonly heuristicData: ISummarizeHeuristicData,
         private readonly submitSummaryCallback: (options: ISubmitSummaryOptions) => Promise<SubmitSummaryResult>,
         private readonly raiseSummarizingError: (errorCode: string) => void,
+        private readonly successfulSummaryCallback: () => void,
         private readonly summaryWatcher: Pick<IClientSummaryWatcher, "watchSummary">,
         private readonly logger: ITelemetryLogger,
     ) {
@@ -334,6 +335,7 @@ export class SummaryGenerator {
             };
             if (ackNackOp.type === MessageType.SummaryAck) {
                 this.heuristicData.markLastAttemptAsSuccessful();
+                this.successfulSummaryCallback();
                 summarizeEvent.end({ ...telemetryProps, handle: ackNackOp.contents.handle, message: "summaryAck" });
                 resultsBuilder.receivedSummaryAckOrNack.resolve({ success: true, data: {
                     summaryAckOp: ackNackOp,

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -222,8 +222,8 @@ describe("Runtime", () => {
                     await emitNextOp(1);
                     assertRunCounts(1, 0, 0);
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
-                        { eventName: "Running:SummaryOp", summaryGenTag: runCount },
+                        { eventName: "Running:GenerateSummary", summarizeCount: runCount },
+                        { eventName: "Running:SummaryOp", summarizeCount: runCount },
                     ]), "unexpected log sequence");
 
                     // should not run, because our summary hasnt been acked/nacked yet
@@ -234,9 +234,9 @@ describe("Runtime", () => {
                     await emitAck();
                     assertRunCounts(2, 0, 0);
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:Summarize_end", summaryGenTag: (runCount - 1) }, // ack for previous run
-                        { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
-                        { eventName: "Running:SummaryOp", summaryGenTag: runCount },
+                        { eventName: "Running:Summarize_end", summarizeCount: (runCount - 1) }, // ack for previous run
+                        { eventName: "Running:GenerateSummary", summarizeCount: runCount },
+                        { eventName: "Running:SummaryOp", summarizeCount: runCount },
                     ]), "unexpected log sequence");
 
                     await emitNextOp();
@@ -396,10 +396,10 @@ describe("Runtime", () => {
                     await emitNextOp(1);
                     assertRunCounts(1, 0, 0);
                     const retryProps1 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 1,
-                        summarizeTotalAttempts: 1,
-                        summarizeAttemptPhase: 1,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 1,
+                        summaryAttempts: 1,
+                        summaryAttemptPhase: 1,
                     };
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:GenerateSummary", ...retryProps1 },
@@ -414,10 +414,10 @@ describe("Runtime", () => {
                     await emitNack();
                     assertRunCounts(2, 0, 1, "retry1 should be refreshLatestAck");
                     const retryProps2 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 1,
-                        summarizeTotalAttempts: 2,
-                        summarizeAttemptPhase: 2,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 1,
+                        summaryAttempts: 2,
+                        summaryAttemptPhase: 2,
                     };
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:Summarize_cancel", ...retryProps1, reason: "summaryNack" },
@@ -434,10 +434,10 @@ describe("Runtime", () => {
                     await tickAndFlushPromises(1);
                     assertRunCounts(3, 0, 2, "retry2 should be refreshLatestAck");
                     const retryProps3 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 1,
-                        summarizeTotalAttempts: 3,
-                        summarizeAttemptPhase: 3,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 1,
+                        summaryAttempts: 3,
+                        summaryAttemptPhase: 3,
                     };
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:Summarize_cancel", ...retryProps2, reason: "summaryNack" },
@@ -454,10 +454,10 @@ describe("Runtime", () => {
                     await tickAndFlushPromises(1);
                     assertRunCounts(4, 1, 3, "retry3 should be fullTree and refreshLatestAck");
                     const retryProps4 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 1,
-                        summarizeTotalAttempts: 4,
-                        summarizeAttemptPhase: 4,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 1,
+                        summaryAttempts: 4,
+                        summaryAttemptPhase: 4,
                     };
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:Summarize_cancel", ...retryProps3, reason: "summaryNack" },
@@ -482,10 +482,10 @@ describe("Runtime", () => {
                     await emitNextOp(1);
                     assertRunCounts(1, 0, 0, "normal run");
                     const retryProps1 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 1,
-                        summarizeTotalAttempts: 1,
-                        summarizeAttemptPhase: 1,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 1,
+                        summaryAttempts: 1,
+                        summaryAttemptPhase: 1,
                     };
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:GenerateSummary", ...retryProps1 },
@@ -505,13 +505,13 @@ describe("Runtime", () => {
                     await tickAndFlushPromises(1);
                     assertRunCounts(2, 0, 0, "rerun after retryAfter delay");
                     const retryProps2 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 2,
-                        summarizeTotalAttempts: 2,
-                        summarizeAttemptPhase: 1,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 2,
+                        summaryAttempts: 2,
+                        summaryAttemptPhase: 1,
                     };
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:Summarize_cancel", summaryGenTag: 1, reason: "summaryNack" },
+                        { eventName: "Running:Summarize_cancel", summarizeCount: 1, reason: "summaryNack" },
                         { eventName: "Running:SummarizeAttemptDelay", ...retryProps2 },
                         { eventName: "Running:GenerateSummary", ...retryProps2 },
                         { eventName: "Running:SummaryOp", ...retryProps2 },
@@ -526,10 +526,10 @@ describe("Runtime", () => {
                     await tickAndFlushPromises(1);
                     assertRunCounts(3, 0, 1, "retry again with refreshLatestAck");
                     const retryProps3 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 1,
-                        summarizeTotalAttempts: 3,
-                        summarizeAttemptPhase: 2,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 1,
+                        summaryAttempts: 3,
+                        summaryAttemptPhase: 2,
                     };
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:Summarize_cancel", ...retryProps2, reason: "summaryNack" },
@@ -553,16 +553,16 @@ describe("Runtime", () => {
 
                     assertRunCounts(1, 0, 0, "failed upload");
                     const retryProps1 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 1,
-                        summarizeTotalAttempts: 1,
-                        summarizeAttemptPhase: 1,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 1,
+                        summaryAttempts: 1,
+                        summaryAttemptPhase: 1,
                      };
                     const retryProps2 = {
-                        summaryGenTag: 1,
-                        summarizeAttemptsPerPhase: 2,
-                        summarizeTotalAttempts: 2,
-                        summarizeAttemptPhase: 1,
+                        summarizeCount: 1,
+                        summaryAttemptsPerPhase: 2,
+                        summaryAttempts: 2,
+                        summaryAttemptPhase: 1,
                     };
                     assert(mockLogger.matchEvents([
                         { eventName: "Running:Summarize_cancel", ...retryProps1 },
@@ -609,8 +609,8 @@ describe("Runtime", () => {
                         "summarize op handle should be test-broadcast-handle");
 
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
-                        { eventName: "Running:SummaryOp", summaryGenTag: runCount },
+                        { eventName: "Running:GenerateSummary", summarizeCount: runCount },
+                        { eventName: "Running:SummaryOp", summarizeCount: runCount },
                     ]), "unexpected log sequence");
 
                     // Verify that heuristics are blocked while waiting for ack
@@ -666,8 +666,8 @@ describe("Runtime", () => {
                         "summarize op handle should be test-broadcast-handle");
 
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
-                        { eventName: "Running:SummaryOp", summaryGenTag: runCount },
+                        { eventName: "Running:GenerateSummary", summarizeCount: runCount },
+                        { eventName: "Running:SummaryOp", summarizeCount: runCount },
                     ]), "unexpected log sequence");
 
                     // Verify that heuristics are blocked while waiting for ack
@@ -777,8 +777,8 @@ describe("Runtime", () => {
                         "summarize op handle should be test-broadcast-handle");
 
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
-                        { eventName: "Running:SummaryOp", summaryGenTag: runCount },
+                        { eventName: "Running:GenerateSummary", summarizeCount: runCount },
+                        { eventName: "Running:SummaryOp", summarizeCount: runCount },
                     ]), "unexpected log sequence");
 
                     // Verify that heuristics are blocked while waiting for ack
@@ -958,8 +958,8 @@ describe("Runtime", () => {
                     await emitNextOp(summaryConfig.maxOps + 1);
                     assertRunCounts(1, 0, 0, "Should run summarizer once");
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:GenerateSummary", summaryGenTag: runCount },
-                        { eventName: "Running:SummaryOp", summaryGenTag: runCount },
+                        { eventName: "Running:GenerateSummary", summarizeCount: runCount },
+                        { eventName: "Running:SummaryOp", summarizeCount: runCount },
                     ]), "unexpected log sequence 2");
 
                     assert(!mockLogger.matchEvents([
@@ -969,7 +969,12 @@ describe("Runtime", () => {
                     // Now emit ack
                     await emitAck();
                     assert(mockLogger.matchEvents([
-                        { eventName: "Running:Summarize_end", summaryGenTag: runCount, summarizeReason: "maxOps" },
+                        {
+                            eventName: "Running:Summarize_end",
+                            summarizeCount: runCount,
+                            summarizerSuccessfulAttempts: runCount,
+                            summarizeReason: "maxOps"
+                        },
                     ]), "unexpected log sequence 3");
                 });
             });


### PR DESCRIPTION
Use RunningSummarizer.totalAttempts to do this. Also rename a couple of existing telemetry properties to make it more clear that they are per-summary counters, not per-summarizer.