### PR TITLE
Cleanup describeCompat and enable skip, only, and noCompat

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -2,9 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
-import { getUnexpectedLogErrorException, ITestObjectProvider, TestObjectProvider } from "@fluidframework/test-utils";
-import { getVersionedTestObjectProvider } from "./compatUtils";
 import { ensurePackageInstalled } from "./testApi";
 import { pkgVersion } from "./packageVersion";
 import {
@@ -17,8 +14,7 @@ import {
     baseVersion,
     reinstall,
 } from "./compatOptions";
-import { ITelemetryGenericEvent } from "@fluidframework/common-definitions";
-import { Context } from "mocha";
+import { Lazy } from "@fluidframework/common-utils";
 
 /*
  * Generate configuration combinations for a particular compat version
@@ -130,171 +126,59 @@ const genLTSConfig = (compatVersion: number | string): CompatConfig[] => {
     ];
 };
 
-// set it in the env for parallel workers
-if (compatKind) {
-    process.env.fluid__test__compatKind = JSON.stringify(compatKind);
-}
-if (compatVersions) {
-    process.env.fluid__test__compatVersion = JSON.stringify(compatVersions);
-}
-process.env.fluid__test__driver = driver;
-process.env.fluid__test__r11sEndpointName = r11sEndpointName;
-process.env.fluid__test__tenantIndex = tenantIndex.toString();
-process.env.fluid__test__baseVersion = baseVersion;
 
-let configList: CompatConfig[] = [];
-if (!compatVersions || compatVersions.length === 0) {
-    defaultVersions.forEach((value) => {
-        configList.push(...genConfig(value));
-    });
-    LTSVersions.forEach((value) => {
-        configList.push(...genLTSConfig(value));
-    });
-} else {
-    compatVersions.forEach((value) => {
-        if (value === "LTS") {
-            LTSVersions.forEach((lts) => {
-                configList.push(...genLTSConfig(lts));
-            });
-        } else {
-            const num = parseInt(value, 10);
-            if (num.toString() === value) {
-                configList.push(...genConfig(num));
+export const configList = new Lazy<readonly CompatConfig[]>(()=>{
+
+    // set it in the env for parallel workers
+    if (compatKind) {
+        process.env.fluid__test__compatKind = JSON.stringify(compatKind);
+    }
+    if (compatVersions) {
+        process.env.fluid__test__compatVersion = JSON.stringify(compatVersions);
+    }
+    process.env.fluid__test__driver = driver;
+    process.env.fluid__test__r11sEndpointName = r11sEndpointName;
+    process.env.fluid__test__tenantIndex = tenantIndex.toString();
+    process.env.fluid__test__baseVersion = baseVersion;
+
+    let configList: CompatConfig[] = [];
+    if (!compatVersions || compatVersions.length === 0) {
+        defaultVersions.forEach((value) => {
+            configList.push(...genConfig(value));
+        });
+        LTSVersions.forEach((value) => {
+            configList.push(...genLTSConfig(value));
+        });
+    } else {
+        compatVersions.forEach((value) => {
+            if (value === "LTS") {
+                LTSVersions.forEach((lts) => {
+                    configList.push(...genLTSConfig(lts));
+                });
             } else {
-                configList.push(...genConfig(value));
+                const num = parseInt(value, 10);
+                if (num.toString() === value) {
+                    configList.push(...genConfig(num));
+                } else {
+                    configList.push(...genConfig(value));
+                }
             }
-        }
-    });
-}
-
-if (compatKind !== undefined) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    configList = configList.filter((value) => compatKind!.includes(value.kind));
-}
-
-function createExpectsTest(orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc){
-    return async function (this:Context){
-        const provider: TestObjectProvider | undefined = this.__fluidTestProvider;
-        if(provider === undefined){
-            throw new Error("Expected __fluidTestProvider on this");
-        }
-        try{
-            provider.logger.registerExpectedEvent(... orderedExpectedEvents);
-            await test.bind(this)();
-        }catch(error){
-            // only use TestException if the event is provided.
-            // it must be last, as the events are ordered, so all other events must come first
-            if(orderedExpectedEvents[orderedExpectedEvents.length -1]?.eventName === "TestException"){
-                provider.logger.sendErrorEvent({eventName:"TestException"},error)
-            }else{
-                throw error;
-            }
-        }
-        const err = getUnexpectedLogErrorException(provider.logger);
-        if(err !== undefined){
-            throw err;
-        }
-    };
-}
-
-export type ExpectsTest =
-    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc) => Mocha.Test
-
-/**
- * Similar to mocha's it function, but allow specifying expected events.
- * That must occur during the execution of the test.
- */
-export const itExpects: ExpectsTest & Record<"only" |"skip", ExpectsTest> =
-    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc): Mocha.Test =>
-        it(name, createExpectsTest(orderedExpectedEvents, test));
-
-itExpects.only =
-    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc) =>
-        it.only(name, createExpectsTest(orderedExpectedEvents, test));
-
-itExpects.skip =
-    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc) =>
-        it.skip(name, createExpectsTest(orderedExpectedEvents, test));
-
-
-/*
- * Mocha Utils for test to generate the compat variants.
- */
-function describeCompat(
-    name: string,
-    tests: (provider: () => ITestObjectProvider) => void,
-    compatFilter?: CompatKind[],
-) {
-    let configs = configList;
-    if (compatFilter !== undefined) {
-        configs = configs.filter((value) => compatFilter.includes(value.kind));
+        });
     }
 
-    describe(name, () => {
-        for (const config of configs) {
-            describe(config.name, () => {
-                let provider: TestObjectProvider;
-                let resetAfterEach: boolean;
-                before(async function () {
-                    provider = await getVersionedTestObjectProvider(
-                        baseVersion,
-                        config.loader,
-                        {
-                            type: driver,
-                            version: config.driver,
-                            config: {
-                                r11s: { r11sEndpointName },
-                                odsp: { tenantIndex },
-                            },
-                        },
-                        config.containerRuntime,
-                        config.dataRuntime,
-                    );
-                    Object.defineProperty(this,"__fluidTestProvider",{get: ()=>provider});
-                });
-                tests((reset: boolean = true) => {
-                    if (reset) {
-                        resetAfterEach = true;
-                    }
-                    return provider;
-                });
-                afterEach(function (done:Mocha.Done) {
-                    done(getUnexpectedLogErrorException(provider.logger, "Use itExpects to specify expected errors. "));
-                    if (resetAfterEach) {
-                        provider.reset();
-                    }
-                });
-            });
-        }
-    });
-}
+    if (compatKind !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        configList = configList.filter((value) => compatKind!.includes(value.kind));
+    }
+    return configList;
+});
 
-export function describeNoCompat(
-    name: string,
-    tests: (provider: (resetAfterEach?: boolean) => ITestObjectProvider) => void,
-) {
-    describeCompat(name, tests, [CompatKind.None]);
-}
-
-export function describeLoaderCompat(
-    name: string,
-    tests: (provider: (resetAfterEach?: boolean) => ITestObjectProvider) => void,
-) {
-    describeCompat(name, tests, [CompatKind.None, CompatKind.Loader]);
-}
-
-export function describeFullCompat(
-    name: string,
-    tests: (provider: (resetAfterEach?: boolean) => ITestObjectProvider) => void,
-) {
-    describeCompat(name, tests);
-}
 
 /*
  * Mocha start up to ensure legacy versions are installed
  */
 export async function mochaGlobalSetup() {
-    const versions = new Set(configList.map((value) => value.compatVersion));
+    const versions = new Set(configList.value.map((value) => value.compatVersion));
     if (versions.size === 0) { return; }
 
     // Make sure we wait for all before returning, even if one of them has error.

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -73,7 +73,7 @@ function createCompatDescribe(compatFilter?: CompatKind[]): DescribeCompat{
         (name, tests) => describe(name, createCompatSuite(tests, compatFilter));
     d.skip = (name, tests) => describe.skip(name, createCompatSuite(tests, compatFilter));
     d.only = (name, tests) => describe.only(name, createCompatSuite(tests, compatFilter));
-    d.noCompat = (name, tests) => describe.only(name, createCompatSuite(tests, [CompatKind.None]));
+    d.noCompat = (name, tests) => describe(name, createCompatSuite(tests, [CompatKind.None]));
     return d;
 }
 

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getUnexpectedLogErrorException, ITestObjectProvider, TestObjectProvider } from "@fluidframework/test-utils";
+import { configList } from "./compatConfig";
+import { CompatKind, baseVersion, driver, r11sEndpointName, tenantIndex } from "./compatOptions";
+import { getVersionedTestObjectProvider } from "./compatUtils";
+
+/*
+ * Mocha Utils for test to generate the compat variants.
+ */
+function createCompatSuite(
+    tests: (this: Mocha.Suite, provider: () => ITestObjectProvider) => void,
+    compatFilter?: CompatKind[],
+) {
+    return function (this: Mocha.Suite){
+        let configs = configList.value;
+        if (compatFilter !== undefined) {
+            configs = configs.filter((value) => compatFilter.includes(value.kind));
+        }
+
+        for (const config of configs) {
+            describe(config.name, function () {
+                let provider: TestObjectProvider;
+                let resetAfterEach: boolean;
+                before(async function () {
+                    provider = await getVersionedTestObjectProvider(
+                        baseVersion,
+                        config.loader,
+                        {
+                            type: driver,
+                            version: config.driver,
+                            config: {
+                                r11s: { r11sEndpointName },
+                                odsp: { tenantIndex },
+                            },
+                        },
+                        config.containerRuntime,
+                        config.dataRuntime,
+                    );
+                    Object.defineProperty(this,"__fluidTestProvider",{get: ()=>provider});
+                });
+                tests.bind(this)((reset: boolean = true) => {
+                    if (reset) {
+                        resetAfterEach = true;
+                    }
+                    return provider;
+                });
+                afterEach(function (done:Mocha.Done) {
+                    done(getUnexpectedLogErrorException(provider.logger, "Use itExpects to specify expected errors. "));
+                    if (resetAfterEach) {
+                        provider.reset();
+                    }
+                });
+            });
+        }
+    };
+}
+
+export type DescribeCompatSuite=
+    (name: string,
+    tests: (
+        this: Mocha.Suite,
+        provider: (resetAfterEach?: boolean) => ITestObjectProvider) => void
+    ) => Mocha.Suite | void
+
+export type DescribeCompat = DescribeCompatSuite & Record<"skip" | "only" | "noCompat", DescribeCompatSuite>;
+
+function createCompatDescribe(compatFilter?: CompatKind[]): DescribeCompat{
+    const d: DescribeCompat =
+        (name, tests) => describe(name, createCompatSuite(tests, compatFilter));
+    d.skip = (name, tests) => describe.skip(name, createCompatSuite(tests, compatFilter));
+    d.only = (name, tests) => describe.only(name, createCompatSuite(tests, compatFilter));
+    d.noCompat = (name, tests) => describe.only(name, createCompatSuite(tests, [CompatKind.None]));
+    return d;
+}
+
+export const describeNoCompat: DescribeCompat = createCompatDescribe([CompatKind.None])
+
+export const describeLoaderCompat: DescribeCompat = createCompatDescribe([CompatKind.None, CompatKind.Loader]);
+
+export const describeFullCompat: DescribeCompat = createCompatDescribe();

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export * from "./compatConfig";
 export * from "./compatUtils";
 export * from "./packageVersion";
 export * from "./testApi";

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -7,3 +7,6 @@ export * from "./compatConfig";
 export * from "./compatUtils";
 export * from "./packageVersion";
 export * from "./testApi";
+export * from "./itExpects";
+export * from "./describeCompat";
+

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
+export {mochaGlobalSetup} from "./compatConfig"
 export * from "./compatUtils";
 export * from "./packageVersion";
 export * from "./testApi";

--- a/packages/test/test-version-utils/src/itExpects.ts
+++ b/packages/test/test-version-utils/src/itExpects.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getUnexpectedLogErrorException, TestObjectProvider } from "@fluidframework/test-utils";
+import { ITelemetryGenericEvent } from "@fluidframework/common-definitions";
+import { Context } from "mocha";
+
+
+function createExpectsTest(orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc){
+    return async function (this:Context){
+        const provider: TestObjectProvider | undefined = this.__fluidTestProvider;
+        if(provider === undefined){
+            throw new Error("Expected __fluidTestProvider on this");
+        }
+        try{
+            provider.logger.registerExpectedEvent(... orderedExpectedEvents);
+            await test.bind(this)();
+        }catch(error){
+            // only use TestException if the event is provided.
+            // it must be last, as the events are ordered, so all other events must come first
+            if(orderedExpectedEvents[orderedExpectedEvents.length -1]?.eventName === "TestException"){
+                provider.logger.sendErrorEvent({eventName:"TestException"},error)
+            }else{
+                throw error;
+            }
+        }
+        const err = getUnexpectedLogErrorException(provider.logger);
+        if(err !== undefined){
+            throw err;
+        }
+    };
+}
+
+export type ExpectsTest =
+    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc) => Mocha.Test
+
+/**
+ * Similar to mocha's it function, but allow specifying expected events.
+ * That must occur during the execution of the test.
+ */
+export const itExpects: ExpectsTest & Record<"only" |"skip", ExpectsTest> =
+    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc): Mocha.Test =>
+        it(name, createExpectsTest(orderedExpectedEvents, test));
+
+itExpects.only =
+    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc) =>
+        it.only(name, createExpectsTest(orderedExpectedEvents, test));
+
+itExpects.skip =
+    (name: string, orderedExpectedEvents: ITelemetryGenericEvent[], test: Mocha.AsyncFunc) =>
+        it.skip(name, createExpectsTest(orderedExpectedEvents, test));


### PR DESCRIPTION
Was debugging some end to end test, and wanted to use skip and only in on our compact tests. I also added an option to easily disable compat. in the future we could also extend skip to support drivers or compat versions for more targeted skipping.

To make things easier to read i put itExpects and describeCompat in their own files as well