### PR TITLE
Eliminate noisy LastSummaryProposedHandleMismatch events

### DIFF
--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -46,7 +46,9 @@ export class OdspSummaryUploadManager {
     public async writeSummaryTree(tree: api.ISummaryTree, context: ISummaryContext) {
         // If the last proposed handle is not the proposed handle of the acked summary(could happen when the last summary get nacked),
         // then re-initialize the caches with the previous ones else just update the previous caches with the caches from acked summary.
-        if (context.proposalHandle !== this.lastSummaryProposalHandle) {
+        // Don't bother logging if lastSummaryProposalHandle hasn't been set before; only log on a positive mismatch.
+        if (this.lastSummaryProposalHandle !== undefined &&
+            this.lastSummaryProposalHandle !== context.proposalHandle) {
             this.mc.logger.sendTelemetryEvent({
                 eventName: "LastSummaryProposedHandleMismatch",
                 ackedSummaryProposedHandle: context.proposalHandle,


### PR DESCRIPTION
Don't bother logging LastSummaryProposedHandleMismatch when there is no lastSummaryProposalHandle to compare the new handle to, which is true if this instance of OdspSummaryUploadManager hasn't written a summary before. Only log on a positive mismatch.