### PR TITLE
Remove Unused and Deprecated IFluidObject augmentations

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,7 +18,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Removed PureDataObject.requestFluidObject_UNSAFE](#Removed-PureDataObject.requestFluidObject_UNSAFE)
 - [Modified PureDataObject.getFluidObjectFromDirectory](#Modified-PureDataObject.getFluidObjectFromDirectory)
 - [Remove IFluidObject from Aqueduct](#Remove-IFluidObject-from-Aqueduct)
-- [Remove IFluidObject from Extensions](#Remove-IFluidObject-from-Extensions)
+- [Remove Unused IFluidObject Augmentations](#Remove-Unused-IFluidObject-Augmentations)
 
 ### IFluidConfiguration removed
 
@@ -69,7 +69,7 @@ This impacts the following public apis:
 
  In general the impact of these changes should be transparent. If you see compile errors related to Fluid object provider types with the above apis, you should transition those usages to [FluidObject](https://github.com/microsoft/FluidFramework/blob/main/common/lib/core-interfaces/src/provider.ts#L61) which is the replacement for the deprecated IFluidObject.
 
-### Remove IFluidObject from Extensions
+### Remove Unused IFluidObject Augmentations
 The following deprecated provider properties are no longer exposed off of IFluidObject
  - IFluidMountableView
  - IAgentScheduler

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,6 +18,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Removed PureDataObject.requestFluidObject_UNSAFE](#Removed-PureDataObject.requestFluidObject_UNSAFE)
 - [Modified PureDataObject.getFluidObjectFromDirectory](#Modified-PureDataObject.getFluidObjectFromDirectory)
 - [Remove IFluidObject from Aqueduct](#Remove-IFluidObject-from-Aqueduct)
+- [Remove IFluidObject from Extensions](#Remove-IFluidObject-from-Extensions)
 
 ### IFluidConfiguration removed
 
@@ -67,6 +68,15 @@ This impacts the following public apis:
  - SingletonContainerServiceFactory.getService
 
  In general the impact of these changes should be transparent. If you see compile errors related to Fluid object provider types with the above apis, you should transition those usages to [FluidObject](https://github.com/microsoft/FluidFramework/blob/main/common/lib/core-interfaces/src/provider.ts#L61) which is the replacement for the deprecated IFluidObject.
+
+### Remove IFluidObject from Extensions
+The following deprecated provider properties are no longer exposed off of IFluidObject
+ - IFluidMountableView
+ - IAgentScheduler
+ - IContainerRuntime
+ - ISummarizer
+
+The interfaces that correspond to the above properties continue to exist, and can use directly, or with the IFluidObject replacement [FluidObject](https://github.com/microsoft/FluidFramework/blob/main/common/lib/core-interfaces/src/provider.ts#L61)
 
 ## 0.56 Breaking changes
 - [`MessageType.Save` and code that handled it was removed](#messageType-save-and-code-that-handled-it-was-removed)

--- a/examples/data-objects/pond/src/interfaces/interfaces.ts
+++ b/examples/data-objects/pond/src/interfaces/interfaces.ts
@@ -3,15 +3,6 @@
  * Licensed under the MIT License.
  */
 
-declare module "@fluidframework/core-interfaces" {
-    export interface IFluidObject extends Readonly<Partial<IProvideFluidUserInformation>> {
-        /**
-         * @deprecated - Use  `FluidObject<IFluidUserInformation>` instead
-        */
-        readonly IFluidUserInformation?: IFluidUserInformation
-     }
-}
-
 export const IFluidUserInformation: keyof IProvideFluidUserInformation = "IFluidUserInformation";
 
 export interface IProvideFluidUserInformation {

--- a/packages/framework/view-interfaces/src/mountableView.ts
+++ b/packages/framework/view-interfaces/src/mountableView.ts
@@ -50,9 +50,3 @@ export interface IFluidMountableView extends IProvideFluidMountableView {
     unmount(): void;
 }
 
-declare module "@fluidframework/core-interfaces" {
-    export interface IFluidObject {
-        /** @deprecated - use `FluidObject<IFluidMountableView> instead */
-        readonly IFluidMountableView?: IFluidMountableView;
-     }
-}

--- a/packages/runtime/agent-scheduler/src/agent.ts
+++ b/packages/runtime/agent-scheduler/src/agent.ts
@@ -64,12 +64,3 @@ export interface IAgentScheduler extends IProvideAgentScheduler, IEventProvider<
      */
     pickedTasks(): string[];
 }
-
-declare module "@fluidframework/core-interfaces" {
-    export interface IFluidObject{
-        /**
-         * @deprecated - use `FluidObject<IAgentScheduler>` instead
-         */
-        readonly IAgentScheduler?: IAgentScheduler;
-    }
-}

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -31,16 +31,6 @@ import {
     IProvideFluidDataStoreRegistry,
  } from "@fluidframework/runtime-definitions";
 
-declare module "@fluidframework/core-interfaces" {
-    export interface IFluidObject {
-        /**
-         * @deprecated - use `FluidObject<IContainerRuntime>` instead
-         */
-        readonly IContainerRuntime?: IContainerRuntime;
-
-     }
-}
-
 /**
  * @deprecated - This will be removed in a later release.
  */

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -20,14 +20,6 @@ import {
 import { ISummaryStats } from "@fluidframework/runtime-definitions";
 import { ISummaryAckMessage, ISummaryNackMessage, ISummaryOpMessage } from "./summaryCollection";
 
-declare module "@fluidframework/core-interfaces" {
-    export interface IFluidObject {
-        /** @deprecated - use `FluidObject<ISummarizer>` instead */
-        readonly ISummarizer?: ISummarizer;
-
-     }
-}
-
 /**
  * @deprecated - This will be removed in a later release.
  */


### PR DESCRIPTION
The following deprecated provider properties are no longer exposed off of IFluidObject
 - IFluidMountableView
 - IAgentScheduler
 - IContainerRuntime
 - ISummarizer

The interfaces that correspond to the above properties continue to exist, and can use directly, or with the IFluidObject replacement [FluidObject](https://github.com/microsoft/FluidFramework/blob/main/common/lib/core-interfaces/src/provider.ts#L61)

related to #8077