### PR TITLE
r11s: adding tenantId/documentId telemetry in runWithRetry

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -13,6 +13,7 @@ import {
     ISequencedOperationMessage,
     runWithRetry,
 } from "@fluidframework/server-services-core";
+import { getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
 import { ICheckpointManager } from "./interfaces";
 
 /**
@@ -54,7 +55,7 @@ export class CheckpointManager implements ICheckpointManager {
                 "writeCheckpointScribe",
                 3 /* maxRetries */,
                 1000 /* retryAfterMs */,
-                this.context.log,
+                getLumberBaseProperties(this.documentId, this.tenantId),
                 (error) => error.code === 11000 /* shouldIgnoreError */);
         }
 

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -13,6 +13,7 @@ import {
     SequencedOperationType,
     runWithRetry,
 } from "@fluidframework/server-services-core";
+import { getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
 
 export class ScriptoriumLambda implements IPartitionLambda {
     private pending = new Map<string, ISequencedOperationMessage[]>();
@@ -21,7 +22,9 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
     constructor(
         private readonly opCollection: ICollection<any>,
-        protected context: IContext) {
+        protected context: IContext,
+        protected readonly tenantId: string,
+        protected readonly documentId: string) {
     }
 
     public handler(message: IQueuedMessage) {
@@ -105,7 +108,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
             "insertOpScriptorium",
             3 /* maxRetries */,
             1000 /* retryAfterMs */,
-            this.context.log,
+            getLumberBaseProperties(this.documentId, this.tenantId),
             (error) => error.code === 11000 /* shouldIgnoreError */);
     }
 }

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambdaFactory.ts
@@ -24,7 +24,7 @@ export class ScriptoriumLambdaFactory extends EventEmitter implements IPartition
     public async create(config: IPartitionLambdaConfig, context: IContext): Promise<IPartitionLambda> {
         // Takes in the io as well as the collection. I can probably keep the same lambda but only ever give it stuff
         // from a single document
-        return new ScriptoriumLambda(this.opCollection, context);
+        return new ScriptoriumLambda(this.opCollection, context, config.tenantId, config.documentId);
     }
 
     public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/test/scriptorium/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scriptorium/lambda.spec.ts
@@ -27,7 +27,7 @@ describe("Routerlicious", () => {
 
                 testCollection = new TestCollection([]);
                 testContext = new TestContext();
-                lambda = new ScriptoriumLambda(testCollection, testContext);
+                lambda = new ScriptoriumLambda(testCollection, testContext,testTenantId, testDocumentId);
 
             });
 

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -240,7 +240,7 @@ export class LocalOrderer implements IOrderer {
             this.scriptoriumContext,
             async (lambdaSetup, context) => {
                 const deltasCollection = await lambdaSetup.deltaCollectionP();
-                return new ScriptoriumLambda(deltasCollection, context);
+                return new ScriptoriumLambda(deltasCollection, context, this.tenantId, this.documentId);
             });
 
         this.broadcasterLambda = new LocalLambdaController(

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -6,7 +6,6 @@
 import { delay } from "@fluidframework/common-utils";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { NetworkError } from "@fluidframework/server-services-client";
-import { ILogger } from "./lambdas";
 
 /**
  * Executes a given API while providing support to retry on failures, ignore failures, and taking action on error.
@@ -14,7 +13,7 @@ import { ILogger } from "./lambdas";
  * @param  {string} callName - name of the api function we are calling
  * @param  {number} maxRetries - maximum retries after which error is thrown. Retry infinitely if set to -1
  * @param  {number} retryAfterMs - interval factor to wait before retrying. Param to calculateIntervalMs
- * @param  {ILogger} logger? - e.g. winston logger to log on error
+ * @param  {Map<string, any> | Record<string, any>} telemetryProperties? - telemetry properties to be used by Lumberjack
  * @param  {(error)=>boolean} shouldIgnoreError? - function that takes error and decides whether to ignore it
  * @param  {(error)=>boolean} shouldRetry? - function that takes error and decides whether to retry on it
  * @param  {(error, numRetries, retryAfterInterval)=>number} calculateIntervalMs
@@ -26,7 +25,7 @@ export async function runWithRetry<T>(
     callName: string,
     maxRetries: number,
     retryAfterMs: number,
-    logger?: ILogger,
+    telemetryProperties?: Map<string, any> | Record<string, any>,
     shouldIgnoreError?: (error) => boolean,
     shouldRetry?: (error) => boolean,
     calculateIntervalMs = (error, numRetries, retryAfterInterval) => retryAfterInterval * 2 ** numRetries,
@@ -40,30 +39,28 @@ export async function runWithRetry<T>(
             result = await api();
             success = true;
             if (retryCount >= 1) {
-                logger?.info(`Succeeded in executing ${callName} with ${retryCount} retries`);
-                Lumberjack.info(`Succeeded in executing ${callName} with ${retryCount} retries`);
+                Lumberjack.info(`Succeeded in executing ${callName} with ${retryCount} retries`, telemetryProperties);
             }
         } catch (error) {
-            logger?.error(`Error running ${callName}: retryCount ${retryCount}, error ${error}`);
-            Lumberjack.error(`Error running ${callName}: retryCount ${retryCount}`, undefined, error);
+            Lumberjack.error(`Error running ${callName}: retryCount ${retryCount}`, telemetryProperties, error);
             if (onErrorFn !== undefined) {
                 onErrorFn(error);
             }
             if (shouldIgnoreError !== undefined && shouldIgnoreError(error) === true) {
-                logger?.info(`Should ignore error for ${callName}`);
-                Lumberjack.info(`Should ignore error for ${callName}`);
+                Lumberjack.info(`Should ignore error for ${callName}`, telemetryProperties);
                 break;
             } else if (shouldRetry !== undefined && shouldRetry(error) === false)
             {
-                logger?.error(`Should not retry ${callName} for the current error, rejecting ${error}`);
-                Lumberjack.error(`Should not retry ${callName} for the current error, rejecting`, undefined, error);
+                Lumberjack.error(
+                    `Should not retry ${callName} for the current error, rejecting`,
+                    telemetryProperties,
+                    error);
                 return Promise.reject(error);
             }
             // if maxRetries is -1, we retry indefinitely
             // unless shouldRetry returns false at some point.
             if (maxRetries !== -1 && retryCount >= maxRetries) {
-                logger?.error(`Error after retrying ${retryCount} times, rejecting`);
-                Lumberjack.error(`Error after retrying ${retryCount} times, rejecting`, undefined, error);
+                Lumberjack.error(`Error after retrying ${retryCount} times, rejecting`, telemetryProperties, error);
                 // Needs to be a full rejection here
                 return Promise.reject(error);
             }
@@ -88,6 +85,7 @@ export async function runWithRetry<T>(
  * anything other than a `T` value - the only other possibility is a promise rejection.
  * @param  {()=>Promise<T>} request - function to run and retry in case of error
  * @param  {string} callName - name of the api function we are calling
+ * @param  {Map<string, any> | Record<string, any>} telemetryProperties? - telemetry properties to be used by Lumberjack
  * @param  {(error)=>boolean} shouldRetry - function that takes error and decides whether to retry on it
  * @param  {number} maxRetries - maximum retries after which error is thrown. Retry infinitely if set to -1
  * @param  {number} retryAfterMs - interval factor to wait before retrying. Param to calculateIntervalMs
@@ -98,6 +96,7 @@ export async function runWithRetry<T>(
  export async function requestWithRetry<T>(
     request: () => Promise<T>,
     callName: string,
+    telemetryProperties?: Map<string, any> | Record<string, any>,
     shouldRetry: (error) => boolean = shouldRetryNetworkError,
     maxRetries: number = -1,
     retryAfterMs: number = 1000,
@@ -113,22 +112,25 @@ export async function runWithRetry<T>(
             result = await request();
             success = true;
             if (retryCount >= 1) {
-                Lumberjack.info(`Succeeded in executing ${callName} with ${retryCount} retries`);
+                Lumberjack.info(`Succeeded in executing ${callName} with ${retryCount} retries`, telemetryProperties);
             }
         } catch (error) {
-            Lumberjack.error(`Error running ${callName}: retryCount ${retryCount}`, undefined, error);
+            Lumberjack.error(`Error running ${callName}: retryCount ${retryCount}`, telemetryProperties, error);
             if (onErrorFn !== undefined) {
                 onErrorFn(error);
             }
             if (shouldRetry !== undefined && shouldRetry(error) === false)
             {
-                Lumberjack.error(`Should not retry ${callName} for the current error, rejecting`, undefined, error);
+                Lumberjack.error(
+                    `Should not retry ${callName} for the current error, rejecting`,
+                    telemetryProperties,
+                    error);
                 return Promise.reject(error);
             }
             // if maxRetries is -1, we retry indefinitely
             // unless shouldRetry returns false at some point.
             if (maxRetries !== -1 && retryCount >= maxRetries) {
-                Lumberjack.error(`Error after retrying ${retryCount} times, rejecting`, undefined, error);
+                Lumberjack.error(`Error after retrying ${retryCount} times, rejecting`, telemetryProperties, error);
                 // Needs to be a full rejection here
                 return Promise.reject(error);
             }


### PR DESCRIPTION
The telemetry data generated by `runWithRetry` and `requestWithRetry` was being filtered out of logs when running queries with specific document/tenant IDs. That is because we forgot to provide those telemetry properties when logging in those functions. This PR aims to fix that, and also removes the outdated `logger` parameter in `runWithRetry` since we now use `Lumberjack`.