### PR TITLE
Synthesizer: Re-add getProvider for backcompat

### DIFF
--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -78,6 +78,27 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
         }
         return false;
     }
+    /**
+     * @deprecated - Needed for back compat
+     */
+    private getProvider(provider: string & keyof TMap){
+        if(this.has(provider)){
+            if(this.providers.has(provider)){
+                return this.providers.get(provider);
+            }
+            for(const parent of this.parents){
+                if(parent instanceof DependencyContainer){
+                    return parent.getProvider(provider);
+                }else{
+                    // eslint-disable-next-line @typescript-eslint/dot-notation
+                    const maybeGetProvider = parent["getProvider"];
+                    if(typeof maybeGetProvider === "function"){
+                        return maybeGetProvider(provider);
+                    }
+                }
+            }
+        }
+    }
 
     private generateRequired<T>(
         base: AsyncRequiredFluidObjectProvider<T>,


### PR DESCRIPTION
Some of our partners have a hard dependency on getProvider. This will enable them calling it at runtime until they can migrate off this pattern.

related #8891 