### PR TITLE
Add accept header in trees latest call

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -361,7 +361,7 @@ async function fetchSnapshotContentsCoreV1(
     const snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
     const url = `${snapshotUrl}/trees/latest?ump=1`;
     const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, storageToken, snapshotOptions);
-    headers["accept"] = "application/json";
+    headers.accept = "application/json";
     const fetchOptions = {
         body,
         headers,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -361,6 +361,7 @@ async function fetchSnapshotContentsCoreV1(
     const snapshotUrl = odspResolvedUrl.endpoints.snapshotStorageUrl;
     const url = `${snapshotUrl}/trees/latest?ump=1`;
     const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, storageToken, snapshotOptions);
+    headers["accept"] = "application/json";
     const fetchOptions = {
         body,
         headers,


### PR DESCRIPTION
This is just a pre change to start sending accept header in trees latest call. Next we will be sending wire format value as value of accept header telling that we can accept the wire format.