### PR TITLE
Remove getApprovalData from IQuorum

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -281,8 +281,6 @@ export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>
     // (undocumented)
     get(key: string): any;
     // (undocumented)
-    getApprovalData(key: string): ICommittedProposal | undefined;
-    // (undocumented)
     has(key: string): boolean;
     // (undocumented)
     propose(key: string, value: any): Promise<void>;

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -68,6 +68,7 @@
           "forwardCompat": false
         },
         "InterfaceDeclaration_IQuorum": {
+          "backCompat": false,
           "forwardCompat": false
         },
         "InterfaceDeclaration_ITree": {
@@ -110,6 +111,9 @@
           "backCompat": false,
           "forwardCompat": false
         },
+        "InterfaceDeclaration_IQuorum": {
+          "backCompat": false
+        },
         "InterfaceDeclaration_IQuorumProposals": {
           "backCompat": false
         }
@@ -127,6 +131,9 @@
         "RemovedInterfaceDeclaration_IPendingProposal": {
           "backCompat": false,
           "forwardCompat": false
+        },
+        "InterfaceDeclaration_IQuorum": {
+          "backCompat": false
         },
         "InterfaceDeclaration_IQuorumProposals": {
           "backCompat": false

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -77,8 +77,6 @@ export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>
     has(key: string): boolean;
 
     get(key: string): any;
-
-    getApprovalData(key: string): ICommittedProposal | undefined;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1024.0.ts
@@ -685,6 +685,7 @@ declare function get_current_InterfaceDeclaration_IQuorum():
 declare function use_old_InterfaceDeclaration_IQuorum(
     use: old.IQuorum);
 use_old_InterfaceDeclaration_IQuorum(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IQuorum());
 
 /*

--- a/common/lib/protocol-definitions/src/test/types/validate0.1025.1.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1025.1.ts
@@ -683,6 +683,7 @@ declare function get_current_InterfaceDeclaration_IQuorum():
 declare function use_old_InterfaceDeclaration_IQuorum(
     use: old.IQuorum);
 use_old_InterfaceDeclaration_IQuorum(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IQuorum());
 
 /*

--- a/common/lib/protocol-definitions/src/test/types/validate0.1026.0.ts
+++ b/common/lib/protocol-definitions/src/test/types/validate0.1026.0.ts
@@ -682,6 +682,7 @@ declare function get_current_InterfaceDeclaration_IQuorum():
 declare function use_old_InterfaceDeclaration_IQuorum(
     use: old.IQuorum);
 use_old_InterfaceDeclaration_IQuorum(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IQuorum());
 
 /*


### PR DESCRIPTION
`.getApprovalData()` is unused and generally irrelevant.  The sequence numbers don't really make any difference, esp. now that committed state is removed.  So it's basically just a cumbersome alias to `.get()`.