### PR TITLE
Codeowners check should run on pull_request instead of pull_request_target

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,6 @@
 /.devcontainer/                                                           @microsoft/fluid-cr-infra
 /.github/                                                                 @microsoft/fluid-cr-infra
 /.github/ISSUE_TEMPLATE/                                                  @microsoft/fluid-cr-docs
-/.github/workflows/azure-static-web-apps-agreeable-hill-0eeff5b10.yml     @microsoft/fluid-cr-docs
 /.md-magic-templates/                                                     @microsoft/fluid-cr-docs
 /.vscode/                                                                 @microsoft/fluid-cr-infra
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,6 +1,6 @@
 name: "Fluid PR Validation"
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches:
     - main


### PR DESCRIPTION
I broke CODEOWNERS in #9283, but CI still passed because the action was configured to run on `pull_request_target`. That makes it run in the base commit instead of the merge commit, so it doesn't test changes. Since we don't need write access, I just switched to `pull_request`. See the difference in the screenshot below.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/19589/156648760-a981e505-ecd9-44ab-828b-ac30453afadf.png">
