### PR TITLE
Simple mechanism to catch a runaway container that is not making progress - backport 0.56

### DIFF
--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -15,6 +15,8 @@ import { MockDeltaManager, MockQuorum } from "@fluidframework/test-runtime-utils
 import { ContainerRuntime, ScheduleManager } from "../containerRuntime";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import { GenericError } from "@fluidframework/container-utils";
+import { PendingStateManager } from "../pendingStateManager";
+import { DataStores } from "../dataStores";
 
 describe("Runtime", () => {
     describe("Container Runtime", () => {
@@ -452,6 +454,182 @@ describe("Runtime", () => {
 
                 testWrongBatches();
             });
+        });
+        describe("Pending state progress tracking", () => {
+            const maxReconnects = 15;
+
+            let containerRuntime: ContainerRuntime;
+            const mockLogger = new MockLogger();
+            const containerErrors: ICriticalContainerError[] = [];
+            const getMockContext = (): Partial<IContainerContext> => {
+                return {
+                    clientId: "fakeClientId",
+                    deltaManager: new MockDeltaManager(),
+                    quorum: new MockQuorum(),
+                    logger: mockLogger,
+                    clientDetails: { capabilities: { interactive: true } },
+                    closeFn: (error?: ICriticalContainerError): void => {
+                        if (error !== undefined) {
+                            containerErrors.push(error);
+                        }
+                    },
+                    updateDirtyContainerState: (dirty: boolean) => { },
+                };
+            };
+            const getMockPendingStateManager = (hasPendingMessages: boolean): PendingStateManager => {
+                return {
+                    replayPendingStates: () => { },
+                    hasPendingMessages: () => hasPendingMessages,
+                    processMessage: (_message: ISequencedDocumentMessage, _local: boolean) => {
+                        return { localAck: false, localOpMetadata: undefined };
+                    },
+                } as PendingStateManager;
+            }
+            const getMockDataStores = (): DataStores => {
+                return {
+                    processFluidDataStoreOp:
+                        (_message: ISequencedDocumentMessage,
+                            _local: boolean,
+                            _localMessageMetadata: unknown) => { },
+                    setConnectionState: (_connected: boolean, _clientId?: string) => { },
+                } as DataStores;
+            }
+
+            const getFirstContainerError = (): ICriticalContainerError => {
+                assert.ok(containerErrors.length > 0, "Container should have errors");
+                return containerErrors[0];
+            };
+
+            beforeEach(async () => {
+                containerErrors.length = 0;
+                containerRuntime = await ContainerRuntime.load(
+                    getMockContext() as IContainerContext,
+                    [],
+                    undefined, // requestHandler
+                    {
+                        summaryOptions: {
+                            disableSummaries: true,
+                        },
+                    },
+                );
+            });
+
+            function patchRuntime(
+                pendingStateManager: PendingStateManager,
+                maxReconnects: number | undefined = undefined
+            ) {
+                const runtime = containerRuntime as any;
+                runtime.pendingStateManager = pendingStateManager;
+                runtime.dataStores = getMockDataStores();
+                runtime.maxConsecutiveReconnects = maxReconnects ?? runtime.maxConsecutiveReconnects;
+                return runtime as ContainerRuntime;
+            }
+
+            it(`No progress for ${maxReconnects} connection state changes and pending state will ` +
+                "close the container", async () => {
+                    patchRuntime(getMockPendingStateManager(true /* always has pending messages */));
+
+                    for (let i = 0; i < maxReconnects; i++) {
+                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                    }
+
+                    const error = getFirstContainerError();
+                    assert.ok(error instanceof GenericError);
+                    assert.strictEqual(error.fluidErrorCode, "MaxReconnectsWithNoProgress");
+                    assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
+                    mockLogger.assertMatchAny([{
+                        eventName: "ContainerRuntime:ReconnectsWithNoProgress",
+                        attempts: 7,
+                    }]);
+                });
+
+            it(`No progress for ${maxReconnects} / 2 connection state changes and pending state will ` +
+                "not close the container", async () => {
+                    patchRuntime(getMockPendingStateManager(true /* always has pending messages */));
+
+                    for (let i = 0; i < maxReconnects / 2; i++) {
+                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                    }
+
+                    assert.equal(containerErrors.length, 0);
+                    mockLogger.assertMatchAny([{
+                        eventName: "ContainerRuntime:ReconnectsWithNoProgress",
+                        attempts: 7,
+                    }]);
+                });
+
+            it(`No progress for ${maxReconnects} connection state changes and pending state with` +
+                "feature disabled will not close the container", async () => {
+                    patchRuntime(
+                        getMockPendingStateManager(true /* always has pending messages */),
+                        -1 /* maxConsecutiveReplays */);
+
+                    for (let i = 0; i < maxReconnects; i++) {
+                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                    }
+
+                    assert.equal(containerErrors.length, 0);
+                    mockLogger.assertMatch([]);
+                });
+
+            it(`No progress for ${maxReconnects} connection state changes and no pending state will ` +
+                "not close the container", async () => {
+                    patchRuntime(getMockPendingStateManager(false /* always has no pending messages */));
+
+                    for (let i = 0; i < maxReconnects; i++) {
+                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                    }
+
+                    assert.equal(containerErrors.length, 0);
+                    mockLogger.assertMatch([]);
+                });
+
+            it(`No progress for ${maxReconnects} connection state changes and pending state but successfully ` +
+                "processing local op will not close the container", async () => {
+                    patchRuntime(getMockPendingStateManager(true /* always has pending messages */));
+
+                    for (let i = 0; i < maxReconnects; i++) {
+                        containerRuntime.setConnectionState(!containerRuntime.connected);
+                        containerRuntime.process({
+                            type: "op",
+                            clientId: "clientId",
+                            sequenceNumber: 0,
+                            contents: {
+                                address: "address",
+                            },
+                        } as any as ISequencedDocumentMessage, true /* local */);
+                    }
+
+                    assert.equal(containerErrors.length, 0);
+                    mockLogger.assertMatch([]);
+                });
+
+            it(`No progress for ${maxReconnects} connection state changes and pending state but successfully ` +
+                "processing remote op will close the container", async () => {
+                    patchRuntime(getMockPendingStateManager(true /* always has pending messages */));
+
+                    for (let i = 0; i < maxReconnects; i++) {
+                        containerRuntime.setConnectionState(false);
+                        containerRuntime.setConnectionState(true);
+                        containerRuntime.process({
+                            type: "op",
+                            clientId: "clientId",
+                            sequenceNumber: 0,
+                            contents: {
+                                address: "address",
+                            },
+                        } as any as ISequencedDocumentMessage, false /* local */);
+                    }
+
+                    const error = getFirstContainerError();
+                    assert.ok(error instanceof GenericError);
+                    assert.strictEqual(error.fluidErrorCode, "MaxReconnectsWithNoProgress");
+                    assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
+                    mockLogger.assertMatchAny([{
+                        eventName: "ContainerRuntime:ReconnectsWithNoProgress",
+                        attempts: 7,
+                    }]);
+                });
         });
     });
 });

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -537,10 +537,10 @@ describe("Runtime", () => {
                     assert.ok(error instanceof GenericError);
                     assert.strictEqual(error.fluidErrorCode, "MaxReconnectsWithNoProgress");
                     assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
-                    mockLogger.assertMatchAny([{
+                    assert.ok(mockLogger.matchAnyEvent([{
                         eventName: "ContainerRuntime:ReconnectsWithNoProgress",
                         attempts: 7,
-                    }]);
+                    }]));
                 });
 
             it(`No progress for ${maxReconnects} / 2 connection state changes and pending state will ` +
@@ -552,10 +552,10 @@ describe("Runtime", () => {
                     }
 
                     assert.equal(containerErrors.length, 0);
-                    mockLogger.assertMatchAny([{
+                    assert.ok(mockLogger.matchAnyEvent([{
                         eventName: "ContainerRuntime:ReconnectsWithNoProgress",
                         attempts: 7,
-                    }]);
+                    }]));
                 });
 
             it(`No progress for ${maxReconnects} connection state changes and pending state with` +
@@ -569,7 +569,7 @@ describe("Runtime", () => {
                     }
 
                     assert.equal(containerErrors.length, 0);
-                    mockLogger.assertMatch([]);
+                    mockLogger.matchEvents([]);
                 });
 
             it(`No progress for ${maxReconnects} connection state changes and no pending state will ` +
@@ -581,7 +581,7 @@ describe("Runtime", () => {
                     }
 
                     assert.equal(containerErrors.length, 0);
-                    mockLogger.assertMatch([]);
+                    mockLogger.matchEvents([]);
                 });
 
             it(`No progress for ${maxReconnects} connection state changes and pending state but successfully ` +
@@ -601,7 +601,7 @@ describe("Runtime", () => {
                     }
 
                     assert.equal(containerErrors.length, 0);
-                    mockLogger.assertMatch([]);
+                    mockLogger.matchEvents([]);
                 });
 
             it(`No progress for ${maxReconnects} connection state changes and pending state but successfully ` +
@@ -625,10 +625,10 @@ describe("Runtime", () => {
                     assert.ok(error instanceof GenericError);
                     assert.strictEqual(error.fluidErrorCode, "MaxReconnectsWithNoProgress");
                     assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
-                    mockLogger.assertMatchAny([{
+                    assert.ok(mockLogger.matchAnyEvent([{
                         eventName: "ContainerRuntime:ReconnectsWithNoProgress",
                         attempts: 7,
-                    }]);
+                    }]));
                 });
         });
     });


### PR DESCRIPTION
Original: https://github.com/microsoft/FluidFramework/pull/9243

Part of #9023 as this behavior is always observed when we hit the socket.io payload size limit and the container enters an endless reconnect loop.