### PR TITLE
Switch to 1ES agent pool for repo-policy-check

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -12,7 +12,7 @@ pr:
 - release/*
 
 pool:
-  vmImage: 'ubuntu-latest'
+  Small
 
 variables:
 - name: skipComponentGovernanceDetection


### PR DESCRIPTION
For some unknown reason, our hosted ADO agent pool stopped working this morning and is blocking all PRs.

There is an internal thread about this problem going on, I won't add more details here.