### PR TITLE
Added more telemetry to help us catch issues with the summary process

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -562,6 +562,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 error: {
                     // load information to associate errors with the specific load point
                     dmInitialSeqNumber: () => this._deltaManager?.initialSequenceNumber,
+                    dmLastProcessedSeqNumber: () => this._deltaManager?.lastSequenceNumber,
                     dmLastKnownSeqNumber: () => this._deltaManager?.lastKnownSeqNumber,
                     containerLoadedFromVersionId: () => this.loadedFromVersion?.id,
                     containerLoadedFromVersionDate: () => this.loadedFromVersion?.date,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -762,6 +762,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
     private processInboundMessage(message: ISequencedDocumentMessage): void {
         const startTime = Date.now();
+        this.lastProcessedMessage = message;
 
         // All non-system messages are coming from some client, and should have clientId
         // System messages may have no clientId (but some do, like propose, noop, summarize)
@@ -806,7 +807,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                 clientId: this.connectionManager.clientId,
             });
         }
-        this.lastProcessedMessage = message;
         this.lastProcessedSequenceNumber = message.sequenceNumber;
 
         // a bunch of code assumes that this is true

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -762,7 +762,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
     private processInboundMessage(message: ISequencedDocumentMessage): void {
         const startTime = Date.now();
-        this.lastProcessedMessage = message;
 
         // All non-system messages are coming from some client, and should have clientId
         // System messages may have no clientId (but some do, like propose, noop, summarize)
@@ -807,6 +806,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                 clientId: this.connectionManager.clientId,
             });
         }
+        this.lastProcessedMessage = message;
         this.lastProcessedSequenceNumber = message.sequenceNumber;
 
         // a bunch of code assumes that this is true

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2083,8 +2083,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             if (summaryRefSeqNum !== this.deltaManager.lastMessage?.sequenceNumber) {
                 summaryLogger.sendErrorEvent({
                     eventName: "LastSequenceMismatch",
-                    lastSequenceNumber: summaryRefSeqNum,
-                    lastMsgSequenceNumber: this.deltaManager.lastMessage?.sequenceNumber,
+                    message,
                 });
             }
 
@@ -2498,7 +2497,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             async () => this.fetchSnapshotFromStorage(ackHandle, summaryLogger, {
                 eventName: "RefreshLatestSummaryGetSnapshot",
                 ackHandle,
-                referenceSequenceNumber: summaryRefSeq,
+                summaryRefSeq,
                 fetchLatest: false,
             }),
             readAndParseBlob,


### PR DESCRIPTION
Added / updated the following telemetry:
1. When summarizing, if we haven't seen an op or the last op's seq# does not match last processed seq#, log an error. In https://github.com/microsoft/FluidFramework/issues/8066, one possibility is that the seq# of the message added to the metadata blob does not match the last processed seq# during summary. This is unlikely but adding a log to validate this is not happening.
2. In `refreshLatestSummaryAck`, log the ref seq# and handle from the received ack. This should give us an idea of which previous ack we received and can help us connect some dots.
3. In delta manager, assigned the last processed message and last processed sequence number together to avoid any chances of a mismatch.