### PR TITLE
Log an error when inactive data store is loaded

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -116,8 +116,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     // (undocumented)
     getAudience(): IAudience;
-    // (undocumented)
-    protected getDataStore(id: string, wait?: boolean): Promise<IFluidRouter>;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     // (undocumented)
     getPendingLocalState(): IPendingLocalState | undefined;
@@ -589,6 +587,13 @@ export type OpActionEventListener = (op: ISequencedDocumentMessage) => void;
 
 // @public (undocumented)
 export type OpActionEventName = MessageType.Summarize | MessageType.SummaryAck | MessageType.SummaryNack | "default";
+
+// @public
+export enum RuntimeHeaders {
+    externalRequest = "externalRequest",
+    viaHandle = "viaHandle",
+    wait = "wait"
+}
 
 // @public (undocumented)
 export enum RuntimeMessage {

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -59,6 +59,7 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/container-definitions": "^0.46.0-0",
+    "@fluidframework/container-runtime": "^0.57.0",
     "@fluidframework/container-utils": "^0.57.0",
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/datastore": "^0.57.0",

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -43,7 +43,8 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
 
     public async get(): Promise<any> {
         if (this.objectP === undefined) {
-            const request = { url: this.absolutePath };
+            // Add `viaHandle` header to distinguish from requests from non-handle paths.
+            const request: IRequest = { url: this.absolutePath, headers: { viaHandle: true } };
             this.objectP = this.routeContext.resolveHandle(request)
                 .then<FluidObject>((response) => {
                     if (response.mimeType === "fluid/object") {

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -4,6 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
+import { RuntimeHeaders } from "@fluidframework/container-runtime"
 import {
     IFluidHandle,
     IFluidHandleContext,
@@ -44,7 +45,7 @@ export class RemoteFluidObjectHandle implements IFluidHandle {
     public async get(): Promise<any> {
         if (this.objectP === undefined) {
             // Add `viaHandle` header to distinguish from requests from non-handle paths.
-            const request: IRequest = { url: this.absolutePath, headers: { viaHandle: true } };
+            const request: IRequest = { url: this.absolutePath, headers: { [RuntimeHeaders.viaHandle]: true } };
             this.objectP = this.routeContext.resolveHandle(request)
                 .then<FluidObject>((response) => {
                     if (response.mimeType === "fluid/object") {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -295,6 +295,21 @@ export interface IRootSummaryTreeWithStats extends ISummaryTreeWithStats {
 };
 
 /**
+ * Accepted header keys for requests coming to the runtime.
+ */
+export enum RuntimeHeaders {
+    /** True to wait for a data store to be created and loaded before returning it. */
+    wait = "wait",
+    /**
+     * True if the request is from an external app. Used for GC to handle scenarios where a data store
+     * is deleted and requested via an external app.
+     */
+    externalRequest = "externalRequest",
+    /** True if the request is coming from an IFluidHandle. */
+    viaHandle = "viaHandle",
+}
+
+/**
  * @deprecated
  * Untagged logger is unsupported going forward. There are old loaders with old ContainerContexts that only
  * have the untagged logger, so to accommodate that scenario the below interface is used. It can be removed once
@@ -1053,7 +1068,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             (id: string) => this.summarizerNode.deleteChild(id),
             this.mc.logger,
             async () => this.garbageCollector.getDataStoreBaseGCDetails(),
-            (id: string, packagePath?: readonly string[]) => this.garbageCollector.nodeChanged(id, packagePath),
             (dataStorePath: string, packagePath?: readonly string[]) =>
                 this.garbageCollector.nodeUpdated(dataStorePath, "Changed", packagePath),
             new Map<string, string>(dataStoreAliasMap),
@@ -1318,19 +1332,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     return create404Response(request);
                 }
             } else if (requestParser.pathParts.length > 0) {
-                /**
-                 * If GC should run and this an external app request with "externalRequest" header, we need to return
-                 * an error if the data store being requested is marked as unreferenced as per the data store's initial
-                 * summary.
-                 *
-                 * This is a workaround to handle scenarios where a data store shared with an external app is deleted
-                 * and marked as unreferenced by GC. Returning an error will fail to load the data store for the app.
-                 */
-                const wait = typeof request.headers?.wait === "boolean" ? request.headers.wait : undefined;
-                const dataStore = request.headers?.externalRequest && this.garbageCollector.shouldRunGC
-                    ? await this.getDataStoreIfInitiallyReferenced(id, wait)
-                    : await this.getDataStore(id, wait);
-
+                const dataStore = await this.getDataStoreFromRequest(id, request);
                 const subRequest = requestParser.createSubRequest(1);
                 // We always expect createSubRequest to include a leading slash, but asserting here to protect against
                 // unintentionally modifying the url if that changes.
@@ -1343,6 +1345,36 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         } catch (error) {
             return exceptionToResponse(error);
         }
+    }
+
+    private async getDataStoreFromRequest(id: string, request: IRequest): Promise<IFluidRouter> {
+        const wait = typeof request.headers?.[RuntimeHeaders.wait] === "boolean"
+            ? request.headers?.[RuntimeHeaders.wait]
+            : true;
+        const dataStoreContext = await this.dataStores.getDataStore(id, wait);
+
+        /**
+         * If GC should run and this an external app request with "externalRequest" header, we need to return
+         * an error if the data store being requested is marked as unreferenced as per the data store's base
+         * GC data.
+         *
+         * This is a workaround to handle scenarios where a data store shared with an external app is deleted
+         * and marked as unreferenced by GC. Returning an error will fail to load the data store for the app.
+         */
+        if (request.headers?.[RuntimeHeaders.externalRequest] && this.garbageCollector.shouldRunGC) {
+            // The data store is referenced if used routes in the base summary has a route to self.
+            // Older documents may not have used routes in the summary. They are considered referenced.
+            const usedRoutes = (await dataStoreContext.getBaseGCDetails()).usedRoutes;
+            if (!(usedRoutes === undefined || usedRoutes.includes("") || usedRoutes.includes("/"))) {
+                throw responseToException(create404Response(request), request);
+            }
+        }
+
+        const dataStoreChannel = await dataStoreContext.realize();
+        // Let the garbage collector know that a data store was requested / loaded. Realize the data store first so
+        // that the package path is available.
+        this.garbageCollector.nodeUpdated(`/${id}`, "Loaded", dataStoreContext.packagePath, request?.headers);
+        return dataStoreChannel;
     }
 
     private formMetadata(): IContainerRuntimeMetadata {
@@ -1570,35 +1602,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const context = await this.dataStores.getDataStore(id, wait);
         assert(await context.isRoot(), 0x12b /* "did not get root data store" */);
         return context.realize();
-    }
-
-    protected async getDataStore(id: string, wait = true, viaHandle?: boolean): Promise<IFluidRouter> {
-        const dataStoreContext = await this.dataStores.getDataStore(id, wait);
-        // Let the garbage collector know that a data store was requested / loaded.
-        this.garbageCollector.nodeUpdated(`/${id}`, "Loaded", viaHandle);
-        return dataStoreContext.realize();
-    }
-
-    /**
-     * Retrieves the runtime for a data store if it's referenced as per the initially summary that it is loaded with.
-     * This is a workaround to handle scenarios where a data store shared with an external app is deleted and marked
-     * as unreferenced by GC.
-     * @param id - Id supplied during creating the data store.
-     * @param wait - True if you want to wait for it.
-     * @returns the data store runtime if the data store exists and is initially referenced; undefined otherwise.
-     */
-    private async getDataStoreIfInitiallyReferenced(id: string, wait = true): Promise<IFluidRouter> {
-        const dataStoreContext = await this.dataStores.getDataStore(id, wait);
-        // The data store is referenced if used routes in the initial summary has a route to self.
-        // Older documents may not have used routes in the summary. They are considered referenced.
-        const usedRoutes = (await dataStoreContext.getBaseGCDetails()).usedRoutes;
-        if (usedRoutes === undefined || usedRoutes.includes("") || usedRoutes.includes("/")) {
-            return dataStoreContext.realize();
-        }
-
-        // The data store is unreferenced. Throw a 404 response exception.
-        const request = { url: id };
-        throw responseToException(create404Response(request), request);
     }
 
     public setFlushMode(mode: FlushMode): void {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -114,7 +114,7 @@ export class DataStores implements IDisposable {
         private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
         getBaseGCDetails: () => Promise<Map<string, IGarbageCollectionDetailsBase>>,
-        private readonly dataStoreChanged: (id: string, packagePath?: readonly string[]) => void,
+        private readonly dataStoreChanged: (dataStorePath: string, packagePath?: readonly string[]) => void,
         private readonly aliasMap: Map<string, string>,
         private readonly writeGCDataAtRoot: boolean,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
@@ -410,7 +410,7 @@ export class DataStores implements IDisposable {
         context.process(transformed, local, localMessageMetadata);
 
         // Notify that a data store changed. This is used to detect if a deleted data store is being used.
-        this.dataStoreChanged(envelope.address, context.isLoaded ? context.packagePath : undefined);
+        this.dataStoreChanged(`/${envelope.address}`, context.isLoaded ? context.packagePath : undefined);
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<FluidDataStoreContext> {

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -17,6 +17,7 @@ export {
     ScheduleManager,
     agentSchedulerId,
     ContainerRuntime,
+    RuntimeHeaders,
 } from "./containerRuntime";
 export { DeltaScheduler } from "./deltaScheduler";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -89,17 +89,17 @@ describe("Garbage Collection Tests", () => {
     });
 
     describe("Inactive events", () => {
-        const inactiveObjectRevivedEvent = "GarbageCollector:inactiveObjectRevived";
-        const inactiveObjectChangedEvent = "GarbageCollector:inactiveObjectChanged";
-        const inactiveObjectLoadedEvent = "GarbageCollector:inactiveObjectLoaded";
+        const revivedEvent = "GarbageCollector:inactiveObject_Revived";
+        const changedEvent = "GarbageCollector:inactiveObject_Changed";
+        const loadedEvent = "GarbageCollector:inactiveObject_Loaded";
 
         // Validates that no inactive event has been fired.
         function validateNoInactiveEvents() {
             assert(
                 !mockLogger.matchAnyEvent([
-                    { eventName: inactiveObjectRevivedEvent },
-                    { eventName: inactiveObjectChangedEvent },
-                    { eventName: inactiveObjectLoadedEvent },
+                    { eventName: revivedEvent },
+                    { eventName: changedEvent },
+                    { eventName: loadedEvent },
                 ]),
                 "inactive object events should not have been logged",
             );
@@ -174,19 +174,19 @@ describe("Garbage Collection Tests", () => {
             updateAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive events not generated as expected",
             );
 
-            // Add reference from node 1 to node 3 and validate that we get inactiveObjectRevivedEvent event.
+            // Add reference from node 1 to node 3 and validate that we get revivedEvent event.
             garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
@@ -207,8 +207,8 @@ describe("Garbage Collection Tests", () => {
             updateAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive events not generated as expected",
             );
@@ -266,17 +266,17 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive events not generated as expected",
             );
 
-            // Add reference from node 2 to node 3 and validate that we get inactiveObjectRevivedEvent event.
+            // Add reference from node 2 to node 3 and validate that we get revivedEvent event.
             garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
@@ -319,17 +319,17 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
-                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
 
-            // Add reference from node 2 to node 3 and validate that we get inactiveObjectRevivedEvent event.
+            // Add reference from node 2 to node 3 and validate that we get revivedEvent event.
             garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: revivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactive event not generated as expected",
             );
@@ -388,9 +388,9 @@ describe("Garbage Collection Tests", () => {
             garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
             assert(
                 mockLogger.matchEvents([
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[1], pkg: eventPkg },
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[1], pkg: eventPkg },
+                    { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: loadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
             );

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -91,6 +91,7 @@ describe("Garbage Collection Tests", () => {
     describe("Inactive events", () => {
         const inactiveObjectRevivedEvent = "GarbageCollector:inactiveObjectRevived";
         const inactiveObjectChangedEvent = "GarbageCollector:inactiveObjectChanged";
+        const inactiveObjectLoadedEvent = "GarbageCollector:inactiveObjectLoaded";
 
         // Validates that no inactive event has been fired.
         function validateNoInactiveEvents() {
@@ -98,15 +99,17 @@ describe("Garbage Collection Tests", () => {
                 !mockLogger.matchAnyEvent([
                     { eventName: inactiveObjectRevivedEvent },
                     { eventName: inactiveObjectChangedEvent },
+                    { eventName: inactiveObjectLoadedEvent },
                 ]),
                 "inactive object events should not have been logged",
             );
         }
 
-        // Simulates node changed activity for all the nodes in the graph.
-        function changeAllNodes(garbageCollector: IGarbageCollector) {
+        // Simulates node loaded and changed activity for all the nodes in the graph.
+        function updateAllNodes(garbageCollector: IGarbageCollector) {
             nodes.forEach((nodeId) => {
-                garbageCollector.nodeChanged(nodeId, testPkgPath);
+                garbageCollector.nodeUpdated(nodeId, "Changed", testPkgPath);
+                garbageCollector.nodeUpdated(nodeId, "Loaded", testPkgPath);
             });
         }
 
@@ -133,17 +136,17 @@ describe("Garbage Collection Tests", () => {
             // Run garbage collection on the default GC data where everything is referenced.
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Change all nodes.
-            changeAllNodes(garbageCollector);
+            // Update all nodes.
+            updateAllNodes(garbageCollector);
 
             // Validate that no inactive events are generated yet.
             validateNoInactiveEvents();
 
-            // Wait for unreferenced timer (if any) to expire.
+            // Expire the unreferenced timer (if any).
             clock.tick(deleteTimeoutMs + 1);
 
             // Change all nodes again.
-            changeAllNodes(garbageCollector);
+            updateAllNodes(garbageCollector);
 
             // Validate that no inactive events are generated since everything is referenced.
             validateNoInactiveEvents();
@@ -157,36 +160,35 @@ describe("Garbage Collection Tests", () => {
 
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Change all nodes.
-            changeAllNodes(garbageCollector);
+            // Update all nodes.
+            updateAllNodes(garbageCollector);
 
             // Validate that no inactive events are generated yet.
             validateNoInactiveEvents();
 
-            // Wait for unreferenced timer (if any) to expire.
+            // Expire the unreferenced timer (if any).
             clock.tick(deleteTimeoutMs + 1);
 
-            // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
+            // Update all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
             // are inactive.
-            changeAllNodes(garbageCollector);
+            updateAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
+                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
                     { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectChanged event not generated as expected",
+                "inactive events not generated as expected",
             );
 
-            // Add reference to node 3 from node 1.
-            defaultGCData.gcNodes[nodes[1]] = [ nodes[3] ];
-
-            // Run GC and validate that we get inactiveObjectRevived for node 3.
-            await garbageCollector.collectGarbage({ runGC: true });
+            // Add reference from node 1 to node 3 and validate that we get inactiveObjectRevivedEvent event.
+            garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectRevived event not generated as expected",
+                "inactive event not generated as expected",
             );
         });
 
@@ -198,21 +200,22 @@ describe("Garbage Collection Tests", () => {
 
             await garbageCollector.collectGarbage({ runGC: true });
 
+            // Expire the unreferenced timer (if any).
             clock.tick(deleteTimeoutMs + 1);
 
-            // Change all nodes. This should result in an inactiveObjectChanged event for node 2 and node 3 since they
-            // are inactive.
-            changeAllNodes(garbageCollector);
+            // Update all nodes. This should result in an inactiveObjectChanged event for node 3 since it's inactive.
+            updateAllNodes(garbageCollector);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectChanged event not generated as expected",
+                "inactive events not generated as expected",
             );
 
-            // Change all nodes. There shouldn't be any more inactive events since for each node the event is only
+            // Update all nodes. There shouldn't be any more inactive events since for each node the event is only
             // once.
-            changeAllNodes(garbageCollector);
+            updateAllNodes(garbageCollector);
             validateNoInactiveEvents();
         });
 
@@ -258,23 +261,24 @@ describe("Garbage Collection Tests", () => {
             defaultGCData.gcNodes[nodes[2]] = [];
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
-            garbageCollector.nodeChanged(nodes[3], testPkgPath);
+            // Update node 3. This should result in an inactiveObjectChanged/Loaded event since it should be inactive.
+            garbageCollector.nodeUpdated(nodes[3], "Changed", testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectChanged event not generated as expected",
+                "inactive events not generated as expected",
             );
 
-            // Add a reference to node 3 from node 2. Run GC and validate that we get inactiveObjectRevived for node 3.
-            defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
-            await garbageCollector.collectGarbage({ runGC: true });
+            // Add reference from node 2 to node 3 and validate that we get inactiveObjectRevivedEvent event.
+            garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectRevived event not generated as expected",
+                "inactive event not generated as expected",
             );
         });
 
@@ -310,23 +314,24 @@ describe("Garbage Collection Tests", () => {
             defaultGCData.gcNodes[nodes[2]] = [];
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Change node 3. This should result in an inactiveObjectChanged event for it since it should be inactive.
-            garbageCollector.nodeChanged(nodes[3], testPkgPath);
+            // Change node 3. This should result in an inactiveObjectChanged/Loaded event since it should be inactive.
+            garbageCollector.nodeUpdated(nodes[3], "Changed", testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectChanged event not generated as expected",
+                "inactive event not generated as expected",
             );
 
-            // Add a reference to node 3 from node 2. Run GC and validate that we get inactiveObjectRevived for node 3.
-            defaultGCData.gcNodes[nodes[2]] = [ nodes[3] ];
-            await garbageCollector.collectGarbage({ runGC: true });
+            // Add reference from node 2 to node 3 and validate that we get inactiveObjectRevivedEvent event.
+            garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectRevivedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
-                "inactiveObjectRevived event not generated as expected",
+                "inactive event not generated as expected",
             );
         });
 
@@ -377,15 +382,15 @@ describe("Garbage Collection Tests", () => {
 
             await garbageCollector.collectGarbage({ runGC: true });
 
-            // Change the nodes and validate that an inactiveObjectChanged event is generated for each.
-            garbageCollector.nodeChanged(nodes[1], testPkgPath);
-            garbageCollector.nodeChanged(nodes[2], testPkgPath);
-            garbageCollector.nodeChanged(nodes[3], testPkgPath);
+            // Update the nodes and validate that inactive events is correctly generated for each.
+            garbageCollector.nodeUpdated(nodes[1], "Changed", testPkgPath);
+            garbageCollector.nodeUpdated(nodes[2], "Changed", testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
             assert(
                 mockLogger.matchEvents([
                     { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[1], pkg: eventPkg },
                     { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[2], pkg: eventPkg },
-                    { eventName: inactiveObjectChangedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
+                    { eventName: inactiveObjectLoadedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
                 ]),
                 "inactiveObjectChanged event not generated as expected",
             );

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
@@ -15,7 +15,12 @@ import { ISummaryConfiguration } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
-import { IAckedSummary, IContainerRuntimeOptions, SummaryCollection } from "@fluidframework/container-runtime";
+import {
+    IAckedSummary,
+    IContainerRuntimeOptions,
+    RuntimeHeaders,
+    SummaryCollection,
+} from "@fluidframework/container-runtime";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { TestDataObject } from "./mockSummarizerClient";
 
@@ -134,7 +139,7 @@ describeFullCompat("GC Data Store Requests", (getTestObjectProvider) => {
         );
 
         // Add externalRequest = true to the header and verify that we are unable to load dataStore2.
-        request.headers = { externalRequest: true };
+        request.headers = { [RuntimeHeaders.externalRequest]: true };
         response = await container2.request(request);
         assert(response.status === 404, "dataStore2 should have failed to load");
     });
@@ -164,7 +169,7 @@ describeFullCompat("GC Data Store Requests", (getTestObjectProvider) => {
         // load dataStore2.
         const request: IRequest = {
             url: dataStore2.id,
-            headers: { externalRequest: true },
+            headers: { [RuntimeHeaders.externalRequest]: true },
         };
         let response = await container2.request(request);
         assert(response.status === 404, "dataStore2 should have failed to load");
@@ -226,7 +231,7 @@ describeFullCompat("GC Data Store Requests", (getTestObjectProvider) => {
         // load it even though it is marked as unreferenced in initial summary.
         const request: IRequest = {
             url: dataStore2.id,
-            headers: { externalRequest: true },
+            headers: { [RuntimeHeaders.externalRequest]: true },
         };
         const response = await container2.request(request);
         assert(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveDataStore.spec.ts
@@ -43,9 +43,9 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
         runtimeOptions,
     );
     const summaryLogger = new TelemetryNullLogger();
-    const inactiveObjectRevivedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObjectRevived";
-    const inactiveObjectChangedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObjectChanged";
-    const inactiveObjectLoadedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObjectLoaded";
+    const revivedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObject_Revived";
+    const changedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObject_Changed";
+    const loadedEvent = "fluid:telemetry:ContainerRuntime:GarbageCollector:inactiveObject_Loaded";
 
     let provider: ITestObjectProvider;
     let summarizerRuntime: ContainerRuntime;
@@ -63,9 +63,9 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
     function validateNoInactiveEvents() {
         assert(
             !mockLogger.matchAnyEvent([
-                { eventName: inactiveObjectRevivedEvent },
-                { eventName: inactiveObjectChangedEvent },
-                { eventName: inactiveObjectLoadedEvent },
+                { eventName: revivedEvent },
+                { eventName: changedEvent },
+                { eventName: loadedEvent },
             ]),
             "inactive object events should not have been logged",
         );
@@ -122,7 +122,7 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
         assert(
             mockLogger.matchEvents([
                 {
-                    eventName: inactiveObjectChangedEvent,
+                    eventName: changedEvent,
                     timeout: deleteTimeoutMs,
                     id: `/${dataStore1.id}`,
                     pkg: { value: `/${pkg}`, tag: TelemetryDataTag.PackageData },
@@ -135,7 +135,7 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
         assert(
             mockLogger.matchEvents([
                 {
-                    eventName: inactiveObjectLoadedEvent,
+                    eventName: loadedEvent,
                     timeout: deleteTimeoutMs,
                     id: `/${dataStore1.id}`,
                 },
@@ -149,13 +149,13 @@ describeNoCompat("GC inactive data store tests", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
         validateNoInactiveEvents();
 
-        // Revive the inactive data store and validate that we get the inactiveObjectRevivedEvent event.
+        // Revive the inactive data store and validate that we get the revivedEvent event.
         defaultDataStore._root.set("dataStore1", dataStore1.handle);
         await provider.ensureSynchronized();
         assert(
             mockLogger.matchEvents([
                 {
-                    eventName: inactiveObjectRevivedEvent,
+                    eventName: revivedEvent,
                     timeout: deleteTimeoutMs,
                     id: `/${dataStore1.id}`,
                     pkg: { value: `/${pkg}`, tag: TelemetryDataTag.PackageData },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
@@ -11,7 +11,12 @@ import {
 } from "@fluidframework/aqueduct";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
-import { IAckedSummary, IContainerRuntimeOptions, SummaryCollection } from "@fluidframework/container-runtime";
+import {
+    IAckedSummary,
+    IContainerRuntimeOptions,
+    RuntimeHeaders,
+    SummaryCollection,
+} from "@fluidframework/container-runtime";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { Marker, ReferenceType, reservedMarkerIdKey } from "@fluidframework/merge-tree";
@@ -155,7 +160,7 @@ describeFullCompat("GC reference updates in summarizer", (getTestObjectProvider)
             const dataStore2 = await factory.createInstance(mainDataStore._context.containerRuntime);
 
             // The request to use to load dataStore2.
-            const request: IRequest = { url: dataStore2.id, headers: { externalRequest: true } };
+            const request: IRequest = { url: dataStore2.id, headers: { [RuntimeHeaders.externalRequest]: true } };
 
             // Add the handle of dataStore2 to the matrix to mark it as referenced.
             {
@@ -193,7 +198,7 @@ describeFullCompat("GC reference updates in summarizer", (getTestObjectProvider)
             const dataStore2 = await factory.createInstance(mainDataStore._context.containerRuntime);
 
             // The request to use to load dataStore2.
-            const request: IRequest = { url: dataStore2.id, headers: { externalRequest: true } };
+            const request: IRequest = { url: dataStore2.id, headers: { [RuntimeHeaders.externalRequest]: true } };
 
             // Add and then remove the handle of dataStore2 to the matrix to mark it as unreferenced.
             {
@@ -256,7 +261,7 @@ describeFullCompat("GC reference updates in summarizer", (getTestObjectProvider)
             const dataStore2 = await factory.createInstance(mainDataStore._context.containerRuntime);
 
             // The request to use to load dataStore2.
-            const request: IRequest = { url: dataStore2.id, headers: { externalRequest: true } };
+            const request: IRequest = { url: dataStore2.id, headers: { [RuntimeHeaders.externalRequest]: true } };
 
             // Add the handle of dataStore2 to the shared string to mark it as referenced.
             {

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -17,6 +17,7 @@ import { createAndAttachContainer, ITestObjectProvider } from "@fluidframework/t
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { RuntimeHeaders } from "@fluidframework/container-runtime";
 
 class TestSharedDataObject1 extends DataObject {
     public get _root() {
@@ -276,7 +277,7 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
         const url = await container.getAbsoluteUrl(dataStoreWithRequestHeaders.id);
         assert(url, "Container should return absolute url");
 
-        const headers = { wait: false, externalRequest: true };
+        const headers = { wait: false, [RuntimeHeaders.externalRequest]: true };
         // Request to the newly created data store with headers.
         const response = await loader.request({ url, headers });
 

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -346,6 +346,13 @@ export class ReplayTool {
             }
             return false;
         }
+
+        // GC will consider unreferenced node in old documents to be inactive. When such nodes receive ops or are
+        // loaded, GC will log an error. Ignore those errors since we don't care about them when replaying old docs.
+        if (event.eventName.includes("GarbageCollector:inactiveObject_")) {
+            return false;
+        }
+
         return this.shouldReportError(errorString);
     }
 


### PR DESCRIPTION
Fixes #9053.
When an inactive data store is loaded, an error will be logged. Couple of things to note:
- Currently, only the summarizer client loads the GC data from the base snapshot. However, in order for this event to be logged, the all clients will have to do this. So, added an initialization step when the garbage collector is created to load this data.
- Only the summarizer client has up-to-date data of what is referenced and what is unreferenced. So, the inactivity event logged by other clients might be based off of stale data. However, we can diff these with the events from the summarizer and get the appropriate data.
- Added a property to the event that differentiates between data stores loaded via handles vs data stores loaded via request route.