### PR TITLE
[->0.56] Port Rename telemetry prop (#9045)

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -159,7 +159,7 @@ export async function createNewEmptyFluidFile(
                 }
                 event.end({
                     headers: Object.keys(headers).length !== 0 ? true : undefined,
-                    ...fetchResponse.commonSpoHeaders,
+                    ...fetchResponse.propsToLog,
                 });
                 return content.id;
             },
@@ -220,7 +220,7 @@ export async function createNewFluidFileFromSummary(
                 event.end({
                     headers: Object.keys(headers).length !== 0 ? true : undefined,
                     attempts: options.refresh ? 2 : 1,
-                    ...fetchResponse.commonSpoHeaders,
+                    ...fetchResponse.propsToLog,
                 });
                 return content;
             },

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -182,10 +182,7 @@ export class EpochTracker implements IPersistedFileCache {
         ).then((response) => {
             epochFromResponse = response.headers.get("x-fluid-epoch");
             this.validateEpochFromResponse(epochFromResponse, fetchType);
-            response.commonSpoHeaders = {
-                ...response.commonSpoHeaders,
-                "X-RequestStats": clientCorrelationId,
-            };
+            response.propsToLog.XRequestStatsHeader = clientCorrelationId;
             return response;
         }).catch(async (error) => {
             // Get the server epoch from error in case we don't have it as if undefined we won't be able
@@ -224,10 +221,7 @@ export class EpochTracker implements IPersistedFileCache {
         ).then((response) => {
             epochFromResponse = response.headers.get("x-fluid-epoch");
             this.validateEpochFromResponse(epochFromResponse, fetchType);
-            response.commonSpoHeaders = {
-                ...response.commonSpoHeaders,
-                "X-RequestStats": clientCorrelationId,
-            };
+            response.propsToLog.XRequestStatsHeader = clientCorrelationId;
             return response;
         }).catch(async (error) => {
             // Get the server epoch from error in case we don't have it as if undefined we won't be able

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -317,7 +317,7 @@ async function fetchLatestSnapshotCore(
                     // Azure Fluid Relay service is the redeem status (S means success), and FRP is a flag to indicate
                     // if the permission has changed.
                     sltelemetry: response.odspSnapshotResponse.headers.get("x-fluid-sltelemetry"),
-                    ...response.odspSnapshotResponse.commonSpoHeaders,
+                    ...response.odspSnapshotResponse.propsToLog,
                 });
                 return snapshot;
             },

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -117,7 +117,7 @@ async function getFileLinkCore(
                     },
                 };
                 const response = await fetchHelper(url, requestInit);
-                additionalProps = response.commonSpoHeaders;
+                additionalProps = response.propsToLog;
 
                 const sharingInfo = await response.content.json();
                 const directUrl = sharingInfo?.d?.directUrl;
@@ -174,7 +174,7 @@ async function getFileItemLite(
                 );
                 const requestInit = { method: "GET", headers };
                 const response = await fetchHelper(url, requestInit);
-                additionalProps = response.commonSpoHeaders;
+                additionalProps = response.propsToLog;
 
                 const responseJson = await response.content.json();
                 if (!isFileItemLite(responseJson)) {

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -94,7 +94,7 @@ export class OdspDeltaStorageService {
                 headers: Object.keys(headers).length !== 0 ? true : undefined,
                 length: messages.length,
                 duration: response.duration, // this duration for single attempt!
-                ...response.commonSpoHeaders,
+                ...response.propsToLog,
                 attempts: options.refresh ? 2 : 1,
                 from,
                 to,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -270,7 +270,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                     ));
                     event.end({
                         blobId: res.content.id,
-                        ...res.commonSpoHeaders,
+                        ...res.propsToLog,
                     });
                     return res;
                 },
@@ -309,7 +309,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                         const res = await this.epochTracker.fetchArray(url, { headers }, "blob");
                         event.end({
                             waitQueueLength: this.epochTracker.rateLimiter.waitQueueLength,
-                            ...res.commonSpoHeaders,
+                            ...res.propsToLog,
                             attempts: options.refresh ? 2 : 1,
                         });
                         const cacheControl = res.headers.get("cache-control");
@@ -318,7 +318,7 @@ export class OdspDocumentStorageService implements IDocumentStorageService {
                                 eventName: "NonCacheableBlob",
                                 cacheControl,
                                 blobId,
-                                ...res.commonSpoHeaders,
+                                ...res.propsToLog,
                             });
                         }
                         return res.content;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -52,7 +52,7 @@ export interface ISnapshotContents {
 export interface IOdspResponse<T> {
     content: T;
     headers: Map<string, string>;
-    commonSpoHeaders: ITelemetryProperties;
+    propsToLog: ITelemetryProperties;
     duration: number,
 }
 
@@ -122,7 +122,7 @@ export async function fetchHelper(
         return {
             content: response,
             headers,
-            commonSpoHeaders: getSPOAndGraphRequestIdsFromResponse(headers),
+            propsToLog: getSPOAndGraphRequestIdsFromResponse(headers),
             duration: performance.now() - start,
         };
     }, (error) => {
@@ -165,14 +165,14 @@ export async function fetchArray(
     requestInfo: RequestInfo,
     requestInit: RequestInit | undefined,
 ): Promise<IOdspResponse<ArrayBuffer>> {
-    const { content, headers, commonSpoHeaders, duration } = await fetchHelper(requestInfo, requestInit);
+    const { content, headers, propsToLog, duration } = await fetchHelper(requestInfo, requestInit);
 
     const arrayBuffer = await content.arrayBuffer();
-    commonSpoHeaders.bodySize = arrayBuffer.byteLength;
+    propsToLog.bodySize = arrayBuffer.byteLength;
     return {
         headers,
         content: arrayBuffer,
-        commonSpoHeaders,
+        propsToLog,
         duration,
     };
 }
@@ -186,7 +186,7 @@ export async function fetchAndParseAsJSONHelper<T>(
     requestInfo: RequestInfo,
     requestInit: RequestInit | undefined,
 ): Promise<IOdspResponse<T>> {
-    const { content, headers, commonSpoHeaders, duration } = await fetchHelper(requestInfo, requestInit);
+    const { content, headers, propsToLog, duration } = await fetchHelper(requestInfo, requestInit);
     let text: string | undefined;
     try {
         text = await content.text();
@@ -204,11 +204,11 @@ export async function fetchAndParseAsJSONHelper<T>(
         );
     }
 
-    commonSpoHeaders.bodySize = text.length;
+    propsToLog.bodySize = text.length;
     const res = {
         headers,
         content: JSON.parse(text),
-        commonSpoHeaders,
+        propsToLog,
         duration,
     };
     return res;

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -173,7 +173,7 @@ describe("Tests for Epoch Tracker", () => {
                 async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "test"),
                 {},
                 { "x-fluid-epoch": "epoch1" });
-        assert(response.commonSpoHeaders["X-RequestStats"] !== undefined, "CorrelationId should be present");
+        assert(response.propsToLog.XRequestStatsHeader !== undefined, "CorrelationId should be present");
     });
 
     it("Epoch error should not occur if response does not contain epoch", async () => {

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -94,7 +94,7 @@ export async function fetchJoinSession(
 
             // TODO SPO-specific telemetry
             event.end({
-                ...response.commonSpoHeaders,
+                ...response.propsToLog,
                 // pushV2 websocket urls will contain pushf
                 pushv2: socketUrl.includes("pushf"),
                 webSocketHostName,


### PR DESCRIPTION
The office telemetry logging code doesn't like dashes in telemetry prop names. I thought I fixed this in #8449 but the fix was incomplete. That PR addressed the error case, but I didn't realize that for successful requests we were stashing the same telemetry prop on the internal response object and later logging it as well.

So I fixed that, and renamed the property bag to be more clear that it's for logging and not for business logic.