### PR TITLE
Fix for data stores resummarized without changes.

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -362,6 +362,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
 
 // @public
 export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "stage"> {
+    readonly forcedFullTree: boolean;
     readonly generateDuration: number;
     // (undocumented)
     readonly stage: "generate";

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2014,7 +2014,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const forcedFullTree = this.garbageCollector.summaryStateNeedsReset;
             try {
                 summarizeResult = await this.summarize({
-                    summaryLogger,
                     fullTree: fullTree || forcedFullTree,
                     trackState: true,
                     summaryLogger,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2009,11 +2009,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             const trace = Trace.start();
             let summarizeResult: ISummaryTreeWithStats;
+            // If the GC state needs to be reset, we need to force a full tree summary and update the unreferenced
+            // state of all the nodes.
+            const forcedFullTree = this.garbageCollector.summaryStateNeedsReset;
             try {
                 summarizeResult = await this.summarize({
-                    // If the GC state needs to be reset, we need to regenerate the summary and update the unreferenced
-                    // state of all the nodes.
-                    fullTree: fullTree || this.garbageCollector.summaryStateNeedsReset,
+                    summaryLogger,
+                    fullTree: fullTree || forcedFullTree,
                     trackState: true,
                     summaryLogger,
                     runGC: this.garbageCollector.shouldRunGC,
@@ -2042,6 +2044,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 summaryTree,
                 summaryStats,
                 generateDuration: trace.trace().duration,
+                forcedFullTree,
             } as const;
 
             continueResult = checkContinue();

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -158,6 +158,8 @@ export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "
     readonly summaryStats: IGeneratedSummaryStats;
     /** Time it took to generate the summary tree and stats. */
     readonly generateDuration: number;
+    /** True if the full tree regeneration with no handle reuse optimizations was forced. */
+    readonly forcedFullTree: boolean;
 }
 
 /** Results of submitSummary after uploading the tree to storage. */

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -245,10 +245,11 @@ export class SummaryGenerator {
 
             // Cumulatively add telemetry properties based on how far generateSummary went.
             const { referenceSequenceNumber: refSequenceNumber } = summaryData;
+            const opsSinceLastSummary = refSequenceNumber - this.heuristicData.lastSuccessfulSummary.refSequenceNumber;
             generateTelemetryProps = {
                 referenceSequenceNumber: refSequenceNumber,
                 opsSinceLastAttempt: refSequenceNumber - this.heuristicData.lastAttempt.refSequenceNumber,
-                opsSinceLastSummary: refSequenceNumber - this.heuristicData.lastSuccessfulSummary.refSequenceNumber,
+                opsSinceLastSummary,
             };
             if (summaryData.stage !== "base") {
                 generateTelemetryProps = {
@@ -275,6 +276,26 @@ export class SummaryGenerator {
 
             if (summaryData.stage !== "submit") {
                 return fail("submitSummaryFailure", summaryData.error, generateTelemetryProps);
+            }
+
+            /**
+             * With incremental summaries, if the full tree was not summarized, only data stores that changed should
+             * be summarized. A data store is considered changed if either or both of the following is true:
+             * - It has received an op.
+             * - Its reference state changed, i.e., it went from referenced to unreferenced or vice-versa.
+             *
+             * Since an op in a data store can change the reference state of another data store, each op can potentially
+             * result in two data stores being summarized. So, the number of summarized data stores should not exceed
+             * twice the number of ops since last summary.
+             */
+            if (!fullTree
+                && !summaryData.forcedFullTree
+                && summaryData.summaryStats.summarizedDataStoreCount <= 2 * opsSinceLastSummary) {
+                logger.sendErrorEvent({
+                    eventName: "IncrementalSummaryViolation",
+                    summarizedDataStoreCount: summaryData.summaryStats.summarizedDataStoreCount,
+                    opsSinceLastSummary,
+                });
             }
 
             // Log event here on summary success only, as Summarize_cancel duplicates failure logging.

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -278,26 +278,6 @@ export class SummaryGenerator {
                 return fail("submitSummaryFailure", summaryData.error, generateTelemetryProps);
             }
 
-            /**
-             * With incremental summaries, if the full tree was not summarized, only data stores that changed should
-             * be summarized. A data store is considered changed if either or both of the following is true:
-             * - It has received an op.
-             * - Its reference state changed, i.e., it went from referenced to unreferenced or vice-versa.
-             *
-             * Since an op in a data store can change the reference state of another data store, each op can potentially
-             * result in two data stores being summarized. So, the number of summarized data stores should not exceed
-             * twice the number of ops since last summary.
-             */
-            if (!fullTree
-                && !summaryData.forcedFullTree
-                && summaryData.summaryStats.summarizedDataStoreCount <= 2 * opsSinceLastSummary) {
-                logger.sendErrorEvent({
-                    eventName: "IncrementalSummaryViolation",
-                    summarizedDataStoreCount: summaryData.summaryStats.summarizedDataStoreCount,
-                    opsSinceLastSummary,
-                });
-            }
-
             // Log event here on summary success only, as Summarize_cancel duplicates failure logging.
             logger.sendTelemetryEvent({ eventName: "GenerateSummary", ...generateTelemetryProps });
             resultsBuilder.summarySubmitted.resolve({ success: true, data: summaryData });

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -170,6 +170,7 @@ describe("Runtime", () => {
                             },
                             handle: "test-handle",
                             clientSequenceNumber: lastClientSeq,
+                            forcedFullTree: false,
                         } as const;
                     },
                     new SummarizeHeuristicData(0, { refSequenceNumber: 0, summaryTime: Date.now() }),

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -149,7 +149,9 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         if (baseGCDetails.gcData !== undefined) {
             this.gcData = cloneGCData(baseGCDetails.gcData);
         }
-        this.referenceUsedRoutes = baseGCDetails.usedRoutes;
+        // Sort the used routes because we compare them with the current used routes to check if they changed between
+        // summaries. Both are sorted so that the order of elements is the same.
+        this.referenceUsedRoutes = baseGCDetails.usedRoutes?.sort();
         this.unreferencedTimestampMs = baseGCDetails.unrefTimestamp;
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/FluidFramework/issues/8963.

**Issue**
When a container is loaded, garbage collector reads the GC blobs for data stores from the base snapshot and passes it to data stores during creation. However, it does not sort the used routes before passing it to the data stores. These used routes become `referenceUsedRoutes` for the data stores, i.e., used routes in the previous summary.
During summarize, the current used routes are compared with the `referenceUsedRoutes` to determine if the reference state of the data store changed.  The used routes must be sorted so that they can be compared correctly.

**Fix**
Data stores sort the used routes passed by the container runtime before saving it as `referenceUsedRoutes`.

The tests added in https://github.com/microsoft/FluidFramework/pull/8983 now pass with this change.