### PR TITLE
Bump version on container defs & removing snapshot API

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -47,7 +47,6 @@ import { ISummaryStats } from '@fluidframework/runtime-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
-import { ITree } from '@fluidframework/protocol-definitions';
 import { MessageType } from '@fluidframework/protocol-definitions';
 import { NamedFluidDataStoreRegistryEntries } from '@fluidframework/runtime-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
@@ -161,8 +160,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     setConnectionState(connected: boolean, clientId?: string): void;
     // (undocumented)
     setFlushMode(mode: FlushMode): void;
-    // @deprecated
-    snapshot(): Promise<ITree>;
     // (undocumented)
     get storage(): IDocumentStorageService;
     // (undocumented)

--- a/examples/data-objects/client-ui-lib/package.json
+++ b/examples/data-objects/client-ui-lib/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-example/search-menu": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/ink": "^0.57.0",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.57.0",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/examples/data-objects/key-value-cache/package.json
+++ b/examples/data-objects/key-value-cache/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fluidframework/aqueduct": "^0.57.0",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/merge-tree": "^0.57.0",
     "@fluidframework/runtime-definitions": "^0.57.0",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/examples/data-objects/scribe/package.json
+++ b/examples/data-objects/scribe/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-example/host-service-interfaces": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -43,7 +43,7 @@
     "@fluid-example/client-ui-lib": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -40,7 +40,7 @@
     "@fluid-example/table-document": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/matrix": "^0.57.0",
     "@fluidframework/runtime-utils": "^0.57.0",

--- a/examples/data-objects/task-selection/package.json
+++ b/examples/data-objects/task-selection/package.json
@@ -38,7 +38,7 @@
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/request-handler": "^0.57.0",

--- a/examples/hosts/app-integration/container-views/package.json
+++ b/examples/hosts/app-integration/container-views/package.json
@@ -35,7 +35,7 @@
     "@fluid-experimental/get-container": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/examples/hosts/host-service-interfaces/package.json
+++ b/examples/hosts/host-service-interfaces/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0"
   },
   "devDependencies": {

--- a/examples/hosts/hosts-sample/package.json
+++ b/examples/hosts/hosts-sample/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fluid-example/example-utils": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-utils": "^0.57.0",

--- a/examples/hosts/iframe-host/package.json
+++ b/examples/hosts/iframe-host/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fluid-example/todo": "^0.57.0",
     "@fluid-experimental/get-container": "^0.57.0",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -27,7 +27,7 @@ import {
     OuterUrlResolver,
 } from "@fluidframework/iframe-driver";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { ISequencedDocumentMessage, ITree, ISummaryTree } from "@fluidframework/protocol-definitions";
+import { ISequencedDocumentMessage, ISummaryTree } from "@fluidframework/protocol-definitions";
 import { RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
 
 export interface IFrameInnerApi {

--- a/examples/hosts/iframe-host/src/inframehost.ts
+++ b/examples/hosts/iframe-host/src/inframehost.ts
@@ -77,9 +77,6 @@ class ProxyRuntime implements IRuntime {
     async request(request: IRequest): Promise<IResponse> {
         throw new Error("Method not implemented.");
     }
-    async snapshot(tagMessage: string, fullTree?: boolean | undefined): Promise<ITree | null> {
-        throw new Error("Method not implemented.");
-    }
     async setConnectionState(connected: boolean, clientId?: string) {
     }
     async process(message: ISequencedDocumentMessage, local: boolean, context: any) {

--- a/examples/hosts/node-host/package.json
+++ b/examples/hosts/node-host/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@fluid-example/key-value-cache": "^0.57.0",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.44.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/schemas": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -34,7 +34,7 @@
     "@fluid-experimental/property-changeset": "^0.57.0",
     "@fluid-experimental/property-properties": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/experimental/examples/bubblebench/baseline/package.json
+++ b/experimental/examples/bubblebench/baseline/package.json
@@ -41,7 +41,7 @@
     "@fluid-experimental/bubblebench-common": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/map": "^0.57.0",

--- a/experimental/examples/bubblebench/common/package.json
+++ b/experimental/examples/bubblebench/common/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fluid-experimental/tree": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/map": "^0.57.0",

--- a/experimental/examples/bubblebench/ot/package.json
+++ b/experimental/examples/bubblebench/ot/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/sharejs-json1": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/map": "^0.57.0",

--- a/experimental/examples/bubblebench/sharedtree/package.json
+++ b/experimental/examples/bubblebench/sharedtree/package.json
@@ -42,7 +42,7 @@
     "@fluid-experimental/tree": "^0.57.0",
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/map": "^0.57.0",

--- a/experimental/framework/get-container/package.json
+++ b/experimental/framework/get-container/package.json
@@ -26,7 +26,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.44.0",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2029,9 +2029,9 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "0.45.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0.tgz",
-			"integrity": "sha512-juwnf5uyTiya9ZupsF29xxrBZ4sWQ5YVctoacwu/44s98a+zctc2rChmakl26pmdk8i6dvLZzx7EVISWnNn4Kw==",
+			"version": "0.46.0-50372",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.46.0-50372.tgz",
+			"integrity": "sha512-i8ZOPAdVSCRTC+wh7l4lwz2w6EANCgUO/QVSkHZm+gYdmYJIL1Rei5EwQDVbPsp0iq3mLNuX26C/tiVQw+hZsg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0",
 				"@fluidframework/core-interfaces": "^0.42.0",
@@ -2342,6 +2342,17 @@
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.45.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0.tgz",
+					"integrity": "sha512-juwnf5uyTiya9ZupsF29xxrBZ4sWQ5YVctoacwu/44s98a+zctc2rChmakl26pmdk8i6dvLZzx7EVISWnNn4Kw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.42.0",
+						"@fluidframework/driver-definitions": "^0.44.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.56.1",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.1.tgz",
@@ -2666,6 +2677,17 @@
 				"@types/node": "^14.18.0"
 			},
 			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.45.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0.tgz",
+					"integrity": "sha512-juwnf5uyTiya9ZupsF29xxrBZ4sWQ5YVctoacwu/44s98a+zctc2rChmakl26pmdk8i6dvLZzx7EVISWnNn4Kw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.42.0",
+						"@fluidframework/driver-definitions": "^0.44.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				},
 				"@fluidframework/runtime-definitions": {
 					"version": "0.56.1",
 					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.1.tgz",
@@ -3034,6 +3056,19 @@
 				"@fluidframework/driver-definitions": "^0.44.0",
 				"@fluidframework/protocol-definitions": "^0.1026.0",
 				"@types/node": "^14.18.0"
+			},
+			"dependencies": {
+				"@fluidframework/container-definitions": {
+					"version": "0.45.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.45.0.tgz",
+					"integrity": "sha512-juwnf5uyTiya9ZupsF29xxrBZ4sWQ5YVctoacwu/44s98a+zctc2rChmakl26pmdk8i6dvLZzx7EVISWnNn4Kw==",
+					"requires": {
+						"@fluidframework/common-definitions": "^0.20.0",
+						"@fluidframework/core-interfaces": "^0.42.0",
+						"@fluidframework/driver-definitions": "^0.44.0",
+						"@fluidframework/protocol-definitions": "^0.1026.0"
+					}
+				}
 			}
 		},
 		"@fluidframework/server-lambdas": {

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-utils": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",

--- a/packages/framework/azure-client/package.json
+++ b/packages/framework/azure-client/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.44.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -29,7 +29,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/fluid-static": "^0.57.0",
     "@fluidframework/map": "^0.57.0",
     "@fluidframework/sequence": "^0.57.0"

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -32,7 +32,7 @@
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/driver-definitions": "^0.44.0",
     "@fluidframework/driver-utils": "^0.57.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-utils": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.44.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/telemetry-utils": "^0.57.0"
   },

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -28,7 +28,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "isomorphic-fetch": "^3.0.0"
   },

--- a/packages/runtime/agent-scheduler/package.json
+++ b/packages/runtime/agent-scheduler/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",
     "@fluidframework/datastore-definitions": "^0.57.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.44.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",
     "@fluidframework/container-utils": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1372,14 +1372,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         throw responseToException(create404Response(request), request);
     }
 
-    /**
-     * Notifies this object to take the snapshot of the container.
-     * @deprecated - Use summarize to get summary of the container runtime.
-     */
-    public async snapshot(): Promise<ITree> {
-        throw new Error("Do not call this API, to be removed in the following release.");
-    }
-
     private addContainerStateToSummary(summaryTree: ISummaryTreeWithStats) {
         addBlobToSummary(summaryTree, metadataBlobName, JSON.stringify(this.formMetadata()));
         if (this.chunkMap.size > 0) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -64,7 +64,6 @@ import {
     ISummaryConfiguration,
     ISummaryContent,
     ISummaryTree,
-    ITree,
     MessageType,
     SummaryType,
 } from "@fluidframework/protocol-definitions";

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/runtime-definitions": "^0.57.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-utils": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.44.0",
     "@fluidframework/protocol-definitions": "^0.1026.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/azure-service-utils": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore-definitions": "^0.57.0",
     "@fluidframework/driver-definitions": "^0.44.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -54,7 +54,7 @@
     "@fluidframework/build-common": "^0.23.0",
     "@fluidframework/cell": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -56,7 +56,7 @@
     "@fluid-internal/replay-tool": "^0.57.0",
     "@fluidframework/cell": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/counter": "^0.57.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -70,7 +70,7 @@
     "@fluidframework/cell": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -66,7 +66,7 @@
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/cell": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -33,7 +33,7 @@
     "@fluidframework/cell": "^0.57.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/container-runtime-definitions": "^0.57.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fluidframework/aqueduct": "^0.57.0",
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/container-definitions": "^0.45.0",
+    "@fluidframework/container-definitions": "^0.46.0-0",
     "@fluidframework/container-loader": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.44.0",


### PR DESCRIPTION
1. @fluidframework/container-definitions": "^0.45.0" -> "^0.46.0-0"
2. Removing snapshot API from container runtime. This PR calls out breaking changes: https://github.com/microsoft/FluidFramework/pull/9010

Closes https://github.com/microsoft/FluidFramework/issues/8286.

