### PR TITLE
emit resumeConnection event from container

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AttachState } from '@fluidframework/container-definitions';
+import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
 import { EventEmitterWithErrorHandling } from '@fluidframework/telemetry-utils';
 import { FluidObject } from '@fluidframework/core-interfaces';
@@ -49,8 +50,10 @@ export enum ConnectionState {
     Disconnected = 0
 }
 
+// Warning: (ae-forgotten-export) The symbol "IContainerEvents2" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export class Container extends EventEmitterWithErrorHandling<IContainerEvents> implements IContainer {
+export class Container extends EventEmitterWithErrorHandling<IContainerEvents2> implements IContainer {
     constructor(loader: Loader, config: IContainerConfig);
     // (undocumented)
     attach(request: IRequest): Promise<void>;

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -50,8 +50,6 @@ export enum ConnectionState {
     Disconnected = 0
 }
 
-// Warning: (ae-forgotten-export) The symbol "IContainerEvents2" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export class Container extends EventEmitterWithErrorHandling<IContainerEvents2> implements IContainer {
     constructor(loader: Loader, config: IContainerConfig);
@@ -129,6 +127,14 @@ export interface IContainerConfig {
     clientDetailsOverride?: IClientDetails;
     // (undocumented)
     resolvedUrl?: IFluidResolvedUrl;
+}
+
+// @public
+export interface IContainerEvents2 extends IContainerEvents {
+    // Warning: (ae-forgotten-export) The symbol "IConnectionArgs" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    (event: "resumeConnection", listener: (connectionArgs: IConnectionArgs) => void): any;
 }
 
 // @public (undocumented)

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1044,8 +1044,12 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents2> 
             args.mode = "write";
         }
 
-        // Notify listeners that we are attempting to resume the delta connection
-        this.emit("resumeConnection", args);
+        if (this.connectionState === ConnectionState.Disconnected) {
+            // Notify listeners that we are attempting to resume the delta connection
+            // This codepath may be hit multiple times before connecting, so consumers
+            // are responsible to dedupe these events in that case.
+            this.emit("resumeConnection", args);
+        }
 
         this._deltaManager.connect(args);
     }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -225,7 +225,15 @@ const getCodeProposal =
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     (quorum: IQuorumProposals) => quorum.get("code") ?? quorum.get("code2");
 
-export class Container extends EventEmitterWithErrorHandling<IContainerEvents> implements IContainer {
+
+/**
+ * Temporary extension of IContainerEvents, will be removed once IContainerEvents is updated
+ */
+export interface IContainerEvents2 extends IContainerEvents {
+    (event: "resumeConnection", listener: (connectionArgs: IConnectionArgs) => void);
+}
+
+export class Container extends EventEmitterWithErrorHandling<IContainerEvents2> implements IContainer {
     public static version = "^0.1.0";
 
     /**
@@ -1035,6 +1043,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         if (!this._canReconnect || !this.client.details.capabilities.interactive) {
             args.mode = "write";
         }
+
+        // Notify listeners that we are attempting to resume the delta connection
+        this.emit("resumeConnection", args);
 
         this._deltaManager.connect(args);
     }

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -6,6 +6,7 @@
 export {
     ConnectionState,
     Container,
+    IContainerEvents2, // Temporary until the new event is moved to container-definitions
     IContainerLoadOptions,
     IContainerConfig,
     waitContainerToCatchUp,


### PR DESCRIPTION
Our internal Loop partners are trying to measure performance and reliability when establishing the websocket connection.  However, there is no centralized place to detect when we are actually starting to connect.

It could be from them calling `resume`, or `setAutoreconnect`, or some time after "disconnect" event is raised as the framework tries to reconnect.  And in the case of `resume`, one supported configuration is to let the host app call `resume`, in which case the shared code being instrumented has _no_ visibility into when the connection attempt begins.

So, this PR adds a new "resumeConnection" event which is fired from the Container when it is kicking off the connection.

My intention would be to add this event to `IContainEvents` in `container-definitions` package once this implementation goes in.