### PR TITLE
Add GitHub issue template for deprecated APIs

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_deprecation.md
+++ b/.github/ISSUE_TEMPLATE/api_deprecation.md
@@ -17,7 +17,10 @@ assignees: ''
 <!-- An explanation of the intended replacement/solution -->
 
 **Dependencies**
-<!-- Indicate if there are any dependencies that must be handled first -->
+<!-- Indicate if there is any other work that must be completed first -->
+
+**Compatibility Concerns**
+<!-- List any compatibility concerns such as persistent data, loader compatibility (LTS), or runtime compatibility (N-1) -->
 
 **Phases**
 <!-- Layout a clear plan listing each step necessary to complete the cleanup -->
@@ -28,6 +31,7 @@ assignees: ''
 **Open Questions**
 <!-- List any unknowns that need to be addressed before removing the API -->
 
+<!-- Reminder: Assign this issue to somebody, if you are unsure who, assign it to yourself -->
 
 <!-- By filing an Issue, you are expected to comply with the Code of Conduct: https://github.com/microsoft/FluidFramework/blob/main/CODE_OF_CONDUCT.md -->
 

--- a/.github/ISSUE_TEMPLATE/api_deprecation.md
+++ b/.github/ISSUE_TEMPLATE/api_deprecation.md
@@ -1,0 +1,32 @@
+---
+name: Deprecated API
+about: Track the cleanup of a deprecated API
+title: ''
+labels: 'api deprecation'
+assignees: ''
+
+---
+
+## Deprecated API
+**Context**
+<!-- An explanation of why this API should be deprecated and ultimately removed -->
+
+**Approach**
+<!-- An explanation of the intended replacement/solution -->
+
+**Dependencies**
+<!-- Indicate if there are any dependencies that must be handled first -->
+
+**Phases**
+<!-- Layout a clear plan listing each step necessary to complete the cleanup -->
+
+**Expected Timeline**
+<!-- When you expect this API will be fully removed. If possible give a release version -->
+
+**Open Questions**
+<!-- List any unknowns that need to be addressed before removing the API -->
+
+
+<!-- By filing an Issue, you are expected to comply with the Code of Conduct: https://github.com/microsoft/FluidFramework/blob/main/CODE_OF_CONDUCT.md -->
+
+<!-- Lastly, be sure to preview your issue before saving. Thanks! -->

--- a/.github/ISSUE_TEMPLATE/api_deprecation.md
+++ b/.github/ISSUE_TEMPLATE/api_deprecation.md
@@ -8,6 +8,8 @@ assignees: ''
 ---
 
 ## Deprecated API
+<!-- Describe the API along with its associated classes, interfaces, packages, etc. -->
+
 **Context**
 <!-- An explanation of why this API should be deprecated and ultimately removed -->
 


### PR DESCRIPTION
This PR adds a GitHub issue template for deprecated APIs. The issue will automatically have the "api deprecation" label applied, and have sections generated for the recommended information to include.

If this is merged, the [API deprecation wiki doc](https://github.com/microsoft/FluidFramework/wiki/API-Deprecation) should be updated to include use of this template.