### PR TITLE
Update the current timestamps used by garbage collector

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -339,6 +339,7 @@ export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
 
 // @public
 export interface IGarbageCollectionRuntime {
+    closeFn(error?: ICriticalContainerError): void;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     updateStateBeforeGC(): Promise<void>;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -952,8 +952,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * and is the single source of truth for this container.
      */
     public readonly disableIsolatedChannels: boolean;
-    /** The message in the metadata of the base summary this container is loaded from. */
-    private readonly baseSummaryMessage: ISummaryMetadataMessage | undefined;
+    /** The last message processed at the time of the last summary. */
+    private messageAtLastSummary: ISummaryMetadataMessage | undefined;
 
     private get summarizer(): Summarizer {
         assert(this._summarizer !== undefined, 0x257 /* "This is not summarizing container" */);
@@ -984,7 +984,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         private _storage?: IDocumentStorageService,
     ) {
         super();
-        this.baseSummaryMessage = metadata?.message;
+
+        this.messageAtLastSummary = metadata?.message;
 
         // If this is an existing container, we get values from metadata.
         // otherwise, we initialize them.
@@ -1020,25 +1021,17 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             (this.mc.config.getBoolean(useDataStoreAliasingKey) ?? false) ||
             (runtimeOptions.useDataStoreAliasing ?? false);
 
-        /**
-         * Function that return the current server timestamp. This is used by the garbage collector to set the
-         * time when a node becomes unreferenced.
-         * We use the timestamp of the last op for current timestamp. However, there can be cases where
-         * we don't have an op (on demand summaries for instance). In those cases, we will use the timestamp
-         * of this client's connection.
-         */
-         const getCurrentTimestamp = () => {
-            const client = this.clientId !== undefined ? this.getAudience().getMember(this.clientId) : undefined;
-            const timestamp = client?.timestamp;
-            return this.deltaManager.lastMessage?.timestamp ?? timestamp ?? Date.now();
-        };
         this.garbageCollector = GarbageCollector.create(
             this,
             this.runtimeOptions.gcOptions,
             (unusedRoutes: string[]) => this.dataStores.deleteUnusedRoutes(unusedRoutes),
             (nodePath: string) => this.dataStores.getNodePackagePath(nodePath),
-            getCurrentTimestamp,
-            this.closeFn,
+            /**
+             * Returns the timestamp of the last message seen by this client. This is used by garbage collector as
+             * the current reference timestamp for tracking unreferenced objects.
+             */
+            () => this.deltaManager.lastMessage?.timestamp ?? this.messageAtLastSummary?.timestamp,
+            () => this.messageAtLastSummary?.timestamp,
             context.baseSnapshot,
             async <T>(id: string) => readAndParse<T>(this.storage, id),
             this.mc.logger,
@@ -1090,8 +1083,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             (id: string) => this.summarizerNode.deleteChild(id),
             this.mc.logger,
             async () => this.garbageCollector.getDataStoreBaseGCDetails(),
-            (dataStorePath: string, packagePath?: readonly string[]) =>
-                this.garbageCollector.nodeUpdated(dataStorePath, "Changed", packagePath),
+            (path: string, timestampMs: number, packagePath?: readonly string[]) => this.garbageCollector.nodeUpdated(
+                path,
+                "Changed",
+                timestampMs,
+                packagePath,
+            ),
             new Map<string, string>(dataStoreAliasMap),
             this.garbageCollector.writeDataAtRoot,
         );
@@ -1393,9 +1390,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
 
         const dataStoreChannel = await dataStoreContext.realize();
-        // Let the garbage collector know that a data store was requested / loaded. Realize the data store first so
-        // that the package path is available.
-        this.garbageCollector.nodeUpdated(`/${id}`, "Loaded", dataStoreContext.packagePath, request?.headers);
+        this.garbageCollector.nodeUpdated(
+            `/${id}`,
+            "Loaded",
+            undefined /* timestampMs */,
+            dataStoreContext.packagePath,
+            request?.headers,
+        );
         return dataStoreChannel;
     }
 
@@ -1406,9 +1407,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             summaryFormatVersion: 1,
             disableIsolatedChannels: this.disableIsolatedChannels || undefined,
             gcFeature: this.garbageCollector.gcSummaryFeatureVersion,
-            // The last message processed at the time of summary. If there are no messages, nothing has changed from
-            // the base summary we loaded from. So, use the message from its metadata blob.
-            message: extractSummaryMetadataMessage(this.deltaManager.lastMessage) ?? this.baseSummaryMessage,
+            // The last message processed at the time of summary. If there are no new messages, use the message from the
+            // last summary.
+            message: extractSummaryMetadataMessage(this.deltaManager.lastMessage) ?? this.messageAtLastSummary,
             sessionExpiryTimeoutMs: this.garbageCollector.sessionExpiryTimeoutMs,
         };
     }
@@ -2135,6 +2136,9 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 return { stage: "base", referenceSequenceNumber: summaryRefSeqNum, error };
             }
             const { summary: summaryTree, stats: partialStats } = summarizeResult;
+
+            // Now that we have generated the summary, update the message at last summary to the last message processed.
+            this.messageAtLastSummary = this.deltaManager.lastMessage;
 
             // Counting dataStores and handles
             // Because handles are unchanged dataStores in the current logic,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -91,7 +91,8 @@ export class DataStores implements IDisposable {
         private readonly deleteChildSummarizerNodeFn: (id: string) => void,
         baseLogger: ITelemetryBaseLogger,
         getBaseGCDetails: () => Promise<Map<string, IGarbageCollectionDetailsBase>>,
-        private readonly dataStoreChanged: (dataStorePath: string, packagePath?: readonly string[]) => void,
+        private readonly dataStoreChanged: (
+            dataStorePath: string, timestampMs: number, packagePath?: readonly string[]) => void,
         private readonly aliasMap: Map<string, string>,
         private readonly writeGCDataAtRoot: boolean,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
@@ -387,7 +388,11 @@ export class DataStores implements IDisposable {
         context.process(transformed, local, localMessageMetadata);
 
         // Notify that a data store changed. This is used to detect if a deleted data store is being used.
-        this.dataStoreChanged(`/${envelope.address}`, context.isLoaded ? context.packagePath : undefined);
+        this.dataStoreChanged(
+            `/${envelope.address}`,
+            message.timestamp,
+            context.isLoaded ? context.packagePath : undefined,
+        );
     }
 
     public async getDataStore(id: string, wait: boolean): Promise<FluidDataStoreContext> {

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -93,6 +93,7 @@ interface IUnreferencedEvent {
     id: string;
     age: number;
     timeout: number;
+    lastSummaryTime?: number;
     externalRequest?: boolean;
     viaHandle?: boolean;
 };
@@ -105,6 +106,8 @@ export interface IGarbageCollectionRuntime {
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     /** After GC has run, called to notify the runtime of routes that are used in it. */
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
+    /** Called when the runtime should close because of an error. */
+    closeFn(error?: ICriticalContainerError): void;
 }
 
 /** Defines the contract for the garbage collector. */
@@ -137,6 +140,7 @@ export interface IGarbageCollector {
     nodeUpdated(
         nodePath: string,
         reason: "Loaded" | "Changed",
+        timestampMs?: number,
         packagePath?: readonly string[],
         requestHeaders?: IRequestHeader,
     ): void;
@@ -155,23 +159,43 @@ class UnreferencedStateTracker {
         return this._inactive;
     }
 
-    private readonly timer: Timer | undefined;
+    private timer: Timer | undefined;
 
     constructor(
         public readonly unreferencedTimestampMs: number,
-        inactiveTimeoutMs: number,
+        private readonly inactiveTimeoutMs: number,
+        currentReferenceTimestampMs?: number,
     ) {
-        // If the timeout has already expired, the node should become inactive immediately. Otherwise, start a timer of
-        // inactiveTimeoutMs after which the node will become inactive.
-        if (inactiveTimeoutMs <= 0) {
-            this._inactive = true;
-        } else {
-            this.timer = new Timer(inactiveTimeoutMs, () => { this._inactive = true; });
-            this.timer.start();
+        // If there is no current reference timestamp, don't track the node's inactive state. This will happen later
+        // when updateTracking is called with a reference timestamp.
+        if (currentReferenceTimestampMs !== undefined) {
+            this.updateTracking(currentReferenceTimestampMs);
         }
     }
 
-    /** Stop tracking this node. Reset the unreferenced timer, if any, and reset inactive state. */
+    /**
+     * Updates the tracking state based on the provided timestamp.
+     */
+    public updateTracking(currentReferenceTimestampMs: number) {
+        const unreferencedDurationMs = currentReferenceTimestampMs - this.unreferencedTimestampMs;
+        // If the timeout has already expired, the node has become inactive.
+        if (unreferencedDurationMs > this.inactiveTimeoutMs) {
+            this._inactive = true;
+            this.timer?.clear();
+            return;
+        }
+
+        // The node isn't inactive yet. Restart a timer for the duration remaining for it to become inactive.
+        const remainingDurationMs = this.inactiveTimeoutMs - unreferencedDurationMs; 
+        if (this.timer === undefined) {
+            this.timer = new Timer(remainingDurationMs, () => { this._inactive = true; });
+        }
+        this.timer.restart(remainingDurationMs);
+    }
+
+    /**
+     * Stop tracking this node. Reset the unreferenced timer, if any, and reset inactive state.
+     */
     public stopTracking() {
         this.timer?.clear();
         this._inactive = false;
@@ -188,8 +212,8 @@ export class GarbageCollector implements IGarbageCollector {
         gcOptions: IGCRuntimeOptions,
         deleteUnusedRoutes: (unusedRoutes: string[]) => void,
         getNodePackagePath: (nodeId: string) => readonly string[] | undefined,
-        getCurrentTimestampMs: () => number,
-        closeFn: (error?: ICriticalContainerError) => void,
+        getCurrentReferenceTimestampMs: () => number | undefined,
+        getLastSummaryTimestampMs: () => number | undefined,
         baseSnapshot: ISnapshotTree | undefined,
         readAndParseBlob: ReadAndParseBlob,
         baseLogger: ITelemetryLogger,
@@ -201,8 +225,8 @@ export class GarbageCollector implements IGarbageCollector {
             gcOptions,
             deleteUnusedRoutes,
             getNodePackagePath,
-            getCurrentTimestampMs,
-            closeFn,
+            getCurrentReferenceTimestampMs,
+            getLastSummaryTimestampMs,
             baseSnapshot,
             readAndParseBlob,
             baseLogger,
@@ -307,9 +331,14 @@ export class GarbageCollector implements IGarbageCollector {
         private readonly deleteUnusedRoutes: (unusedRoutes: string[]) => void,
         /** For a given node path, returns the node's package path. */
         private readonly getNodePackagePath: (nodePath: string) => readonly string[] | undefined,
-        /** Returns the current timestamp to be assigned to nodes that become unreferenced. */
-        private readonly getCurrentTimestampMs: () => number,
-        private readonly closeFn: (error?: ICriticalContainerError) => void,
+        /**
+         * Returns a referenced timestamp to be used to track unreferenced nodes. This is a server generated timestamp
+         * and may not be available if there aren't any ops processed yet. If so, we skip tracking unreferenced state
+         * such as time when node becomes unreferenced or inactive.
+         */
+        private readonly getCurrentReferenceTimestampMs: () => number | undefined,
+        /** Returns the timestamp of the last summary generated for this container. */
+        private readonly getLastSummaryTimestampMs: () => number | undefined,
         baseSnapshot: ISnapshotTree | undefined,
         readAndParseBlob: ReadAndParseBlob,
         baseLogger: ITelemetryLogger,
@@ -346,7 +375,7 @@ export class GarbageCollector implements IGarbageCollector {
             const timeoutMs = this.sessionExpiryTimeoutMs;
             setLongTimeout(timeoutMs,
                 () => {
-                    this.closeFn(new ClientSessionExpiredError(`Client session expired.`, timeoutMs));
+                    this.provider.closeFn(new ClientSessionExpiredError(`Client session expired.`, timeoutMs));
                 },
                 (timer) => {
                     this.sessionExpiryTimer = timer;
@@ -448,10 +477,13 @@ export class GarbageCollector implements IGarbageCollector {
             return Object.keys(gcState.gcNodes).length === 1 ? undefined : gcState;
         });
 
-        // Set up the initializer which initializes the base GC state from the base snapshot. Use lazy promise because
-        // we only do this once - the very first time we run GC.
+        /**
+         * Set up the initializer which initializes the base GC state from the base snapshot. Note that the reference
+         * timestamp maybe from old ops which were not summarized and stored in the file. So, the unreferenced state
+         * may be out of date. This is fine because the state is updated every time GC runs based on the time then.
+         */
         this.initializeBaseStateP = new LazyPromise<void>(async () => {
-            const currentTimestampMs = this.getCurrentTimestampMs();
+            const currentReferenceTimestampMs = this.getCurrentReferenceTimestampMs();
             const baseState = await baseSummaryStateP;
             if (baseState === undefined) {
                 return;
@@ -459,16 +491,13 @@ export class GarbageCollector implements IGarbageCollector {
 
             const gcNodes: { [ id: string ]: string[] } = {};
             for (const [nodeId, nodeData] of Object.entries(baseState.gcNodes)) {
-                const unreferencedTimestampMs = nodeData.unreferencedTimestampMs;
-                if (unreferencedTimestampMs !== undefined) {
-                    // Get how long it has been since the node was unreferenced. Start a timeout for the remaining time
-                    // left for it to be eligible for deletion.
-                    const unreferencedDurationMs = currentTimestampMs - unreferencedTimestampMs;
+                if (nodeData.unreferencedTimestampMs !== undefined) {
                     this.unreferencedNodesState.set(
                         nodeId,
                         new UnreferencedStateTracker(
-                            unreferencedTimestampMs,
-                            this.deleteTimeoutMs - unreferencedDurationMs,
+                            nodeData.unreferencedTimestampMs,
+                            this.deleteTimeoutMs,
+                            currentReferenceTimestampMs,
                         ),
                     );
                 }
@@ -571,10 +600,10 @@ export class GarbageCollector implements IGarbageCollector {
             this.updateStateSinceLastRun(gcData);
 
             // Update the current state of the system based on the GC run.
-            const currentTimestampMs = this.getCurrentTimestampMs();
-            this.updateCurrentState(gcData, gcResult, currentTimestampMs);
+            const currentReferenceTimestampMs = this.getCurrentReferenceTimestampMs();
+            this.updateCurrentState(gcData, gcResult, currentReferenceTimestampMs);
 
-            this.provider.updateUsedRoutes(gcResult.referencedNodeIds, currentTimestampMs);
+            this.provider.updateUsedRoutes(gcResult.referencedNodeIds, currentReferenceTimestampMs);
 
             if (runSweep) {
                 // Placeholder for running sweep logic.
@@ -653,12 +682,14 @@ export class GarbageCollector implements IGarbageCollector {
      * Called when a node with the given id is updated. If the node is inactive, log an error.
      * @param nodePath - The id of the node that changed.
      * @param reason - Whether the node was loaded or changed.
+     * @param timestampMs - The timestamp when the node changed.
      * @param packagePath - The package path of the node. This may not be available if the node hasn't been loaded yet.
      * @param requestHeaders - If the node was loaded via request path, the headers in the request.
      */
     public nodeUpdated(
         nodePath: string,
         reason: "Loaded" | "Changed",
+        timestampMs?: number,
         packagePath?: readonly string[],
         requestHeaders?: IRequestHeader,
     ) {
@@ -669,7 +700,7 @@ export class GarbageCollector implements IGarbageCollector {
         this.logIfInactive(
             reason,
             nodePath,
-            this.getCurrentTimestampMs(),
+            timestampMs,
             packagePath,
             requestHeaders,
         );
@@ -695,7 +726,6 @@ export class GarbageCollector implements IGarbageCollector {
         this.logIfInactive(
             "Revived",
             toNodePath,
-            this.getCurrentTimestampMs(),
         );
     }
 
@@ -724,27 +754,15 @@ export class GarbageCollector implements IGarbageCollector {
      * 3. Clears tracking for nodes that were unreferenced but became referenced in this run.
      * @param gcData - The data representing the reference graph on which GC is run.
      * @param gcResult - The result of the GC run on the gcData.
-     * @param currentTimestampMs - The current timestamp to be used for unreferenced nodes' timestamp.
+     * @param currentReferenceTimestampMs - The timestamp to be used for unreferenced nodes' timestamp.
      */
-    private updateCurrentState(gcData: IGarbageCollectionData, gcResult: IGCResult, currentTimestampMs: number) {
+    private updateCurrentState(
+        gcData: IGarbageCollectionData,
+        gcResult: IGCResult,
+        currentReferenceTimestampMs?: number,
+    ) {
         this.gcDataFromLastRun = cloneGCData(gcData);
         this.referencesSinceLastRun.clear();
-
-        // Iterate through the deleted nodes and start tracking if they became unreferenced in this run.
-        for (const nodeId of gcResult.deletedNodeIds) {
-            // The time when the node became unreferenced. This is added to the current GC state.
-            let unreferencedTimestampMs: number = currentTimestampMs;
-            const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
-            if (nodeStateTracker !== undefined) {
-                unreferencedTimestampMs = nodeStateTracker.unreferencedTimestampMs;
-            } else {
-                // Start tracking this node as it became unreferenced in this run.
-                this.unreferencedNodesState.set(
-                    nodeId,
-                    new UnreferencedStateTracker(unreferencedTimestampMs, this.deleteTimeoutMs),
-                );
-            }
-        }
 
         // Iterate through the referenced nodes and stop tracking if they were unreferenced before.
         for (const nodeId of gcResult.referencedNodeIds) {
@@ -754,6 +772,36 @@ export class GarbageCollector implements IGarbageCollector {
                 nodeStateTracker.stopTracking();
                 // Delete the node as we don't need to track it any more.
                 this.unreferencedNodesState.delete(nodeId);
+            }
+        }
+
+        /**
+         * If there is no current reference time, skip tracking when a node becomes unreferenced. This would happen
+         * if no ops have been processed ever and we still try to run GC. If so, there is nothing interesting to track
+         * anyway.
+         */
+        if (currentReferenceTimestampMs === undefined) {
+            return;
+        }
+
+        /**
+         * If a node became unreferenced in this run, start tracking it.
+         * If a node was already unreferenced, update its tracking information. Since the current reference time is
+         * from the ops seen, this will ensure that we keep updating the unreferenced state as time moves forward.
+         */
+        for (const nodeId of gcResult.deletedNodeIds) {
+            const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
+            if (nodeStateTracker === undefined) {
+                this.unreferencedNodesState.set(
+                    nodeId,
+                    new UnreferencedStateTracker(
+                        currentReferenceTimestampMs,
+                        this.deleteTimeoutMs,
+                        currentReferenceTimestampMs,
+                    ),
+                );
+            } else {
+                nodeStateTracker.updateTracking(currentReferenceTimestampMs);
             }
         }
     }
@@ -943,10 +991,16 @@ export class GarbageCollector implements IGarbageCollector {
     private logIfInactive(
         eventSuffix: "Changed" | "Loaded" | "Revived",
         nodeId: string,
-        timestampMs: number,
+        currentReferenceTimestampMs = this.getCurrentReferenceTimestampMs(),
         packagePath?: readonly string[],
         requestHeaders?: IRequestHeader,
     ) {
+        // If there is no reference timestamp to work with, no ops have been processed after creation. If so, skip
+        // logging as nothing interesting would have happened worth logging.
+        if (currentReferenceTimestampMs === undefined) {
+            return;
+        }
+
         const eventName = `inactiveObject_${eventSuffix}`;
         // We log a particular event for a given node only once so that it is not too noisy.
         const uniqueEventId = `${nodeId}-${eventName}`;
@@ -956,8 +1010,9 @@ export class GarbageCollector implements IGarbageCollector {
             const event: IUnreferencedEvent = {
                 eventName,
                 id: nodeId,
-                age: timestampMs - nodeState.unreferencedTimestampMs,
+                age: currentReferenceTimestampMs - nodeState.unreferencedTimestampMs,
                 timeout: this.deleteTimeoutMs,
+                lastSummaryTime: this.getLastSummaryTimestampMs(),
                 externalRequest: requestHeaders?.[RuntimeHeaders.externalRequest],
                 viaHandle: requestHeaders?.[RuntimeHeaders.viaHandle],
             };

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -54,7 +54,7 @@ describe("Garbage Collection Tests", () => {
         updateStateBeforeGC: async () => {},
         getGCData,
         updateUsedRoutes,
-        closeFn: () => {},
+        closeFn: () => { closeCalled = true; },
     };
 
     // The GC details in the summary blob of a node. This is used by the garbage collector to initialize GC state.

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -54,6 +54,7 @@ describe("Garbage Collection Tests", () => {
         updateStateBeforeGC: async () => {},
         getGCData,
         updateUsedRoutes,
+        closeFn: () => {},
     };
 
     // The GC details in the summary blob of a node. This is used by the garbage collector to initialize GC state.
@@ -72,7 +73,7 @@ describe("Garbage Collection Tests", () => {
             (unusedRoutes: string[]) => {},
             (nodeId: string) => testPkgPath,
             () => Date.now(),
-            () => { closeCalled = true; },
+            () => Date.now(),
             baseSnapshot,
             async <T>(id: string) => getNodeGCDetails(id) as T,
             mockLogger,
@@ -139,8 +140,8 @@ describe("Garbage Collection Tests", () => {
         // Simulates node loaded and changed activity for all the nodes in the graph.
         function updateAllNodes(garbageCollector: IGarbageCollector) {
             nodes.forEach((nodeId) => {
-                garbageCollector.nodeUpdated(nodeId, "Changed", testPkgPath);
-                garbageCollector.nodeUpdated(nodeId, "Loaded", testPkgPath);
+                garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
             });
         }
 
@@ -293,8 +294,8 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
 
             // Update node 3. This should result in an inactiveObjectChanged/Loaded event since it should be inactive.
-            garbageCollector.nodeUpdated(nodes[3], "Changed", testPkgPath);
-            garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
@@ -346,8 +347,8 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
 
             // Change node 3. This should result in an inactiveObjectChanged/Loaded event since it should be inactive.
-            garbageCollector.nodeUpdated(nodes[3], "Changed", testPkgPath);
-            garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[3], pkg: eventPkg },
@@ -414,9 +415,9 @@ describe("Garbage Collection Tests", () => {
             await garbageCollector.collectGarbage({ runGC: true });
 
             // Update the nodes and validate that inactive events is correctly generated for each.
-            garbageCollector.nodeUpdated(nodes[1], "Changed", testPkgPath);
-            garbageCollector.nodeUpdated(nodes[2], "Changed", testPkgPath);
-            garbageCollector.nodeUpdated(nodes[3], "Loaded", testPkgPath);
+            garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
+            garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+            garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
             assert(
                 mockLogger.matchEvents([
                     { eventName: changedEvent, timeout: deleteTimeoutMs, id: nodes[1], pkg: eventPkg },


### PR DESCRIPTION
Fixes #9108 and #9134. This change updates how we use the timestamp to track unreferenced objects.
- For the current timestamp, the timestamp of the last processed op is used. If there aren't any ops, the timestamp of the last summary is used. If that is also unavailable, we don't start tracking when a node becomes unreferenced. We should not use any timestamp other than in ops because of this scenario:
  - An unreferenced node may have been referenced but the op that did that was not summarized and was part of the file. This file is opened after a while (say 30+ days).
  - When we first run GC, the op may not have been processed if there are a lot of pending ops. If we use any current timestamp, we will consider the node as inactive / deleted and may end up deleting it.
  - Using op timestamp will ensure that this doesn't happen.
  - Now, in the same scenario, there can be unreferenced nodes which were not referenced and should be deleted now. The first GC may not do this but subsequent GC runs in the presence of new ops will update the state and delete these nodes.
- When an op is received for an inactive object, the timestamp of the op is now used to determine how long the object has been unreferenced.
- Added time of the last summary to the inactive telemetry. This can help filter out scenarios where an unreferenced object is revived but the op that did that is not summarized and is part of the file. When this file is opened much later and this op is processed (along with newer ops), we may fire the inactiveObjectRevived event. In this case, we can ignore cases where the last summary is very old.