### PR TITLE
Removing the call to ensureFluidResolvedUrl within ContainerContext.id (#9289)

### DIFF
--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -46,7 +46,7 @@ import {
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { assert, LazyPromise } from "@fluidframework/common-utils";
 import { Container } from "./container";
-import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
+import { isFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { ICodeDetailsLoader, IFluidModuleWithDetails } from "./loader";
 
 const PackageNotFactoryError = "Code package does not implement IRuntimeFactory";
@@ -109,8 +109,10 @@ export class ContainerContext implements IContainerContext {
     /** @deprecated Added back to unblock 0.56 integration */
     public get id(): string {
         const resolvedUrl = this.container.resolvedUrl;
-        ensureFluidResolvedUrl(resolvedUrl);
-        return resolvedUrl.id;
+        if (isFluidResolvedUrl(resolvedUrl)) {
+            return resolvedUrl.id;
+        }
+        return "";
     }
 
     public get clientDetails(): IClientDetails {


### PR DESCRIPTION
Cherry-picked from https://github.com/microsoft/FluidFramework/pull/9289.
As part of https://github.com/microsoft/FluidFramework/issues/9288

[Teams post with the investigation](https://teams.microsoft.com/l/message/19:2309a5f41d894db984a8efc811dbb4b6@thread.skype/1646203767372?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=422665a0-7ad3-4d0d-9171-e8881d0397d9&parentMessageId=1644349038923&teamName=FFX%20(Fluid%20Framework%20and%20Experiences)&channelName=Dev%20%F0%9F%91%A9%E2%80%8D%F0%9F%92%BB&createdTime=1646203767372)