### PR TITLE
Fix for data stores resummarized without changes. (#8990)

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -365,6 +365,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
 
 // @public
 export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "stage"> {
+    readonly forcedFullTree: boolean;
     readonly generateDuration: number;
     // (undocumented)
     readonly stage: "generate";

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2010,12 +2010,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
             const trace = Trace.start();
             let summarizeResult: ISummaryTreeWithStats;
+            // If the GC state needs to be reset, we need to force a full tree summary and update the unreferenced
+            // state of all the nodes.
+            const forcedFullTree = this.garbageCollector.summaryStateNeedsReset;
             try {
                 summarizeResult = await this.summarize({
                     summaryLogger,
-                    // If the GC state needs to be reset, we need to regenerate the summary and update the unreferenced
-                    // state of all the nodes.
-                    fullTree: fullTree || this.garbageCollector.summaryStateNeedsReset,
+                    fullTree: fullTree || forcedFullTree,
                     trackState: true,
                     runGC: this.garbageCollector.shouldRunGC,
                 });
@@ -2043,6 +2044,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 summaryTree,
                 summaryStats,
                 generateDuration: trace.trace().duration,
+                forcedFullTree,
             } as const;
 
             continueResult = checkContinue();

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -166,6 +166,8 @@ export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "
     readonly summaryStats: IGeneratedSummaryStats;
     /** Time it took to generate the summary tree and stats. */
     readonly generateDuration: number;
+    /** True if the full tree regeneration with no handle reuse optimizations was forced. */
+    readonly forcedFullTree: boolean;
 }
 
 /** Results of submitSummary after uploading the tree to storage. */

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -244,10 +244,11 @@ export class SummaryGenerator {
 
             // Cumulatively add telemetry properties based on how far generateSummary went.
             const { referenceSequenceNumber: refSequenceNumber } = summaryData;
+            const opsSinceLastSummary = refSequenceNumber - this.heuristicData.lastSuccessfulSummary.refSequenceNumber;
             generateTelemetryProps = {
                 referenceSequenceNumber: refSequenceNumber,
                 opsSinceLastAttempt: refSequenceNumber - this.heuristicData.lastAttempt.refSequenceNumber,
-                opsSinceLastSummary: refSequenceNumber - this.heuristicData.lastSuccessfulSummary.refSequenceNumber,
+                opsSinceLastSummary,
             };
             if (summaryData.stage !== "base") {
                 generateTelemetryProps = {

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -170,6 +170,7 @@ describe("Runtime", () => {
                             },
                             handle: "test-handle",
                             clientSequenceNumber: lastClientSeq,
+                            forcedFullTree: false,
                         } as const;
                     },
                     new SummarizeHeuristicData(0, { refSequenceNumber: 0, summaryTime: Date.now() }),

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -149,7 +149,9 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         if (baseGCDetails.gcData !== undefined) {
             this.gcData = cloneGCData(baseGCDetails.gcData);
         }
-        this.referenceUsedRoutes = baseGCDetails.usedRoutes;
+        // Sort the used routes because we compare them with the current used routes to check if they changed between
+        // summaries. Both are sorted so that the order of elements is the same.
+        this.referenceUsedRoutes = baseGCDetails.usedRoutes?.sort();
         this.unreferencedTimestampMs = baseGCDetails.unrefTimestamp;
     }
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcResummarizationTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcResummarizationTests.spec.ts
@@ -1,0 +1,233 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { ContainerRuntimeFactoryWithDefaultDataStore, DataObjectFactory } from "@fluidframework/aqueduct";
+import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import {
+    ContainerRuntime,
+    IAckedSummary,
+    IContainerRuntimeOptions,
+    SummaryCollection,
+} from "@fluidframework/container-runtime";
+import { ISummaryContext } from "@fluidframework/driver-definitions";
+import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { channelsTreeName, IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { wrapDocumentServiceFactory } from "./gcDriverWrappers";
+import { loadSummarizer, TestDataObject, submitAndAckSummary } from "./mockSummarizerClient";
+
+/**
+ * Validates that unchanged Fluid objects are not resummarized again. Basically, only objects that have changed since
+ * the previous summary should be resummarized and for the rest, we add handles that refer to the previous summary.
+ * A Fluid object is considered changed since the last summary if either or both of the following is true:
+ * - It received an op.
+ * - Its reference state changed, i.e., it was referenced and became unreferenced or vice-versa.
+ */
+describeNoCompat("GC resummarization state", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+    const dataObjectFactory = new DataObjectFactory("TestDataObject", TestDataObject, [], []);
+    const runtimeOptions: IContainerRuntimeOptions = {
+        summaryOptions: { disableSummaries: true },
+        gcOptions: { gcAllowed: true },
+    };
+    const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+        runtime.IFluidHandleContext.resolveHandle(request);
+    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+        dataObjectFactory,
+        [
+            [dataObjectFactory.type, Promise.resolve(dataObjectFactory)],
+        ],
+        undefined,
+        [innerRequestHandler],
+        runtimeOptions,
+    );
+    const logger = new TelemetryNullLogger();
+
+    // Stores the latest summary uploaded to the server.
+    let latestUploadedSummary: ISummaryTree | undefined;
+    // Stores the latest summary context uploaded to the server.
+    let latestSummaryContext: ISummaryContext | undefined;
+    // Stores the latest acked summary for the document.
+    let latestAckedSummary: IAckedSummary | undefined;
+
+    let mainContainer: IContainer;
+    let dataStoreA: TestDataObject;
+
+    const createContainer = async (): Promise<IContainer> => {
+        return provider.createContainer(runtimeFactory);
+    };
+
+    const getNewSummarizer = async (summaryVersion?: string) => {
+        return loadSummarizer(
+            provider,
+            runtimeFactory,
+            mainContainer.deltaManager.lastSequenceNumber,
+            summaryVersion,
+        );
+    };
+
+    /**
+     * Callback that will be called by the document storage service whenever a summary is uploaded by the client.
+     * Update the summary context to include the summary proposal and ack handle as per the latest ack for the
+     * document.
+     */
+    function uploadSummaryCb(summaryTree: ISummaryTree, context: ISummaryContext): ISummaryContext {
+        latestUploadedSummary = summaryTree;
+        latestSummaryContext = context;
+        const newSummaryContext = { ...context };
+        // If we received an ack for this document, update the summary context with its information. The
+        // server rejects the summary if it doesn't have the proposal and ack handle of the previous
+        // summary.
+        if (latestAckedSummary !== undefined) {
+            newSummaryContext.ackHandle = latestAckedSummary.summaryAck.contents.handle;
+            newSummaryContext.proposalHandle = latestAckedSummary.summaryOp.contents.handle;
+        }
+        return newSummaryContext;
+    }
+
+    /**
+     * Submits a summary and validates that the data stores with ids in `changedDataStoreIds` are resummarized. All
+     * other data stores are not resummarized and a handle is sent for them in the summary.
+     */
+    async function validateResummaryState(
+        summarizerClient: { containerRuntime: ContainerRuntime, summaryCollection: SummaryCollection },
+        changedDataStoreIds: string[] = [],
+    ) {
+        const summaryResult = await submitAndAckSummary(provider, summarizerClient, logger, false /* fullTree */);
+        latestAckedSummary = summaryResult.ackedSummary;
+        assert(
+            latestSummaryContext && latestSummaryContext.referenceSequenceNumber >= summaryResult.summarySequenceNumber,
+            `Did not get expected summary. Expected: ${summaryResult.summarySequenceNumber}. ` +
+            `Actual: ${latestSummaryContext?.referenceSequenceNumber}.`,
+        );
+
+        assert(latestUploadedSummary !== undefined, "Did not get a summary");
+        const channelsTree = (latestUploadedSummary.tree[channelsTreeName] as ISummaryTree).tree;
+        for (const [ id, summaryObject ] of Object.entries(channelsTree)) {
+            if (changedDataStoreIds.includes(id)) {
+                assert(summaryObject.type === SummaryType.Tree, `Data store ${id}'s entry should be a tree`);
+            } else {
+                assert(summaryObject.type === SummaryType.Handle, `Data store ${id}'s entry should be a handle`);
+            }
+        }
+    }
+
+    beforeEach(async () => {
+        provider = getTestObjectProvider();
+        // Wrap the document service factory in the driver so that the `uploadSummaryCb` function is called every
+        // time the summarizer client uploads a summary.
+        (provider as any)._documentServiceFactory = wrapDocumentServiceFactory(
+            provider.documentServiceFactory,
+            uploadSummaryCb,
+        );
+
+        mainContainer = await createContainer();
+        dataStoreA = await requestFluidObject<TestDataObject>(mainContainer, "default");
+
+        await provider.ensureSynchronized();
+    });
+
+    afterEach(() => {
+        latestAckedSummary = undefined;
+        latestSummaryContext = undefined;
+        latestUploadedSummary = undefined;
+    });
+
+    describe("resummarization state in summary", () => {
+        it("only resummarizes changed data stores", async () => {
+            const summarizerClient1 = await getNewSummarizer();
+
+            // Create data stores B and C, and mark them as referenced.
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+            // Summarize and validate that all data store entries are trees since this is the first summary.
+            await validateResummaryState(summarizerClient1, [dataStoreA.id, dataStoreB.id, dataStoreC.id]);
+
+            // Make a change in dataStoreA.
+            dataStoreA._root.set("key", "value");
+
+            // Summarize and validate that dataStoreA's entry is a tree and rest of the data store entries are handles.
+            await validateResummaryState(summarizerClient1, [dataStoreA.id]);
+
+            // Summarize again and validate that all data store entries are trees since none of them changed.
+            await validateResummaryState(summarizerClient1, []);
+        });
+
+        it("only resummarizes changed data stores across multiple summarizer clients", async () => {
+            const summarizerClient1 = await getNewSummarizer();
+
+            // Create data stores B and C, and mark them as referenced.
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+            // Validate that all data store entries are trees since this is the first summary.
+            await validateResummaryState(summarizerClient1, [dataStoreA.id, dataStoreB.id, dataStoreC.id]);
+
+            // Load a new client from the summary generated above.
+            assert(latestAckedSummary !== undefined, "Ack'd summary isn't available as expected");
+            const summarizerClient2 = await getNewSummarizer(latestAckedSummary.summaryAck.contents.handle);
+
+            // Summarize the new client and validate that all data store entries are handles since none of them changed.
+            await validateResummaryState(summarizerClient2, []);
+
+            // Make a change in dataStoreA.
+            dataStoreA._root.set("key", "value");
+
+            // Load a new client from the summary generated above.
+            const summarizerClient3 = await getNewSummarizer(latestAckedSummary.summaryAck.contents.handle);
+
+            // Summarize the new client and validate that dataStoreA's entry is a tree and rest of the data store
+            // entries are handles.
+            await validateResummaryState(summarizerClient3, [dataStoreA.id]);
+        });
+
+        it("resummarizes data stores whose reference state changed across summarizer clients", async () => {
+            const summarizerClient1 = await getNewSummarizer();
+
+            // Create data stores B and C, and mark them as referenced.
+            const dataStoreB = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            const dataStoreC = await dataObjectFactory.createInstance(dataStoreA.containerRuntime);
+            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+            // Summarize and validate that all data store entries are trees since this is the first summary.
+            await validateResummaryState(summarizerClient1, [dataStoreA.id, dataStoreB.id, dataStoreC.id]);
+
+            // Remove the reference to dataStoreB.
+            dataStoreA._root.delete("dataStoreB");
+
+            // Summarize and validate that both dataStoreA and dataStoreB changed. dataStoreA because it has a new
+            // op and dataStoreB because its reference state changed from referenced -> unreferenced.
+            await validateResummaryState(summarizerClient1, [dataStoreA.id, dataStoreB.id]);
+
+            // Load a new client from the summary generated above.
+            assert(latestAckedSummary !== undefined, "Ack'd summary isn't available as expected");
+            const summarizerClient2 = await getNewSummarizer(latestAckedSummary.summaryAck.contents.handle);
+
+            // Add back the reference to dataStoreB.
+            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+            // Summarize the new client and validate that both dataStoreA and dataStoreB changed. dataStoreA because it
+            // has a new op and dataStoreB because its reference state changed from unreferenced -> referenced.
+            await validateResummaryState(summarizerClient2, [dataStoreA.id, dataStoreB.id]);
+
+            // Load a new client from the summary generated above.
+            const summarizerClient3 = await getNewSummarizer(latestAckedSummary.summaryAck.contents.handle);
+
+            // Validate that all data store entries are handles since none of them changed.
+            await validateResummaryState(summarizerClient3, []);
+        });
+    });
+});


### PR DESCRIPTION
Cherry-pick from https://github.com/microsoft/FluidFramework/pull/8990.

Fixes https://github.com/microsoft/FluidFramework/issues/8963.

**Issue**
When a container is loaded, garbage collector reads the GC blobs for data stores from the base snapshot and passes it to data stores during creation. However, it does not sort the used routes before passing it to the data stores. These used routes become referenceUsedRoutes for the data stores, i.e., used routes in the previous summary.
During summarize, the current used routes are compared with the referenceUsedRoutes to determine if the reference state of the data store changed. The used routes must be sorted so that they can be compared correctly.

**Fix**
Data stores sort the used routes passed by the container runtime before saving it as referenceUsedRoutes.