### PR TITLE
Add virtual patch support to build-tools

### DIFF
--- a/tools/build-tools/src/bumpVersion/README.md
+++ b/tools/build-tools/src/bumpVersion/README.md
@@ -28,6 +28,10 @@ For each package/monorepo that needs to be release, from the bottom of the depen
 - run `npm install` to update all the lock file
 - commit the change and repeat on the next level of the dependency change
 
+#### Virtual patches
+
+The tool supports virtual patch versioning using the `--virtualPatch` flag.  The beta versioning scheme we use (0.x.x) does not have room to differentiate major/minor/patch because we only have 2 version components. We can simulate this by making the second component represent the major version, and combine minor and patch into the third by representing minor as a 1000 increment and patch as a 1 increment. This reserves number space (999 of them) between each minor version, allowing room for patches.  This mechanism is not needed outside of the beta versioning scheme.
+
 ### Update dependencies across monorepo or independent packages
 
 Note that the dependencies update is all done in the context of the current branch, regardless of what version it is in main or release/* branches

--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -111,7 +111,8 @@ function translateVirtualVersion(
         fatal("unable to deconstruct package version for virtual patch");
     }
     virtualVersion.patch += versionBump === "minor" ? 1000 : 1;
-    console.log(`    Translated ${pkgOrMonoRepoName} from ${versionBump} to ${virtualVersion}`);
+    virtualVersion.format(); // semver must be reformated after edits
+    console.log(`    Translated ${pkgOrMonoRepoName} from ${versionString} to ${virtualVersion} for virtual patch`);
     return virtualVersion;
 }
 /**

--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -4,22 +4,22 @@
  */
 
 import { strict as assert } from "assert";
-import { Context, VersionChangeType } from "./context";
-import { getRepoStateChange } from "./versionBag";
+import { Context, isVersionBumpType, VersionChangeType } from "./context";
+import { getRepoStateChange, VersionBag } from "./versionBag";
 import { fatal, exec } from "./utils";
 import { MonoRepo, MonoRepoKind } from "../common/monoRepo";
 import { Package } from "../common/npmPackage";
 import { getPackageShortName } from "./releaseVersion";
 import * as semver from "semver";
 
-export async function bumpVersionCommand(context:Context, bump: string, version: VersionChangeType, commit: boolean) {
+export async function bumpVersionCommand(context:Context, bump: string, version: VersionChangeType, commit: boolean, virtualPatch: boolean) {
     const bumpBranch = `bump_${version}_${Date.now()}`;
     if (commit) {
         console.log(`Creating branch ${bumpBranch}`);
         await context.createBranch(bumpBranch);
     }
 
-    await bumpVersion(context, [bump], version, getPackageShortName(bump), commit ? "" : undefined);
+    await bumpVersion(context, [bump], version, getPackageShortName(bump), virtualPatch, commit ? "" : undefined);
 
     if (commit) {
         console.log("======================================================================================================");
@@ -30,7 +30,7 @@ export async function bumpVersionCommand(context:Context, bump: string, version:
 /**
  * Functions and utilities to update the package versions
  */
-export async function bumpVersion(context: Context, bump: string[], version: VersionChangeType, packageShortNames: string, commit?: string) {
+export async function bumpVersion(context: Context, bump: string[], version: VersionChangeType, packageShortNames: string, virtualPatch: boolean, commit?: string) {
     console.log(`Bumping ${packageShortNames} to ${version}`);
 
     let clientNeedBump = false;
@@ -67,7 +67,7 @@ export async function bumpVersion(context: Context, bump: string[], version: Ver
     }
 
     const oldVersions = context.collectVersions();
-    const newVersions = await bumpRepo(context, version, clientNeedBump, serverNeedBump, packageNeedBump);
+    const newVersions = await bumpRepo(context, version, clientNeedBump, serverNeedBump, packageNeedBump, virtualPatch, oldVersions);
     const bumpRepoState = getRepoStateChange(oldVersions, newVersions);
     console.log(bumpRepoState);
 
@@ -76,31 +76,83 @@ export async function bumpVersion(context: Context, bump: string[], version: Ver
     }
 }
 
+
+/**
+ * Translate a VersionChangeType for the virtual patch scenario where we overload a beta version number
+ * to include all of major, minor, and patch.  Actual semver type is not translated
+ * "major" maps to "minor" (<N + 1>.x.x -> x.<N + 1>.x)
+ * "minor" maps to "patch" * 1000 (x.<N + 1>.x -> x.x.<N + 1>00x)
+ * "patch" is unchanged
+ */
+function translateVirtualVersion(
+    versionBump: VersionChangeType,
+    versionBag: VersionBag,
+    pkgOrMonoRepoName: string,
+    virtualPatch: boolean,
+): VersionChangeType {
+    if (!virtualPatch) {
+        return versionBump;
+    }
+
+    // Virtual patch can only be used for a major/minor/patch bump and not a specifc version
+    if (!isVersionBumpType(versionBump)) {
+        fatal("Can only use virtual patches when doing major/minor/patch bumps");
+    }
+
+    if (versionBump === "major") {
+        return "minor";
+    }
+
+    const versionString = versionBag.get(pkgOrMonoRepoName);
+
+    // minor adds 1000, patch adds 1
+    const virtualVersion = semver.parse(versionString);
+    if (!virtualVersion) {
+        fatal("unable to deconstruct package version for virtual patch");
+    }
+    virtualVersion.patch += versionBump === "minor" ? 1000 : 1;
+    console.log(`    Translated ${pkgOrMonoRepoName} from ${versionBump} to ${virtualVersion}`);
+    return virtualVersion;
+}
 /**
  * Bump version of packages in the repo
  *
  * @param versionBump the kind of version bump
  */
-export async function bumpRepo(context: Context, versionBump: VersionChangeType, clientNeedBump: boolean, serverNeedBump: boolean, packageNeedBump: Set<Package>) {
-    const bumpMonoRepo = async (monoRepo: MonoRepo) => {
-        return exec(`npx lerna version ${versionBump} --no-push --no-git-tag-version -y && npm run build:genver`, monoRepo.repoPath, "bump mono repo");
+export async function bumpRepo(
+    context: Context,
+    versionBump: VersionChangeType,
+    clientNeedBump: boolean,
+    serverNeedBump: boolean,
+    packageNeedBump: Set<Package>,
+    virtualPatch: boolean,
+    versionBag: VersionBag,
+) {
+    const bumpMonoRepo = async (repoVersionBump: VersionChangeType, monoRepo: MonoRepo) => {
+        return exec(`npx lerna version ${repoVersionBump} --no-push --no-git-tag-version -y && npm run build:genver`, monoRepo.repoPath, "bump mono repo");
     }
 
     if (clientNeedBump) {
         console.log("  Bumping client version");
-        await bumpLegacyDependencies(context, versionBump);
-        await bumpMonoRepo(context.repo.clientMonoRepo);
+        // Translate the versionBump into the appropriate change for virtual patch versioning
+        const translatedVersionBump = translateVirtualVersion(versionBump, versionBag, "Client", virtualPatch);
+        await bumpLegacyDependencies(context, translatedVersionBump);
+        await bumpMonoRepo(translatedVersionBump, context.repo.clientMonoRepo);
     }
 
     if (serverNeedBump) {
         console.log("  Bumping server version");
         assert(context.repo.serverMonoRepo, "Attempted server version bump on a Fluid repo with no server directory");
-        await bumpMonoRepo(context.repo.serverMonoRepo!);
+        // Translate the versionBump into the appropriate change for virtual patch versioning
+        const translatedVersionBump = translateVirtualVersion(versionBump, versionBag, "Server", virtualPatch);
+        await bumpMonoRepo(translatedVersionBump, context.repo.serverMonoRepo!);
     }
 
     for (const pkg of packageNeedBump) {
         console.log(`  Bumping ${pkg.name}`);
-        let cmd = `npm version ${versionBump}`;
+        // Translate the versionBump into the appropriate change for virtual patch versioning
+        const translatedVersionBump = translateVirtualVersion(versionBump, versionBag, pkg.name, virtualPatch);
+        let cmd = `npm version ${translatedVersionBump}`;
         if (pkg.getScript("build:genver")) {
             cmd += " && npm run build:genver";
         }

--- a/tools/build-tools/src/bumpVersion/context.ts
+++ b/tools/build-tools/src/bumpVersion/context.ts
@@ -19,6 +19,9 @@ import * as semver from "semver";
 
 export type VersionBumpType = "major" | "minor" | "patch";
 export type VersionChangeType = VersionBumpType | semver.SemVer;
+export function isVersionBumpType(type: VersionChangeType | string): type is VersionBumpType {
+    return type === "major" || type === "minor" || type === "patch";
+}
 
 export class Context {
     public readonly repo: FluidRepo;

--- a/tools/build-tools/src/typeValidator/runValidator.ts
+++ b/tools/build-tools/src/typeValidator/runValidator.ts
@@ -56,7 +56,7 @@ async function main() {
         validationResults.forEach((value, key) => {
             const changeType = incrementToVersionChangeType(value.level);
             if (changeType !== undefined) {
-                bumpVersionCommand(context, key, changeType, false);
+                bumpVersionCommand(context, key, changeType, false, false);
                 console.log(`Version for ${key} has been updated. Create a pre-release and update dependencies to consume it.`);
             }
         })


### PR DESCRIPTION
Fixes #9292

Add support for virtual patch versioning (where "minor" changes are a 1000 increment to the patch component, which reserves space for actual patches) in build-tools.  This is enabled through a `--virtualPatch` flag when running `bump-version` and will be used during the transition period between the 0.58 release and 1.0.

Q: What is virtual patch
A: The current beta versioning scheme we use (0.x.x) does not have room to differentiate major/minor/patch because we only have 2 version components.  We can simulate this by making the second component represent the major version, and combine minor and patch into the third by representing minor as a 1000 increment and patch as a 1 increment.  This reserves number space (999 of them) between each minor version, allowing room for patches.