### PR TITLE
Add Quorum tests

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -202,7 +202,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
         const clientSequenceNumber = this.sendProposal(key, value);
         if (clientSequenceNumber < 0) {
             this.emit("error", { eventName: "ProposalInDisconnectedState", key });
-            return Promise.reject(new Error("Can't proposal in disconnected state"));
+            throw new Error("Can't proposal in disconnected state");
         }
 
         const deferred = new Deferred<void>();

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -42,24 +42,24 @@ describe("Quorum", () => {
             quorum.on(
                 "approveProposal",
                 (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => {
-                    assert.equal(evented, false, "Double event");
+                    assert.strictEqual(evented, false, "Double event");
                     evented = true;
-                    assert.equal(
+                    assert.strictEqual(
                         sequenceNumber,
                         proposalSequenceNumber,
                         "Unexpected proposal sequenceNumber",
                     );
-                    assert.equal(
+                    assert.strictEqual(
                         key,
                         proposalKey,
                         "Unexpected proposal key",
                     );
-                    assert.equal(
+                    assert.strictEqual(
                         value,
                         proposalValue,
                         "Unexpected proposal value",
                     );
-                    assert.equal(
+                    assert.strictEqual(
                         approvalSequenceNumber,
                         justRightMessage.sequenceNumber,
                         "Approved on wrong sequence number",
@@ -72,29 +72,34 @@ describe("Quorum", () => {
             const proposalP = quorum.propose(proposalKey, proposalValue)
                 .then(() => {
                     resolved = true;
-                    assert.equal(acceptanceState, "just right", ".propose() promise resolved at wrong time");
+                    assert.strictEqual(acceptanceState, "just right", ".propose() promise resolved at wrong time");
                 });
 
+            assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 1");
             // Client sequence number will be 1 for this first proposal.
             // The info must match the proposal we sent above.
             quorum.addProposal(proposalKey, proposalValue, proposalSequenceNumber, true, 1);
+            assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 2");
 
             // This message does nothing since the msn is higher than the sequence number of the proposal.
             const immediateNoOp1 = quorum.updateMinimumSequenceNumber(tooEarlyMessage);
-            assert.equal(immediateNoOp1, false, "Should not no-op if no proposal was completed");
-            assert.equal(evented, false, "Should not have evented yet 1");
+            assert.strictEqual(immediateNoOp1, false, "Should not no-op if no proposal was completed");
+            assert.strictEqual(evented, false, "Should not have evented yet 1");
+            assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 3");
 
             // Wait to see if the proposal promise resolved.
             await Promise.resolve().then(() => {});
 
-            assert.equal(evented, false, "Should not have evented yet 2");
+            assert.strictEqual(evented, false, "Should not have evented yet 2");
+            assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 4");
 
             acceptanceState = "just right";
 
             // This message accepts the proposal since the msn is higher than the sequence number of the proposal.
             const immediateNoOp2 = quorum.updateMinimumSequenceNumber(justRightMessage);
-            assert.equal(immediateNoOp2, true, "Should no-op if proposal was completed");
-            assert.equal(evented, true, "Should have evented");
+            assert.strictEqual(immediateNoOp2, true, "Should no-op if proposal was completed");
+            assert.strictEqual(evented, true, "Should have evented");
+            assert.strictEqual(quorum.get(proposalKey), proposalValue, "Should have the proposal value");
 
             // Wait to see if the proposal promise resolved.
             await Promise.resolve().then(() => {});
@@ -126,24 +131,24 @@ describe("Quorum", () => {
             quorum.on(
                 "approveProposal",
                 (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => {
-                    assert.equal(evented, false, "Double event");
+                    assert.strictEqual(evented, false, "Double event");
                     evented = true;
-                    assert.equal(
+                    assert.strictEqual(
                         sequenceNumber,
                         proposalSequenceNumber,
                         "Unexpected proposal sequenceNumber",
                     );
-                    assert.equal(
+                    assert.strictEqual(
                         key,
                         proposalKey,
                         "Unexpected proposal key",
                     );
-                    assert.equal(
+                    assert.strictEqual(
                         value,
                         proposalValue,
                         "Unexpected proposal value",
                     );
-                    assert.equal(
+                    assert.strictEqual(
                         approvalSequenceNumber,
                         justRightMessage.sequenceNumber,
                         "Approved on wrong sequence number",
@@ -154,23 +159,34 @@ describe("Quorum", () => {
             // Client sequence number shouldn't matter for remote proposals.
             quorum.addProposal(proposalKey, proposalValue, proposalSequenceNumber, false, -5);
 
+            assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 1");
+
             // This message does nothing since the msn is higher than the sequence number of the proposal.
             const immediateNoOp1 = quorum.updateMinimumSequenceNumber(tooEarlyMessage);
-            assert.equal(immediateNoOp1, false, "Should not no-op if no proposal was completed");
-            assert.equal(evented, false, "Should not have evented yet 1");
+            assert.strictEqual(immediateNoOp1, false, "Should not no-op if no proposal was completed");
+            assert.strictEqual(evented, false, "Should not have evented yet 1");
+            assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 2");
 
             // Wait to see if any async stuff is waiting (shouldn't be).
             await Promise.resolve().then(() => {});
 
-            assert.equal(evented, false, "Should not have evented yet 2");
+            assert.strictEqual(evented, false, "Should not have evented yet 2");
+            assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 3");
 
             // This message accepts the proposal since the msn is higher than the sequence number of the proposal.
             const immediateNoOp2 = quorum.updateMinimumSequenceNumber(justRightMessage);
-            assert.equal(immediateNoOp2, true, "Should no-op if proposal was completed");
-            assert.equal(evented, true, "Should have evented");
+            assert.strictEqual(immediateNoOp2, true, "Should no-op if proposal was completed");
+            assert.strictEqual(evented, true, "Should have evented");
+            assert.strictEqual(quorum.get(proposalKey), proposalValue, "Should have the proposal value");
 
             // Wait to see if any async stuff is waiting (shouldn't be).
             await Promise.resolve().then(() => {});
+        });
+    });
+
+    describe("Members", () => {
+        it("Add/remove members", () => {
+            assert.strictEqual(quorum.getMembers().size, 0, "Should have no members to start");
         });
     });
 });

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -219,17 +219,23 @@ describe("Quorum", () => {
             quorum.addMember(client1Info.clientId, client1Info.details);
             assert.strictEqual(addCount, 1, "Failed to event for add");
             assert.strictEqual(quorum.getMembers().size, 1, "Should have 1 member after add");
+            assert.strictEqual(quorum.getMember(client1Info.clientId), client1Info.details, "Expecting client 1");
+            assert.strictEqual(quorum.getMember(client2Info.clientId), undefined, "Not expecting client 2");
 
             expectedAdd = client2Info;
             quorum.addMember(client2Info.clientId, client2Info.details);
             assert.strictEqual(addCount, 2, "Failed to event for add");
             assert.strictEqual(quorum.getMembers().size, 2, "Should have 2 members after second add");
+            assert.strictEqual(quorum.getMember(client1Info.clientId), client1Info.details, "Expecting client 1");
+            assert.strictEqual(quorum.getMember(client2Info.clientId), client2Info.details, "Expecting client 2");
 
             expectedAdd = unexpected;
             expectedRemove = client1Info;
             quorum.removeMember(client1Info.clientId);
             assert.strictEqual(removeCount, 1, "Failed to event for remove");
             assert.strictEqual(quorum.getMembers().size, 1, "Should have 1 member after remove");
+            assert.strictEqual(quorum.getMember(client1Info.clientId), undefined, "Not expecting client 1");
+            assert.strictEqual(quorum.getMember(client2Info.clientId), client2Info.details, "Expecting client 2");
         });
     });
 });

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -3,26 +3,110 @@
  * Licensed under the MIT License.
  */
 
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { strict as assert } from "assert";
 import { Quorum } from "../quorum";
 
-describe("Loader", () => {
-    describe("Quorum", () => {
-        let quorum: Quorum;
+describe("Quorum", () => {
+    let quorum: Quorum;
 
-        beforeEach(() => {
-            quorum = new Quorum(
-                [],
-                [],
-                [],
-                (key, value) => 0,
+    beforeEach(() => {
+        let clientSequenceNumber = 0;
+        quorum = new Quorum(
+            [],
+            [],
+            [],
+            (key, value) => ++clientSequenceNumber,
+        );
+    });
+
+    describe("Proposal", () => {
+        it("Local proposal", async () => {
+            let resolved = false;
+            let evented = false;
+            let acceptanceState = "too early";
+
+            const proposalKey = "hello";
+            const proposalValue = "world";
+            const proposalSequenceNumber = 53;
+            const tooEarlyMessage = {
+                minimumSequenceNumber: 37,
+                sequenceNumber: 73,
+            } as ISequencedDocumentMessage;
+            const justRightMessage = {
+                minimumSequenceNumber: 64,
+                sequenceNumber: 79,
+            } as ISequencedDocumentMessage;
+
+            // Observe eventing.  We expect a single event, with the correct values, to fire at the right time.
+            quorum.on(
+                "approveProposal",
+                (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => {
+                    assert.equal(evented, false, "Double event");
+                    evented = true;
+                    assert.equal(
+                        sequenceNumber,
+                        proposalSequenceNumber,
+                        "Unexpected proposal sequenceNumber",
+                    );
+                    assert.equal(
+                        key,
+                        proposalKey,
+                        "Unexpected proposal key",
+                    );
+                    assert.equal(
+                        value,
+                        proposalValue,
+                        "Unexpected proposal value",
+                    );
+                    assert.equal(
+                        approvalSequenceNumber,
+                        justRightMessage.sequenceNumber,
+                        "Approved on wrong sequence number",
+                    );
+                },
             );
-        });
 
-        describe(".propose()", async () => {
-            /* tslint:disable:no-floating-promises */
-            it("Should be able to propose a new value", () => {
-                quorum.propose("hello", "world");
-            });
+            // Proposal generates a promise that will resolve once the proposal is accepted
+            // This happens by advancing the msn past the sequence number of the proposal.
+            const proposalP = quorum.propose(proposalKey, proposalValue)
+                .then(() => {
+                    resolved = true;
+                    assert.equal(acceptanceState, "just right", ".propose() promise resolved at wrong time");
+                });
+
+            // Client sequence number will be 1 for this first proposal.
+            // The info must match the proposal we sent above.
+            quorum.addProposal(proposalKey, proposalValue, proposalSequenceNumber, true, 1);
+
+            // This message does nothing since the msn is higher than the sequence number of the proposal.
+            const immediateNoOp1 = quorum.updateMinimumSequenceNumber(tooEarlyMessage);
+            assert.equal(immediateNoOp1, false, "Should not no-op if no proposal was completed");
+            assert.equal(evented, false, "Should not have evented yet 1");
+
+            // Wait to see if the proposal promise resolved.
+            await Promise.resolve().then(() => {});
+
+            assert.equal(evented, false, "Should not have evented yet 2");
+
+            acceptanceState = "just right";
+            
+            // Create a fake message that would update the msn.
+            // This message accepts the proposal since the msn is higher than the sequence number of the proposal.
+            const immediateNoOp2 = quorum.updateMinimumSequenceNumber(justRightMessage);
+            assert.equal(immediateNoOp2, true, "Should no-op if proposal was completed");
+            assert.equal(evented, true, "Should have evented");
+
+            // Wait to see if the proposal promise resolved.
+            await Promise.resolve().then(() => {});
+
+            // Acceptance should have happened before the above await resolves.
+            acceptanceState = "too late";
+
+            assert(resolved, ".propose() promise should have resolved");
+
+            await assert.doesNotReject(proposalP);
         });
     });
+
 });


### PR DESCRIPTION
Resolves #9059

Adds some basic tests for the most important flows of the Quorum (both proposals and clients).