### PR TITLE
Run JS tests for folders one level lower than test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -276,7 +276,8 @@
             ],
             "cwd": "${fileDirname}",
             "outFiles": [
-                "${fileDirname}/../../dist/**/*.js"
+                "${fileDirname}/../../dist/**/*.js",
+                "${fileDirname}/../../../dist/**/*.js"
             ],
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -272,6 +272,7 @@
                 "--no-timeouts",
                 "--exit",
                 "../../dist/test/${fileBasenameNoExtension}.js",
+                "../../../dist/test/**/${fileBasenameNoExtension}.js",
             ],
             "cwd": "${fileDirname}",
             "outFiles": [


### PR DESCRIPTION
This allows users to run tests for subdirectories of the `test`.
i.e. `packages/test/test-end-to-end-tests/src/test/gc` tests will now run successfully with Debug Current Tests (JS).