### PR TITLE
Fix for regression where `createProps` property was removed from LocalFluidDataStoreContextBase

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -847,6 +847,10 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
     private readonly snapshotTree: ISnapshotTree | undefined;
     protected isRootDataStore: boolean | undefined;
+    /**
+     * @deprecated 0.16 Issue #1635, #3631
+     */
+    public readonly createProps?: any;
 
     constructor(props: ILocalFluidDataStoreContextProps) {
         super(
@@ -859,6 +863,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 
         this.snapshotTree = props.snapshotTree;
         this.isRootDataStore = props.isRootDataStore;
+        this.createProps = props.createProps;
         this.attachListeners();
     }
 


### PR DESCRIPTION
The `createProps` property was accidentally removed during the refactor by this issue -https://github.com/microsoft/FluidFramework/pull/8910/files. Added it back since its still used.