### PR TITLE
Scope ConnectionStateHandler's ProtocolOpHandler/Quorum access to IQuorumClients

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -5,14 +5,13 @@
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { IConnectionDetails } from "@fluidframework/container-definitions";
-import { ProtocolOpHandler } from "@fluidframework/protocol-base";
-import { ConnectionMode, ISequencedClient } from "@fluidframework/protocol-definitions";
+import { ConnectionMode, IQuorumClients, ISequencedClient } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { assert, Timer } from "@fluidframework/common-utils";
 import { ConnectionState } from "./container";
 
 export interface IConnectionStateHandler {
-    protocolHandler: () => ProtocolOpHandler | undefined,
+    quorumClients: () => IQuorumClients | undefined,
     logConnectionStateChangeTelemetry:
         (value: ConnectionState, oldState: ConnectionState, reason?: string | undefined) => void,
     shouldClientJoinWrite: () => boolean,
@@ -129,14 +128,14 @@ export class ConnectionStateHandler {
     }
 
     private applyForConnectedState(source: "removeMemberEvent" | "addMemberEvent" | "timeout" | "containerSaved") {
-        const protocolHandler = this.handler.protocolHandler();
-        assert(protocolHandler !== undefined, 0x236 /* "In all cases it should be already installed" */);
+        const quorumClients = this.handler.quorumClients();
+        assert(quorumClients !== undefined, 0x236 /* "In all cases it should be already installed" */);
         // Move to connected state only if we are in Connecting state, we have seen our join op
         // and there is no timer running which means we are not waiting for previous client to leave
         // or timeout has occured while doing so.
         if (this.pendingClientId !== this.clientId
             && this.pendingClientId !== undefined
-            && protocolHandler.quorum.getMember(this.pendingClientId) !== undefined
+            && quorumClients.getMember(this.pendingClientId) !== undefined
             && !this.prevClientLeftTimer.hasTimer
         ) {
             this.waitEvent?.end({ source });
@@ -150,8 +149,8 @@ export class ConnectionStateHandler {
                 pendingClientId: this.pendingClientId,
                 clientId: this.clientId,
                 hasTimer: this.prevClientLeftTimer.hasTimer,
-                inQuorum: protocolHandler !== undefined && this.pendingClientId !== undefined
-                    && protocolHandler.quorum.getMember(this.pendingClientId) !== undefined,
+                inQuorum: quorumClients !== undefined && this.pendingClientId !== undefined
+                    && quorumClients.getMember(this.pendingClientId) !== undefined,
             });
         }
     }
@@ -189,13 +188,13 @@ export class ConnectionStateHandler {
         // Report telemetry after we set client id, but before transitioning to Connected state below!
         this.handler.logConnectionStateChangeTelemetry(ConnectionState.Connecting, oldState);
 
-        const protocolHandler = this.handler.protocolHandler();
+        const quorumClients = this.handler.quorumClients();
         // Check if we already processed our own join op through delta storage!
         // we are fetching ops from storage in parallel to connecting to ordering service
         // Given async processes, it's possible that we have already processed our own join message before
         // connection was fully established.
         // Note that we might be still initializing quorum - connection is established proactively on load!
-        if ((protocolHandler !== undefined && protocolHandler.quorum.getMember(details.clientId) !== undefined)
+        if ((quorumClients !== undefined && quorumClients.getMember(details.clientId) !== undefined)
             || connectionMode === "read"
         ) {
             assert(!this.prevClientLeftTimer.hasTimer, 0x2a6 /* "there should be no timer for 'read' connections" */);
@@ -216,10 +215,10 @@ export class ConnectionStateHandler {
 
         const oldState = this._connectionState;
         this._connectionState = value;
-        const quorum = this.handler.protocolHandler()?.quorum;
+        const quorumClients = this.handler.quorumClients();
         let client: ILocalSequencedClient | undefined;
         if (this._clientId !== undefined) {
-            client = quorum?.getMember(this._clientId);
+            client = quorumClients?.getMember(this._clientId);
         }
         if (value === ConnectionState.Connected) {
             assert(oldState === ConnectionState.Connecting,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -588,7 +588,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         this.connectionStateHandler = new ConnectionStateHandler(
             {
-                protocolHandler: () => this._protocolHandler,
+                quorumClients: () => this._protocolHandler?.quorum,
                 logConnectionStateChangeTelemetry: (value, oldState, reason) =>
                     this.logConnectionStateChangeTelemetry(value, oldState, reason),
                 shouldClientJoinWrite: () => this._deltaManager.connectionManager.shouldJoinWrite(),

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -73,7 +73,7 @@ describe("ConnectionStateHandler Tests", () => {
             {
                 logConnectionStateChangeTelemetry: () => undefined,
                 maxClientLeaveWaitTime: expectedTimeout,
-                protocolHandler: () => protocolHandler,
+                quorumClients: () => protocolHandler.quorum,
                 shouldClientJoinWrite: () => shouldClientJoinWrite,
                 logConnectionIssue: (eventName: string) => { throw new Error("logConnectionIssue"); },
                 connectionStateChanged: () => {},


### PR DESCRIPTION
`ConnectionStateHandler` currently gets access to a `ProtocolOpHandler`, which means it in turn has access to a full `Quorum` (not even an `IQuorum`).  This change instead gives it an `IQuorumClients` which is all it needs.