### PR TITLE
Update rootiness for aliased datastores

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -212,7 +212,10 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     }
 
     public async isRoot(): Promise<boolean> {
-        return this.isRootDataStore || (await this.getInitialSnapshotDetails()).isRootDataStore;
+        // This call updates this.isRootDataStore if it has not yet been updated
+        // The initial value is stored in the initial snapshot of the data store
+        await this.getInitialSnapshotDetails();
+        return this.isRootDataStore;
     }
 
     protected registry: IFluidDataStoreRegistry | undefined;
@@ -863,7 +866,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         );
 
         this.snapshotTree = props.snapshotTree;
-        this.isRootDataStore = props.isRootDataStore ? props.isRootDataStore : false;
+        this.isRootDataStore = props.isRootDataStore ?? false;
         this.createProps = props.createProps;
         this.attachListeners();
     }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -106,11 +106,6 @@ export function createAttributesBlob(
 
 interface ISnapshotDetails {
     pkg: readonly string[];
-    /**
-     * This tells whether a data store is root. Root data stores are never collected.
-     * Non-root data stores may be collected if they are not used.
-     */
-    isRootDataStore: boolean;
     snapshot?: ISnapshotTree;
 }
 
@@ -813,7 +808,6 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             pkg: this.pkg!,
             snapshot: tree,
-            isRootDataStore,
         };
     });
 
@@ -942,7 +936,6 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
         return {
             pkg: this.pkg,
             snapshot,
-            isRootDataStore: this.isRootDataStore,
         };
     }
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -83,6 +83,8 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
     });
 
+    // TODO: fully validate that GC is notified. Currently this tests the race condition
+    // where a remote datastore is summarized before the alias op arrives when trySetAlias is called.
     itExpects("GC is notified when datastores are aliased.", [], async () => {
         await summarizeOnContainer(container2);
         const containerRuntime1 = mainDataStore1.containerRuntime;
@@ -111,7 +113,7 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
         const aliasedDataStore2 = aliasedDataStoreResponse2.value as TestDataObject;
         assert(aliasedDataStore2._context.baseSnapshot?.unreferenced !== true, "datastore should be referenced");
         
-        // await summarizeOnContainer(container2);
-        // Check GC is notified
+        await summarizeOnContainer(container2);
+        // TODO: Check GC is notified
     });
 }); 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    ContainerRuntimeFactoryWithDefaultDataStore,
+    DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
+import {
+    AliasResult,
+    IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime";
+import { IContainerRuntimeBase, } from "@fluidframework/runtime-definitions";
+import { TestDataObject } from "./mockSummarizerClient";
+import { mockConfigProvider } from "./mockConfigProivder";
+
+/**
+ * Validates this scenario: When a data store is shared with an external app, if the data store becomes unreferenced
+ * by the time it is requested via this external app, we return a failure (404).
+ * Basically, for data stores that are unreferenced in the base snapshot that a container loads from, we return a
+ * failure (404) when they are requested with "externalRequest" flag in the request header.
+ */
+describeNoCompat("GC Data Store Requests", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+    const dataObjectFactory = new DataObjectFactory(
+        "TestDataObject",
+        TestDataObject,
+        [],
+        []);
+
+    const runtimeOptions: IContainerRuntimeOptions = {
+        summaryOptions: {
+            disableSummaries: true,
+        },
+        gcOptions: {
+            gcAllowed: true,
+        },
+    };
+    const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+        runtime.IFluidHandleContext.resolveHandle(request);
+    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+        dataObjectFactory,
+        [
+            [dataObjectFactory.type, Promise.resolve(dataObjectFactory)],
+        ],
+        undefined,
+        [innerRequestHandler],
+        runtimeOptions,
+    );
+    
+    // Enable config provider setting to write GC data at the root.
+    const settings = { "Fluid.GarbageCollection.LogUnknownOutboundRoutes": "true" };
+    const configProvider = mockConfigProvider(settings);
+
+    let container1: IContainer;
+    let container2: IContainer;
+    let mainDataStore1: TestDataObject;
+    let mainDataStore2: TestDataObject;
+
+    /**
+     * Waits for a summary with the current state of the document (including all in-flight changes). It basically
+     * synchronizes all containers and waits for a summary that contains the last processed sequence number.
+     * @returns the version of this summary. This version can be used to load a Container with the summary associated
+     * with it.
+     */
+     async function summarizeRemoteContainer(container: IContainer) {
+        const dataStore = await requestFluidObject<TestDataObject>(container, "default");
+        return dataStore.containerRuntime.summarize({runGC: true, trackState: false});
+    }
+
+    const createContainer = async (): Promise<IContainer> => {
+        return provider.createContainer(runtimeFactory, { configProvider });
+    }
+    const loadContainer = async (): Promise<IContainer> => {
+        return provider.loadContainer(runtimeFactory, { configProvider });
+    };
+    beforeEach(async () => {
+        provider = getTestObjectProvider();
+
+        // Create a Container for the first client.
+        container1 = await createContainer();
+        container2 = await loadContainer();
+
+        mainDataStore1 = await requestFluidObject<TestDataObject>(container1, "default");
+        mainDataStore2 = await requestFluidObject<TestDataObject>(container2, "default");
+        await provider.ensureSynchronized();
+    });
+
+    itExpects("GC is notified when datastores are aliased.", [], async () => {
+        await summarizeRemoteContainer(container2);
+        const containerRuntime1 = mainDataStore1.containerRuntime;
+        const aliasableDataStore1 = await containerRuntime1.createDataStore("TestDataObject");
+
+        (aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
+        await provider.ensureSynchronized();
+
+        // Summarize before aliasing
+        const containerRuntime2 = mainDataStore2.containerRuntime;
+
+        // We run the summary so await this.getInitialSnapshotDetails() is called before the datastore is aliased
+        // and after the datastore is attached. This sets the isRootDataStore. This should be passing as there is 
+        // further GC work that will require this test to pass https://github.com/microsoft/FluidFramework/issues/8859
+        await summarizeRemoteContainer(container2);
+
+        // Alias a datastore
+        const alias = "alias";
+        const aliasResult1 = await aliasableDataStore1.trySetAlias(alias);
+        assert(aliasResult1 === AliasResult.Success, `Expected an successful aliasing. Got: ${aliasResult1}`);
+        await provider.ensureSynchronized();
+        
+        // Should be able to retrieve root datastore from remote
+        const aliasableDataStore2 = await containerRuntime2.getRootDataStore(alias);
+        const aliasedDataStoreResponse2 = await aliasableDataStore2.request({url:"/"});
+        const aliasedDataStore2 = aliasedDataStoreResponse2.value as TestDataObject;
+        assert(aliasedDataStore2._context.baseSnapshot?.unreferenced !== true, "datastore should be referenced");
+        
+        // await summarizeRemoteContainer(container2);
+        // Check GC is notified
+    });
+}); 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -12,7 +12,7 @@ import { IContainer } from "@fluidframework/container-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
-import { describeFullCompat, itExpects } from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import {
     IContainerRuntimeOptions,
 } from "@fluidframework/container-runtime";
@@ -85,16 +85,13 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
 
     // TODO: fully validate that GC is notified. Currently this tests the race condition
     // where a remote datastore is summarized before the alias op arrives when trySetAlias is called.
-    itExpects("GC is notified when datastores are aliased.", [], async () => {
+    it("GC is notified when datastores are aliased.", async () => {
         await summarizeOnContainer(container2);
         const containerRuntime1 = mainDataStore1.containerRuntime;
         const aliasableDataStore1 = await containerRuntime1.createDataStore("TestDataObject");
 
         (aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
         await provider.ensureSynchronized();
-
-        // Summarize before aliasing
-        const containerRuntime2 = mainDataStore2.containerRuntime;
 
         // We run the summary so await this.getInitialSnapshotDetails() is called before the datastore is aliased
         // and after the datastore is attached. This sets the isRootDataStore. This should be passing as there is 
@@ -108,6 +105,7 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
         
         // Should be able to retrieve root datastore from remote
+        const containerRuntime2 = mainDataStore2.containerRuntime;
         const aliasableDataStore2 = await containerRuntime2.getRootDataStore(alias);
         const aliasedDataStoreResponse2 = await aliasableDataStore2.request({url:"/"});
         const aliasedDataStore2 = aliasedDataStoreResponse2.value as TestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
@@ -6,6 +6,7 @@
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 
 export const mockConfigProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => {
+    settings["Fluid.ContainerRuntime.UseDataStoreAliasing"] = "true";
     return {
         getRawConfig: (name: string): ConfigTypes => settings[name],
     };

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
@@ -37,6 +37,10 @@ export class TestDataObject extends DataObject {
     public get containerRuntime(): ContainerRuntime {
         return this.context.containerRuntime as ContainerRuntime;
     }
+
+    public get _context() {
+        return this.context;
+    }
 }
 
 /**


### PR DESCRIPTION
Resolves #9286 

This resolves the issue of the rootiness of aliased datastores when this race condition occurs
1. A connected client begins creating an aliased datastore
2. The connected client sends the attach op via bindToContext
3. A remote client summarizes the datastore attach op setting the rootiness of the datastore to be false
4. The connected client sends the alias op
5. The remote client summarizes the alias op and fails to update the datastore rootiness

For documents where this has occurred, the new clients will properly update the rootiness of aliased datastores in which this bug has occurred