### PR TITLE
Extend eslint7 with minimal.js

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -10,6 +10,7 @@ module.exports = {
         "node": true
     },
     "extends": [
+        "./eslint7",
         "@rushstack/eslint-config/profile/web-app",
         "plugin:eslint-comments/recommended",
         "plugin:import/errors",


### PR DESCRIPTION
This will get our eslint rules back up and running.  I'm planning to run a prerelease build and prep the integration, but hold the integration PR until 0.57 release completes to avoid overcomplicating anything.