### PR TITLE
_createDataStoreWithProps returns IDataStore and Data store aliasing interface adjustments - backport 0.57

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -16,6 +16,7 @@ import { IContainerContext } from '@fluidframework/container-definitions';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';
 import { IContainerRuntimeEvents } from '@fluidframework/container-runtime-definitions';
 import { ICriticalContainerError } from '@fluidframework/container-definitions';
+import { IDataStore } from '@fluidframework/runtime-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
 import { IDisposable } from '@fluidframework/common-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
@@ -53,14 +54,6 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
 export const agentSchedulerId = "_scheduler";
-
-// @public
-export enum AliasResult {
-    Aliasing = "Aliasing",
-    AlreadyAliased = "AlreadyAliased",
-    Conflict = "Conflict",
-    Success = "Success"
-}
 
 // @public (undocumented)
 export enum ContainerMessageType {
@@ -324,11 +317,6 @@ export interface IContainerRuntimeOptions {
     // (undocumented)
     summaryOptions?: ISummaryRuntimeOptions;
     useDataStoreAliasing?: boolean;
-}
-
-// @public
-export interface IDataStore extends IFluidRouter {
-    trySetAlias(alias: string): Promise<AliasResult>;
 }
 
 // @public

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -92,7 +92,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     createDataStore(pkg: string | string[]): Promise<IDataStore>;
     // (undocumented)
-    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IFluidRouter>;
+    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IDataStore>;
     // (undocumented)
     createDetachedDataStore(pkg: Readonly<string[]>): IFluidDataStoreContextDetached;
     // (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -29,6 +29,9 @@ import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { SummaryTree } from '@fluidframework/protocol-definitions';
 
+// @public
+export type AliasResult = "Success" | "Conflict" | "Aliasing" | "AlreadyAliased";
+
 // @public (undocumented)
 export const channelsTreeName = ".channels";
 
@@ -79,7 +82,7 @@ export interface IAttachMessage {
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents>, IProvideFluidHandleContext {
     // (undocumented)
     readonly clientDetails: IClientDetails;
-    createDataStore(pkg: string | string[]): Promise<IFluidRouter>;
+    createDataStore(pkg: string | string[]): Promise<IDataStore>;
     // @internal @deprecated (undocumented)
     _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IFluidRouter>;
     createDetachedDataStore(pkg: Readonly<string[]>): IFluidDataStoreContextDetached;
@@ -104,6 +107,11 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
     (event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): any;
     // (undocumented)
     (event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): any;
+}
+
+// @public
+export interface IDataStore extends IFluidRouter {
+    trySetAlias(alias: string): Promise<AliasResult>;
 }
 
 // @public

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -84,7 +84,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     readonly clientDetails: IClientDetails;
     createDataStore(pkg: string | string[]): Promise<IDataStore>;
     // @internal @deprecated (undocumented)
-    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IFluidRouter>;
+    _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string, isRoot?: boolean): Promise<IDataStore>;
     createDetachedDataStore(pkg: Readonly<string[]>): IFluidDataStoreContextDetached;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getAudience(): IAudience;
@@ -377,7 +377,6 @@ export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRe
 
 // @public (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -138,6 +138,20 @@
           "backCompat": false,
           "forwardCompat": false
         }
+      },
+      "0.56.0": {
+        "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IProvideContainerRuntime": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IContainerRuntime": {
+          "backCompat": true,
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.56.0.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.56.0.ts
@@ -43,6 +43,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -67,6 +68,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -115,6 +117,7 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -87,6 +87,7 @@ import {
     SummarizeInternalFn,
     channelsTreeName,
     IAttachMessage,
+    IDataStore,
 } from "@fluidframework/runtime-definitions";
 import {
     addBlobToSummary,
@@ -147,9 +148,7 @@ import {
     IGCStats,
 } from "./garbageCollection";
 import {
-    AliasResult,
     channelToDataStore,
-    IDataStore,
     IDataStoreAliasMessage,
     isDataStoreAliasMessage,
 } from "./dataStore";
@@ -1809,7 +1808,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const dataStore = await this._createDataStore(pkg, false /* isRoot */, internalId, props);
         const aliasedDataStore = channelToDataStore(dataStore, internalId, this,this.dataStores, this.mc.logger);
         const result = await aliasedDataStore.trySetAlias(alias);
-        if (result !== AliasResult.Success) {
+        if (result !== "Success") {
             throw new GenericError(
                 "dataStoreAliasFailure",
                 undefined /* error */,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1803,10 +1803,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      * @param props - Properties for the data store
      * @returns - An aliased data store which can can be found / loaded by alias.
      */
-    private async createAndAliasDataStore(pkg: string | string[], alias: string, props?: any): Promise<IFluidRouter> {
+    private async createAndAliasDataStore(pkg: string | string[], alias: string, props?: any): Promise<IDataStore> {
         const internalId = uuid();
         const dataStore = await this._createDataStore(pkg, false /* isRoot */, internalId, props);
-        const aliasedDataStore = channelToDataStore(dataStore, internalId, this,this.dataStores, this.mc.logger);
+        const aliasedDataStore = channelToDataStore(dataStore, internalId, this, this.dataStores, this.mc.logger);
         const result = await aliasedDataStore.trySetAlias(alias);
         if (result !== "Success") {
             throw new GenericError(
@@ -1850,13 +1850,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         props?: any,
         id = uuid(),
         isRoot = false,
-    ): Promise<IFluidRouter> {
+    ): Promise<IDataStore> {
         const fluidDataStore = await this.dataStores._createFluidDataStoreContext(
             Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
         if (isRoot) {
             fluidDataStore.bindToContext();
         }
-        return fluidDataStore;
+        return channelToDataStore(fluidDataStore, id, this, this.dataStores, this.mc.logger);
     }
 
     public async _createDataStoreWithProps(
@@ -1864,7 +1864,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         props?: any,
         id = uuid(),
         isRoot = false,
-    ): Promise<IFluidRouter> {
+    ): Promise<IDataStore> {
         return this._aliasingEnabled === true && isRoot ?
             this.createAndAliasDataStore(pkg, id, props) :
             this._createDataStoreWithPropsLegacy(pkg, props, id, isRoot);

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -19,7 +19,6 @@ export {
     ContainerRuntime,
     RuntimeHeaders,
 } from "./containerRuntime";
-export { IDataStore, AliasResult } from "./dataStore";
 export { DeltaScheduler } from "./deltaScheduler";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";
 export {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -291,6 +291,20 @@
           "backCompat": false,
           "forwardCompat": false
         }
+      },
+      "0.56.0": {
+        "InterfaceDeclaration_IContainerRuntimeBase": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContext": {
+          "backCompat": true,
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IFluidDataStoreContextDetached": {
+          "backCompat": true,
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -64,6 +64,25 @@ export interface IContainerRuntimeBaseEvents extends IEvent{
 }
 
 /**
+ * Encapsulates the return codes of the aliasing API
+ */
+ export type AliasResult = "Success" | "Conflict" | "Aliasing" | "AlreadyAliased";
+
+/**
+ * A fluid router with the capability of being assigned an alias
+ */
+ export interface IDataStore extends IFluidRouter {
+    /**
+     * Attempt to assign an alias to the datastore.
+     * If the operation succeeds, the datastore can be referenced
+     * by the supplied alias.
+     *
+     * @param alias - Given alias for this datastore.
+     */
+    trySetAlias(alias: string): Promise<AliasResult>;
+}
+
+/**
  * A reduced set of functionality of IContainerRuntime that a data store context/data store runtime will need
  * TODO: this should be merged into IFluidDataStoreContext
  */
@@ -115,7 +134,7 @@ export interface IContainerRuntimeBase extends
      * gets attached to storage) will result in this store being attached to storage.
      * @param pkg - Package name of the data store factory
      */
-    createDataStore(pkg: string | string[]): Promise<IFluidRouter>;
+    createDataStore(pkg: string | string[]): Promise<IDataStore>;
 
     /**
      * Creates detached data store context. only after context.attachRuntime() is called,

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -125,7 +125,7 @@ export interface IContainerRuntimeBase extends
         props?: any,
         id?: string,
         isRoot?: boolean,
-    ): Promise<IFluidRouter>;
+    ): Promise<IDataStore>;
 
     /**
      * Creates data store. Returns router of data store. Data store is not bound to container,

--- a/packages/runtime/runtime-definitions/src/test/types/validate0.56.0.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validate0.56.0.ts
@@ -211,6 +211,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: current.IContainerRuntimeBase);
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*
@@ -307,6 +308,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: current.IFluidDataStoreContext);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -331,6 +333,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: current.IFluidDataStoreContextDetached);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -209,26 +209,28 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             assert.ok(await getRootDataStore(dataObject1, "2"));
         });
 
-        it("Root datastore creation with aliasing turned on and legacy API returns already aliased datastore", async () => {
-            // Containers need to be recreated in order for the settings to be picked up
-            await reset();
-            await setupContainers(testContainerConfig, { "Fluid.ContainerRuntime.UseDataStoreAliasing": "true" });
+        it("Root datastore creation with aliasing turned on and legacy API returns already aliased datastore",
+            async () => {
+                // Containers need to be recreated in order for the settings to be picked up
+                await reset();
+                await setupContainers(testContainerConfig, { "Fluid.ContainerRuntime.UseDataStoreAliasing": "true" });
 
-            const ds1 = await createDataStoreWithProps(dataObject1, "1", true /* root */);
-            const aliasResult1 = await ds1.trySetAlias("2");
-            assert.equal(aliasResult1, "AlreadyAliased");
+                const ds1 = await createDataStoreWithProps(dataObject1, "1", true /* root */);
+                const aliasResult1 = await ds1.trySetAlias("2");
+                assert.equal(aliasResult1, "AlreadyAliased");
 
-            const ds2 = await runtimeOf(dataObject1).createDataStore(packageName);
-            const aliasResult2 = await ds2.trySetAlias("1");
-            assert.equal(aliasResult2, "Conflict");
-        });
+                const ds2 = await runtimeOf(dataObject1).createDataStore(packageName);
+                const aliasResult2 = await ds2.trySetAlias("1");
+                assert.equal(aliasResult2, "Conflict");
+            });
 
-        it("Datastore creation with aliasing turned off and legacy API returns datastore which can be aliased ", async () => {
-            await createDataStoreWithProps(dataObject1, "1", false /* root */);
-            const ds = await runtimeOf(dataObject1).createDataStore(packageName);
-            const aliasResult = await ds.trySetAlias("2");
-            assert.equal(aliasResult, "Success");
-        });
+        it("Datastore creation with aliasing turned off and legacy API returns datastore which can be aliased ",
+            async () => {
+                await createDataStoreWithProps(dataObject1, "1", false /* root */);
+                const ds = await runtimeOf(dataObject1).createDataStore(packageName);
+                const aliasResult = await ds.trySetAlias("2");
+                assert.equal(aliasResult, "Success");
+            });
 
         it("Root datastore creation fails when already attached - same container", async () => {
             let error: Error | undefined;

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -209,6 +209,27 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             assert.ok(await getRootDataStore(dataObject1, "2"));
         });
 
+        it("Root datastore creation with aliasing turned on and legacy API returns already aliased datastore", async () => {
+            // Containers need to be recreated in order for the settings to be picked up
+            await reset();
+            await setupContainers(testContainerConfig, { "Fluid.ContainerRuntime.UseDataStoreAliasing": "true" });
+
+            const ds1 = await createDataStoreWithProps(dataObject1, "1", true /* root */);
+            const aliasResult1 = await ds1.trySetAlias("2");
+            assert.equal(aliasResult1, "AlreadyAliased");
+
+            const ds2 = await runtimeOf(dataObject1).createDataStore(packageName);
+            const aliasResult2 = await ds2.trySetAlias("1");
+            assert.equal(aliasResult2, "Conflict");
+        });
+
+        it("Datastore creation with aliasing turned off and legacy API returns datastore which can be aliased ", async () => {
+            await createDataStoreWithProps(dataObject1, "1", false /* root */);
+            const ds = await runtimeOf(dataObject1).createDataStore(packageName);
+            const aliasResult = await ds.trySetAlias("2");
+            assert.equal(aliasResult, "Success");
+        });
+
         it("Root datastore creation fails when already attached - same container", async () => {
             let error: Error | undefined;
             try {


### PR DESCRIPTION
PRs for main:

https://github.com/microsoft/FluidFramework/pull/9319
https://github.com/microsoft/FluidFramework/pull/9281

This would enable Bohemia to start prototyping with aliasing from 0.57.