### PR TITLE
ODSP driver: TreesLatest telemetry cleanup

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -216,23 +216,29 @@ async function fetchLatestSnapshotCore(
             logger,
             perfEvent,
             async (event) => {
-                const startTime = performance.now();
                 const response = await snapshotDownloader(
                     odspResolvedUrl,
                     storageToken,
                     snapshotOptions,
                     controller,
                 );
-                const endTime = performance.now();
-                const overallTime = endTime - startTime;
                 const snapshot = response.odspSnapshotResponse.content;
+                // From: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
+                // fetchStart: immediately before the browser starts to fetch the resource.
+                // requestStart: immediately before the browser starts requesting the resource from the server
+                // responseStart: immediately after the browser receives the first byte of the response from the server.
+                // responseEnd: immediately after the browser receives the last byte of the resource
+                //              or immediately before the transport connection is closed, whichever comes first.
+                // secureConnectionStart: immediately before the browser starts the handshake process to secure the
+                //              current connection. If a secure connection is not used, this property returns zero.
+                // startTime: Time when the resource fetch started. This value is equivalent to fetchStart.
                 let dnstime: number | undefined; // domainLookupEnd - domainLookupStart
                 let redirectTime: number | undefined; // redirectEnd -redirectStart
                 let tcpHandshakeTime: number | undefined; // connectEnd  - connectStart
                 let secureConntime: number | undefined; // connectEnd  - secureConnectionStart
                 let responseTime: number | undefined; // responsEnd - responseStart
-                let fetchStToRespEndTime: number | undefined; // responseEnd  - fetchStart
-                let reqStToRespEndTime: number | undefined; // responseEnd - requestStart
+                let fetchStartToResponseEndTime: number | undefined; // responseEnd  - fetchStart
+                let reqStartToResponseEndTime: number | undefined; // responseEnd - requestStart
                 let networkTime: number | undefined; // responseEnd - startTime
                 const spReqDuration = response.odspSnapshotResponse.headers.get("sprequestduration");
 
@@ -249,14 +255,16 @@ async function fetchLatestSnapshotCore(
                         dnstime = indResTime.domainLookupEnd - indResTime.domainLookupStart;
                         tcpHandshakeTime = indResTime.connectEnd - indResTime.connectStart;
                         secureConntime = (indResTime.secureConnectionStart > 0) ?
-                            (indResTime.connectEnd - indResTime.secureConnectionStart) : 0;
-                        responseTime = indResTime.responseEnd - indResTime.responseStart;
-                        fetchStToRespEndTime = (indResTime.fetchStart > 0) ?
-                            (indResTime.responseEnd - indResTime.fetchStart) : 0;
-                        reqStToRespEndTime = (indResTime.requestStart > 0) ?
-                            (indResTime.responseEnd - indResTime.requestStart) : 0;
-                        networkTime = (indResTime.startTime > 0) ? (indResTime.responseEnd - indResTime.startTime) : 0;
-                        if (spReqDuration) {
+                            (indResTime.connectEnd - indResTime.secureConnectionStart) : undefined;
+                        responseTime = (indResTime.responseStart > 0) ?
+                            (indResTime.responseEnd - indResTime.responseStart) : undefined;
+                        fetchStartToResponseEndTime = (indResTime.fetchStart > 0) ?
+                            (indResTime.responseEnd - indResTime.fetchStart) : undefined;
+                        reqStartToResponseEndTime = (indResTime.requestStart > 0) ?
+                            (indResTime.responseEnd - indResTime.requestStart) : undefined;
+                        networkTime = (indResTime.startTime > 0) ?
+                            (indResTime.responseEnd - indResTime.fetchStart) : undefined;
+                        if (spReqDuration && networkTime) {
                             networkTime = networkTime - parseInt(spReqDuration, 10);
                         }
                         break;
@@ -265,7 +273,6 @@ async function fetchLatestSnapshotCore(
 
                 const { numTrees, numBlobs, encodedBlobsSize } =
                     validateAndEvalBlobsAndTrees(response.odspSnapshotResponse.content);
-                const clientTime = networkTime ? overallTime - networkTime : undefined;
 
                 // There are some scenarios in ODSP where we cannot cache, trees/latest will explicitly tell us when we
                 // cannot cache using an HTTP response header.
@@ -303,16 +310,14 @@ async function fetchLatestSnapshotCore(
                     sequenceNumber,
                     ops: snapshot.ops?.length ?? 0,
                     headers: Object.keys(response.requestHeaders).length !== 0 ? true : undefined,
-                    redirecttime: redirectTime,
-                    dnsLookuptime: dnstime,
-                    responsenetworkTime: responseTime,
-                    tcphandshakeTime: tcpHandshakeTime,
-                    secureconnectiontime: secureConntime,
-                    fetchstarttorespendtime: fetchStToRespEndTime,
-                    reqstarttorespendtime: reqStToRespEndTime,
-                    overalltime: overallTime,
-                    networktime: networkTime,
-                    clienttime: clientTime,
+                    redirectTime: redirectTime,
+                    dnsLookupTime: dnstime,
+                    responseNetworkTime: responseTime,
+                    tcpHandshakeTime: tcpHandshakeTime,
+                    secureConnectionTime: secureConntime,
+                    fetchStartToResponseEndTime: fetchStartToResponseEndTime,
+                    reqStartToResponseEndTime: reqStartToResponseEndTime,
+                    networkTime: networkTime,
                     // Sharing link telemetry regarding sharing link redeem status and performance. Ex: FRL; dur=100,
                     // Azure Fluid Relay service; desc=S, FRP; desc=False. Here, FRL is the duration taken for redeem,
                     // Azure Fluid Relay service is the redeem status (S means success), and FRP is a flag to indicate


### PR DESCRIPTION
Fixes #9181 
From the bug: 
1. We should remove overalltime property. We have duration that tracks same thing.
**(nichoc)** removed overalltime property
2. fetchstarttorespendtime, and others - should it be "respond", not "respend"? Also should it be fetchStartToRespondTime (camal case to make it more readable)?
**(nichoc)** Renaming - fecthStartToResponseEndTime
3. At 95% percentile, I see responsenetworkTime > duration. This seems really odd. I'd expect for any session that to be not the case, and thus true at any percentile. It's possible that some events do not have one or the other property and that's what makes it work that way. We need to get to the bottom of it.
**(nichoc)** There are scenarios where requestStart and responseStart can return 0 -  #do not calculate the reqStartToResponseEndTime and responseNetworkTime in these cases. 
4. fetchstarttorespendtime - I find name not telling me what it is. Looking at the code, it sounds like it's pretty much the same as networktime? What's the difference? Can we someone capture it in the name?
**(nichoc)** - Added comments in the code to allow understanding of these fields.
5. This code (and similar code) should not log zeros, it should log undefined if we do not have data:
fetchStToRespEndTime = (indResTime.fetchStart > 0) ?
(indResTime.responseEnd - indResTime.fetchStart) : 0;
**(nichoc)** changed to undefined if we do not have data. 
@andre4i @vladsud FYI