### PR TITLE
r11s-driver: implement persistent caching for RestLess HTTP requests

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -24780,6 +24780,14 @@
 				"postcss": "^7.0.14"
 			}
 		},
+		"idb-keyval": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.1.0.tgz",
+			"integrity": "sha512-u/qHZ75rlD3gH+Zah8dAJVJcGW/RfCnfNrFkElC5RpRCnpsCXXhqjVk+6MoVKJ3WhmNbRYdI6IIVP88e+5sxGw==",
+			"requires": {
+				"safari-14-idb-fix": "^3.0.0"
+			}
+		},
 		"identity-obj-proxy": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
@@ -38049,6 +38057,11 @@
 			"requires": {
 				"tslib": "^1.9.0"
 			}
+		},
+		"safari-14-idb-fix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+			"integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
 		},
 		"safe-buffer": {
 			"version": "5.1.2",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -12701,6 +12701,11 @@
 			"resolved": "https://registry.npmjs.org/@types/overlayscrollbars/-/overlayscrollbars-1.12.1.tgz",
 			"integrity": "sha512-V25YHbSoKQN35UasHf0EKD9U2vcmexRSp78qa8UglxFH8H3D+adEa9zGZwrqpH4TdvqeMrgMqVqsLB4woAryrQ=="
 		},
+		"@types/parse-cache-control": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+			"integrity": "sha512-JMJ+AEndsDvFiD1GxKcz9B5lJUrWDuXAgpHi2zdTplGtg3qu43OyQRaJQho/fsfE0H5WRmKwvBh+BUIdUPX4nQ=="
+		},
 		"@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -65,6 +65,7 @@
     "@fluidframework/protocol-definitions": "^0.1026.0",
     "@fluidframework/server-services-client": "^0.1034.0",
     "@fluidframework/telemetry-utils": "^0.58.0",
+    "idb-keyval": "^6.1.0",
     "json-stringify-safe": "5.0.1",
     "node-fetch": "^2.6.1",
     "socket.io-client": "^4.4.1",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -68,6 +68,7 @@
     "idb-keyval": "^6.1.0",
     "json-stringify-safe": "5.0.1",
     "node-fetch": "^2.6.1",
+    "parse-cache-control": "^1.0.1",
     "socket.io-client": "^4.4.1",
     "url-parse": "^1.5.8",
     "uuid": "^8.3.1"
@@ -81,6 +82,7 @@
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",
     "@types/node-fetch": "^2.5.10",
+    "@types/parse-cache-control": "^1.0.1",
     "@types/sinon": "^7.0.13",
     "@types/socket.io-client": "^1.4.32",
     "@types/url-parse": "^1.4.4",

--- a/packages/drivers/routerlicious-driver/src/cache.ts
+++ b/packages/drivers/routerlicious-driver/src/cache.ts
@@ -9,7 +9,10 @@ export const isNode = () => typeof window === "undefined";
 
 export interface ICacheEntry<T> {
     value: T;
-    expiration?: Date;
+    /**
+     * Milliseconds since UNIX Epoch.
+     */
+    expiration?: number;
 }
 export interface ICache {
     get<T>(key: string): Promise<T | undefined>;
@@ -17,7 +20,7 @@ export interface ICache {
 }
 
 function isCacheEntryExpired(entry: ICacheEntry<any>): boolean {
-    return entry.expiration !== undefined && Date.now() > entry.expiration.getTime()
+    return entry.expiration !== undefined && Date.now() > entry.expiration
 }
 
 export class InMemoryCache implements ICache {

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -55,7 +55,10 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             ...driverPolicies,
         };
         // Node.js runtime does not have access to IndexedDB.
-        this.persistedCache = isNode() ? new InMemoryCache() : new IndexedDBCache();
+        // TODO: We cannot store WholeSummaries across browser tabs (yet).
+        this.persistedCache = (isNode() || this.driverPolicies.enableWholeSummaryUpload)
+            ? new InMemoryCache()
+            : new IndexedDBCache();
     }
 
     public async createContainer(

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -21,7 +21,6 @@ import { IRouterliciousDriverPolicies } from "./policies";
 import { ICache } from "./cache";
 import { WholeSummaryDocumentStorageService } from "./wholeSummaryDocumentStorageService";
 import { ShreddedSummaryDocumentStorageService } from "./shreddedSummaryDocumentStorageService";
-import { ISnapshotTreeVersion } from "./definitions";
 
 export class DocumentStorageService extends DocumentStorageServiceProxy {
     private _logTailSha: string | undefined = undefined;
@@ -36,25 +35,21 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
         logger: ITelemetryLogger,
         policies: IDocumentStorageServicePolicies,
         driverPolicies?: IRouterliciousDriverPolicies,
-        blobCache?: ICache<ArrayBufferLike>,
-        snapshotTreeCache?: ICache<ISnapshotTreeVersion>): IDocumentStorageService {
+        cache?: ICache,    
+    ): IDocumentStorageService {
         const storageService = driverPolicies?.enableWholeSummaryUpload ?
             new WholeSummaryDocumentStorageService(
                 id,
                 manager,
                 logger,
                 policies,
-                blobCache,
-                snapshotTreeCache,
+                cache
             ) :
             new ShreddedSummaryDocumentStorageService(
                 id,
                 manager,
                 logger,
                 policies,
-                driverPolicies,
-                blobCache,
-                snapshotTreeCache,
             );
         // TODO: worth prefetching latest summary making version + snapshot call with WholeSummary storage?
         if (!driverPolicies?.enableWholeSummaryUpload && policies.caching === LoaderCachingPolicy.Prefetch) {
@@ -69,16 +64,15 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
         logger: ITelemetryLogger,
         policies: IDocumentStorageServicePolicies = {},
         driverPolicies?: IRouterliciousDriverPolicies,
-        blobCache?: ICache<ArrayBufferLike>,
-        snapshotTreeCache?: ICache<ISnapshotTreeVersion>) {
+        cache?: ICache,
+    ) {
         super(DocumentStorageService.loadInternalDocumentStorageService(
             id,
             manager,
             logger,
             policies,
             driverPolicies,
-            blobCache,
-            snapshotTreeCache,
+            cache,
         ));
     }
 


### PR DESCRIPTION
RestLess requests are not compatible with Browsers' built-in cache because they are all POST requests. We can use IndexedDB to replace the built-in browser cache when needed.

Bonus: previous additions of in-memory cache were a bit haphazard and not well-thought-out. This PR also cleans those up.