### PR TITLE
Removing code loader deps from driver definitions.

### DIFF
--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -70,9 +70,8 @@ export interface IAuthorizationError extends IDriverErrorBase {
     readonly tenantId?: string;
 }
 
-// @public (undocumented)
+// @public
 export interface IContainerPackageInfo {
-    // (undocumented)
     name: string;
 }
 

--- a/common/lib/driver-definitions/api-report/driver-definitions.api.md
+++ b/common/lib/driver-definitions/api-report/driver-definitions.api.md
@@ -71,6 +71,12 @@ export interface IAuthorizationError extends IDriverErrorBase {
 }
 
 // @public (undocumented)
+export interface IContainerPackageInfo {
+    // (undocumented)
+    name: string;
+}
+
+// @public (undocumented)
 export interface IDeltasFetchResult {
     messages: ISequencedDocumentMessage[];
     partialResult: boolean;
@@ -262,7 +268,7 @@ export interface IThrottlingWarning extends IDriverErrorBase {
 // @public (undocumented)
 export interface IUrlResolver {
     // (undocumented)
-    getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string, codeDetails?: IFluidCodeDetails): Promise<string>;
+    getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string, packageInfoSource?: IFluidCodeDetails | IContainerPackageInfo): Promise<string>;
     // (undocumented)
     resolve(request: IRequest): Promise<IResolvedUrl | undefined>;
 }

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -316,14 +316,6 @@
         "@fluidframework/common-definitions": "^0.20.0",
         "@fluidframework/core-interfaces": "^0.42.0",
         "@fluidframework/protocol-definitions": "^0.1026.0"
-      },
-      "dependencies": {
-        "@fluidframework/core-interfaces": {
-          "version": "0.42.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.42.0.tgz",
-          "integrity": "sha512-++hCu5X6e2CL2swrhXoGaJanGjvaHZNmTT/cSYI8tfnX4cW7eRJuIy8Kcg6K3nMn4thxbVPW7+QG4VPRNuGlMQ==",
-          "dev": true
-        }
       }
     },
     "@fluidframework/eslint-config-fluid": {

--- a/common/lib/driver-definitions/src/urlResolver.ts
+++ b/common/lib/driver-definitions/src/urlResolver.ts
@@ -27,6 +27,10 @@ export interface IFluidResolvedUrl extends IResolvedUrlBase {
     endpoints: { [name: string]: string };
 }
 
+export interface IContainerPackageInfo {
+    name: string;
+}
+
 export interface IUrlResolver {
 
     // Like DNS should be able to cache resolution requests. Then possibly just have a token provider go and do stuff?
@@ -38,7 +42,7 @@ export interface IUrlResolver {
     getAbsoluteUrl(
         resolvedUrl: IResolvedUrl,
         relativeUrl: string,
-        codeDetails?: IFluidCodeDetails,
+        packageInfoSource?: IFluidCodeDetails | IContainerPackageInfo,
     ): Promise<string>;
 }
 

--- a/common/lib/driver-definitions/src/urlResolver.ts
+++ b/common/lib/driver-definitions/src/urlResolver.ts
@@ -27,7 +27,13 @@ export interface IFluidResolvedUrl extends IResolvedUrlBase {
     endpoints: { [name: string]: string };
 }
 
+/**
+ * Container package info handed off to resolver.
+ */
 export interface IContainerPackageInfo {
+    /**
+     * Container package name.
+     */
     name: string;
 }
 


### PR DESCRIPTION
As part of https://github.com/microsoft/FluidFramework/issues/8193 we would like to move code loader types to container definitions. To avoid circular dependency and failed layer checks we need to make sure driver definitions do not refer to code loader types.

Offering `IContainerPackageInfo` as a new interface in case we need to extract and pass further information (in future) from `IFluidCodeDetails` when calling `getAbsoluteUrl`.

Closes the first step of: https://github.com/microsoft/FluidFramework/issues/9032.