### PR TITLE
Launch.json: Specify Outdir for debug mocha tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -254,6 +254,9 @@
             "skipFiles": [
                 "<node_internals>/**/*.js"
             ],
+            "outFiles": [
+                "${fileDirname}/../../dist/**/*.js"
+            ],
             "preLaunchTask": "Build Current Tests",
             "internalConsoleOptions": "openOnSessionStart",
         },


### PR DESCRIPTION
Was hitting an out of memory error in vs code. this resolves it for me.