### PR TITLE
Fix Debug Current Mocha Test Cross Package Break Points

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -240,11 +240,10 @@
             "windows": {
                 "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha.cmd"
             },
-            "program": "${file}",
+            "sourceMaps": true,
             "stopOnEntry": false,
+            "program": "${file}",
             "args": [
-                "--require",
-                "source-map-support/register",
                 // "--fgrep",               // Uncomment to filter by test case name
                 // "<test case name>",
                 "--no-timeouts",
@@ -252,10 +251,16 @@
             ],
             "cwd": "${fileDirname}",
             "skipFiles": [
-                "<node_internals>/**/*.js"
+                "<node_internals>/**",
+                "**/node_modules/**"
+            ],
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/**/dist/**/*.js",
+                "!**/node_modules/**"
             ],
             "outFiles": [
-                "${fileDirname}/../../dist/**/*.js"
+                "${workspaceFolder}/**/dist/**/*.js",
+                "!**/node_modules/**"
             ],
             "preLaunchTask": "Build Current Tests",
             "internalConsoleOptions": "openOnSessionStart",


### PR DESCRIPTION
Explicitly setting all the paths: skipFiles, resolveSourceMapLocations, and outFiles seems to prevent the out of memory error, and allow cross package break points.