### PR TITLE
Data store aliasing interface adjustments

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -16,6 +16,7 @@ import { IContainerContext } from '@fluidframework/container-definitions';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
 import { IContainerRuntimeEvents } from '@fluidframework/container-runtime-definitions';
 import { ICriticalContainerError } from '@fluidframework/container-definitions';
+import { IDataStore } from '@fluidframework/runtime-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
 import { IDisposable } from '@fluidframework/common-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
@@ -53,14 +54,6 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
 export const agentSchedulerId = "_scheduler";
-
-// @public
-export enum AliasResult {
-    Aliasing = "Aliasing",
-    AlreadyAliased = "AlreadyAliased",
-    Conflict = "Conflict",
-    Success = "Success"
-}
 
 // @public (undocumented)
 export enum ContainerMessageType {
@@ -324,11 +317,6 @@ export interface IContainerRuntimeOptions {
     // (undocumented)
     summaryOptions?: ISummaryRuntimeOptions;
     useDataStoreAliasing?: boolean;
-}
-
-// @public
-export interface IDataStore extends IFluidRouter {
-    trySetAlias(alias: string): Promise<AliasResult>;
 }
 
 // @public

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -30,12 +30,7 @@ import { ITree } from '@fluidframework/protocol-definitions';
 import { SummaryTree } from '@fluidframework/protocol-definitions';
 
 // @public
-export enum AliasResult {
-    Aliasing = "Aliasing",
-    AlreadyAliased = "AlreadyAliased",
-    Conflict = "Conflict",
-    Success = "Success"
-}
+export type AliasResult = "Success" | "Conflict" | "Aliasing" | "AlreadyAliased";
 
 // @public (undocumented)
 export const channelsTreeName = ".channels";
@@ -382,6 +377,7 @@ export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRe
 
 // @public (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -29,6 +29,14 @@ import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { SummaryTree } from '@fluidframework/protocol-definitions';
 
+// @public
+export enum AliasResult {
+    Aliasing = "Aliasing",
+    AlreadyAliased = "AlreadyAliased",
+    Conflict = "Conflict",
+    Success = "Success"
+}
+
 // @public (undocumented)
 export const channelsTreeName = ".channels";
 
@@ -79,7 +87,7 @@ export interface IAttachMessage {
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents>, IProvideFluidHandleContext {
     // (undocumented)
     readonly clientDetails: IClientDetails;
-    createDataStore(pkg: string | string[]): Promise<IFluidRouter>;
+    createDataStore(pkg: string | string[]): Promise<IDataStore>;
     // @internal @deprecated (undocumented)
     _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IFluidRouter>;
     createDetachedDataStore(pkg: Readonly<string[]>): IFluidDataStoreContextDetached;
@@ -104,6 +112,11 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
     (event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): any;
     // (undocumented)
     (event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): any;
+}
+
+// @public
+export interface IDataStore extends IFluidRouter {
+    trySetAlias(alias: string): Promise<AliasResult>;
 }
 
 // @public
@@ -369,7 +382,6 @@ export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRe
 
 // @public (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -138,6 +138,20 @@
           "backCompat": false,
           "forwardCompat": false
         }
+      },
+      "0.56.0": {
+        "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideContainerRuntime": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": true,
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.56.0.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.56.0.ts
@@ -43,6 +43,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -67,6 +68,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -115,6 +117,7 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -88,7 +88,6 @@ import {
     channelsTreeName,
     IAttachMessage,
     IDataStore,
-    AliasResult,
 } from "@fluidframework/runtime-definitions";
 import {
     addBlobToSummary,
@@ -1825,7 +1824,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const dataStore = await this._createDataStore(pkg, false /* isRoot */, internalId, props);
         const aliasedDataStore = channelToDataStore(dataStore, internalId, this,this.dataStores, this.mc.logger);
         const result = await aliasedDataStore.trySetAlias(alias);
-        if (result !== AliasResult.Success) {
+        if (result !== "Success") {
             throw new GenericError(
                 "dataStoreAliasFailure",
                 undefined /* error */,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -87,6 +87,8 @@ import {
     SummarizeInternalFn,
     channelsTreeName,
     IAttachMessage,
+    IDataStore,
+    AliasResult,
 } from "@fluidframework/runtime-definitions";
 import {
     addBlobToSummary,
@@ -147,9 +149,7 @@ import {
     IGCStats,
 } from "./garbageCollection";
 import {
-    AliasResult,
     channelToDataStore,
-    IDataStore,
     IDataStoreAliasMessage,
     isDataStoreAliasMessage,
 } from "./dataStore";

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -58,11 +58,11 @@ class DataStore implements IDataStore {
         switch (this.aliasState) {
             // If we're already aliasing, throw an exception
             case AliasState.Aliasing:
-                return AliasResult.Aliasing;
+                return "Aliasing";
             // If this datastore is already aliased, return true only if this
             // is a repeated call for the same alias
             case AliasState.Aliased:
-                return this.alias === alias ? AliasResult.Success : AliasResult.AlreadyAliased;
+                return this.alias === alias ? "Success" : "AlreadyAliased";
             // There is no current or past alias operation for this datastore,
             // it is safe to continue execution
             case AliasState.None: break;
@@ -82,7 +82,7 @@ class DataStore implements IDataStore {
             // Explicitly Lock-out future attempts of aliasing,
             // regardless of result
             this.aliasState = AliasState.Aliased;
-            return localResult ? AliasResult.Success : AliasResult.Conflict;
+            return localResult ? "Success" : "Conflict";
         }
 
         const aliased = await this.ackBasedPromise<boolean>((resolve) => {
@@ -112,7 +112,7 @@ class DataStore implements IDataStore {
             return false;
         });
 
-        return aliased ? AliasResult.Success : AliasResult.Conflict;
+        return aliased ? "Success" : "Conflict";
     }
 
     async request(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -6,7 +6,7 @@
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { unreachableCase } from "@fluidframework/common-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { IFluidRouter, IRequest, IResponse } from "@fluidframework/core-interfaces";
+import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ContainerRuntime } from "./containerRuntime";
@@ -35,42 +35,6 @@ export interface IDataStoreAliasMessage {
     return typeof maybeDataStoreAliasMessage?.internalId === "string"
         && typeof maybeDataStoreAliasMessage?.alias === "string";
 };
-
-/**
- * Encapsulates the return codes of the aliasing API
- */
-export enum AliasResult {
-    /**
-     * The datastore has been successfully aliased
-     */
-    Success = "Success",
-    /**
-     * There is already a datastore bound to the provided alias
-     */
-    Conflict = "Conflict",
-    /**
-     * The datastore is currently in the process of being aliased
-     */
-    Aliasing = "Aliasing",
-    /**
-     * The datastore has been attempted to be aliased before
-     */
-    AlreadyAliased = "AlreadyAliased",
-}
-
-/**
- * A fluid router with the capability of being assigned an alias
- */
- export interface IDataStore extends IFluidRouter {
-    /**
-     * Attempt to assign an alias to the datastore.
-     * If the operation succeeds, the datastore can be referenced
-     * by the supplied alias.
-     *
-     * @param alias - Given alias for this datastore.
-     */
-    trySetAlias(alias: string): Promise<AliasResult>;
-}
 
 export const channelToDataStore = (
     fluidDataStoreChannel: IFluidDataStoreChannel,

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -7,7 +7,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { unreachableCase } from "@fluidframework/common-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IRequest, IResponse } from "@fluidframework/core-interfaces";
-import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
+import { AliasResult, IDataStore, IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ContainerRuntime } from "./containerRuntime";
 import { DataStores } from "./dataStores";

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -19,7 +19,6 @@ export {
     ContainerRuntime,
     RuntimeHeaders,
 } from "./containerRuntime";
-export { IDataStore, AliasResult } from "./dataStore";
 export { DeltaScheduler } from "./deltaScheduler";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";
 export {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -291,6 +291,20 @@
           "backCompat": false,
           "forwardCompat": false
         }
+      },
+      "0.56.0": {
+        "InterfaceDeclaration_IContainerRuntimeBase": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContext": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContextDetached": {
+          "backCompat": true,
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -66,24 +66,7 @@ export interface IContainerRuntimeBaseEvents extends IEvent{
 /**
  * Encapsulates the return codes of the aliasing API
  */
- export enum AliasResult {
-    /**
-     * The datastore has been successfully aliased
-     */
-    Success = "Success",
-    /**
-     * There is already a datastore bound to the provided alias
-     */
-    Conflict = "Conflict",
-    /**
-     * The datastore is currently in the process of being aliased
-     */
-    Aliasing = "Aliasing",
-    /**
-     * The datastore has been attempted to be aliased before
-     */
-    AlreadyAliased = "AlreadyAliased",
-}
+ export type AliasResult = "Success" | "Conflict" | "Aliasing" | "AlreadyAliased";
 
 /**
  * A fluid router with the capability of being assigned an alias

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -64,6 +64,42 @@ export interface IContainerRuntimeBaseEvents extends IEvent{
 }
 
 /**
+ * Encapsulates the return codes of the aliasing API
+ */
+ export enum AliasResult {
+    /**
+     * The datastore has been successfully aliased
+     */
+    Success = "Success",
+    /**
+     * There is already a datastore bound to the provided alias
+     */
+    Conflict = "Conflict",
+    /**
+     * The datastore is currently in the process of being aliased
+     */
+    Aliasing = "Aliasing",
+    /**
+     * The datastore has been attempted to be aliased before
+     */
+    AlreadyAliased = "AlreadyAliased",
+}
+
+/**
+ * A fluid router with the capability of being assigned an alias
+ */
+ export interface IDataStore extends IFluidRouter {
+    /**
+     * Attempt to assign an alias to the datastore.
+     * If the operation succeeds, the datastore can be referenced
+     * by the supplied alias.
+     *
+     * @param alias - Given alias for this datastore.
+     */
+    trySetAlias(alias: string): Promise<AliasResult>;
+}
+
+/**
  * A reduced set of functionality of IContainerRuntime that a data store context/data store runtime will need
  * TODO: this should be merged into IFluidDataStoreContext
  */
@@ -115,7 +151,7 @@ export interface IContainerRuntimeBase extends
      * gets attached to storage) will result in this store being attached to storage.
      * @param pkg - Package name of the data store factory
      */
-    createDataStore(pkg: string | string[]): Promise<IFluidRouter>;
+    createDataStore(pkg: string | string[]): Promise<IDataStore>;
 
     /**
      * Creates detached data store context. only after context.attachRuntime() is called,

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.56.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.56.0.ts
@@ -211,6 +211,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: current.IContainerRuntimeBase);
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -307,6 +308,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: current.IFluidDataStoreContext);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -331,6 +333,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: current.IFluidDataStoreContextDetached);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -21,9 +21,9 @@ import {
 } from "@fluidframework/container-runtime";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ConfigTypes, IConfigProviderBase, TelemetryDataTag } from "@fluidframework/telemetry-utils";
-import { AliasResult } from "@fluidframework/container-runtime/dist/dataStore";
 import { Loader } from "@fluidframework/container-loader";
 import { GenericError } from "@fluidframework/container-utils";
+import { AliasResult } from "@fluidframework/runtime-definitions";
 
 describeNoCompat("Named root data stores", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -24,6 +24,7 @@ import { ConfigTypes, IConfigProviderBase, TelemetryDataTag } from "@fluidframew
 import { Loader } from "@fluidframework/container-loader";
 import { GenericError } from "@fluidframework/container-utils";
 import { AliasResult } from "@fluidframework/runtime-definitions";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
 describeNoCompat("Named root data stores", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
@@ -78,8 +79,8 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             resolve(error?.errorType === ContainerErrorType.dataCorruptionError);
         })))).then((all)=>!all.includes(false));
 
-    const runtimeOf = (dataObject: ITestFluidObject): ContainerRuntime =>
-        dataObject.context.containerRuntime as ContainerRuntime;
+    const runtimeOf = (dataObject: ITestFluidObject): IContainerRuntime =>
+        dataObject.context.containerRuntime as IContainerRuntime;
 
     const createRootDataStore = async (dataObject: ITestFluidObject, id: string) =>
         runtimeOf(dataObject).createRootDataStore(packageName, id);
@@ -90,13 +91,13 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
     const getRootDataStore = async (dataObject: ITestFluidObject, id: string) =>
         runtimeOf(dataObject).getRootDataStore(id);
 
-    const corruptedAPIAliasOp = async (runtime: ContainerRuntime, alias: string): Promise<boolean | Error> =>
+    const corruptedAPIAliasOp = async (runtime: IContainerRuntime, alias: string): Promise<boolean | Error> =>
         new Promise<boolean>((resolve, reject) => {
             runtime.once("dispose", () => reject(new Error("Runtime disposed")));
-            runtime.submitDataStoreAliasOp({ id: alias }, resolve);
+            (runtime as ContainerRuntime).submitDataStoreAliasOp({ id: alias }, resolve);
         }).catch((error) => new Error(error.fluidErrorCode));
 
-    const corruptedAliasOp = async (runtime: ContainerRuntime, alias: string): Promise<boolean | Error> =>
+    const corruptedAliasOp = async (runtime: IContainerRuntime, alias: string): Promise<boolean | Error> =>
         new Promise<boolean>((resolve, reject) => {
             runtime.once("dispose", () => reject(new Error("Runtime disposed")));
             (runtime as any).submit(ContainerMessageType.Alias, { id: alias }, resolve);

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -23,7 +23,6 @@ import { TelemetryNullLogger } from "@fluidframework/common-utils";
 import { ConfigTypes, IConfigProviderBase, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { Loader } from "@fluidframework/container-loader";
 import { GenericError } from "@fluidframework/container-utils";
-import { AliasResult } from "@fluidframework/runtime-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
 describeNoCompat("Named root data stores", (getTestObjectProvider) => {
@@ -183,7 +182,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
                     value: "2",
                     tag: TelemetryDataTag.UserData,
                 });
-            assert.equal(error.getTelemetryProperties().aliasResult, AliasResult.Conflict);
+            assert.equal(error.getTelemetryProperties().aliasResult, "Conflict");
             assert.ok(await getRootDataStore(dataObject1, "2"));
         });
 
@@ -207,7 +206,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
                     value: "2",
                     tag: TelemetryDataTag.UserData,
                 });
-            assert.equal(error.getTelemetryProperties().aliasResult, AliasResult.Conflict);
+            assert.equal(error.getTelemetryProperties().aliasResult, "Conflict");
             assert.ok(await getRootDataStore(dataObject1, "2"));
         });
 
@@ -242,15 +241,15 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasResult1 = await ds1.trySetAlias(alias);
             const aliasResult2 = await ds2.trySetAlias(alias);
 
-            assert.equal(aliasResult1, AliasResult.Success);
-            assert.equal(aliasResult2, AliasResult.Conflict);
+            assert.equal(aliasResult1, "Success");
+            assert.equal(aliasResult2, "Conflict");
 
             assert.ok(await getRootDataStore(dataObject, alias));
 
             await container.attach(request);
             const ds3 = await runtimeOf(dataObject).createDataStore(packageName);
             const aliasResult3 = await ds3.trySetAlias(alias);
-            assert.equal(aliasResult3, AliasResult.Conflict);
+            assert.equal(aliasResult3, "Conflict");
         });
 
         it("Assign multiple data stores to the same alias, first write wins, same container", async () => {
@@ -260,8 +259,8 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasResult1 = await ds1.trySetAlias(alias);
             const aliasResult2 = await ds2.trySetAlias(alias);
 
-            assert.equal(aliasResult1, AliasResult.Success);
-            assert.equal(aliasResult2, AliasResult.Conflict);
+            assert.equal(aliasResult1, "Success");
+            assert.equal(aliasResult2, "Conflict");
 
             assert.ok(await getRootDataStore(dataObject1, alias));
         });
@@ -272,8 +271,8 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasResult1 = await ds1.trySetAlias(alias);
             const aliasResult2 = await ds1.trySetAlias(alias);
 
-            assert.equal(aliasResult1, AliasResult.Success);
-            assert.equal(aliasResult2, AliasResult.Success);
+            assert.equal(aliasResult1, "Success");
+            assert.equal(aliasResult2, "Success");
 
             assert.ok(await getRootDataStore(dataObject1, alias));
         });
@@ -284,8 +283,8 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasResult1 = await ds1.trySetAlias(alias);
             const aliasResult2 = await ds1.trySetAlias(alias + alias);
 
-            assert.equal(aliasResult1, AliasResult.Success);
-            assert.equal(aliasResult2, AliasResult.AlreadyAliased);
+            assert.equal(aliasResult1, "Success");
+            assert.equal(aliasResult2, "AlreadyAliased");
 
             assert.ok(await getRootDataStore(dataObject1, alias));
         });
@@ -299,9 +298,9 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasResult3 = await ds2.trySetAlias(alias + alias);
 
 
-            assert.equal(aliasResult1, AliasResult.Success);
-            assert.equal(aliasResult2, AliasResult.Conflict);
-            assert.equal(aliasResult3, AliasResult.AlreadyAliased);
+            assert.equal(aliasResult1, "Success");
+            assert.equal(aliasResult2, "Conflict");
+            assert.equal(aliasResult3, "AlreadyAliased");
 
             assert.ok(await getRootDataStore(dataObject1, alias));
         });
@@ -312,7 +311,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
         ], async () => {
             const dataCorruption = anyDataCorruption([container1, container2]);
             const ds1 = await runtimeOf(dataObject1).createDataStore(packageName);
-            assert.equal(await ds1.trySetAlias(alias), AliasResult.Success);
+            assert.equal(await ds1.trySetAlias(alias), "Success");
 
             await provider.ensureSynchronized();
             await createRootDataStore(dataObject2, alias);
@@ -342,8 +341,8 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasResult1 = await ds1.trySetAlias(alias);
             const aliasResult2 = await ds2.trySetAlias(alias);
 
-            assert.equal(aliasResult1, AliasResult.Success);
-            assert.equal(aliasResult2, AliasResult.Conflict);
+            assert.equal(aliasResult1, "Success");
+            assert.equal(aliasResult2, "Conflict");
 
             await provider.ensureSynchronized();
 
@@ -357,7 +356,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             await createRootDataStore(dataObject1, alias);
             const ds2 = await runtimeOf(dataObject1).createDataStore(packageName);
             const aliasResult2 = await ds2.trySetAlias(alias);
-            assert.equal(aliasResult2, AliasResult.Conflict);
+            assert.equal(aliasResult2, "Conflict");
 
             assert.ok(await getRootDataStore(dataObject2, alias));
         });
@@ -402,8 +401,8 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasResult1 = await ds1.trySetAlias(alias);
             const aliasResult2 = await ds2.trySetAlias(alias);
 
-            assert.equal(aliasResult1, AliasResult.Success);
-            assert.equal(aliasResult2, AliasResult.Conflict);
+            assert.equal(aliasResult1, "Success");
+            assert.equal(aliasResult2, "Conflict");
 
             await provider.ensureSynchronized();
             const version = await waitForSummary(provider, container1, sc);
@@ -418,7 +417,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const ds3 = await runtimeOf(dataObject3).createDataStore(packageName);
             const aliasResult3 = await ds3.trySetAlias(alias);
 
-            assert.equal(aliasResult3, AliasResult.Conflict);
+            assert.equal(aliasResult3, "Conflict");
             assert.ok(await getRootDataStore(dataObject3, alias));
         });
     });


### PR DESCRIPTION
Part of https://github.com/microsoft/FluidFramework/pull/7940

See https://github.com/microsoft/FluidFramework/issues/6465

Currently, in order to adopt the aliasing API, the client needs to use the `ContainerRuntime` class. This change adjusts the `IContainerRuntimeBase` to have the proper return type in order to get an `IDataStore` which can be aliased.