### PR TITLE
Added a deprecated interface to facilitate calling bindToContext on created data stores

### DIFF
--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -10,6 +10,7 @@ import { FlushMode } from '@fluidframework/runtime-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
 import { IContainerRuntimeBaseEvents } from '@fluidframework/runtime-definitions';
+import { IDataStore } from '@fluidframework/runtime-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
@@ -66,6 +67,14 @@ export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     (event: "connected", listener: (clientId: string) => void): any;
     // (undocumented)
     (event: "localHelp", listener: (message: IHelpMessage) => void): any;
+}
+
+// @public @deprecated (undocumented)
+export interface IDataStoreWithBindToContext_Deprecated extends IDataStore {
+    // (undocumented)
+    fluidDataStoreChannel?: {
+        bindToContext?(): void;
+    };
 }
 
 // @public @deprecated (undocumented)

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -29,7 +29,7 @@ import {
     IContainerRuntimeBaseEvents,
     IFluidDataStoreContextDetached,
     IProvideFluidDataStoreRegistry,
- } from "@fluidframework/runtime-definitions";
+} from "@fluidframework/runtime-definitions";
 
 /**
  * @deprecated - This will be removed in a later release.

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -27,9 +27,17 @@ import {
     FlushMode,
     IContainerRuntimeBase,
     IContainerRuntimeBaseEvents,
+    IDataStore,
     IFluidDataStoreContextDetached,
     IProvideFluidDataStoreRegistry,
 } from "@fluidframework/runtime-definitions";
+
+/**
+ * @deprecated - This will be removed once https://github.com/microsoft/FluidFramework/issues/9127 is fixed.
+ */
+export interface IDataStoreWithBindToContext_Deprecated extends IDataStore {
+    fluidDataStoreChannel?: { bindToContext?(): void; }
+}
 
 /**
  * @deprecated - This will be removed in a later release.

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -36,7 +36,7 @@ import {
  * @deprecated - This will be removed once https://github.com/microsoft/FluidFramework/issues/9127 is fixed.
  */
 export interface IDataStoreWithBindToContext_Deprecated extends IDataStore {
-    fluidDataStoreChannel?: { bindToContext?(): void; }
+    fluidDataStoreChannel?: { bindToContext?(): void; };
 }
 
 /**

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -13,13 +13,6 @@ import { ContainerRuntime } from "./containerRuntime";
 import { DataStores } from "./dataStores";
 
 /**
- * @deprecated - This will be removed once https://github.com/microsoft/FluidFramework/issues/9127 is fixed.
- */
-export interface IDataStoreWithBindToContext_Deprecated extends IDataStore {
-    bindToContext(): void;
-}
-
-/**
  * Interface for an op to be used for assigning an
  * alias to a datastore
  */
@@ -134,13 +127,6 @@ class DataStore implements IDataStore {
         private readonly logger: ITelemetryLogger,
     ) { }
     public get IFluidRouter() { return this.fluidDataStoreChannel; }
-
-    /**
-     * @deprecated - This will be removed once https://github.com/microsoft/FluidFramework/issues/9127 is fixed.
-     */
-    public bindToContext() {
-        this.fluidDataStoreChannel.bindToContext();
-    }
 
     private async ackBasedPromise<T>(
         executor: (resolve: (value: T | PromiseLike<T>) => void,

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -13,6 +13,13 @@ import { ContainerRuntime } from "./containerRuntime";
 import { DataStores } from "./dataStores";
 
 /**
+ * @deprecated - This will be removed once https://github.com/microsoft/FluidFramework/issues/9127 is fixed.
+ */
+export interface IDataStoreWithBindToContext_Deprecated extends IDataStore {
+    bindToContext(): void;
+}
+
+/**
  * Interface for an op to be used for assigning an
  * alias to a datastore
  */
@@ -127,6 +134,13 @@ class DataStore implements IDataStore {
         private readonly logger: ITelemetryLogger,
     ) { }
     public get IFluidRouter() { return this.fluidDataStoreChannel; }
+
+    /**
+     * @deprecated - This will be removed once https://github.com/microsoft/FluidFramework/issues/9127 is fixed.
+     */
+    public bindToContext() {
+        this.fluidDataStoreChannel.bindToContext();
+    }
 
     private async ackBasedPromise<T>(
         executor: (resolve: (value: T | PromiseLike<T>) => void,


### PR DESCRIPTION
Added new deprecated interface derived from `IDataStore`. This is a workaround to bind data stores in detached container until https://github.com/microsoft/FluidFramework/issues/9127 is fixed. Once the above bug is fixed, this will be removed.
The usage is to cast the IDataStore to IDataStoreWithBindToContext_Deprecated and call fluidDataStoreChannel?.bindToContext() on it.