### PR TITLE
Disable failing stashedOps tests until fix is made

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -151,8 +151,13 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         [...Array(lots).keys()].map((i) => assert.strictEqual(map2.get(i.toString()), i));
     });
 
-    // Github issue #9163
-    it.skip("doesn't resend a lot of successful ops", async function() {
+    it("doesn't resend a lot of successful ops", async function() {
+        // Github issue #9163
+        if ((provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") ||
+            provider.driver.type === "tinylicious") {
+            this.skip();
+        }
+
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {
             [...Array(lots).keys()].map((i) => map.set(i.toString(), i));
         });
@@ -224,8 +229,13 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(map2.get(testKey), bigString);
     });
 
-    // Github issue #9163
-    it.skip(" re resend successful chunked op", async function() {
+    it("doesn't resend successful chunked op", async function() {
+        // Github issue #9163
+        if ((provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") ||
+            provider.driver.type === "tinylicious") {
+            this.skip();
+        }
+
         const bigString = "a".repeat(container1.deltaManager.maxMessageSize);
 
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -151,7 +151,8 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         [...Array(lots).keys()].map((i) => assert.strictEqual(map2.get(i.toString()), i));
     });
 
-    it("doesn't resend a lot of successful ops", async function() {
+    // Github issue #9163
+    it.skip("doesn't resend a lot of successful ops", async function() {
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {
             [...Array(lots).keys()].map((i) => map.set(i.toString(), i));
         });
@@ -223,7 +224,8 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
         assert.strictEqual(map2.get(testKey), bigString);
     });
 
-    it("doesn't resend successful chunked op", async function() {
+    // Github issue #9163
+    it.skip(" re resend successful chunked op", async function() {
         const bigString = "a".repeat(container1.deltaManager.maxMessageSize);
 
         const pendingOps = await getPendingOps(provider, true, (c, d, map) => {


### PR DESCRIPTION
These tests are consistently timing out in the end-to-end-tests CI pipeline under t9s and r11s-frs.  #9163 tracks investigating/fixing the issue and re-enabling these tests.