### PR TITLE
logging latency of the last ping and remove aggregation of delta latency

### DIFF
--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -19,7 +19,7 @@ export const latencyThreshold = 5000;
 
 class OpPerfTelemetry {
     private pongCount: number = 0;
-    private lastPingLatency = 0;
+    private pingLatency: number | undefined;
 
     // Collab window tracking. This is timestamp of %1000 message.
     private opSendTimeForLatencyStatisticsForMsnStatistics: number | undefined;
@@ -100,9 +100,9 @@ class OpPerfTelemetry {
 
     private recordPingTime(latency: number) {
         this.pongCount++;
-        this.lastPingLatency = latency;
-        const aggregateCount = 100;
-        if (this.pongCount === aggregateCount) {
+        this.pingLatency = latency;
+        // logging one in every 100 pongs
+        if (this.pongCount === 100) {
             this.logger.sendPerformanceEvent({
                 eventName: "DeltaLatency",
                 duration: latency,
@@ -161,7 +161,7 @@ class OpPerfTelemetry {
                 referenceSequenceNumber: message.referenceSequenceNumber,
                 duration,
                 category,
-                lastPingLatency: this.lastPingLatency,
+                pingLatency: this.pingLatency,
             });
             this.clientSequenceNumberForLatencyStatistics = undefined;
         }

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -19,7 +19,7 @@ export const latencyThreshold = 5000;
 
 class OpPerfTelemetry {
     private pongCount: number = 0;
-    private socketLatency = 0;
+    private lastPingLatency = 0;
 
     // Collab window tracking. This is timestamp of %1000 message.
     private opSendTimeForLatencyStatisticsForMsnStatistics: number | undefined;
@@ -100,15 +100,14 @@ class OpPerfTelemetry {
 
     private recordPingTime(latency: number) {
         this.pongCount++;
-        this.socketLatency += latency;
+        this.lastPingLatency = latency;
         const aggregateCount = 100;
         if (this.pongCount === aggregateCount) {
             this.logger.sendPerformanceEvent({
                 eventName: "DeltaLatency",
-                duration: this.socketLatency / aggregateCount,
+                duration: latency,
             });
             this.pongCount = 0;
-            this.socketLatency = 0;
         }
     }
 
@@ -162,6 +161,7 @@ class OpPerfTelemetry {
                 referenceSequenceNumber: message.referenceSequenceNumber,
                 duration,
                 category,
+                lastPingLatency: this.lastPingLatency,
             });
             this.clientSequenceNumberForLatencyStatistics = undefined;
         }


### PR DESCRIPTION
Fixes #8914 
In `DeltaLatency` event, instead of logging the avg of 100 pings' latency, we are logging the latency of one ping in every 100.
Also in `OpRoundtripTime` event, logging the latency of the last ping so that we can get how long it takes to process an op by subtracting latency from total duration