### PR TITLE
`_createDataStoreWithProps` returns `IDataStore`

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -92,7 +92,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     createDataStore(pkg: string | string[]): Promise<IDataStore>;
     // (undocumented)
-    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IFluidRouter>;
+    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IDataStore>;
     // (undocumented)
     createDetachedDataStore(pkg: Readonly<string[]>): IFluidDataStoreContextDetached;
     // (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -84,7 +84,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     readonly clientDetails: IClientDetails;
     createDataStore(pkg: string | string[]): Promise<IDataStore>;
     // @internal @deprecated (undocumented)
-    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IFluidRouter>;
+    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IDataStore>;
     createDetachedDataStore(pkg: Readonly<string[]>): IFluidDataStoreContextDetached;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getAudience(): IAudience;
@@ -377,7 +377,6 @@ export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRe
 
 // @public (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1814,10 +1814,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * @param props - Properties for the data store
      * @returns - An aliased data store which can can be found / loaded by alias.
      */
-    private async createAndAliasDataStore(pkg: string | string[], alias: string, props?: any): Promise<IFluidRouter> {
+    private async createAndAliasDataStore(pkg: string | string[], alias: string, props?: any): Promise<IDataStore> {
         const internalId = uuid();
         const dataStore = await this._createDataStore(pkg, false /* isRoot */, internalId, props);
-        const aliasedDataStore = channelToDataStore(dataStore, internalId, this,this.dataStores, this.mc.logger);
+        const aliasedDataStore = channelToDataStore(dataStore, internalId, this, this.dataStores, this.mc.logger);
         const result = await aliasedDataStore.trySetAlias(alias);
         if (result !== "Success") {
             throw new GenericError(
@@ -1861,13 +1861,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         props?: any,
         id = uuid(),
         isRoot = false,
-    ): Promise<IFluidRouter> {
+    ): Promise<IDataStore> {
         const fluidDataStore = await this.dataStores._createFluidDataStoreContext(
             Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
         if (isRoot) {
             fluidDataStore.bindToContext();
         }
-        return fluidDataStore;
+        return channelToDataStore(fluidDataStore, id, this, this.dataStores, this.mc.logger);
     }
 
     public async _createDataStoreWithProps(
@@ -1875,7 +1875,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         props?: any,
         id = uuid(),
         isRoot = false,
-    ): Promise<IFluidRouter> {
+    ): Promise<IDataStore> {
         return this._aliasingEnabled === true && isRoot ?
             this.createAndAliasDataStore(pkg, id, props) :
             this._createDataStoreWithPropsLegacy(pkg, props, id, isRoot);

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -125,7 +125,7 @@ export interface IContainerRuntimeBase extends
         props?: any,
         id?: string,
         isRoot?: boolean,
-    ): Promise<IFluidRouter>;
+    ): Promise<IDataStore>;
 
     /**
      * Creates data store. Returns router of data store. Data store is not bound to container,

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -212,6 +212,24 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             assert.ok(await getRootDataStore(dataObject1, "2"));
         });
 
+        it("Root datastore creation with aliasing turned on and legacy API returns already aliased datastore", async () => {
+            // Containers need to be recreated in order for the settings to be picked up
+            await reset();
+            await setupContainers(testContainerConfig, { "Fluid.ContainerRuntime.UseDataStoreAliasing": "true" });
+
+            await createDataStoreWithProps(dataObject1, "1", true /* root */);
+            const ds = await runtimeOf(dataObject1).createDataStore(packageName);
+            const aliasResult = await ds.trySetAlias("1");
+            assert.equal(aliasResult, "Conflict");
+        });
+
+        it("Datastore creation with aliasing turned off and legacy API returns datastore which can be aliased ", async () => {
+            await createDataStoreWithProps(dataObject1, "1", false /* root */);
+            const ds = await runtimeOf(dataObject1).createDataStore(packageName);
+            const aliasResult = await ds.trySetAlias("2");
+            assert.equal(aliasResult, "Success");
+        });
+
         it("Root datastore creation fails when already attached - same container", async () => {
             let error: Error | undefined;
             try {

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -217,10 +217,13 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             await reset();
             await setupContainers(testContainerConfig, { "Fluid.ContainerRuntime.UseDataStoreAliasing": "true" });
 
-            await createDataStoreWithProps(dataObject1, "1", true /* root */);
-            const ds = await runtimeOf(dataObject1).createDataStore(packageName);
-            const aliasResult = await ds.trySetAlias("1");
-            assert.equal(aliasResult, "Conflict");
+            const ds1 = await createDataStoreWithProps(dataObject1, "1", true /* root */);
+            const aliasResult1 = await ds1.trySetAlias("2");
+            assert.equal(aliasResult1, "AlreadyAliased");
+
+            const ds2 = await runtimeOf(dataObject1).createDataStore(packageName);
+            const aliasResult2 = await ds2.trySetAlias("1");
+            assert.equal(aliasResult2, "Conflict");
         });
 
         it("Datastore creation with aliasing turned off and legacy API returns datastore which can be aliased ", async () => {


### PR DESCRIPTION
Part of https://github.com/microsoft/FluidFramework/pull/7940

See https://github.com/microsoft/FluidFramework/issues/8698

In order to make it easier for adoption, `_createDataStoreWithProps` should return an aliasible object.