### PR TITLE
Batch processing logic is broken in presence of system op before incomplete batch

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -398,9 +398,8 @@ class ScheduleManagerCore {
         }
 
         // We are intentionally directly listening to the "op" to inspect system ops as well.
-        // If we do not observer system ops, we are likely to hit 0x296 assert when system ops
-        // precedes start of partial batch.
-        // incomplete batch.
+        // If we do not observe system ops, we are likely to hit 0x296 assert when system ops
+        // precedes start of incomplete batch.
         this.deltaManager.on("op", (message) => this.afterOpProcessing(message.sequenceNumber));
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -552,7 +552,7 @@ export class ScheduleManager {
             this.deltaManager,
             ChildLogger.create(this.logger, "DeltaScheduler"),
         );
-        const scheduler = new ScheduleManagerCore(deltaManager, logger);
+        void new ScheduleManagerCore(deltaManager, logger);
     }
 
     public beforeOpProcessing(message: ISequencedDocumentMessage) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -397,6 +397,10 @@ class ScheduleManagerCore {
             this.trackPending(pending);
         }
 
+        // We are intentionally directly listening to the "op" to inspect system ops as well.
+        // If we do not observer system ops, we are likely to hit 0x296 assert when system ops
+        // precedes start of partial batch.
+        // incomplete batch.
         this.deltaManager.on("op", (message) => this.afterOpProcessing(message.sequenceNumber));
     }
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -212,6 +212,7 @@ describe("Runtime", () => {
                     deltaManager.inbound.processCallback = (message: ISequencedDocumentMessage) => {
                         scheduleManager.beforeOpProcessing(message);
                         scheduleManager.afterOpProcessing(undefined, message);
+                        deltaManager.emit("op", message);
                     };
                     scheduleManager = new ScheduleManager(
                         deltaManager,

--- a/packages/test/functional-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/functional-tests/src/test/containerRuntime.spec.ts
@@ -79,6 +79,7 @@ describe("Container Runtime", () => {
             while (Date.now() - startTime < processingDelay) { }
 
             scheduleManager.afterOpProcessing(undefined, message);
+            deltaManager.emit("op", message);
         }
 
         beforeEach(async () => {


### PR DESCRIPTION
Issue: https://portal.microsofticm.com/imp/v3/incidents/details/288005685/home

The issue is that system ops do not reach container runtime.
So, the logic that assumes we can pause op processing when we see an op preceding start of incomplete batch is wrong.
Assert 0x296 will fire when we start processing this incomplete batch because we did not stop processing.

The fix changes how we observe ops to leverage DM events instead of ops processed by runtime.
So, for most part it does not change behavior, only for system ops.