### PR TITLE
Remove Quorum rejections and committed proposal state

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -21,6 +21,7 @@ There are a few steps you can take to write a good change note and avoid needing
 - [Removing snapshot API from IRuntime](#Removing-snapshot-api-from-IRuntime)
 - [Remove Unused IFluidObject Augmentations](#Remove-Unused-IFluidObject-Augmentations)
 - [Duplicate extractLogSafeErrorProperties removed](#duplicate-extractlogsafeerrorproperties-removed)
+- [Code proposal rejection removed](#Code-proposal-rejection-removed)
 
 ### IFluidConfiguration removed
 
@@ -87,6 +88,9 @@ The interfaces that correspond to the above properties continue to exist, and ca
 
 The helper function `extractLogSafeErrorProperties` existed in both telemetry-utils and common-utils packages.
 The copy in common-utils was out of date and unused in this repo, and has now been removed.
+
+### Code proposal rejection removed
+Rejection functionality has been removed from Quorum.  As a result, the `"codeDetailsProposed"` event on `IContainer` now provides an `ISequencedProposal` rather than an `IPendingProposal`.
 
 ## 0.56 Breaking changes
 - [`MessageType.Save` and code that handled it was removed](#messageType-save-and-code-that-handled-it-was-removed)

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -22,13 +22,13 @@ import { IFluidPackage as IFluidPackage_2 } from '@fluidframework/core-interface
 import { IFluidPackageEnvironment as IFluidPackageEnvironment_2 } from '@fluidframework/core-interfaces';
 import { IFluidResolvedUrl } from '@fluidframework/driver-definitions';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
-import { IPendingProposal } from '@fluidframework/protocol-definitions';
 import { IProvideFluidCodeDetailsComparer as IProvideFluidCodeDetailsComparer_2 } from '@fluidframework/core-interfaces';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
+import { ISequencedProposal } from '@fluidframework/protocol-definitions';
 import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
@@ -213,7 +213,7 @@ export interface IContainerEvents extends IEvent {
     // (undocumented)
     (event: "connected", listener: (clientId: string) => void): any;
     // (undocumented)
-    (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails_2, proposal: IPendingProposal) => void): any;
+    (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails_2, proposal: ISequencedProposal) => void): any;
     // (undocumented)
     (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails_2) => void): any;
     // (undocumented)

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -465,6 +465,24 @@
         },
         "InterfaceDeclaration_IRuntimeFactory": {
           "backCompat": false
+        },
+        "InterfaceDeclaration_IContainer": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IContainerContext": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IHostLoader": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_ILoader": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IProvideLoader": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IProxyLoaderFactory": {
+          "backCompat": false
         }
       }
     }

--- a/common/lib/container-definitions/src/loader.ts
+++ b/common/lib/container-definitions/src/loader.ts
@@ -14,9 +14,9 @@ import {
 import {
     IClientDetails,
     IDocumentMessage,
-    IPendingProposal,
     IQuorumClients,
     ISequencedDocumentMessage,
+    ISequencedProposal,
 } from "@fluidframework/protocol-definitions";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
@@ -114,7 +114,7 @@ export interface ICodeAllowList {
 export interface IContainerEvents extends IEvent {
     (event: "readonly", listener: (readonly: boolean) => void): void;
     (event: "connected", listener: (clientId: string) => void);
-    (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: IPendingProposal) => void);
+    (event: "codeDetailsProposed", listener: (codeDetails: IFluidCodeDetails, proposal: ISequencedProposal) => void);
     (event: "contextChanged", listener: (codeDetails: IFluidCodeDetails) => void);
     (event: "disconnected" | "attached", listener: () => void);
     (event: "closed", listener: (error?: ICriticalContainerError) => void);

--- a/common/lib/container-definitions/src/test/types/validate0.45.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.45.0.ts
@@ -345,6 +345,7 @@ declare function get_current_InterfaceDeclaration_IContainer():
 declare function use_old_InterfaceDeclaration_IContainer(
     use: old.IContainer);
 use_old_InterfaceDeclaration_IContainer(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainer());
 
 /*
@@ -369,6 +370,7 @@ declare function get_current_InterfaceDeclaration_IContainerContext():
 declare function use_old_InterfaceDeclaration_IContainerContext(
     use: old.IContainerContext);
 use_old_InterfaceDeclaration_IContainerContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerContext());
 
 /*
@@ -995,6 +997,7 @@ declare function get_current_InterfaceDeclaration_IHostLoader():
 declare function use_old_InterfaceDeclaration_IHostLoader(
     use: old.IHostLoader);
 use_old_InterfaceDeclaration_IHostLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IHostLoader());
 
 /*
@@ -1019,6 +1022,7 @@ declare function get_current_InterfaceDeclaration_ILoader():
 declare function use_old_InterfaceDeclaration_ILoader(
     use: old.ILoader);
 use_old_InterfaceDeclaration_ILoader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILoader());
 
 /*
@@ -1187,6 +1191,7 @@ declare function get_current_InterfaceDeclaration_IProvideLoader():
 declare function use_old_InterfaceDeclaration_IProvideLoader(
     use: old.IProvideLoader);
 use_old_InterfaceDeclaration_IProvideLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideLoader());
 
 /*
@@ -1236,6 +1241,7 @@ declare function get_current_InterfaceDeclaration_IProxyLoaderFactory():
 declare function use_old_InterfaceDeclaration_IProxyLoaderFactory(
     use: old.IProxyLoaderFactory);
 use_old_InterfaceDeclaration_IProxyLoaderFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProxyLoaderFactory());
 
 /*

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -296,8 +296,6 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
     (event: "approveProposal", listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => void): any;
     // (undocumented)
     (event: "commitProposal", listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number, commitSequenceNumber: number) => void): any;
-    // (undocumented)
-    (event: "rejectProposal", listener: (sequenceNumber: number, key: string, value: any, rejections: string[]) => void): any;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -213,13 +213,6 @@ export interface INackContent {
     type: NackErrorType;
 }
 
-// @public
-export interface IPendingProposal extends ISequencedProposal {
-    disableRejection(): any;
-    reject(): any;
-    readonly rejectionDisabled: boolean;
-}
-
 // @public (undocumented)
 export interface IProcessMessageResult {
     // (undocumented)
@@ -298,7 +291,7 @@ export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>
 // @public
 export interface IQuorumProposalsEvents extends IErrorEvent {
     // (undocumented)
-    (event: "addProposal", listener: (proposal: IPendingProposal) => void): any;
+    (event: "addProposal", listener: (proposal: ISequencedProposal) => void): any;
     // (undocumented)
     (event: "approveProposal", listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => void): any;
     // (undocumented)

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -294,8 +294,6 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
     (event: "addProposal", listener: (proposal: ISequencedProposal) => void): any;
     // (undocumented)
     (event: "approveProposal", listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => void): any;
-    // (undocumented)
-    (event: "commitProposal", listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number, commitSequenceNumber: number) => void): any;
 }
 
 // @public (undocumented)

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -87,6 +87,10 @@
         },
         "InterfaceDeclaration_ICreateBlobResponse": {
           "backCompat": false
+        },
+        "RemovedInterfaceDeclaration_IPendingProposal": {
+          "backCompat": false,
+          "forwardCompat": false
         }
       },
       "0.1025.1": {
@@ -101,6 +105,13 @@
         },
         "InterfaceDeclaration_ICreateBlobResponse": {
           "backCompat": false
+        },
+        "RemovedInterfaceDeclaration_IPendingProposal": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IQuorumProposals": {
+          "backCompat": false
         }
       },
       "0.1026.0": {
@@ -111,6 +122,13 @@
           "forwardCompat": false
         },
         "InterfaceDeclaration_ICreateBlobResponse": {
+          "backCompat": false
+        },
+        "RemovedInterfaceDeclaration_IPendingProposal": {
+          "backCompat": false,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IQuorumProposals": {
           "backCompat": false
         }
       }

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -52,14 +52,6 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
     (
         event: "approveProposal",
         listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => void);
-    (
-        event: "commitProposal",
-        listener: (
-            sequenceNumber: number,
-            key: string,
-            value: any,
-            approvalSequenceNumber: number,
-            commitSequenceNumber: number) => void);
 }
 
 /**

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -37,26 +37,6 @@ export type IApprovedProposal = { approvalSequenceNumber: number } & ISequencedP
 export type ICommittedProposal = { commitSequenceNumber: number } & IApprovedProposal;
 
 /**
- * A proposal that has been propposed, but not yet accepted or committed
- */
-export interface IPendingProposal extends ISequencedProposal {
-    /**
-     * Sends a rejection for the proposal
-     */
-    reject();
-
-    /**
-     * Disables the sending of rejections for this proposal
-     */
-    disableRejection();
-
-    /**
-     * Returns true if rejections has been disable, otherwise false
-     */
-    readonly rejectionDisabled: boolean;
-}
-
-/**
  * Events fired by a Quorum in response to client tracking.
  */
 export interface IQuorumClientsEvents extends IErrorEvent {
@@ -68,7 +48,7 @@ export interface IQuorumClientsEvents extends IErrorEvent {
  * Events fired by a Quorum in response to proposal tracking.
  */
 export interface IQuorumProposalsEvents extends IErrorEvent {
-    (event: "addProposal", listener: (proposal: IPendingProposal) => void);
+    (event: "addProposal", listener: (proposal: ISequencedProposal) => void);
     (
         event: "approveProposal",
         listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => void);

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -60,9 +60,6 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
             value: any,
             approvalSequenceNumber: number,
             commitSequenceNumber: number) => void);
-    (
-        event: "rejectProposal",
-        listener: (sequenceNumber: number, key: string, value: any, rejections: string[]) => void);
 }
 
 /**

--- a/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
@@ -543,26 +543,28 @@ use_old_InterfaceDeclaration_INackContent(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
-* "InterfaceDeclaration_IPendingProposal": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IPendingProposal": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IPendingProposal():
     old.IPendingProposal;
-declare function use_current_InterfaceDeclaration_IPendingProposal(
+declare function use_current_RemovedInterfaceDeclaration_IPendingProposal(
+    // @ts-expect-error compatibility expected to be broken
     use: current.IPendingProposal);
-use_current_InterfaceDeclaration_IPendingProposal(
+use_current_RemovedInterfaceDeclaration_IPendingProposal(
     get_old_InterfaceDeclaration_IPendingProposal());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1024.0:
-* "InterfaceDeclaration_IPendingProposal": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IPendingProposal": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IPendingProposal():
+declare function get_current_RemovedInterfaceDeclaration_IPendingProposal():
+    // @ts-expect-error compatibility expected to be broken
     current.IPendingProposal;
 declare function use_old_InterfaceDeclaration_IPendingProposal(
     use: old.IPendingProposal);
 use_old_InterfaceDeclaration_IPendingProposal(
-    get_current_InterfaceDeclaration_IPendingProposal());
+    get_current_RemovedInterfaceDeclaration_IPendingProposal());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/common/lib/protocol-definitions/src/test/types/validate0.1025.1.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1025.1.ts
@@ -542,26 +542,28 @@ use_old_InterfaceDeclaration_INackContent(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
-* "InterfaceDeclaration_IPendingProposal": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IPendingProposal": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IPendingProposal():
     old.IPendingProposal;
-declare function use_current_InterfaceDeclaration_IPendingProposal(
+declare function use_current_RemovedInterfaceDeclaration_IPendingProposal(
+    // @ts-expect-error compatibility expected to be broken
     use: current.IPendingProposal);
-use_current_InterfaceDeclaration_IPendingProposal(
+use_current_RemovedInterfaceDeclaration_IPendingProposal(
     get_old_InterfaceDeclaration_IPendingProposal());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1025.1:
-* "InterfaceDeclaration_IPendingProposal": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IPendingProposal": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IPendingProposal():
+declare function get_current_RemovedInterfaceDeclaration_IPendingProposal():
+    // @ts-expect-error compatibility expected to be broken
     current.IPendingProposal;
 declare function use_old_InterfaceDeclaration_IPendingProposal(
     use: old.IPendingProposal);
 use_old_InterfaceDeclaration_IPendingProposal(
-    get_current_InterfaceDeclaration_IPendingProposal());
+    get_current_RemovedInterfaceDeclaration_IPendingProposal());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -777,6 +779,7 @@ declare function get_current_InterfaceDeclaration_IQuorumProposals():
 declare function use_old_InterfaceDeclaration_IQuorumProposals(
     use: old.IQuorumProposals);
 use_old_InterfaceDeclaration_IQuorumProposals(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IQuorumProposals());
 
 /*

--- a/common/lib/protocol-definitions/src/test/types/validate0.1026.0.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1026.0.ts
@@ -541,26 +541,28 @@ use_old_InterfaceDeclaration_INackContent(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken.0.1026.0:
-* "InterfaceDeclaration_IPendingProposal": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IPendingProposal": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IPendingProposal():
     old.IPendingProposal;
-declare function use_current_InterfaceDeclaration_IPendingProposal(
+declare function use_current_RemovedInterfaceDeclaration_IPendingProposal(
+    // @ts-expect-error compatibility expected to be broken
     use: current.IPendingProposal);
-use_current_InterfaceDeclaration_IPendingProposal(
+use_current_RemovedInterfaceDeclaration_IPendingProposal(
     get_old_InterfaceDeclaration_IPendingProposal());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken.0.1026.0:
-* "InterfaceDeclaration_IPendingProposal": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IPendingProposal": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IPendingProposal():
+declare function get_current_RemovedInterfaceDeclaration_IPendingProposal():
+    // @ts-expect-error compatibility expected to be broken
     current.IPendingProposal;
 declare function use_old_InterfaceDeclaration_IPendingProposal(
     use: old.IPendingProposal);
 use_old_InterfaceDeclaration_IPendingProposal(
-    get_current_InterfaceDeclaration_IPendingProposal());
+    get_current_RemovedInterfaceDeclaration_IPendingProposal());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -776,6 +778,7 @@ declare function get_current_InterfaceDeclaration_IQuorumProposals():
 declare function use_old_InterfaceDeclaration_IQuorumProposals(
     use: old.IQuorumProposals);
 use_old_InterfaceDeclaration_IQuorumProposals(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IQuorumProposals());
 
 /*

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1322,7 +1322,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             proposals,
             values,
             (key, value) => this.submitMessage(MessageType.Propose, { key, value }),
-            (sequenceNumber) => this.submitMessage(MessageType.Reject, sequenceNumber));
+            // Quorum proposal rejection removed, delete when updated protocol-base is integrated.
+            () => {});
 
         const protocolLogger = ChildLogger.create(this.subLogger, "ProtocolHandler");
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1321,7 +1321,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             proposals,
             values,
             (key, value) => this.submitMessage(MessageType.Propose, { key, value }),
-            // Quorum proposal rejection removed, delete when updated protocol-base is integrated.
+            // Quorum proposal rejection removed, delete when protocol-base 0.1035 is integrated.
             () => {});
 
         const protocolLogger = ChildLogger.create(this.subLogger, "ProtocolHandler");

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -63,7 +63,6 @@ import {
     ICommittedProposal,
     IDocumentAttributes,
     IDocumentMessage,
-    IPendingProposal,
     IProcessMessageResult,
     IQuorumClients,
     IQuorumProposals,
@@ -1340,7 +1339,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             this.connectionStateHandler.receivedRemoveMemberEvent(clientId);
         });
 
-        protocol.quorum.on("addProposal", (proposal: IPendingProposal) => {
+        protocol.quorum.on("addProposal", (proposal: ISequencedProposal) => {
             if (proposal.key === "code" || proposal.key === "code2") {
                 this.emit("codeDetailsProposed", proposal.value, proposal);
             }

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -44,7 +44,8 @@ describe("ConnectionStateHandler Tests", () => {
     });
 
     beforeEach(() => {
-        protocolHandler = new ProtocolOpHandler(0, 0, 1, [], [], [], (key, value) => 0, (seqNum) => undefined);
+        // Quorum proposal rejection removed, delete when protocol-base 0.1035 is integrated.
+        protocolHandler = new ProtocolOpHandler(0, 0, 1, [], [], [], (key, value) => 0, () => {});
         connectionDetails = {
             clientId: pendingClientId,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -192,8 +192,7 @@ export class RunningSummarizer implements IDisposable {
         switch (op.type) {
             case MessageType.ClientLeave:
             case MessageType.ClientJoin:
-            case MessageType.Propose:
-            case MessageType.Reject: {
+            case MessageType.Propose: {
                 // Synchronously handle quorum ops like regular ops
                 this.handleOp(undefined, op);
                 return;

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -262,7 +262,6 @@ export class MockQuorum implements IQuorum, EventEmitter {
         }
         this.map.set(key, value);
         this.eventEmitter.emit("approveProposal", 0, key, value);
-        this.eventEmitter.emit("commitProposal", 0, key, value);
     }
 
     has(key: string): boolean {
@@ -314,7 +313,6 @@ export class MockQuorum implements IQuorum, EventEmitter {
             case "removeMember":
             case "addProposal":
             case "approveProposal":
-            case "commitProposal":
                 this.eventEmitter.on(event, listener);
                 this.eventEmitter.emit("afterOn", event);
                 return this;

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -177,38 +177,6 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
         }
     });
 
-    it("Code Proposal Rejection", async () => {
-        for (let i = 0; i < containers.length; i++) {
-            containers[i].once("contextChanged", () => {
-                throw Error(`context should not change for containers[${i}]`);
-            });
-        }
-
-        const proposal: IFluidCodeDetails = { package: packageV2 };
-        containers[1].on("codeDetailsProposed", (c, p) => {
-            assert.deepStrictEqual(
-                c,
-                proposal,
-                "codeDetails2 should have been proposed");
-            p.reject();
-        });
-
-        const res = await Promise.all([
-            containers[0].proposeCodeDetails(proposal),
-            provider.ensureSynchronized(),
-        ]);
-
-        assert.strictEqual(res[0], false, "Code proposal should be rejected");
-
-        for (let i = 0; i < containers.length; i++) {
-            assert.strictEqual(containers[i].closed, false, `containers[${i}] should not be closed`);
-            assert.deepStrictEqual(
-                containers[i].getSpecifiedCodeDetails?.(),
-                { package: packageV1 },
-                `containers[${i}] code details should not update`);
-        }
-    });
-
     it("Code Proposal With Compatible Existing", async () => {
         for (let i = 0; i < containers.length; i++) {
             containers[i].once("contextChanged", () => {

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -103,7 +103,7 @@ export function mergeAppAndProtocolTree(appSummaryTree: ITree_2, protocolTree: I
 
 // @public
 export class ProtocolOpHandler {
-    constructor(minimumSequenceNumber: number, sequenceNumber: number, term: number | undefined, members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number, sendReject: (sequenceNumber: number) => void);
+    constructor(minimumSequenceNumber: number, sequenceNumber: number, term: number | undefined, members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
     // (undocumented)
     close(): void;
     getProtocolState(): IScribeProtocolState;
@@ -121,7 +121,7 @@ export class ProtocolOpHandler {
 
 // @public
 export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum {
-    constructor(members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number, sendReject: (sequenceNumber: number) => void);
+    constructor(members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
     addMember(clientId: string, details: ISequencedClient): void;
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
     // (undocumented)
@@ -136,16 +136,12 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     getMembers(): Map<string, ISequencedClient>;
     has(key: string): boolean;
     propose(key: string, value: any): Promise<void>;
-    rejectProposal(clientId: string, sequenceNumber: number): void;
     removeMember(clientId: string): void;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
     snapshot(): IQuorumSnapshot;
-    snapshotMembers(): IQuorumSnapshot["members"];
-    snapshotProposals(): IQuorumSnapshot["proposals"];
-    snapshotValues(): IQuorumSnapshot["values"];
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
-    }
+}
 
 // @public
 export class TreeTreeEntry {
@@ -159,7 +155,6 @@ export class TreeTreeEntry {
     // (undocumented)
     readonly value: ITree;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/server/routerlicious/packages/lambdas/src/scribe/utils.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/utils.ts
@@ -18,7 +18,6 @@ export const initializeProtocol = (
     protocolState.proposals,
     protocolState.values,
     () => -1,
-    () => { return; },
 );
 
 // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -331,7 +331,7 @@ export class LocalOrderer implements IOrderer {
             lastState.proposals,
             lastState.values,
             () => -1,
-            () => { return; });
+        );
 
         const summaryWriter = new SummaryWriter(
             this.tenantId,

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -56,14 +56,14 @@ export class ProtocolOpHandler {
         proposals: [number, ISequencedProposal, string[]][],
         values: [string, ICommittedProposal][],
         sendProposal: (key: string, value: any) => number,
-        sendReject: (sequenceNumber: number) => void) {
+    ) {
         this.term = term ?? 1;
         this.quorum = new Quorum(
             members,
             proposals,
             values,
             sendProposal,
-            sendReject);
+        );
     }
 
     public close() {
@@ -112,11 +112,6 @@ export class ProtocolOpHandler {
 
                 // On a quorum proposal, immediately send a response to expedite the approval.
                 immediateNoOp = true;
-                break;
-
-            case MessageType.Reject:
-                const sequenceNumber = message.contents as number;
-                this.quorum.rejectProposal(message.clientId, sequenceNumber);
                 break;
 
             default:

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -114,6 +114,9 @@ export class ProtocolOpHandler {
                 immediateNoOp = true;
                 break;
 
+            case MessageType.Reject:
+                throw new Error("Quorum rejection is removed.");
+
             default:
         }
 

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -275,10 +275,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
 
         for (const proposal of completed) {
             // If it was a local proposal - resolve the promise
-            if (proposal.deferred) {
-                // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                proposal.deferred.resolve();
-            }
+            proposal.deferred?.resolve();
 
             const committedProposal: ICommittedProposal = {
                 approvalSequenceNumber: message.sequenceNumber,

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -136,7 +136,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
      * Snapshots quorum members
      * @returns a deep cloned array of members
      */
-    public snapshotMembers(): IQuorumSnapshot["members"] {
+    private snapshotMembers(): IQuorumSnapshot["members"] {
         return cloneDeep(Array.from(this.members));
     }
 
@@ -144,7 +144,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
      * Snapshots quorum proposals
      * @returns a deep cloned array of proposals
      */
-    public snapshotProposals(): IQuorumSnapshot["proposals"] {
+    private snapshotProposals(): IQuorumSnapshot["proposals"] {
         return Array.from(this.proposals).map(
             ([sequenceNumber, proposal]) => [
                 sequenceNumber,
@@ -156,7 +156,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
      * Snapshots quorum values
      * @returns a deep cloned array of values
      */
-    public snapshotValues(): IQuorumSnapshot["values"] {
+    private snapshotValues(): IQuorumSnapshot["values"] {
         return cloneDeep(Array.from(this.values));
     }
 

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -9,7 +9,6 @@ import cloneDeep from "lodash/cloneDeep";
 import { assert, Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
     ICommittedProposal,
-    IPendingProposal,
     IQuorum,
     IQuorumEvents,
     ISequencedClient,
@@ -21,39 +20,12 @@ import {
  * Appends a deferred and rejection count to a sequenced proposal. For locally generated promises this allows us to
  * attach a Deferred which we will resolve once the proposal is either accepted or rejected.
  */
-class PendingProposal implements IPendingProposal, ISequencedProposal {
-    public readonly rejections: Set<string>;
-    private canReject = true;
-
+class PendingProposal implements ISequencedProposal {
     constructor(
-        private readonly sendReject: (sequenceNumber: number) => void,
         public sequenceNumber: number,
         public key: string,
         public value: any,
-        rejections: string[],
         public deferred?: Deferred<void>) {
-        this.rejections = new Set(rejections);
-    }
-
-    public reject() {
-        if (!this.canReject) {
-            throw new Error("Can no longer reject this proposal");
-        }
-
-        this.sendReject(this.sequenceNumber);
-    }
-
-    public get rejectionDisabled() {
-        return !this.canReject;
-    }
-
-    public disableRejection() {
-        this.canReject = false;
-    }
-
-    public addRejection(clientId: string) {
-        assert(!this.rejections.has(clientId), 0x1cd /* `!this.rejections.has(${clientId})` */);
-        this.rejections.add(clientId);
     }
 }
 
@@ -93,20 +65,19 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
         proposals: [number, ISequencedProposal, string[]][],
         values: [string, ICommittedProposal][],
         private readonly sendProposal: (key: string, value: any) => number,
-        private readonly sendReject: (sequenceNumber: number) => void) {
+    ) {
         super();
 
         this.members = new Map(members);
         this.proposals = new Map(
-            proposals.map(([, proposal, rejections]) => {
+            proposals.map(([, proposal]) => {
                 return [
                     proposal.sequenceNumber,
                     new PendingProposal(
-                        this.sendReject,
                         proposal.sequenceNumber,
                         proposal.key,
                         proposal.value,
-                        rejections),
+                    ),
                 ] as [number, PendingProposal];
             }));
         this.values = new Map(values);
@@ -149,7 +120,9 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
             ([sequenceNumber, proposal]) => [
                 sequenceNumber,
                 { sequenceNumber, key: proposal.key, value: proposal.value },
-                Array.from(proposal.rejections)] as [number, ISequencedProposal, string[]]);
+                [], // rejections, which has been removed
+            ],
+        );
     }
 
     /**
@@ -257,19 +230,17 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
             0x1d1 /* `!${local} || this.localProposals.has(${clientSequenceNumber})` */);
 
         const proposal = new PendingProposal(
-            this.sendReject,
             sequenceNumber,
             key,
             value,
-            [],
-            local ? this.localProposals.get(clientSequenceNumber) : undefined);
+            local ? this.localProposals.get(clientSequenceNumber) : undefined,
+        );
         this.proposals.set(sequenceNumber, proposal);
 
         // Emit the event - which will also provide clients an opportunity to reject the proposal. We require
         // clients to make a rejection decision at the time of receiving the proposal and so disable rejecting it
         // after we have emitted the event.
         this.emit("addProposal", proposal);
-        proposal.disableRejection();
 
         if (local) {
             this.localProposals.delete(clientSequenceNumber);
@@ -277,27 +248,6 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
 
         // clear the proposal cache
         this.snapshotCache.proposals = undefined;
-    }
-
-    /**
-     * Rejects the given proposal
-     */
-    public rejectProposal(clientId: string, sequenceNumber: number) {
-        // Proposals require unanimous approval so any rejection results in a rejection of the proposal. For error
-        // detection we will keep a rejected proposal in the pending list until the MSN advances so that we can
-        // track the total number of rejections.
-        assert(this.proposals.has(sequenceNumber), 0x1d2 /* `this.proposals.has(${sequenceNumber})` */);
-
-        const proposal = this.proposals.get(sequenceNumber);
-        if (proposal !== undefined) {
-            proposal.addRejection(clientId);
-        }
-
-        // clear the proposal cache
-        this.snapshotCache.proposals = undefined;
-
-        // We will emit approval and rejection messages once the MSN advances past the sequence number of the
-        // proposal. This will allow us to convey all clients who rejected the proposal.
     }
 
     /**
@@ -324,54 +274,41 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
         completed.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
 
         for (const proposal of completed) {
-            const approved = proposal.rejections.size === 0;
-
             // If it was a local proposal - resolve the promise
             if (proposal.deferred) {
                 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                approved
-                    ? proposal.deferred.resolve()
-                    : proposal.deferred.reject(`Rejected by ${Array.from(proposal.rejections)}`);
+                proposal.deferred.resolve();
             }
 
-            if (approved) {
-                const committedProposal: ICommittedProposal = {
-                    approvalSequenceNumber: message.sequenceNumber,
-                    commitSequenceNumber: -1,
-                    key: proposal.key,
-                    sequenceNumber: proposal.sequenceNumber,
-                    value: proposal.value,
-                };
+            const committedProposal: ICommittedProposal = {
+                approvalSequenceNumber: message.sequenceNumber,
+                commitSequenceNumber: -1,
+                key: proposal.key,
+                sequenceNumber: proposal.sequenceNumber,
+                value: proposal.value,
+            };
 
-                // TODO do we want to notify when a proposal doesn't make it to the commit phase - i.e. because
-                // a new proposal was made before it made it to the committed phase? For now we just will never
-                // emit this message
+            // TODO do we want to notify when a proposal doesn't make it to the commit phase - i.e. because
+            // a new proposal was made before it made it to the committed phase? For now we just will never
+            // emit this message
 
-                this.values.set(committedProposal.key, committedProposal);
-                this.pendingCommit.set(committedProposal.key, committedProposal);
+            this.values.set(committedProposal.key, committedProposal);
+            this.pendingCommit.set(committedProposal.key, committedProposal);
 
-                // clear the values cache
-                this.snapshotCache.values = undefined;
+            // clear the values cache
+            this.snapshotCache.values = undefined;
 
-                // Send no-op on approval to expedite commit
-                // accept means that all clients have seen the proposal and nobody has rejected it
-                // commit means that all clients have seen that the proposal was accepted by everyone
-                immediateNoOp = true;
+            // Send no-op on approval to expedite commit
+            // accept means that all clients have seen the proposal and nobody has rejected it
+            // commit means that all clients have seen that the proposal was accepted by everyone
+            immediateNoOp = true;
 
-                this.emit(
-                    "approveProposal",
-                    committedProposal.sequenceNumber,
-                    committedProposal.key,
-                    committedProposal.value,
-                    committedProposal.approvalSequenceNumber);
-            } else {
-                this.emit(
-                    "rejectProposal",
-                    proposal.sequenceNumber,
-                    proposal.key,
-                    proposal.value,
-                    Array.from(proposal.rejections));
-            }
+            this.emit(
+                "approveProposal",
+                committedProposal.sequenceNumber,
+                committedProposal.key,
+                committedProposal.value,
+                committedProposal.approvalSequenceNumber);
 
             this.proposals.delete(proposal.sequenceNumber);
 

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -15,7 +15,6 @@ describe("Loader", () => {
                 [],
                 [],
                 (key, value) => 0,
-                (value) => { return; },
             );
         });
 


### PR DESCRIPTION
Resolves #9058, see that issue for thoughts on why this is not useful in current state and alternative options for the scenario if desired.

Additionally removes committed state, which isn't particularly interesting (there's nothing special about the period between approval and committed) and isn't used.