### PR TITLE
Added test to validate non-root data stores can be requested in detached container

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -136,6 +136,27 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(subDataStore.context.attachState, AttachState.Detached, "DataStore should be detached!!");
     });
 
+    /**
+     * This test times out because of the following bug. To be enabled once the bug is fixed.
+     * https://github.com/microsoft/FluidFramework/issues/9127
+     */
+    it.skip("Requesting non-root data stores in detached container", async () => {
+        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        // Get the root dataStore from the detached container.
+        const rootDataStore = await requestFluidObject<ITestFluidObject>(container, "/");
+
+        // Create another data store and bind it by adding its handle in the root data store's DDS.
+        const dataStore2 = await createFluidObject(rootDataStore.context, "default");
+        rootDataStore.root.set("dataStore2", dataStore2.handle);
+
+        // Request the new data store via the request API on the container.
+        const dataStore2Response = await container.request({ url: dataStore2.handle.absolutePath });
+        assert(
+            dataStore2Response.mimeType === "fluid/object" && dataStore2Response.status === 200,
+            "Unable to load bound data store in detached container",
+        );
+    });
+
     it("DataStores in attached container", async () => {
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
         // Get the root dataStore from the detached container.


### PR DESCRIPTION
Test that validates that non-root data stores can be requested in detached container once their handle is added to a bound DDS.
Basically, validates this bug doesn't exist - https://github.com/microsoft/FluidFramework/issues/9127.
The test is currently skipped and should be enabled once the above bug is fixed.