### PR TITLE
Add docker-compose.dev.yml to server/

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -33,7 +33,18 @@ To get started with Routerlicious and the Fluid reference implementation, you mu
   "start:docker": "docker-compose -f server/docker-compose.yml up"
   ```
 
+### Developing the Reference Server
+
 For development, you'll also need to give docker access to your drive (Shared Drives). The instructions for local development are available in [Routerlicious](./routerlicious).
+
+To locally test changes across [GitRest](./gitrest), [Historian](./historian), and [Routerlicious](./routerlicious), run `docker compose -f docker-compose.dev.yml up` from `server/` instead of `server/routerlicious`. Then, when making a change, rebuild the relevant service and restart it. For example,
+
+```shell
+cd server/gitrest
+npm run build
+cd ..
+docker compose restart gitrest
+```
 
 ### Common Issues
 * Port already allocated

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -1,0 +1,172 @@
+version: '3.4'
+services:
+  proxy:
+    image: nginx:latest
+    depends_on:
+      - "alfred"
+      - "historian"
+    volumes:
+      - ./routerlicious/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "3003:3003"
+      - "3001:3001"
+  alfred:
+    build:
+      context: ./routerlicious
+      target: runner
+    expose:
+      - "3000"
+    command: node packages/routerlicious/dist/alfred/www.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules/zookeeper
+      - /usr/src/server/node_modules/node-rdkafka
+      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+    restart: on-failure
+  deli:
+    build:
+      context: ./routerlicious
+      target: runner
+    command: node packages/routerlicious/dist/kafka-service/index.js deli /usr/src/server/packages/routerlicious/dist/deli/index.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules/zookeeper
+      - /usr/src/server/node_modules/node-rdkafka
+      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+    restart: on-failure
+  scriptorium:
+    build:
+      context: ./routerlicious
+      target: runner
+    command: node packages/routerlicious/dist/kafka-service/index.js scriptorium /usr/src/server/packages/routerlicious/dist/scriptorium/index.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules/zookeeper
+      - /usr/src/server/node_modules/node-rdkafka
+      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+    restart: on-failure
+  copier:
+    build:
+      context: ./routerlicious
+      target: runner
+    command: node packages/routerlicious/dist/kafka-service/index.js copier /usr/src/server/packages/routerlicious/dist/copier/index.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules/zookeeper
+      - /usr/src/server/node_modules/node-rdkafka
+      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+    restart: on-failure
+  scribe:
+    build:
+      context: ./routerlicious
+      target: runner
+    command: node packages/routerlicious/dist/kafka-service/index.js scribe /usr/src/server/packages/routerlicious/dist/scribe/index.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules/zookeeper
+      - /usr/src/server/node_modules/node-rdkafka
+      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+    restart: on-failure
+  foreman:
+    build:
+      context: ./routerlicious
+      target: runner
+    command: node packages/routerlicious/dist/kafka-service/index.js foreman /usr/src/server/packages/routerlicious/dist/foreman/index.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules/zookeeper
+      - /usr/src/server/node_modules/node-rdkafka
+      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+    restart: on-failure
+  riddler:
+    build:
+      context: ./routerlicious
+      target: runner
+    depends_on:
+      - "gitrest"
+    ports:
+      - "5000:5000"
+    command: node packages/routerlicious/dist/riddler/www.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules/zookeeper
+      - /usr/src/server/node_modules/node-rdkafka
+      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+    restart: on-failure
+  historian:
+    build:
+      context: ./historian
+      target: runner
+    expose:
+      - "3000"
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - ./historian:/home/node/server
+    restart: on-failure
+  gitrest:
+    build:
+      context: ./gitrest
+      target: runner
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+    volumes:
+      - git:/home/node/documents
+      - ./gitrest:/home/node/server
+      - /home/node/server/node_modules/nodegit
+    restart: on-failure
+  git:
+    image: mcr.microsoft.com/fluidframework/routerlicious/gitssh:latest
+    ports:
+      - "3022:22"
+    volumes:
+      - git:/home/git
+    restart: on-failure
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    ports:
+      - "2181:2181"
+    restart: on-failure
+  kafka:
+    image: wurstmeister/kafka:2.11-1.1.1
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: "kafka"
+      KAFKA_ADVERTISED_PORT: "9092"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+      KAFKA_CREATE_TOPICS: "deltas:8:1,rawdeltas:8:1,testtopic:8:1,deltas2:8:1,rawdeltas2:8:1"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    restart: on-failure
+  redis:
+    image: "redis:alpine"
+  mongodb:
+    image: "mongo:3.4.3"
+  rabbitmq:
+    image: "rabbitmq:alpine"
+volumes:
+  git:
+    driver: local


### PR DESCRIPTION
It's currently a bit of a pain to develop across R11s, Historian, and Gitrest. This docker-compose.dev file makes it as easy as `docker compose -f docker-compose.dev.yml up`, then you can simply make any necessary changes in R11s, Historian, or Gitrest, rebuild that service, then `docker compose restart <service>`