### PR TITLE
Add packagePath to GC inactive telemetry.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1000,7 +1000,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this,
             this.runtimeOptions.gcOptions,
             (unusedRoutes: string[]) => this.dataStores.deleteUnusedRoutes(unusedRoutes),
-            (nodeId: string) => this.dataStores.getDataStorePackagePath(nodeId),
+            (nodePath: string) => this.dataStores.getNodePackagePath(nodePath),
             getCurrentTimestamp,
             this.closeFn,
             context.baseSnapshot,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1000,6 +1000,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this,
             this.runtimeOptions.gcOptions,
             (unusedRoutes: string[]) => this.dataStores.deleteUnusedRoutes(unusedRoutes),
+            (nodeId: string) => this.dataStores.getDataStorePackagePath(nodeId),
             getCurrentTimestamp,
             this.closeFn,
             context.baseSnapshot,
@@ -1053,7 +1054,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             (id: string) => this.summarizerNode.deleteChild(id),
             this.mc.logger,
             async () => this.garbageCollector.getDataStoreBaseGCDetails(),
-            (id: string) => this.garbageCollector.nodeChanged(id),
+            (id: string, packagePath: readonly string[]) => this.garbageCollector.nodeChanged(id, packagePath),
             new Map<string, string>(dataStoreAliasMap),
             this.garbageCollector.writeDataAtRoot,
         );

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1054,7 +1054,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             (id: string) => this.summarizerNode.deleteChild(id),
             this.mc.logger,
             async () => this.garbageCollector.getDataStoreBaseGCDetails(),
-            (id: string, packagePath: readonly string[]) => this.garbageCollector.nodeChanged(id, packagePath),
+            (id: string, packagePath?: readonly string[]) => this.garbageCollector.nodeChanged(id, packagePath),
             new Map<string, string>(dataStoreAliasMap),
             this.garbageCollector.writeDataAtRoot,
         );

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -114,7 +114,7 @@ export class DataStores implements IDisposable {
         private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
         getBaseGCDetails: () => Promise<Map<string, IGarbageCollectionDetailsBase>>,
-        private readonly dataStoreChanged: (id: string, packagePath: readonly string[]) => void,
+        private readonly dataStoreChanged: (id: string, packagePath?: readonly string[]) => void,
         private readonly aliasMap: Map<string, string>,
         private readonly writeGCDataAtRoot: boolean,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
@@ -410,7 +410,7 @@ export class DataStores implements IDisposable {
         context.process(transformed, local, localMessageMetadata);
 
         // Notify that a data store changed. This is used to detect if a deleted data store is being used.
-        this.dataStoreChanged(envelope.address, context.packagePath);
+        this.dataStoreChanged(envelope.address, context.isLoaded ? context.packagePath : undefined);
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<FluidDataStoreContext> {
@@ -633,7 +633,7 @@ export class DataStores implements IDisposable {
     public getDataStorePackagePath(id: string): readonly string[] | undefined {
         const context = this.contexts.get(id);
         assert(context !== undefined, "Data store with given id does not exist");
-        return context.packagePath;
+        return context.isLoaded ? context.packagePath : undefined;
     }
 }
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -628,10 +628,11 @@ export class DataStores implements IDisposable {
     }
 
     /**
-     * Returns the package path of the data store with the given id, if the data store exists.
+     * Returns the package path of the node with the given path.
      */
-    public getDataStorePackagePath(id: string): readonly string[] | undefined {
-        const context = this.contexts.get(id);
+    public getNodePackagePath(nodePath: string): readonly string[] | undefined {
+        const dataStoreId = nodePath.split("/")[1];
+        const context = this.contexts.get(dataStoreId);
         assert(context !== undefined, "Data store with given id does not exist");
         return context.isLoaded ? context.packagePath : undefined;
     }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -628,9 +628,11 @@ export class DataStores implements IDisposable {
     }
 
     /**
-     * Returns the package path of the node with the given path.
+     * Returns the package path of the node with the given path. This is used by GC to log when an inactive / deleted
+     * node is used.
      */
     public getNodePackagePath(nodePath: string): readonly string[] | undefined {
+        // Currently, only return the data store package path for the node since GC is only interested in data stores.
         const dataStoreId = nodePath.split("/")[1];
         const context = this.contexts.get(dataStoreId);
         assert(context !== undefined, "Data store with given id does not exist");

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -631,9 +631,9 @@ export class DataStores implements IDisposable {
      * Returns the package path of the data store with the given id, if the data store exists.
      */
     public getDataStorePackagePath(id: string): readonly string[] | undefined {
-        const internalId = this.aliasMap.get(id) ?? id;
-        const context = this.contexts.get(internalId);
-        return context?.packagePath;
+        const context = this.contexts.get(id);
+        assert(context !== undefined, "Data store with given id does not exist");
+        return context.packagePath;
     }
 }
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -114,7 +114,7 @@ export class DataStores implements IDisposable {
         private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
         getBaseGCDetails: () => Promise<Map<string, IGarbageCollectionDetailsBase>>,
-        private readonly dataStoreChanged: (id: string) => void,
+        private readonly dataStoreChanged: (id: string, packagePath: readonly string[]) => void,
         private readonly aliasMap: Map<string, string>,
         private readonly writeGCDataAtRoot: boolean,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
@@ -410,7 +410,7 @@ export class DataStores implements IDisposable {
         context.process(transformed, local, localMessageMetadata);
 
         // Notify that a data store changed. This is used to detect if a deleted data store is being used.
-        this.dataStoreChanged(envelope.address);
+        this.dataStoreChanged(envelope.address, context.packagePath);
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<FluidDataStoreContext> {
@@ -625,6 +625,15 @@ export class DataStores implements IDisposable {
             }
         }
         return outboundRoutes;
+    }
+
+    /**
+     * Returns the package path of the data store with the given id, if the data store exists.
+     */
+    public getDataStorePackagePath(id: string): readonly string[] | undefined {
+        const internalId = this.aliasMap.get(id) ?? id;
+        const context = this.contexts.get(internalId);
+        return context?.packagePath;
     }
 }
 

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -165,7 +165,9 @@ class UnreferencedStateTracker {
         inactiveNodeId: string,
         pkgPath?: readonly string[],
     ) {
-        if (this.inactive && !this.inactiveEventsLogged.has(eventName)) {
+        // We want to log this event at least once with the package path.
+        const uniqueEventId = `${eventName}-${pkgPath ?? ""}`;
+        if (this.inactive && !this.inactiveEventsLogged.has(uniqueEventId)) {
             logger.sendErrorEvent({
                 eventName,
                 age: currentTimestampMs - this.unreferencedTimestampMs,
@@ -173,7 +175,7 @@ class UnreferencedStateTracker {
                 id: inactiveNodeId,
                 pkg: pkgPath ? { value: `/${pkgPath.join("/")}`, tag: TelemetryDataTag.PackageData } : undefined,
             });
-            this.inactiveEventsLogged.add(eventName);
+            this.inactiveEventsLogged.add(uniqueEventId);
         }
     }
 }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -82,6 +82,14 @@ export interface IGCStats {
     updatedDataStoreCount: number;
 }
 
+/** The event that is logged when unreferenced node is used after a certain time. */
+interface IUnreferencedEvent {
+    eventName: string;
+    id: string;
+    age: number;
+    timeout: number;
+};
+
 /** Defines the APIs for the runtime object to be passed to the garbage collector. */
 export interface IGarbageCollectionRuntime {
     /** Before GC runs, called to notify the runtime to update any pending GC state. */
@@ -130,10 +138,11 @@ export interface IGarbageCollector {
  * the node's state to inactive if it remains unreferenced for a given amount of time (inactiveTimeoutMs).
  */
 class UnreferencedStateTracker {
-    private inactive: boolean = false;
-    // Keeps track of all inactive events that are logged. This is used to limit the log generation for each event to 1
-    // so that it is not noisy.
-    private readonly inactiveEventsLogged: Set<string> = new Set();
+    private _inactive: boolean = false;
+    public get inactive(): boolean {
+        return this._inactive;
+    }
+
     private readonly timer: Timer | undefined;
 
     constructor(
@@ -143,9 +152,9 @@ class UnreferencedStateTracker {
         // If the timeout has already expired, the node should become inactive immediately. Otherwise, start a timer of
         // inactiveTimeoutMs after which the node will become inactive.
         if (inactiveTimeoutMs <= 0) {
-            this.inactive = true;
+            this._inactive = true;
         } else {
-            this.timer = new Timer(inactiveTimeoutMs, () => { this.inactive = true; });
+            this.timer = new Timer(inactiveTimeoutMs, () => { this._inactive = true; });
             this.timer.start();
         }
     }
@@ -153,30 +162,7 @@ class UnreferencedStateTracker {
     /** Stop tracking this node. Reset the unreferenced timer, if any, and reset inactive state. */
     public stopTracking() {
         this.timer?.clear();
-        this.inactive = false;
-    }
-
-    /** Logs an error with the given properties if the node  is inactive. */
-    public logIfInactive(
-        logger: ITelemetryLogger,
-        eventName: string,
-        currentTimestampMs: number,
-        deleteTimeoutMs: number,
-        inactiveNodeId: string,
-        pkgPath?: readonly string[],
-    ) {
-        // We want to log this event at least once with the package path.
-        const uniqueEventId = `${eventName}-${pkgPath ?? ""}`;
-        if (this.inactive && !this.inactiveEventsLogged.has(uniqueEventId)) {
-            logger.sendErrorEvent({
-                eventName,
-                age: currentTimestampMs - this.unreferencedTimestampMs,
-                timeout: deleteTimeoutMs,
-                id: inactiveNodeId,
-                pkg: pkgPath ? { value: `/${pkgPath.join("/")}`, tag: TelemetryDataTag.PackageData } : undefined,
-            });
-            this.inactiveEventsLogged.add(uniqueEventId);
-        }
+        this._inactive = false;
     }
 }
 
@@ -296,13 +282,19 @@ export class GarbageCollector implements IGarbageCollector {
     // The timeout responsible for closing the container when the session has expired
     private sessionExpiryTimer?: ReturnType<typeof setTimeout>;
 
+    // Keeps track of unreferenced events that are logged for a node. This is used to limit the log generation to one
+    // per event per node.
+    private readonly loggedUnreferencedEvents: Set<string> = new Set();
+    // Queue for unreferenced events that should be logged the next time GC runs.
+    private pendingEventsQueue: IUnreferencedEvent[] = [];
+
     protected constructor(
         private readonly provider: IGarbageCollectionRuntime,
         private readonly gcOptions: IGCRuntimeOptions,
         /** After GC has run, called to delete objects in the runtime whose routes are unused. */
         private readonly deleteUnusedRoutes: (unusedRoutes: string[]) => void,
-        /** For a given node id, returns its package path. */
-        private readonly getNodePackagePath: (nodeId: string) => readonly string[] | undefined,
+        /** For a given node path, returns the node's package path. */
+        private readonly getNodePackagePath: (nodePath: string) => readonly string[] | undefined,
         /** Returns the current timestamp to be assigned to nodes that become unreferenced. */
         private readonly getCurrentTimestampMs: () => number,
         private readonly closeFn: (error?: ICriticalContainerError) => void,
@@ -534,12 +526,14 @@ export class GarbageCollector implements IGarbageCollector {
                 [ "/" ],
                 logger,
             );
-            const gcStats = this.getGCStats(gcResult);
+            const gcStats = this.generateStatsAndLogEvents(gcResult);
 
-            this.updateStateSinceLatestRun(gcData);
+            // Update the state since the last GC run. There can be nodes that were referenced between the last and
+            // the current run. We need to identify than and update their unreferenced state if needed.
+            this.updateStateSinceLastRun(gcData);
 
-            const currentTimestampMs = this.getCurrentTimestampMs();
             // Update the current state of the system based on the GC run.
+            const currentTimestampMs = this.getCurrentTimestampMs();
             this.updateCurrentState(gcData, gcResult, currentTimestampMs);
 
             this.provider.updateUsedRoutes(gcResult.referencedNodeIds, currentTimestampMs);
@@ -625,12 +619,10 @@ export class GarbageCollector implements IGarbageCollector {
     public nodeChanged(id: string, packagePath?: readonly string[]) {
         // Prefix "/" if needed to make it relative to the root.
         const nodeId = id.startsWith("/") ? id : `/${id}`;
-        this.unreferencedNodesState.get(nodeId)?.logIfInactive(
-            this.mc.logger,
+        this.logIfInactive(
             "inactiveObjectChanged",
-            this.getCurrentTimestampMs(),
-            this.deleteTimeoutMs,
             nodeId,
+            this.getCurrentTimestampMs(),
             packagePath,
         );
     }
@@ -701,14 +693,12 @@ export class GarbageCollector implements IGarbageCollector {
             if (nodeStateTracker !== undefined) {
                 // If this node has been unreferenced for longer than deleteTimeoutMs and is being referenced,
                 // log an error as this may mean the deleteTimeoutMs is not long enough.
-                nodeStateTracker.logIfInactive(
-                    this.mc.logger,
+                this.logIfInactive(
                     "inactiveObjectRevived",
-                    currentTimestampMs,
-                    this.deleteTimeoutMs,
                     nodeId,
+                    currentTimestampMs,
                     // Get the package path of the data store to which this node belongs.
-                    this.getNodePackagePath(nodeId.split("/")[1]),
+                    this.getNodePackagePath(nodeId),
                 );
                 // Stop tracking so as to clear out any running timers.
                 nodeStateTracker.stopTracking();
@@ -726,7 +716,7 @@ export class GarbageCollector implements IGarbageCollector {
      * This function identifies nodes that were referenced since last run and removes their unreferenced state, if any.
      * If these nodes are currently unreferenced, they will be assigned new unreferenced state by the current run.
      */
-    private updateStateSinceLatestRun(currentGCData: IGarbageCollectionData) {
+    private updateStateSinceLastRun(currentGCData: IGarbageCollectionData) {
         // If we haven't run GC before or no references were added since the last run, there is nothing to do.
         if (this.gcDataFromLastRun === undefined || this.referencesSinceLastRun.size === 0) {
             return;
@@ -831,11 +821,24 @@ export class GarbageCollector implements IGarbageCollector {
     }
 
     /**
-     * Generates the stats of a garbage collection run from the given results of the run.
+     * Generates the stats of a garbage collection run from the given results of the run. Also, logs any pending events
+     * in the pendingEventsQueue.
      * @param gcResult - The result of a GC run.
      * @returns the GC stats of the GC run.
      */
-    private getGCStats(gcResult: IGCResult): IGCStats {
+    private generateStatsAndLogEvents(gcResult: IGCResult): IGCStats {
+        // Log pending events for unreferenced nodes after GC has run. We should have the package data available for
+        // them now since the GC run should have loaded these nodes.
+        let event = this.pendingEventsQueue.shift();
+        while (event !== undefined) {
+            const pkg = this.getNodePackagePath(event.id);
+            this.mc.logger.sendErrorEvent({
+                ...event,
+                pkg: pkg ? { value: `/${pkg.join("/")}`, tag: TelemetryDataTag.PackageData } : undefined,
+            });
+            event = this.pendingEventsQueue.shift();
+        }
+
         const gcStats: IGCStats = {
             nodeCount: 0,
             dataStoreCount: 0,
@@ -880,6 +883,33 @@ export class GarbageCollector implements IGarbageCollector {
         }
 
         return gcStats;
+    }
+
+    /**
+     * Logs an event if a node is inactive and is used. If the package data for the node exists, log immediately. Else,
+     * queue it and it will be logged the next time GC runs as the package data should be available then.
+     */
+    private logIfInactive(eventName: string, nodeId: string, timestampMs: number, packagePath?: readonly string[]) {
+        // We log a particular event for a given node only once so that it is not too noisy.
+        const uniqueEventId = `${nodeId}-${eventName}`;
+        const nodeState = this.unreferencedNodesState.get(nodeId);
+        if (nodeState?.inactive && !this.loggedUnreferencedEvents.has(uniqueEventId)) {
+            this.loggedUnreferencedEvents.add(uniqueEventId);
+            const event: IUnreferencedEvent = {
+                eventName,
+                id: nodeId,
+                age: timestampMs - nodeState.unreferencedTimestampMs,
+                timeout: this.deleteTimeoutMs,
+            };
+            if (packagePath !== undefined) {
+                this.mc.logger.sendErrorEvent({
+                    ...event,
+                    pkg: { value: `/${packagePath.join("/")}`, tag: TelemetryDataTag.PackageData },
+                });
+            } else {
+                this.pendingEventsQueue.push(event);
+            }
+        }
     }
 }
 

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -37,6 +37,8 @@ describe("Garbage Collection Tests", () => {
     let closeCalled = false;
     // Time after which unreferenced nodes can be deleted.
     const deleteTimeoutMs = 500;
+    const testPkgPath = [ "testPkg" ];
+    const eventPkg = `/${testPkgPath.join("/")}`;
 
     // The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
     const defaultGCData: IGarbageCollectionData = { gcNodes: {} };
@@ -65,6 +67,7 @@ describe("Garbage Collection Tests", () => {
             gcRuntime,
             { gcAllowed: true, deleteTimeoutMs, gcTestSessionTimeoutMs },
             (unusedRoutes: string[]) => {},
+            (nodeId: string) => testPkgPath,
             () => Date.now(),
             () => { closeCalled = true; },
             baseSnapshot,
@@ -115,7 +118,7 @@ describe("Garbage Collection Tests", () => {
         // Simulates node changed activity for all the nodes in the graph.
         function changeAllNodes(garbageCollector: IGarbageCollector) {
             nodes.forEach((nodeId) => {
-                garbageCollector.nodeChanged(nodeId);
+                garbageCollector.nodeChanged(nodeId, testPkgPath);
             });
         }
 
@@ -180,8 +183,8 @@ describe("Garbage Collection Tests", () => {
             changeAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2] },
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
             );
@@ -193,7 +196,7 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectRevived event not generated as expected",
             );
@@ -214,7 +217,7 @@ describe("Garbage Collection Tests", () => {
             changeAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
             );
@@ -268,10 +271,10 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
 
             // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
-            garbageCollector.nodeChanged(nodes[3]);
+            garbageCollector.nodeChanged(nodes[3], testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
             );
@@ -281,7 +284,7 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectRevived event not generated as expected",
             );
@@ -320,10 +323,10 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
 
             // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
-            garbageCollector.nodeChanged(nodes[3]);
+            garbageCollector.nodeChanged(nodes[3], testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
             );
@@ -333,7 +336,7 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectRevived event not generated as expected",
             );
@@ -387,14 +390,14 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
 
             // Change the nodes and validate that an inactiveObjectChanged event is generated for each.
-            garbageCollector.nodeChanged(nodes[1]);
-            garbageCollector.nodeChanged(nodes[2]);
-            garbageCollector.nodeChanged(nodes[3]);
+            garbageCollector.nodeChanged(nodes[1], testPkgPath);
+            garbageCollector.nodeChanged(nodes[2], testPkgPath);
+            garbageCollector.nodeChanged(nodes[3], testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[1] },
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2] },
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3] },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[1], pkg: eventPkg },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
             );

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -14,7 +14,7 @@ import {
     IGarbageCollectionState,
     IGarbageCollectionDetailsBase,
 } from "@fluidframework/runtime-definitions";
-import { MockLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import {
     GarbageCollector,
     gcBlobPrefix,
@@ -38,7 +38,8 @@ describe("Garbage Collection Tests", () => {
     // Time after which unreferenced nodes can be deleted.
     const deleteTimeoutMs = 500;
     const testPkgPath = [ "testPkg" ];
-    const eventPkg = `/${testPkgPath.join("/")}`;
+    // The package data is tagged in the telemetry event .
+    const eventPkg = { value:`/${testPkgPath.join("/")}`, tag: TelemetryDataTag.PackageData };
 
     // The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
     const defaultGCData: IGarbageCollectionData = { gcNodes: {} };

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -12,7 +12,7 @@ import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { Container } from "@fluidframework/container-loader";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { MockLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { TestDataObject } from "./mockSummarizerClient";
@@ -125,7 +125,7 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
                     eventName: inactiveObjectChangedEvent,
                     timeout: deleteTimeoutMs,
                     id: `/${dataStore1.id}`,
-                    pkg: `/${pkg}`,
+                    pkg: { value: `/${pkg}`, tag: TelemetryDataTag.PackageData },
                 },
             ]),
             "inactiveObjectChanged event not generated as expected",
@@ -152,7 +152,7 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
                     eventName: inactiveObjectRevivedEvent,
                     timeout: deleteTimeoutMs,
                     id: `/${dataStore1.id}`,
-                    pkg: `/${pkg}`,
+                    pkg: { value: `/${pkg}`, tag: TelemetryDataTag.PackageData },
                 },
             ]),
             "inactiveObjectRevived event not generated as expected",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -22,8 +22,9 @@ import { TestDataObject } from "./mockSummarizerClient";
  * using that data store results in an error telemetry.
  */
 describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
+    const pkg = "TestDataObject";
     const dataObjectFactory = new DataObjectFactory(
-        "TestDataObject",
+        pkg,
         TestDataObject,
         [],
         []);
@@ -124,6 +125,7 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
                     eventName: inactiveObjectChangedEvent,
                     timeout: deleteTimeoutMs,
                     id: `/${dataStore1.id}`,
+                    pkg: `/${pkg}`,
                 },
             ]),
             "inactiveObjectChanged event not generated as expected",
@@ -150,6 +152,7 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
                     eventName: inactiveObjectRevivedEvent,
                     timeout: deleteTimeoutMs,
                     id: `/${dataStore1.id}`,
+                    pkg: `/${pkg}`,
                 },
             ]),
             "inactiveObjectRevived event not generated as expected",


### PR DESCRIPTION
Fixes https://github.com/microsoft/FluidFramework/issues/9057.

Added package path to `inactiveObjectRevived` and `inactiveObjectChanged` events.