### PR TITLE
Set raiseContainerWarning as optional on IContainerContext

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -11,8 +11,9 @@ There are a few steps you can take to write a good change note and avoid needing
 - Consider providing code examples as part of guidance for non-trivial changes.
 
 ## 0.58 Breaking changes
-- [Move IntervalType from merge-tree to sequence package](#Move-IntervalType-from merge-tree-to-sequence-package)
+- [Move IntervalType from merge-tree to sequence package](#Move-IntervalType-from-merge-tree-to-sequence-package)
 - [Remove logger property from IContainerContext](#Remove-logger-property-from-IContainerContext)
+- [Set raiseContainerWarning property as optional parameter on IContainerContext](#Set-raiseContainerWarning-property-as-optional-parameter-on-IContainerContext)
 
 ### Move IntervalType from merge-tree to sequence package
 Move the type from the merge-tree package where it isn't used to the sequence package where it is used
@@ -23,6 +24,9 @@ Move the type from the merge-tree package where it isn't used to the sequence pa
 
 ## Remove logger property from IContainerContext
 The logger property in IContainerContext became an optional parameter in [release 0.56](#Set-logger-property-as-optional-parameter-in-IContainerContext). This property has now been removed. The `taggedLogger` property is now set as a required parameter in `IContainerContext` interface.
+
+## Set raiseContainerWarning property as optional parameter on IContainerContext
+`raiseContainerWarning` is set as an optional parameter on `IContainerContext` interface and would be removed from `IContainerContext` interface and `ContainerContext` class in the next release. Please see [#Set-raiseContainerWarning-property-as-optional-parameter-on-IContainerContext] for more details.
 
 ## 0.57 Breaking changes
 - [IFluidConfiguration removed](#IFluidConfiguration-removed)

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -26,7 +26,7 @@ Move the type from the merge-tree package where it isn't used to the sequence pa
 The logger property in IContainerContext became an optional parameter in [release 0.56](#Set-logger-property-as-optional-parameter-in-IContainerContext). This property has now been removed. The `taggedLogger` property is now set as a required parameter in `IContainerContext` interface.
 
 ## Set raiseContainerWarning property as optional parameter on IContainerContext
-`raiseContainerWarning` is set as an optional parameter on `IContainerContext` interface and would be removed from `IContainerContext` interface and `ContainerContext` class in the next release. Please see [#Set-raiseContainerWarning-property-as-optional-parameter-on-IContainerContext] for more details.
+`raiseContainerWarning` is set as an optional parameter on `IContainerContext` interface and would be removed from `IContainerContext` interface and `ContainerContext` class in the next release. Please see [#Remove-raiseContainerWarning-property] for more details.
 
 ## 0.57 Breaking changes
 - [IFluidConfiguration removed](#IFluidConfiguration-removed)

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -188,7 +188,7 @@ export interface IContainerContext extends IDisposable {
     // (undocumented)
     readonly quorum: IQuorumClients;
     // @deprecated (undocumented)
-    raiseContainerWarning(warning: ContainerWarning): void;
+    raiseContainerWarning?(warning: ContainerWarning): void;
     readonly scope: IFluidObject & FluidObject;
     // (undocumented)
     readonly serviceConfiguration: IClientConfiguration | undefined;

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -491,6 +491,27 @@
       },
       "0.46.0": {
         "InterfaceDeclaration_IContainerContext": {
+          "forwardCompat": false,
+          "backCompat": false
+        },
+        "InterfaceDeclaration_ICodeDetailsLoader": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_ICodeLoader": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidModule": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IFluidModuleWithDetails": {
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IProvideRuntimeFactory": {
+          "forwardCompat": false,
+          "backCompat": false
+        },
+        "InterfaceDeclaration_IRuntimeFactory": {
+          "backCompat": false,
           "forwardCompat": false
         }
       }

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -149,7 +149,7 @@ export interface IContainerContext extends IDisposable {
     /**
      * @deprecated 0.56, will be removed in the next release
      */
-    raiseContainerWarning(warning: ContainerWarning): void;
+    raiseContainerWarning?(warning: ContainerWarning): void;
 
     /**
      * Get an absolute url for a provided container-relative request.

--- a/common/lib/container-definitions/src/test/types/validate0.46.0.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.46.0.ts
@@ -271,6 +271,7 @@ declare function get_current_InterfaceDeclaration_ICodeDetailsLoader():
 declare function use_old_InterfaceDeclaration_ICodeDetailsLoader(
     use: old.ICodeDetailsLoader);
 use_old_InterfaceDeclaration_ICodeDetailsLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ICodeDetailsLoader());
 
 /*
@@ -295,6 +296,7 @@ declare function get_current_InterfaceDeclaration_ICodeLoader():
 declare function use_old_InterfaceDeclaration_ICodeLoader(
     use: old.ICodeLoader);
 use_old_InterfaceDeclaration_ICodeLoader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ICodeLoader());
 
 /*
@@ -368,6 +370,7 @@ declare function get_current_InterfaceDeclaration_IContainerContext():
 declare function use_old_InterfaceDeclaration_IContainerContext(
     use: old.IContainerContext);
 use_old_InterfaceDeclaration_IContainerContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerContext());
 
 /*
@@ -824,6 +827,7 @@ declare function get_current_InterfaceDeclaration_IFluidModule():
 declare function use_old_InterfaceDeclaration_IFluidModule(
     use: old.IFluidModule);
 use_old_InterfaceDeclaration_IFluidModule(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidModule());
 
 /*
@@ -848,6 +852,7 @@ declare function get_current_InterfaceDeclaration_IFluidModuleWithDetails():
 declare function use_old_InterfaceDeclaration_IFluidModuleWithDetails(
     use: old.IFluidModuleWithDetails);
 use_old_InterfaceDeclaration_IFluidModuleWithDetails(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidModuleWithDetails());
 
 /*
@@ -1196,6 +1201,7 @@ declare function get_old_InterfaceDeclaration_IProvideRuntimeFactory():
 declare function use_current_InterfaceDeclaration_IProvideRuntimeFactory(
     use: current.IProvideRuntimeFactory);
 use_current_InterfaceDeclaration_IProvideRuntimeFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideRuntimeFactory());
 
 /*
@@ -1208,6 +1214,7 @@ declare function get_current_InterfaceDeclaration_IProvideRuntimeFactory():
 declare function use_old_InterfaceDeclaration_IProvideRuntimeFactory(
     use: old.IProvideRuntimeFactory);
 use_old_InterfaceDeclaration_IProvideRuntimeFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideRuntimeFactory());
 
 /*
@@ -1316,6 +1323,7 @@ declare function get_old_InterfaceDeclaration_IRuntimeFactory():
 declare function use_current_InterfaceDeclaration_IRuntimeFactory(
     use: current.IRuntimeFactory);
 use_current_InterfaceDeclaration_IRuntimeFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRuntimeFactory());
 
 /*
@@ -1328,6 +1336,7 @@ declare function get_current_InterfaceDeclaration_IRuntimeFactory():
 declare function use_old_InterfaceDeclaration_IRuntimeFactory(
     use: old.IRuntimeFactory);
 use_old_InterfaceDeclaration_IRuntimeFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IRuntimeFactory());
 
 /*

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -21,7 +21,6 @@ import {
     IDeltaManager,
     IDeltaSender,
     IRuntime,
-    ContainerWarning,
     ICriticalContainerError,
     AttachState,
     ILoaderOptions,
@@ -930,8 +929,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private dirtyContainer: boolean;
     private emitDirtyDocumentEvent = true;
 
-    private readonly summarizerWarning = (warning: ContainerWarning) =>
-        this.mc.logger.sendTelemetryEvent({ eventName: "summarizerWarning" }, warning);
     /**
      * Summarizer is responsible for coordinating when to send generate and send summaries.
      * It is the main entry point for summary work.
@@ -1213,7 +1210,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     },
                     this.runtimeOptions.summaryOptions.summarizerOptions,
                 );
-                this.summaryManager.on("summarizerWarning", this.summarizerWarning);
                 this.summaryManager.start();
             }
         }
@@ -1280,7 +1276,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }, error);
 
         if (this.summaryManager !== undefined) {
-            this.summaryManager.off("summarizerWarning", this.summarizerWarning);
             this.summaryManager.dispose();
         }
         this.garbageCollector.dispose();

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -259,7 +259,8 @@ export class Summarizer extends EventEmitter implements ISummarizer {
             ),
             (errorCode: string) => {
                 if (!this._disposed) {
-                    this.emit("summarizingError", createSummarizingWarning(errorCode, true));
+                    this.logger.sendErrorEvent({ eventName: "summarizingError" },
+                        createSummarizingWarning(errorCode, true));
                 }
             },
             this.summaryCollection,

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -172,7 +172,6 @@ describe("Summary Manager", () => {
     afterEach(() => {
         clientElection.removeAllListeners();
         summarizer.removeAllListeners();
-        summaryManager.removeAllListeners();
         connectedState.removeAllListeners();
         throttler.delayMs = 0;
         summaryCollection.opsSinceLastAck = 0;


### PR DESCRIPTION
In this PR, 

1. `raiseContainerWarning` is set as an optional parameter on `IContainerContext` and would be removed from `IContainerContext` and `ContainerContext` in the next release.
2. `summarizerWarning` concept is removed altogether
3. In `delayBeforeCreatingSummarizer()`, `summarizerWarning` set before `CreatingSummarizer` is removed and all the information is logged in the payload.
4. `SummarizerException` event - `summarizerWarning` event is removed as it's already logged to telemetry as an error.
5. `summarizingError` is logged as an error event.

Context: https://github.com/microsoft/FluidFramework/pull/8791
Resolves: https://github.com/microsoft/FluidFramework/issues/8903