### PR TITLE
Fix Mocklogger assert functions

### DIFF
--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -171,8 +171,8 @@ export function mixinMonitoringContext<L extends ITelemetryBaseLogger = ITelemet
 // @public
 export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     constructor();
-    assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): void;
-    assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): void;
+    assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string): void;
+    assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string): void;
     // (undocumented)
     events: ITelemetryBaseEvent[];
     matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): boolean;

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -4,7 +4,6 @@
  */
 
 import { ITelemetryLogger, ITelemetryBaseEvent } from "@fluidframework/common-definitions";
-import { assert } from "@fluidframework/common-utils";
 import { TelemetryLogger } from "./logger";
 
 /**
@@ -35,14 +34,17 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     }
 
     /** Asserts that matchEvents is true, and prints the actual/expected output if not */
-    assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]) {
-        // const actualEvents = this.events;
-        assert(this.matchEvents(expectedEvents), 0x2ba /* `
-            expected:
-            ${JSON.stringify(expectedEvents)}
+    assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
+        const actualEvents = this.events;
+        if (this.matchEvents(expectedEvents)) {
+            return;
+        }
+        throw new Error(`${message}
+expected:
+${JSON.stringify(expectedEvents)}
 
-            actual:
-            ${JSON.stringify(actualEvents)}` */);
+actual:
+${JSON.stringify(actualEvents)}`);
     }
 
     /**
@@ -59,15 +61,18 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     }
 
     /** Asserts that matchAnyEvent is true, and prints the actual/expected output if not */
-    assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]) {
-        // const actualEvents = this.events;
+    assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
+        const actualEvents = this.events;
+        if (this.matchAnyEvent(expectedEvents)) {
+            return;
+        }
 
-        assert(this.matchAnyEvent(expectedEvents), 0x2bb /* `
-            expected:
-            ${JSON.stringify(expectedEvents)}
+        throw new Error(`${message}
+expected:
+${JSON.stringify(expectedEvents)}
 
-            actual:
-            ${JSON.stringify(actualEvents)}` */);
+actual:
+${JSON.stringify(actualEvents)}`);
     }
 
     private getMatchedEventsCount(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): number {

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -36,15 +36,14 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     /** Asserts that matchEvents is true, and prints the actual/expected output if not */
     assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
         const actualEvents = this.events;
-        if (this.matchEvents(expectedEvents)) {
-            return;
-        }
-        throw new Error(`${message}
+        if (!this.matchEvents(expectedEvents)) {
+            throw new Error(`${message}
 expected:
 ${JSON.stringify(expectedEvents)}
 
 actual:
 ${JSON.stringify(actualEvents)}`);
+        }
     }
 
     /**
@@ -63,16 +62,14 @@ ${JSON.stringify(actualEvents)}`);
     /** Asserts that matchAnyEvent is true, and prints the actual/expected output if not */
     assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string) {
         const actualEvents = this.events;
-        if (this.matchAnyEvent(expectedEvents)) {
-            return;
-        }
-
-        throw new Error(`${message}
+        if (!this.matchAnyEvent(expectedEvents)) {
+            throw new Error(`${message}
 expected:
 ${JSON.stringify(expectedEvents)}
 
 actual:
 ${JSON.stringify(actualEvents)}`);
+            }
     }
 
     private getMatchedEventsCount(expectedEvents: Omit<ITelemetryBaseEvent, "category">[]): number {


### PR DESCRIPTION
Before I was using the common-utils assert, which gets tagged.  Now just do the if-then-throw myself.