### PR TITLE
[port 0.55] Respect canRetry from error thrown from token provider

### DIFF
--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -318,7 +318,7 @@ export function toInstrumentedOdspTokenFetcher(
                         errorMessage,
                         OdspErrorType.fetchTokenError,
                         typeof rawCanRetry === "boolean" ? rawCanRetry : false /* canRetry */,
-                        { method: name }));
+                        { method: name, driverVersion: pkgVersion }));
                 throw tokenError;
             }),
             { cancel: "generic" });


### PR DESCRIPTION
Porting https://github.com/microsoft/FluidFramework/pull/8971/