### PR TITLE
Fix rdkafka producer error handling

### DIFF
--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -116,18 +116,13 @@ export abstract class RdkafkaBase extends EventEmitter {
         });
     }
 
-    protected error(error: any, forceRestartOnError: boolean = false) {
-        let restartKafkaBasedOnErrorCode = false;
+    protected error(error: any, errorData: IContextErrorData = { restart: false }) {
         const errorCodesToCauseRestart = this.options.restartOnKafkaErrorCodes ?? this.defaultRestartOnKafkaErrorCodes;
 
         if (RdkafkaBase.isObject(error)
             && errorCodesToCauseRestart.includes((error as kafkaTypes.LibrdKafkaError).code)) {
-                restartKafkaBasedOnErrorCode = true;
+            errorData.restart = true;
         }
-
-        const errorData: IContextErrorData = {
-            restart: forceRestartOnError || restartKafkaBasedOnErrorCode,
-        };
 
         this.emit("error", error, errorData);
     }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -11,7 +11,9 @@ import {
 	IProducer,
 	PendingBoxcar,
 	MaxBatchSize,
+	IContextErrorData,
 } from "@fluidframework/server-services-core";
+import { Deferred } from "@fluidframework/common-utils";
 
 import { IKafkaBaseOptions, IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
 
@@ -28,6 +30,12 @@ export interface IKafkaProducerOptions extends Partial<IKafkaBaseOptions> {
 export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	private readonly producerOptions: IKafkaProducerOptions;
 	private readonly messages = new Map<string, IPendingBoxcar[]>();
+
+	/**
+	 * Boxcar promises that have been queued into rdkafka and we are waiting for a response
+	 */
+	private readonly inflightPromises: Set<Deferred<void>> = new Set();
+
 	private producer?: kafkaTypes.Producer;
 	private sendPending?: NodeJS.Immediate;
 	private connecting = false;
@@ -41,14 +49,14 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 		options?: Partial<IKafkaProducerOptions>) {
 		super(endpoints, clientId, topic, options);
 
-        this.defaultRestartOnKafkaErrorCodes = [
-            this.kafka.CODES.ERRORS.ERR__TRANSPORT,
-            this.kafka.CODES.ERRORS.ERR__UNKNOWN_PARTITION,
-            this.kafka.CODES.ERRORS.ERR__ALL_BROKERS_DOWN,
-            this.kafka.CODES.ERRORS.ERR__SSL,
-            this.kafka.CODES.ERRORS.ERR_UNKNOWN_TOPIC_OR_PART,
-            this.kafka.CODES.ERRORS.ERR_UNKNOWN_MEMBER_ID,
-        ];
+		this.defaultRestartOnKafkaErrorCodes = [
+			this.kafka.CODES.ERRORS.ERR__TRANSPORT,
+			this.kafka.CODES.ERRORS.ERR__UNKNOWN_PARTITION,
+			this.kafka.CODES.ERRORS.ERR__ALL_BROKERS_DOWN,
+			this.kafka.CODES.ERRORS.ERR__SSL,
+			this.kafka.CODES.ERRORS.ERR_UNKNOWN_TOPIC_OR_PART,
+			this.kafka.CODES.ERRORS.ERR_UNKNOWN_MEMBER_ID,
+		];
 
 		this.producerOptions = {
 			...options,
@@ -142,6 +150,13 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			clearImmediate(this.sendPending);
 			this.sendPending = undefined;
 		}
+
+		// reject any messages that are currently inflight
+		for (const promise of this.inflightPromises) {
+			promise.reject(new Error("Closed RdkafkaProducer"));
+		}
+
+		this.inflightPromises.clear();
 
 		await new Promise<void>((resolve) => {
 			const producer = this.producer;
@@ -256,6 +271,8 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 
 			try {
 				if (this.producer && this.connected) {
+					this.inflightPromises.add(boxcar.deferred);
+
 					this.producer.produce(
 						this.topic, // topic
 						boxcar.partitionId ?? null, // partition id or null for consistent random for keyed messages
@@ -263,11 +280,18 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 						boxcar.documentId, // key
 						undefined, // timestamp
 						(err: any, offset?: number) => {
+							this.inflightPromises.delete(boxcar.deferred);
+
 							if (err) {
 								boxcar.deferred.reject(err);
 
 								// eslint-disable-next-line @typescript-eslint/no-floating-promises
-								this.handleError(err);
+								this.handleError(err, {
+									restart: true,
+									tenantId: boxcar.tenantId,
+									documentId: boxcar.documentId,
+								});
+
 							} else {
 								boxcar.deferred.resolve();
 								this.emit("produced", boxcarMessage, offset, message.length);
@@ -286,7 +310,11 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 				boxcar.deferred.reject(ex);
 
 				// eslint-disable-next-line @typescript-eslint/no-floating-promises
-				this.handleError(ex);
+				this.handleError(ex, {
+					restart: true,
+					tenantId: boxcar.tenantId,
+					documentId: boxcar.documentId,
+				});
 			}
 		}
 	}
@@ -294,10 +322,10 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	/**
 	 * Handles an error that requires a reconnect to Kafka
 	 */
-	private async handleError(error: any) {
+	private async handleError(error: any, errorData?: IContextErrorData) {
 		await this.close(true);
 
-		this.error(error);
+		this.error(error, errorData);
 
 		this.connect();
 	}


### PR DESCRIPTION
Based on investigating recent telemetry, I believe it's possible for rdkafka to fail to produce messages and for deli to not realize that happened. This issue I looked at occurred around the same time broker transport failures happened, which trigger a reconnect for the producer.

There are 2 edge cases in the producer where an enqueued boxcar message can get stuck forever and the promises would not be resolved. That would cause deli to never realize the producer had an error and deli would keep working and eventually checkpoint even though some messages were not produced.

Edge case 1: We need to keep track of pending messages that are currently in flight within the rdkafka producer. If the producer is closed while messages are still enqueued, we should reject the promises. That would ensure that messages are not stuck forever, and deli would be notified that the message failed to be produced and correctly handle that error. 

Edge case 2: The `send` call from `sendBoxcars` will be invoked if the producer is not connected. This is bad because it will end up creating a new boxcar, which means it creates a new promise. This essentially leaves the existing boxcar.deferred promise hanging forever.

Changes:
- Track the promises that queued into rdkafka and reject them if the producer is disconnected before a response is received.
- Fixed `send` calls from `sendBoxcars` leaving promises hanging.
- Rework the error handling logic so tenant/documentid is passed through to the "error" event when possible.