### PR TITLE
Build Break: Fix missed lint

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/noDeltaStream.spec.ts
@@ -121,7 +121,7 @@ describeFullCompat("No Delta stream loading mode testing", (getTestObjectProvide
 
     for(const testConfig of testConfigs) {
         it(`Validate Load Modes: ${JSON.stringify(testConfig ?? "undefined")}`, async function() {
-            const provider  = getTestObjectProvider();
+            const provider = getTestObjectProvider();
             switch(provider.driver.type) {
                 case "local":
                 case "tinylicious":


### PR DESCRIPTION
New lint rule came in between the last build of a previous pr, so a lint failure slipped in. this fixes it.