### PR TITLE
[0.55] Port Batch processing logic is broken in presence of system op before inco…

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -382,6 +382,11 @@ class ScheduleManagerCore {
         for (const pending of allPending) {
             this.trackPending(pending);
         }
+
+        // We are intentionally directly listening to the "op" to inspect system ops as well.
+        // If we do not observe system ops, we are likely to hit 0x296 assert when system ops
+        // precedes start of incomplete batch.
+        this.deltaManager.on("op", (message) => this.afterOpProcessing(message.sequenceNumber));
     }
 
     /**
@@ -527,8 +532,6 @@ export class ScheduleManager {
     private batchClientId: string | undefined;
     private hitError = false;
 
-    private readonly scheduler: ScheduleManagerCore;
-
     constructor(
         private readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
         private readonly emitter: EventEmitter,
@@ -538,7 +541,7 @@ export class ScheduleManager {
             this.deltaManager,
             ChildLogger.create(this.logger, "DeltaScheduler"),
         );
-        this.scheduler = new ScheduleManagerCore(deltaManager, logger);
+        void new ScheduleManagerCore(deltaManager, logger);
     }
 
     public beforeOpProcessing(message: ISequencedDocumentMessage) {
@@ -562,10 +565,6 @@ export class ScheduleManager {
     public afterOpProcessing(error: any | undefined, message: ISequencedDocumentMessage) {
         // If this is no longer true, we need to revisit what we do where we set this.hitError.
         assert(!this.hitError, 0x2a3 /* "container should be closed on any error" */);
-
-        // Let the scheduler know how far we progressed, to decide if op processing
-        // should be paused or not.
-        this.scheduler.afterOpProcessing(message.sequenceNumber);
 
         if (error) {
             // We assume here that loader will close container and stop processing all future ops.

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -96,6 +96,7 @@ describe("Runtime", () => {
                     deltaManager.inbound.processCallback = (message: ISequencedDocumentMessage) => {
                         scheduleManager.beforeOpProcessing(message);
                         scheduleManager.afterOpProcessing(undefined, message);
+                        deltaManager.emit("op", message);
                     };
                     scheduleManager = new ScheduleManager(
                         deltaManager,

--- a/packages/test/functional-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/functional-tests/src/test/containerRuntime.spec.ts
@@ -79,6 +79,7 @@ describe("Container Runtime", () => {
             while (Date.now() - startTime < processingDelay) { }
 
             scheduleManager.afterOpProcessing(undefined, message);
+            deltaManager.emit("op", message);
         }
 
         beforeEach(async () => {


### PR DESCRIPTION
…mplete batch (#9090)

Issue: https://portal.microsofticm.com/imp/v3/incidents/details/288005685/home

The issue is that system ops do not reach container runtime.
So, the logic that assumes we can pause op processing when we see an op preceding start of incomplete batch is wrong.
Assert 0x296 will fire when we start processing this incomplete batch because we did not stop processing.

The fix changes how we observe ops to leverage DM events instead of ops processed by runtime.
So, for most part it does not change behavior, only for system ops.