### PR TITLE
Added validation that data stores are not summarized if they haven't changed

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -168,6 +168,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     submitDataStoreSignal(address: string, type: string, content: any): void;
     submitSignal(type: string, content: any): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
+    // Warning: (ae-forgotten-export) The symbol "IRootSummaryTreeWithStats" needs to be exported by the entry point index.d.ts
     summarize(options: {
         fullTree?: boolean;
         trackState?: boolean;
@@ -175,12 +176,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         runGC?: boolean;
         fullGC?: boolean;
         runSweep?: boolean;
-    }): Promise<ISummaryTreeWithStats>;
+    }): Promise<IRootSummaryTreeWithStats>;
     // (undocumented)
     readonly summarizeOnDemand: ISummarizer["summarizeOnDemand"];
     get summarizerClientId(): string | undefined;
     updateStateBeforeGC(): Promise<void>;
-    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
+    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
     }
@@ -327,7 +328,7 @@ export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
 export interface IGarbageCollectionRuntime {
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     updateStateBeforeGC(): Promise<void>;
-    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
+    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
 }
 
 // @public (undocumented)
@@ -342,21 +343,18 @@ export interface IGCRuntimeOptions {
 
 // @public
 export interface IGCStats {
-    // (undocumented)
-    deletedDataStores: number;
-    // (undocumented)
-    deletedNodes: number;
-    // (undocumented)
-    totalDataStores: number;
-    // (undocumented)
-    totalNodes: number;
+    dataStoreCount: number;
+    nodeCount: number;
+    unrefDataStoreCount: number;
+    unrefNodeCount: number;
+    updatedDataStoreCount: number;
+    updatedNodeCount: number;
 }
 
 // @public
 export interface IGeneratedSummaryStats extends ISummaryStats {
-    // (undocumented)
     readonly dataStoreCount: number;
-    // (undocumented)
+    readonly gcStateUpdatedDataStoreCount?: number;
     readonly summarizedDataStoreCount: number;
 }
 
@@ -577,14 +575,6 @@ export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "
     // (undocumented)
     readonly stage: "upload";
     readonly uploadDuration: number;
-}
-
-// @public
-export interface IUsedStateStats {
-    // (undocumented)
-    totalNodeCount: number;
-    // (undocumented)
-    unusedNodeCount: number;
 }
 
 // @public

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -168,7 +168,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     submitDataStoreSignal(address: string, type: string, content: any): void;
     submitSignal(type: string, content: any): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
-    // Warning: (ae-forgotten-export) The symbol "IRootSummaryTreeWithStats" needs to be exported by the entry point index.d.ts
     summarize(options: {
         fullTree?: boolean;
         trackState?: boolean;
@@ -426,6 +425,11 @@ export type IPendingState = IPendingMessage | IPendingFlushMode | IPendingFlush;
 export interface IProvideSummarizer {
     // @deprecated (undocumented)
     readonly ISummarizer: ISummarizer;
+}
+
+// @public
+export interface IRootSummaryTreeWithStats extends ISummaryTreeWithStats {
+    gcStats?: IGCStats;
 }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -143,7 +143,6 @@ import {
     IGarbageCollectionRuntime,
     IGarbageCollector,
     IGCStats,
-    IUsedStateStats,
 } from "./garbageCollection";
 
 export enum ContainerMessageType {
@@ -285,6 +284,14 @@ export interface IContainerRuntimeOptions {
 
 type IRuntimeMessageMetadata = undefined | {
     batch?: boolean;
+};
+
+/**
+ * The summary tree returned by the root node. It adds state relevant to the root of the tree.
+ */
+export interface IRootSummaryTreeWithStats extends ISummaryTreeWithStats {
+    /** The garbage collection stats if GC ran, undefined otherwise. */
+    gcStats?: IGCStats;
 };
 
 /**
@@ -1842,7 +1849,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         fullGC?: boolean,
         /** True to run GC sweep phase after the mark phase */
         runSweep?: boolean,
-    }): Promise<ISummaryTreeWithStats> {
+    }): Promise<IRootSummaryTreeWithStats> {
         this.verifyNotClosed();
 
         const {
@@ -1854,15 +1861,16 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             fullGC,
         } = options;
 
+        let gcStats: IGCStats | undefined;
         if (runGC) {
-            await this.collectGarbage({ logger: summaryLogger, runSweep, fullGC });
+            gcStats = await this.collectGarbage({ logger: summaryLogger, runSweep, fullGC });
         }
 
         const summarizeResult = await this.summarizerNode.summarize(fullTree, trackState);
         assert(summarizeResult.summary.type === SummaryType.Tree,
             0x12f /* "Container Runtime's summarize should always return a tree" */);
 
-        return summarizeResult as ISummaryTreeWithStats;
+        return { ...summarizeResult, gcStats } as IRootSummaryTreeWithStats;
     }
 
     /**
@@ -1890,9 +1898,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * @param usedRoutes - The routes that are used in all nodes in this Container.
      * @param gcTimestamp - The time when GC was run that generated these used routes. If any node node becomes
      * unreferenced as part of this GC run, this should be used to update the time when it happens.
-     * @returns the statistics of the used state of the data stores.
      */
-    public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats {
+    public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {
         // Update our summarizer node's used routes. Updating used routes in summarizer node before
         // summarizing is required and asserted by the the summarizer node. We are the root and are
         // always referenced, so the used routes is only self-route (empty string).
@@ -2008,7 +2015,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             }
 
             const trace = Trace.start();
-            let summarizeResult: ISummaryTreeWithStats;
+            let summarizeResult: IRootSummaryTreeWithStats;
             // If the GC state needs to be reset, we need to force a full tree summary and update the unreferenced
             // state of all the nodes.
             const forcedFullTree = this.garbageCollector.summaryStateNeedsReset;
@@ -2036,6 +2043,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             const summaryStats: IGeneratedSummaryStats = {
                 dataStoreCount: this.dataStores.size,
                 summarizedDataStoreCount: this.dataStores.size - handleCount,
+                gcStateUpdatedDataStoreCount: summarizeResult.gcStats?.updatedDataStoreCount,
                 ...partialStats,
             };
             const generateSummaryData = {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -50,7 +50,6 @@ import {
     LocalDetachedFluidDataStoreContext,
 } from "./dataStoreContext";
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summaryFormat";
-import { IUsedStateStats } from "./garbageCollection";
 
 type PendingAliasResolve = (success: boolean) => void;
 
@@ -582,9 +581,8 @@ export class DataStores implements IDisposable {
      * @param usedRoutes - The routes that are used in all data stores in this Container.
      * @param gcTimestamp - The time when GC was run that generated these used routes. If any node node becomes
      * unreferenced as part of this GC run, this should be used to update the time when it happens.
-     * @returns the statistics of the used state of the data stores.
      */
-    public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats {
+    public updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number) {
         // Get a map of data store ids to routes used in it.
         const usedDataStoreRoutes = unpackChildNodesUsedRoutes(usedRoutes);
 
@@ -597,13 +595,6 @@ export class DataStores implements IDisposable {
         for (const [contextId, context] of this.contexts) {
             context.updateUsedRoutes(usedDataStoreRoutes.get(contextId) ?? [], gcTimestamp);
         }
-
-        // Return the number of data stores that are unused.
-        const dataStoreCount = this.contexts.size;
-        return {
-            totalNodeCount: dataStoreCount,
-            unusedNodeCount: dataStoreCount - usedDataStoreRoutes.size,
-        };
     }
 
     /**

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -65,18 +65,20 @@ const writeAtRootKey = "Fluid.GarbageCollection.WriteDataAtRoot";
 
 const defaultDeleteTimeoutMs = 7 * 24 * 60 * 60 * 1000; // 7 days
 
-/** The used state statistics of a node. */
-export interface IUsedStateStats {
-    totalNodeCount: number;
-    unusedNodeCount: number;
-}
-
 /** The statistics of the system state after a garbage collection run. */
 export interface IGCStats {
-    totalNodes: number;
-    deletedNodes: number;
-    totalDataStores: number;
-    deletedDataStores: number;
+    /** The number of nodes in the container. */
+    nodeCount: number;
+    /** The number of data stores in the container. */
+    dataStoreCount: number;
+    /** The number of unreferenced nodes in the container. */
+    unrefNodeCount: number;
+    /** The number of unreferenced data stores in the container. */
+    unrefDataStoreCount: number;
+    /** The number of nodes whose reference state updated since last GC run. */
+    updatedNodeCount: number;
+    /** The number of data stores whose reference state updated since last GC run. */
+    updatedDataStoreCount: number;
 }
 
 /** Defines the APIs for the runtime object to be passed to the garbage collector. */
@@ -86,7 +88,7 @@ export interface IGarbageCollectionRuntime {
     /** Returns the garbage collection data of the runtime. */
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     /** After GC has run, called to notify the runtime of routes that are used in it. */
-    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): IUsedStateStats;
+    updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
 }
 
 /** Defines the contract for the garbage collector. */
@@ -516,48 +518,34 @@ export class GarbageCollector implements IGarbageCollector {
             // Let the runtime update its pending state before GC runs.
             await this.provider.updateStateBeforeGC();
 
-            const gcStats: {
-                deletedNodes?: number,
-                totalNodes?: number,
-                deletedDataStores?: number,
-                totalDataStores?: number,
-            } = {};
-
             // Get the runtime's GC data and run GC on the reference graph in it.
             const gcData = await this.provider.getGCData(fullGC);
-
-            this.updateStateSinceLatestRun(gcData);
-
             const gcResult = runGarbageCollection(
                 gcData.gcNodes,
                 [ "/" ],
                 logger,
             );
+            const gcStats = this.getGCStats(gcResult);
+
+            this.updateStateSinceLatestRun(gcData);
 
             const currentTimestampMs = this.getCurrentTimestampMs();
             // Update the current state of the system based on the GC run.
             this.updateCurrentState(gcData, gcResult, currentTimestampMs);
 
-            const dataStoreUsedStateStats =
-                this.provider.updateUsedRoutes(gcResult.referencedNodeIds, currentTimestampMs);
+            this.provider.updateUsedRoutes(gcResult.referencedNodeIds, currentTimestampMs);
 
             if (runSweep) {
                 // Placeholder for running sweep logic.
             }
-
-            // Update stats to be reported in the peformance event.
-            gcStats.deletedNodes = gcResult.deletedNodeIds.length;
-            gcStats.totalNodes = gcResult.referencedNodeIds.length + gcResult.deletedNodeIds.length;
-            gcStats.deletedDataStores = dataStoreUsedStateStats.unusedNodeCount;
-            gcStats.totalDataStores = dataStoreUsedStateStats.totalNodeCount;
 
             // If we are running in GC test mode, delete objects for unused routes. This enables testing scenarios
             // involving access to deleted data.
             if (this.testMode) {
                 this.deleteUnusedRoutes(gcResult.deletedNodeIds);
             }
-            event.end(gcStats);
-            return gcStats as IGCStats;
+            event.end({ ...gcStats });
+            return gcStats;
         },
         { end: true, cancel: "error" });
     }
@@ -811,9 +799,9 @@ export class GarbageCollector implements IGarbageCollector {
         // Validate that the current reference graph doesn't have references that we are not already aware of. If this
         // happens, it might indicate data corruption since we may delete objects prematurely.
         currentReferences.forEach((route: string) => {
-            // Validate references for data stores only whose routes are of the format "/dataStoreId". Currently, layers
-            // below data stores don't have GC implemented so there is no guarantee their references will be notified.
-            if (route.split("/").length === 2 && !explicitReferences.includes(route)) {
+            // Validate references for data stores only. Currently, layers below data stores don't have GC implemented
+            // so there is no guarantee their references will be notified.
+            if (isDataStoreNode(route) && !explicitReferences.includes(route)) {
                 /**
                  * The following log will be enabled once this issue is resolved:
                  * https://github.com/microsoft/FluidFramework/issues/8878.
@@ -827,12 +815,64 @@ export class GarbageCollector implements IGarbageCollector {
             }
         });
     }
+
+    /**
+     * Generates the stats of a garbage collection run from the given results of the run.
+     * @param gcResult - The result of a GC run.
+     * @returns the GC stats of the GC run.
+     */
+    private getGCStats(gcResult: IGCResult): IGCStats {
+        const gcStats: IGCStats = {
+            nodeCount: 0,
+            dataStoreCount: 0,
+            unrefNodeCount: 0,
+            unrefDataStoreCount: 0,
+            updatedNodeCount: 0,
+            updatedDataStoreCount: 0,
+        };
+
+        for (const nodeId of gcResult.referencedNodeIds) {
+            gcStats.nodeCount++;
+            const isDataStore = isDataStoreNode(nodeId);
+            if (isDataStore) {
+                gcStats.dataStoreCount++;
+            }
+            // If a referenced node has an entry in `unreferencedNodesState`, it was previously unreferenced. So, its
+            // reference state updated from the last GC run.
+            if (this.unreferencedNodesState.has(nodeId)) {
+                gcStats.updatedNodeCount++;
+                if (isDataStore) {
+                    gcStats.updatedDataStoreCount++;
+                }
+            }
+        }
+
+        for (const nodeId of gcResult.deletedNodeIds) {
+            gcStats.nodeCount++;
+            gcStats.unrefNodeCount++;
+            const isDataStore = isDataStoreNode(nodeId);
+            if (isDataStore) {
+                gcStats.dataStoreCount++;
+                gcStats.unrefDataStoreCount++;
+            }
+            // If an unreferenced node doesn't an entry in `unreferencedNodesState`, it was previously referenced. So,
+            // its reference state updated from the last GC run.
+            if (!this.unreferencedNodesState.has(nodeId)) {
+                gcStats.updatedNodeCount++;
+                if (isDataStore) {
+                    gcStats.updatedDataStoreCount++;
+                }
+            }
+        }
+
+        return gcStats;
+    }
 }
 
 /**
  * Gets the garbage collection state from the given snapshot tree. The GC state may be written into multiple blobs.
  * Merge the GC state from all such blobs and return the merged GC state.
-*/
+ */
 async function getGCStateFromSnapshot(
     gcSnapshotTree: ISnapshotTree,
     readAndParseBlob: ReadAndParseBlob,
@@ -854,4 +894,13 @@ async function getGCStateFromSnapshot(
         rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
     }
     return rootGCState;
+}
+
+/**
+ * Given a GC nodeId, tells whether it belongs to a data store or not.
+ */
+function isDataStoreNode(nodeId: string): boolean {
+    const pathParts = nodeId.split("/");
+    // Data store ids are in the format "/dataStoreId".
+    return pathParts.length === 2 && pathParts[1] !== "" ? true : false;
 }

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -24,7 +24,6 @@ export {
     gcTreeKey,
     IGarbageCollectionRuntime,
     IGCStats,
-    IUsedStateStats,
 } from "./garbageCollection";
 export {
     IPendingFlush,

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -10,6 +10,7 @@ export {
     IGCRuntimeOptions,
     ISummaryRuntimeOptions,
     IContainerRuntimeOptions,
+    IRootSummaryTreeWithStats,
     isRuntimeMessage,
     RuntimeMessage,
     unpackRuntimeMessage,

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -136,8 +136,12 @@ export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
  * only relevant at the root of the tree.
  */
 export interface IGeneratedSummaryStats extends ISummaryStats {
+    /** The total number of data stores in the container. */
     readonly dataStoreCount: number;
+    /** The number of data stores that were summarized in this summary. */
     readonly summarizedDataStoreCount: number;
+    /** The number of data stores whose GC reference state was updated in this summary. */
+    readonly gcStateUpdatedDataStoreCount?: number;
 }
 
 /** Base results for all submitSummary attempts. */


### PR DESCRIPTION
Fixes https://github.com/microsoft/FluidFramework/issues/9017.

- Added count of data stores whose reference state changed in GC telemetry.
- Added validation in summary generator that we don't summarize data stores that did not change since last summary. Currently, an error is logged if this condition is violated. We should switch this to an assert once we are sure all bugs in this area are fixed and we have sufficient testing coverage.