### PR TITLE
Exclude package.json from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,3 +93,6 @@ api-report/undo-redo.api.md                                               @micro
 api-report/view-adapters.api.md                                           @microsoft/fluid-cr-framework
 api-report/view-interfaces.api.md                                         @microsoft/fluid-cr-framework
 api-report/web-code-loader.api.md                                         @microsoft/fluid-cr-loader
+
+# No owners for package.json files to avoid review spam when mono-repo dependencies are updated
+package.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,4 +95,4 @@ api-report/view-interfaces.api.md                                         @micro
 api-report/web-code-loader.api.md                                         @microsoft/fluid-cr-loader
 
 # No owners for package.json files to avoid review spam when mono-repo dependencies are updated
-package.json
+package.json @msfluid-bot


### PR DESCRIPTION
This should help reduce code review spam with repo-wide policy changes. More discussion in #9019.