### PR TITLE
Split Quorum implementation to match interfaces

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2376,9 +2376,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.4.tgz",
-					"integrity": "sha512-qcMN56GPtdmKpvDIrM+/7giJhiGUSNLTl/CpqvoUUROwMCjH0KjWMiCBp+ioUhBuoFxUXEW/YR3BwfmNxp11VQ==",
+					"version": "0.56.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.5.tgz",
+					"integrity": "sha512-/mzRIVx5f8BReLLtRmi0gUY72LAZR6yNynljC+V3gSx0BWThKvQwrELXNeTAUzVH2b+jOlRFBYGDttIx6Q192g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2721,9 +2721,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.4",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.4.tgz",
-					"integrity": "sha512-qcMN56GPtdmKpvDIrM+/7giJhiGUSNLTl/CpqvoUUROwMCjH0KjWMiCBp+ioUhBuoFxUXEW/YR3BwfmNxp11VQ==",
+					"version": "0.56.5",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.5.tgz",
+					"integrity": "sha512-/mzRIVx5f8BReLLtRmi0gUY72LAZR6yNynljC+V3gSx0BWThKvQwrELXNeTAUzVH2b+jOlRFBYGDttIx6Q192g==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -72,14 +72,14 @@ export function getGitType(value: SummaryObject): "blob" | "tree";
 // @public (undocumented)
 export function getQuorumTreeEntries(documentId: string, minimumSequenceNumber: number, sequenceNumber: number, term: number, quorumSnapshot: IQuorumSnapshot): ITreeEntry[];
 
-// @public (undocumented)
+// @public
 export interface IQuorumSnapshot {
     // (undocumented)
-    members: [string, ISequencedClient][];
+    members: QuorumClientsSnapshot;
     // (undocumented)
-    proposals: [number, ISequencedProposal, string[]][];
+    proposals: QuorumProposalsSnapshot["proposals"];
     // (undocumented)
-    values: [string, ICommittedProposal][];
+    values: QuorumProposalsSnapshot["values"];
 }
 
 // @public (undocumented)
@@ -125,7 +125,7 @@ export class ProtocolOpHandler {
 
 // @public
 export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum {
-    constructor(members: IQuorumSnapshot["members"], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
+    constructor(members: QuorumClientsSnapshot, proposals: QuorumProposalsSnapshot["proposals"], values: QuorumProposalsSnapshot["values"], sendProposal: (key: string, value: any) => number);
     addMember(clientId: string, details: ISequencedClient): void;
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
     // (undocumented)
@@ -149,7 +149,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
 
 // @public (undocumented)
 export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> implements IQuorumClients {
-    constructor(members: IQuorumSnapshot["members"]);
+    constructor(members: QuorumClientsSnapshot);
     addMember(clientId: string, details: ISequencedClient): void;
     // (undocumented)
     dispose(): void;
@@ -158,12 +158,15 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
     getMember(clientId: string): ISequencedClient | undefined;
     getMembers(): Map<string, ISequencedClient>;
     removeMember(clientId: string): void;
-    snapshot(): IQuorumSnapshot["members"];
+    snapshot(): QuorumClientsSnapshot;
 }
+
+// @public
+export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
 // @public (undocumented)
 export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
-    constructor(proposals: IQuorumSnapshot["proposals"], values: IQuorumSnapshot["values"], sendProposal: (key: string, value: any) => number);
+    constructor(proposals: QuorumProposalsSnapshot["proposals"], values: QuorumProposalsSnapshot["values"], sendProposal: (key: string, value: any) => number);
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
     // (undocumented)
     dispose(): void;
@@ -175,12 +178,15 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     propose(key: string, value: any): Promise<void>;
     // (undocumented)
     setConnectionState(connected: boolean): void;
-    snapshot(): {
-        proposals: IQuorumSnapshot["proposals"];
-        values: IQuorumSnapshot["values"];
-    };
+    snapshot(): QuorumProposalsSnapshot;
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
 }
+
+// @public
+export type QuorumProposalsSnapshot = {
+    proposals: [number, ISequencedProposal, string[]][];
+    values: [string, ICommittedProposal][];
+};
 
 // @public
 export class TreeTreeEntry {

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -145,7 +145,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
     snapshot(): IQuorumSnapshot;
-    updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
+    updateMinimumSequenceNumber(message: ISequencedDocumentMessage): void;
 }
 
 // @public
@@ -181,7 +181,7 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     // (undocumented)
     setConnectionState(connected: boolean): void;
     snapshot(): QuorumProposalsSnapshot;
-    updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
+    updateMinimumSequenceNumber(message: ISequencedDocumentMessage): void;
 }
 
 // @public

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -149,10 +149,8 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
 
 // @public (undocumented)
 export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> implements IQuorumClients {
-    constructor(members: [string, ISequencedClient][]);
+    constructor(members: IQuorumSnapshot["members"]);
     addMember(clientId: string, details: ISequencedClient): void;
-    // (undocumented)
-    close(): void;
     // (undocumented)
     dispose(): void;
     // (undocumented)
@@ -160,15 +158,13 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
     getMember(clientId: string): ISequencedClient | undefined;
     getMembers(): Map<string, ISequencedClient>;
     removeMember(clientId: string): void;
-    snapshot(): IQuorumSnapshot;
+    snapshot(): IQuorumSnapshot["members"] | undefined;
 }
 
 // @public (undocumented)
 export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
     constructor(proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
-    // (undocumented)
-    close(): void;
     // (undocumented)
     dispose(): void;
     // (undocumented)

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -175,8 +175,10 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     propose(key: string, value: any): Promise<void>;
     // (undocumented)
     setConnectionState(connected: boolean): void;
-    snapshotProposals(): IQuorumSnapshot["proposals"];
-    snapshotValues(): IQuorumSnapshot["values"];
+    snapshot(): {
+        proposals: IQuorumSnapshot["proposals"];
+        values: IQuorumSnapshot["values"];
+    };
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
 }
 

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -163,7 +163,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
 
 // @public (undocumented)
 export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
-    constructor(proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
+    constructor(proposals: IQuorumSnapshot["proposals"], values: IQuorumSnapshot["values"], sendProposal: (key: string, value: any) => number);
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
     // (undocumented)
     dispose(): void;

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -11,7 +11,11 @@ import { ICommittedProposal } from '@fluidframework/protocol-definitions';
 import { ICreateTreeEntry } from '@fluidframework/gitresources';
 import { IProcessMessageResult } from '@fluidframework/protocol-definitions';
 import { IQuorum } from '@fluidframework/protocol-definitions';
+import { IQuorumClients } from '@fluidframework/protocol-definitions';
+import { IQuorumClientsEvents } from '@fluidframework/protocol-definitions';
 import { IQuorumEvents } from '@fluidframework/protocol-definitions';
+import { IQuorumProposals } from '@fluidframework/protocol-definitions';
+import { IQuorumProposalsEvents } from '@fluidframework/protocol-definitions';
 import { ISequencedClient } from '@fluidframework/protocol-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISequencedProposal } from '@fluidframework/protocol-definitions';
@@ -137,6 +141,42 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     has(key: string): boolean;
     propose(key: string, value: any): Promise<void>;
     removeMember(clientId: string): void;
+    // (undocumented)
+    setConnectionState(connected: boolean, clientId?: string): void;
+    snapshot(): IQuorumSnapshot;
+    updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
+}
+
+// @public (undocumented)
+export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> implements IQuorumClients {
+    constructor(members: [string, ISequencedClient][]);
+    addMember(clientId: string, details: ISequencedClient): void;
+    // (undocumented)
+    close(): void;
+    // (undocumented)
+    dispose(): void;
+    // (undocumented)
+    get disposed(): boolean;
+    getMember(clientId: string): ISequencedClient | undefined;
+    getMembers(): Map<string, ISequencedClient>;
+    removeMember(clientId: string): void;
+    snapshot(): IQuorumSnapshot;
+}
+
+// @public (undocumented)
+export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
+    constructor(proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
+    addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
+    // (undocumented)
+    close(): void;
+    // (undocumented)
+    dispose(): void;
+    // (undocumented)
+    get disposed(): boolean;
+    get(key: string): any;
+    getApprovalData(key: string): ICommittedProposal | undefined;
+    has(key: string): boolean;
+    propose(key: string, value: any): Promise<void>;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
     snapshot(): IQuorumSnapshot;

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -174,7 +174,7 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     has(key: string): boolean;
     propose(key: string, value: any): Promise<void>;
     // (undocumented)
-    setConnectionState(connected: boolean, clientId?: string): void;
+    setConnectionState(connected: boolean): void;
     snapshotProposals(): IQuorumSnapshot["proposals"];
     snapshotValues(): IQuorumSnapshot["values"];
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -165,7 +165,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
 // @public
 export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
-// @public (undocumented)
+// @public
 export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
     constructor(snapshot: QuorumProposalsSnapshot, sendProposal: (key: string, value: any) => number);
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -125,7 +125,7 @@ export class ProtocolOpHandler {
 
 // @public
 export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum {
-    constructor(members: [string, ISequencedClient][], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
+    constructor(members: IQuorumSnapshot["members"], proposals: [number, ISequencedProposal, string[]][], values: [string, ICommittedProposal][], sendProposal: (key: string, value: any) => number);
     addMember(clientId: string, details: ISequencedClient): void;
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
     // (undocumented)

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -158,7 +158,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
     getMember(clientId: string): ISequencedClient | undefined;
     getMembers(): Map<string, ISequencedClient>;
     removeMember(clientId: string): void;
-    snapshot(): IQuorumSnapshot["members"] | undefined;
+    snapshot(): IQuorumSnapshot["members"];
 }
 
 // @public (undocumented)
@@ -175,7 +175,8 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     propose(key: string, value: any): Promise<void>;
     // (undocumented)
     setConnectionState(connected: boolean, clientId?: string): void;
-    snapshot(): IQuorumSnapshot;
+    snapshotProposals(): IQuorumSnapshot["proposals"];
+    snapshotValues(): IQuorumSnapshot["values"];
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
 }
 

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -135,6 +135,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     // (undocumented)
     get disposed(): boolean;
     get(key: string): any;
+    // @deprecated
     getApprovalData(key: string): ICommittedProposal | undefined;
     getMember(clientId: string): ISequencedClient | undefined;
     getMembers(): Map<string, ISequencedClient>;
@@ -147,7 +148,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean;
 }
 
-// @public (undocumented)
+// @public
 export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> implements IQuorumClients {
     constructor(snapshot: QuorumClientsSnapshot);
     addMember(clientId: string, details: ISequencedClient): void;
@@ -173,6 +174,7 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     // (undocumented)
     get disposed(): boolean;
     get(key: string): any;
+    // @deprecated
     getApprovalData(key: string): ICommittedProposal | undefined;
     has(key: string): boolean;
     propose(key: string, value: any): Promise<void>;

--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -149,7 +149,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
 
 // @public (undocumented)
 export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> implements IQuorumClients {
-    constructor(members: QuorumClientsSnapshot);
+    constructor(snapshot: QuorumClientsSnapshot);
     addMember(clientId: string, details: ISequencedClient): void;
     // (undocumented)
     dispose(): void;
@@ -166,7 +166,7 @@ export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
 // @public (undocumented)
 export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
-    constructor(proposals: QuorumProposalsSnapshot["proposals"], values: QuorumProposalsSnapshot["values"], sendProposal: (key: string, value: any) => number);
+    constructor(snapshot: QuorumProposalsSnapshot, sendProposal: (key: string, value: any) => number);
     addProposal(key: string, value: any, sequenceNumber: number, local: boolean, clientSequenceNumber: number): void;
     // (undocumented)
     dispose(): void;

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -122,7 +122,7 @@ export class ProtocolOpHandler {
 
         // Notify the quorum of the MSN from the message. We rely on it to handle duplicate values but may
         // want to move that logic to this class.
-        immediateNoOp = this.quorum.updateMinimumSequenceNumber(message) || immediateNoOp;
+        this.quorum.updateMinimumSequenceNumber(message);
 
         return { immediateNoOp };
     }

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -10,7 +10,11 @@ import { assert, Deferred, TypedEventEmitter } from "@fluidframework/common-util
 import {
     ICommittedProposal,
     IQuorum,
+    IQuorumClients,
+    IQuorumClientsEvents,
     IQuorumEvents,
+    IQuorumProposals,
+    IQuorumProposalsEvents,
     ISequencedClient,
     ISequencedDocumentMessage,
     ISequencedProposal,
@@ -33,6 +37,329 @@ export interface IQuorumSnapshot {
     members: [string, ISequencedClient][];
     proposals: [number, ISequencedProposal, string[]][];
     values: [string, ICommittedProposal][];
+}
+
+export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> implements IQuorumClients {
+    private readonly members: Map<string, ISequencedClient>;
+    private isDisposed: boolean = false;
+    public get disposed() { return this.isDisposed; }
+
+    /**
+     * Cached snapshot state
+     * The quorum consists of 3 properties: members, values, and proposals.
+     * Depending on the op being processed, some or none of those properties may change.
+     * Each property will be cached and the cache for each property will be cleared when an op causes a change.
+     */
+    private readonly snapshotCache: Partial<IQuorumSnapshot> = {};
+
+    constructor(
+        members: [string, ISequencedClient][],
+    ) {
+        super();
+
+        this.members = new Map(members);
+    }
+
+    public close() {
+        this.removeAllListeners();
+    }
+
+    /**
+     * Snapshots the entire quorum
+     * @returns a quorum snapshot
+     */
+    public snapshot(): IQuorumSnapshot {
+        this.snapshotCache.members ??= this.snapshotMembers();
+
+        return {
+            ...this.snapshotCache as IQuorumSnapshot,
+        };
+    }
+
+    /**
+     * Snapshots quorum members
+     * @returns a deep cloned array of members
+     */
+    private snapshotMembers(): IQuorumSnapshot["members"] {
+        return cloneDeep(Array.from(this.members));
+    }
+
+    /**
+     * Adds a new client to the quorum
+     */
+    public addMember(clientId: string, details: ISequencedClient) {
+        assert(!this.members.has(clientId), 0x1ce /* `!this.members.has(${clientId})` */);
+        this.members.set(clientId, details);
+        this.emit("addMember", clientId, details);
+
+        // clear the members cache
+        this.snapshotCache.members = undefined;
+    }
+
+    /**
+     * Removes a client from the quorum
+     */
+    public removeMember(clientId: string) {
+        assert(this.members.has(clientId), 0x1cf /* `this.members.has(${clientId})` */);
+        this.members.delete(clientId);
+        this.emit("removeMember", clientId);
+
+        // clear the members cache
+        this.snapshotCache.members = undefined;
+    }
+
+    /**
+     * Retrieves all the members in the quorum
+     */
+    public getMembers(): Map<string, ISequencedClient> {
+        return new Map(this.members);
+    }
+
+    /**
+     * Retrieves a specific member of the quorum
+     */
+    public getMember(clientId: string): ISequencedClient | undefined {
+        return this.members.get(clientId);
+    }
+
+    public dispose(): void {
+        throw new Error("Not implemented.");
+        this.isDisposed = true;
+    }
+}
+
+export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
+    private readonly proposals: Map<number, PendingProposal>;
+    private readonly values: Map<string, ICommittedProposal>;
+    private isDisposed: boolean = false;
+    public get disposed() { return this.isDisposed; }
+
+    // Locally generated proposals
+    private readonly localProposals = new Map<number, Deferred<void>>();
+
+    /**
+     * Cached snapshot state
+     * The quorum consists of 3 properties: members, values, and proposals.
+     * Depending on the op being processed, some or none of those properties may change.
+     * Each property will be cached and the cache for each property will be cleared when an op causes a change.
+     */
+    private readonly snapshotCache: Partial<IQuorumSnapshot> = {};
+
+    constructor(
+        proposals: [number, ISequencedProposal, string[]][],
+        values: [string, ICommittedProposal][],
+        private readonly sendProposal: (key: string, value: any) => number,
+    ) {
+        super();
+
+        this.proposals = new Map(
+            proposals.map(([, proposal]) => {
+                return [
+                    proposal.sequenceNumber,
+                    new PendingProposal(
+                        proposal.sequenceNumber,
+                        proposal.key,
+                        proposal.value,
+                    ),
+                ] as [number, PendingProposal];
+            }));
+        this.values = new Map(values);
+    }
+
+    public close() {
+        this.removeAllListeners();
+    }
+
+    /**
+     * Snapshots the entire quorum
+     * @returns a quorum snapshot
+     */
+    public snapshot(): IQuorumSnapshot {
+        this.snapshotCache.proposals ??= this.snapshotProposals();
+        this.snapshotCache.values ??= this.snapshotValues();
+
+        return {
+            ...this.snapshotCache as IQuorumSnapshot,
+        };
+    }
+
+    /**
+     * Snapshots quorum proposals
+     * @returns a deep cloned array of proposals
+     */
+    private snapshotProposals(): IQuorumSnapshot["proposals"] {
+        return Array.from(this.proposals).map(
+            ([sequenceNumber, proposal]) => [
+                sequenceNumber,
+                { sequenceNumber, key: proposal.key, value: proposal.value },
+                [], // rejections, which has been removed
+            ],
+        );
+    }
+
+    /**
+     * Snapshots quorum values
+     * @returns a deep cloned array of values
+     */
+    private snapshotValues(): IQuorumSnapshot["values"] {
+        return cloneDeep(Array.from(this.values));
+    }
+
+    /**
+     * Returns whether the quorum has achieved a consensus for the given key.
+     */
+    public has(key: string): boolean {
+        return this.values.has(key);
+    }
+
+    /**
+     * Returns the consensus value for the given key
+     */
+    public get(key: string): any {
+        const keyMap = this.values.get(key);
+        if (keyMap !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            return keyMap.value;
+        }
+    }
+
+    /**
+     * Returns additional data about the approved consensus value
+     */
+    public getApprovalData(key: string): ICommittedProposal | undefined {
+        const proposal = this.values.get(key);
+        return proposal ? cloneDeep(proposal) : undefined;
+    }
+
+    /**
+     * Proposes a new value. Returns a promise that will resolve when the proposal is either accepted or rejected.
+     *
+     * TODO: Right now we will only submit proposals for connected clients and not attempt to resubmit on any
+     * nack/disconnect. The correct answer for this should become more clear as we build scenarios on top of the loader.
+     */
+    public async propose(key: string, value: any): Promise<void> {
+        const clientSequenceNumber = this.sendProposal(key, value);
+        if (clientSequenceNumber < 0) {
+            this.emit("error", { eventName: "ProposalInDisconnectedState", key });
+            throw new Error("Can't proposal in disconnected state");
+        }
+
+        const deferred = new Deferred<void>();
+        this.localProposals.set(clientSequenceNumber, deferred);
+        return deferred.promise;
+    }
+
+    /**
+     * Begins tracking a new proposal
+     */
+    public addProposal(
+        key: string,
+        value: any,
+        sequenceNumber: number,
+        local: boolean,
+        clientSequenceNumber: number) {
+        assert(!this.proposals.has(sequenceNumber), 0x1d0 /* `!this.proposals.has(${sequenceNumber})` */);
+        assert(
+            !local || this.localProposals.has(clientSequenceNumber),
+            0x1d1 /* `!${local} || this.localProposals.has(${clientSequenceNumber})` */);
+
+        const proposal = new PendingProposal(
+            sequenceNumber,
+            key,
+            value,
+            local ? this.localProposals.get(clientSequenceNumber) : undefined,
+        );
+        this.proposals.set(sequenceNumber, proposal);
+
+        // Emit the event - which will also provide clients an opportunity to reject the proposal. We require
+        // clients to make a rejection decision at the time of receiving the proposal and so disable rejecting it
+        // after we have emitted the event.
+        this.emit("addProposal", proposal);
+
+        if (local) {
+            this.localProposals.delete(clientSequenceNumber);
+        }
+
+        // clear the proposal cache
+        this.snapshotCache.proposals = undefined;
+    }
+
+    /**
+     * Updates the minimum sequence number. If the MSN advances past the sequence number for any proposal without
+     * a rejection then it becomes an accepted consensus value.  If the MSN advances past the sequence number
+     * that the proposal was accepted, then it becomes a committed consensus value.
+     * Returns true if immediate no-op is required.
+     */
+    public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean {
+        let immediateNoOp = false;
+
+        const msn = message.minimumSequenceNumber;
+
+        // Accept proposals and reject proposals whose sequenceNumber is <= the minimumSequenceNumber
+
+        // Return a sorted list of approved proposals. We sort so that we apply them in their sequence number order
+        // TODO this can be optimized if necessary to avoid the linear search+sort
+        const completed: PendingProposal[] = [];
+        for (const [sequenceNumber, proposal] of this.proposals) {
+            if (sequenceNumber <= msn) {
+                completed.push(proposal);
+            }
+        }
+        completed.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+
+        for (const proposal of completed) {
+            // If it was a local proposal - resolve the promise
+            proposal.deferred?.resolve();
+
+            const committedProposal: ICommittedProposal = {
+                approvalSequenceNumber: message.sequenceNumber,
+                // No longer used.  We still stamp a -1 for compat with older versions of the quorum.
+                // Can be removed after 0.1035 and higher is ubiquitous.
+                commitSequenceNumber: -1,
+                key: proposal.key,
+                sequenceNumber: proposal.sequenceNumber,
+                value: proposal.value,
+            };
+
+            this.values.set(committedProposal.key, committedProposal);
+
+            // clear the values cache
+            this.snapshotCache.values = undefined;
+
+            // Send no-op on approval to expedite commit
+            // accept means that all clients have seen the proposal and nobody has rejected it
+            // commit means that all clients have seen that the proposal was accepted by everyone
+            immediateNoOp = true;
+
+            this.emit(
+                "approveProposal",
+                committedProposal.sequenceNumber,
+                committedProposal.key,
+                committedProposal.value,
+                committedProposal.approvalSequenceNumber);
+
+            this.proposals.delete(proposal.sequenceNumber);
+
+            // clear the proposals cache
+            this.snapshotCache.proposals = undefined;
+        }
+
+        return immediateNoOp;
+    }
+
+    public setConnectionState(connected: boolean, clientId?: string) {
+        if (!connected) {
+            this.localProposals.forEach((deferral) => {
+                deferral.reject(new Error("Client got disconnected"));
+            });
+            this.localProposals.clear();
+        }
+    }
+
+    public dispose(): void {
+        throw new Error("Not implemented.");
+        this.isDisposed = true;
+    }
 }
 
 /**

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -53,9 +53,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
      */
     private snapshotCache: IQuorumSnapshot["members"] | undefined;
 
-    constructor(
-        members: IQuorumSnapshot["members"],
-    ) {
+    constructor(members: IQuorumSnapshot["members"]) {
         super();
 
         this.members = new Map(members);
@@ -63,7 +61,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
     }
 
     /**
-     * Snapshots the clients in the Quorum
+     * Snapshots the current state of the QuorumClients
      * @returns a snapshot of the clients in the quorum
      */
     public snapshot(): IQuorumSnapshot["members"] {
@@ -157,10 +155,10 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     }
 
     /**
-     * Snapshots quorum proposals
-     * @returns a deep cloned array of proposals
+     * Snapshots the current state of the QuorumProposals
+     * @returns deep cloned arrays of proposals and values
      */
-    public snapshotProposals(): IQuorumSnapshot["proposals"] {
+    public snapshot(): { proposals: IQuorumSnapshot["proposals"], values: IQuorumSnapshot["values"] } {
         this.proposalsSnapshotCache ??= Array.from(this.proposals).map(
             ([sequenceNumber, proposal]) => [
                 sequenceNumber,
@@ -168,18 +166,12 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
                 [], // rejections, which has been removed
             ],
         );
-
-        return this.proposalsSnapshotCache;
-    }
-
-    /**
-     * Snapshots quorum values
-     * @returns a deep cloned array of values
-     */
-    public snapshotValues(): IQuorumSnapshot["values"] {
         this.valuesSnapshotCache ??= cloneDeep(Array.from(this.values));
 
-        return this.valuesSnapshotCache;
+        return {
+            proposals: this.proposalsSnapshotCache,
+            values: this.valuesSnapshotCache,
+        };
     }
 
     /**
@@ -389,10 +381,12 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
      * @returns a quorum snapshot
      */
     public snapshot(): IQuorumSnapshot {
+        const members = this.quorumClients.snapshot();
+        const { proposals, values } = this.quorumProposals.snapshot();
         return {
-            members: this.quorumClients.snapshot(),
-            proposals: this.quorumProposals.snapshotProposals(),
-            values: this.quorumProposals.snapshotValues(),
+            members,
+            proposals,
+            values,
         };
     }
 

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -268,11 +268,8 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     /**
      * Updates the minimum sequence number. If the MSN advances past the sequence number for any proposal then it
      * becomes an approved value.
-     * Returns true if immediate no-op is required.
      */
-    public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean {
-        let immediateNoOp = false;
-
+    public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): void {
         const msn = message.minimumSequenceNumber;
 
         // Accept proposals and reject proposals whose sequenceNumber is <= the minimumSequenceNumber
@@ -306,11 +303,6 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
             // clear the values cache
             this.valuesSnapshotCache = undefined;
 
-            // Send no-op on approval to expedite commit
-            // accept means that all clients have seen the proposal and nobody has rejected it
-            // commit means that all clients have seen that the proposal was accepted by everyone
-            immediateNoOp = true;
-
             this.emit(
                 "approveProposal",
                 committedProposal.sequenceNumber,
@@ -323,8 +315,6 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
             // clear the proposals cache
             this.proposalsSnapshotCache = undefined;
         }
-
-        return immediateNoOp;
     }
 
     public setConnectionState(connected: boolean) {
@@ -474,10 +464,9 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
     /**
      * Updates the minimum sequence number. If the MSN advances past the sequence number for any proposal then it
      * becomes an approved value.
-     * Returns true if immediate no-op is required.
      */
-    public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): boolean {
-        return this.quorumProposals.updateMinimumSequenceNumber(message);
+    public updateMinimumSequenceNumber(message: ISequencedDocumentMessage): void {
+        this.quorumProposals.updateMinimumSequenceNumber(message);
     }
 
     public setConnectionState(connected: boolean, clientId?: string) {

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -130,6 +130,10 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
     }
 }
 
+/**
+ * The QuorumProposals holds a key/value store.  Proposed values become finalized in the store once all connected
+ * clients have seen the proposal.
+ */
 export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> implements IQuorumProposals {
     private readonly proposals: Map<number, PendingProposal>;
     private readonly values: Map<string, ICommittedProposal>;

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -67,11 +67,11 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
      */
     private snapshotCache: QuorumClientsSnapshot | undefined;
 
-    constructor(members: QuorumClientsSnapshot) {
+    constructor(snapshot: QuorumClientsSnapshot) {
         super();
 
-        this.members = new Map(members);
-        this.snapshotCache = members;
+        this.members = new Map(snapshot);
+        this.snapshotCache = snapshot;
     }
 
     /**
@@ -146,14 +146,13 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     private valuesSnapshotCache: QuorumProposalsSnapshot["values"] | undefined;
 
     constructor(
-        proposals: QuorumProposalsSnapshot["proposals"],
-        values: QuorumProposalsSnapshot["values"],
+        snapshot: QuorumProposalsSnapshot,
         private readonly sendProposal: (key: string, value: any) => number,
     ) {
         super();
 
         this.proposals = new Map(
-            proposals.map(([, proposal]) => {
+            snapshot.proposals.map(([, proposal]) => {
                 return [
                     proposal.sequenceNumber,
                     new PendingProposal(
@@ -163,9 +162,9 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
                     ),
                 ] as [number, PendingProposal];
             }));
-        this.values = new Map(values);
-        this.proposalsSnapshotCache = proposals;
-        this.valuesSnapshotCache = values;
+        this.values = new Map(snapshot.values);
+        this.proposalsSnapshotCache = snapshot.proposals;
+        this.valuesSnapshotCache = snapshot.values;
     }
 
     /**
@@ -374,7 +373,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
             this.emit("removeMember", clientId);
         });
 
-        this.quorumProposals = new QuorumProposals(proposals, values, sendProposal);
+        this.quorumProposals = new QuorumProposals({ proposals, values }, sendProposal);
         this.quorumProposals.on("addProposal", (proposal: IPendingProposal) => {
             this.emit("addProposal", proposal);
         });

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -132,8 +132,8 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposalsEvents> i
     private readonly snapshotCache: Partial<IQuorumSnapshot> = {};
 
     constructor(
-        proposals: [number, ISequencedProposal, string[]][],
-        values: [string, ICommittedProposal][],
+        proposals: IQuorumSnapshot["proposals"],
+        values: IQuorumSnapshot["values"],
         private readonly sendProposal: (key: string, value: any) => number,
     ) {
         super();

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -82,8 +82,7 @@ describe("Quorum", () => {
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 2");
 
             // This message does nothing since the msn is higher than the sequence number of the proposal.
-            const immediateNoOp1 = quorum.updateMinimumSequenceNumber(tooEarlyMessage);
-            assert.strictEqual(immediateNoOp1, false, "Should not no-op if no proposal was completed");
+            quorum.updateMinimumSequenceNumber(tooEarlyMessage);
             assert.strictEqual(evented, false, "Should not have evented yet 1");
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 3");
 
@@ -96,8 +95,7 @@ describe("Quorum", () => {
             acceptanceState = "just right";
 
             // This message accepts the proposal since the msn is higher than the sequence number of the proposal.
-            const immediateNoOp2 = quorum.updateMinimumSequenceNumber(justRightMessage);
-            assert.strictEqual(immediateNoOp2, true, "Should no-op if proposal was completed");
+            quorum.updateMinimumSequenceNumber(justRightMessage);
             assert.strictEqual(evented, true, "Should have evented");
             assert.strictEqual(quorum.get(proposalKey), proposalValue, "Should have the proposal value");
 
@@ -164,8 +162,7 @@ describe("Quorum", () => {
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 1");
 
             // This message does nothing since the msn is higher than the sequence number of the proposal.
-            const immediateNoOp1 = quorum.updateMinimumSequenceNumber(tooEarlyMessage);
-            assert.strictEqual(immediateNoOp1, false, "Should not no-op if no proposal was completed");
+            quorum.updateMinimumSequenceNumber(tooEarlyMessage);
             assert.strictEqual(evented, false, "Should not have evented yet 1");
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 2");
 
@@ -176,8 +173,7 @@ describe("Quorum", () => {
             assert.strictEqual(quorum.get(proposalKey), undefined, "Should not have the proposal value yet 3");
 
             // This message accepts the proposal since the msn is higher than the sequence number of the proposal.
-            const immediateNoOp2 = quorum.updateMinimumSequenceNumber(justRightMessage);
-            assert.strictEqual(immediateNoOp2, true, "Should no-op if proposal was completed");
+            quorum.updateMinimumSequenceNumber(justRightMessage);
             assert.strictEqual(evented, true, "Should have evented");
             assert.strictEqual(quorum.get(proposalKey), proposalValue, "Should have the proposal value");
 

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -103,6 +103,8 @@ describe("Quorum", () => {
 
             // Wait to see if the proposal promise resolved.
             await Promise.resolve().then(() => {});
+            // Due to the composition of Quorum -> QuorumClients, we require one more microtask deferral to resolve.
+            await Promise.resolve().then(() => {});
 
             // Acceptance should have happened before the above await resolves.
             acceptanceState = "too late";

--- a/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/quorum.spec.ts
@@ -103,7 +103,7 @@ describe("Quorum", () => {
 
             // Wait to see if the proposal promise resolved.
             await Promise.resolve().then(() => {});
-            // Due to the composition of Quorum -> QuorumClients, we require one more microtask deferral to resolve.
+            // Due to the composition of Quorum -> QuorumProposals, we require one more microtask deferral to resolve.
             await Promise.resolve().then(() => {});
 
             // Acceptance should have happened before the above await resolves.


### PR DESCRIPTION
Resolves #9137

In addition to splitting the Quorum class as described in that issue, this change also splits the snapshot format definition.

I also realized the `immediateNoOp` logic was only needed for committed proposals which I removed previously.  So we can send fewer no-ops now.