### PR TITLE
Prototype to see how hard it is to solve 1Mb Kafka / socket.io limit

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -147,6 +147,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     process(messageArg: ISequencedDocumentMessage, local: boolean): void;
     // (undocumented)
+    processCore(message: ISequencedDocumentMessage, local: boolean): void;
+    // (undocumented)
     processSignal(message: ISignalMessage, local: boolean): void;
     refreshLatestSummaryAck(proposalHandle: string | undefined, ackHandle: string, summaryRefSeq: number, summaryLogger: ITelemetryLogger): Promise<void>;
     request(request: IRequest): Promise<IResponse>;
@@ -616,14 +618,19 @@ export enum RuntimeMessage {
     Rejoin = "rejoin"
 }
 
+// Warning: (ae-forgotten-export) The symbol "ScheduleManagerCore" needs to be exported by the entry point index.d.ts
+//
 // @public
-export class ScheduleManager {
-    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, emitter: EventEmitter, logger: ITelemetryLogger);
+export class ScheduleManager extends ScheduleManagerCore {
+    // Warning: (ae-forgotten-export) The symbol "IScheduleManagerSerialized" needs to be exported by the entry point index.d.ts
+    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, emitter: EventEmitter, logger: ITelemetryLogger, state: IScheduleManagerSerialized | undefined, processCallback: (message: ISequencedDocumentMessage, local: boolean) => void, clientIdCallback: () => string | undefined);
     // (undocumented)
-    afterOpProcessing(error: any | undefined, message: ISequencedDocumentMessage): void;
+    process(message: ISequencedDocumentMessage, local: boolean): void;
     // (undocumented)
-    beforeOpProcessing(message: ISequencedDocumentMessage): void;
-    }
+    removeClient(clientId: string): void;
+    // (undocumented)
+    serialize(): IScheduleManagerSerialized;
+}
 
 // @public
 export type SubmitSummaryResult = IBaseSummarizeResult | IGenerateSummaryTreeResult | IUploadSummaryResult | ISubmitSummaryOpResult;

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -7,16 +7,21 @@
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
 import { EventEmitter } from 'events';
+import { EventForwarder } from '@fluidframework/common-utils';
 import { FluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { FlushMode } from '@fluidframework/runtime-definitions';
 import { IAudience } from '@fluidframework/container-definitions';
+import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IContainerContext } from '@fluidframework/container-definitions';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
 import { IContainerRuntimeEvents } from '@fluidframework/container-runtime-definitions';
 import { ICriticalContainerError } from '@fluidframework/container-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
+import { IDeltaManagerEvents } from '@fluidframework/container-definitions';
+import { IDeltaQueue } from '@fluidframework/container-definitions';
+import { IDeltaSender } from '@fluidframework/container-definitions';
 import { IDisposable } from '@fluidframework/common-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
@@ -50,6 +55,7 @@ import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { MessageType } from '@fluidframework/protocol-definitions';
 import { NamedFluidDataStoreRegistryEntries } from '@fluidframework/runtime-definitions';
+import { ReadOnlyInfo } from '@fluidframework/container-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
@@ -147,7 +153,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     process(messageArg: ISequencedDocumentMessage, local: boolean): void;
     // (undocumented)
-    processCore(message: ISequencedDocumentMessage, local: boolean): void;
+    processCore(message: ISequencedDocumentMessage, beginBatch: boolean, endBatch: boolean): void;
     // (undocumented)
     processSignal(message: ISignalMessage, local: boolean): void;
     refreshLatestSummaryAck(proposalHandle: string | undefined, ackHandle: string, summaryRefSeq: number, summaryLogger: ITelemetryLogger): Promise<void>;
@@ -618,18 +624,56 @@ export enum RuntimeMessage {
     Rejoin = "rejoin"
 }
 
-// Warning: (ae-forgotten-export) The symbol "ScheduleManagerCore" needs to be exported by the entry point index.d.ts
-//
 // @public
-export class ScheduleManager extends ScheduleManagerCore {
+export class ScheduleManager extends EventForwarder<IDeltaManagerEvents> implements IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> {
     // Warning: (ae-forgotten-export) The symbol "IScheduleManagerSerialized" needs to be exported by the entry point index.d.ts
-    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, emitter: EventEmitter, logger: ITelemetryLogger, state: IScheduleManagerSerialized | undefined, processCallback: (message: ISequencedDocumentMessage, local: boolean) => void, clientIdCallback: () => string | undefined);
+    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, logger: ITelemetryLogger, state: IScheduleManagerSerialized | undefined, processCallback: (message: ISequencedDocumentMessage, beginBatch: boolean, endBatch: boolean) => void);
     // (undocumented)
-    process(message: ISequencedDocumentMessage, local: boolean): void;
+    get active(): boolean;
+    // (undocumented)
+    get clientDetails(): IClientDetails;
+    // (undocumented)
+    close(): void;
+    // (undocumented)
+    dispose(): void;
+    // (undocumented)
+    flush(): void;
+    // (undocumented)
+    get hasCheckpointSequenceNumber(): boolean;
+    // (undocumented)
+    get IDeltaSender(): IDeltaSender;
+    // (undocumented)
+    readonly inbound: IDeltaQueue<ISequencedDocumentMessage>;
+    // (undocumented)
+    readonly inboundSignal: IDeltaQueue<ISignalMessage>;
+    // (undocumented)
+    readonly initialSequenceNumber: number;
+    // (undocumented)
+    get lastKnownSeqNumber(): number;
+    // (undocumented)
+    lastMessage: ISequencedDocumentMessage | undefined;
+    // (undocumented)
+    get lastSequenceNumber(): number;
+    // (undocumented)
+    get maxMessageSize(): number;
+    // (undocumented)
+    get minimumSequenceNumber(): number;
+    // (undocumented)
+    readonly outbound: IDeltaQueue<IDocumentMessage[]>;
+    // (undocumented)
+    process(message: ISequencedDocumentMessage): void;
+    // (undocumented)
+    get readOnlyInfo(): ReadOnlyInfo;
     // (undocumented)
     removeClient(clientId: string): void;
     // (undocumented)
     serialize(): IScheduleManagerSerialized;
+    // (undocumented)
+    get serviceConfiguration(): IClientConfiguration | undefined;
+    // (undocumented)
+    submitSignal(content: any): void;
+    // (undocumented)
+    get version(): string;
 }
 
 // @public

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -310,7 +310,14 @@ export class ConnectionManager implements IConnectionManager {
                 if (this.connection === undefined) {
                     throw new Error("Attempted to submit an outbound message without connection");
                 }
-                this.connection.submit(messages);
+                // We can break messages how we want here!
+                // Likely best solution is to send 16 messages in a row.
+                // That said, if content is always a string (its type is any), then we can estimate size of envelope,
+                // and use size of content to find reasonable batching strategy to include more ops if they are small.
+                // That said, 16 per batch in current system (of each op being very large, i.e. ~500 bytes) is fine.
+                for (const message of messages) {
+                    this.connection.submit([message]);
+                }
             });
 
         this._outbound.on("error", (error) => {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -458,6 +458,7 @@ export class ScheduleManager extends ScheduleManagerCore {
         if (message.metadata?.batch === true) {
             // Start of a batch. There should be no partial batch from this client
             assert(!this.pending.has(clientId), "two batches from same client?");
+            assert(typeof message.metadata?.batchLength === "number", "no batchLength");
             this.pending.set(clientId, {length: message.metadata?.batchLength, messages: [message]});
         } else if (!this.pending.has(clientId)) {
             // No pending batch from this client, and this is not start of a batch.
@@ -504,7 +505,7 @@ export class ScheduleManager extends ScheduleManagerCore {
                 this.processCallback(message, message.clientId === clientId);
                 first = false;
             }
-            this.emitter.emit("endBegin", messages[messages.length-1]);
+            this.emitter.emit("batchEnd", messages[messages.length-1]);
         } catch (error) {
             this.hitError = true;
             this.emitter.emit("batchEnd", error, message);

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -281,6 +281,11 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         this.runtime.deltaManager.inbound.on("op", this.systemOpListener);
 
         this.opListener = (error: any, op: ISequencedDocumentMessage) => runningSummarizer.handleOp(error, op);
+
+        // This can be changed now, as it does not matter when summaries are created - they can be created
+        // in the middle of the batch!
+        // That sad, likely it's beneficial for summaries to be aligned on end of some batch, as in most cases
+        // that will result in smallest summary (smallest amount of state to track by ScheduleManager)
         this.runtime.on("batchEnd", this.opListener);
 
         return runningSummarizer;

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -139,6 +139,7 @@ export function getMetadataFormatVersion(metadata?: IContainerRuntimeMetadata): 
 export const aliasBlobName = ".aliases";
 export const metadataBlobName = ".metadata";
 export const chunksBlobName = ".chunks";
+export const batchBlobName = ".batches";
 export const electedSummarizerBlobName = ".electedSummarizer";
 export const blobsTreeName = ".blobs";
 


### PR DESCRIPTION
For more info, please see description of algorithm in https://github.com/microsoft/FluidFramework/issues/7599
I've created EPIC https://github.com/microsoft/FluidFramework/issues/9023 to track all the issues that were opened related to this problem space (for easier tracking).

**What**
This change experiments with sending ops from a single batch individually, allowing interleaving with ops from other clients. This allows us to avoid hitting 1Mb limit for batches, assuming each individual op is below 1Mb.
Clients would accumulate ops from a single batch in memory, until all ops are received, and would dispatch batch at that time.
This results in couple complexities:
- Partial batches need to be summarized, for clients (loading from snapshots) to be able to continue assembling partial batch.
- In order to keep same number of sequence numbers, sequence numbers are reused / reordered in runtime: As ops are ready to be dispatched to the runtime (either individual ops, or complete batches), they get assigned next sequence number. For example, if there is a batch from client A = [op1, op3], and batch from client B = [op2, op4], and they show up on the wire as [op1, op2, op3, op4], with sequence numbers [3, 4, 5, 7] (let's say there is system op with 6), then runtime will see op1.seq=3, op3.seq=4, op2.seq=6, op4.seq=7. The end result (when system coalesces) - virtualized sequences numbers in runtime are the same as the ones in protocol
- Partial batches that were not completed on a single connection are discarded, and client needs to resubmit whole batch on reconnection

This is not finished product, however I've validated it to be working (using samples)
The answer I was trying to get it - would it be easier to solve the underlying problem, or work on various mitigations. For example, WB team is asking for addressing infinite reconnection problem that happens on 1Mb limit, which has no direct fix as there is not enough data from socket.io on reason of disconnect.

**Work remaining:**
1. Redesign existing UTs / Add proper UTs for this code
2. Re-work flushing mechanism.
   -  Change DeltaManager layer to flush ops in smaller chunks, i.e. 16 a piece at most.
   - Clear DM queue on disconnect - container runtime will resubmit just fine. This will address all the problems we have with size limits
3. Break it into stages and submit in parts
   - All the code except changes in flushing logic in DM can be shipped together in phase 1.
4. Re-think abstractions and reduce leaking of concepts. For example, referenceSequenceNumber for summary should likely be stamped by adapter layer that hides information of seq remapping from summarizer - entities, for most part, should not be aware of it.

**Possible Future changes:**
1. Simplify protocol and remove batch concept out of it.
2. Come up with algorithm that allows start sending ops earlier, before batch is complete. Currently I rely on a fact that first message in the batch communicates size of the batch to be able to put more strict correctness asserts. I think we can change that to communicate known head of batch, and keep re-communicating that it's continuation of a batch and more ops are coming. That way ops can move through the system faster, even for big batches.
3. We could make some changes to chunking processing, but I'd not touch it (even though we could reduce amount of memory used here, by ensuring that chunked op is always part of a batch, this also removes need to store chunked info in summaries - chunked ops would be always processed in one go).

My guess is that one (with focused time) can have fully ready to go solution in a week.
But in order to deliver that feature, we will need ship some code dark first (reading code, and code putting size of batch in metadata) and get to saturation. And only after that ship the remaining code.
That's likely will take 1.5 months end-to-end. So likely even in best case, March 15 data that I saw in teams is not achievable.

Thoughts on next steps?