### PR TITLE
[r11s] Adding request retries to summary reader

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/summaryReader.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryReader.ts
@@ -25,6 +25,7 @@ export class SummaryReader implements ISummaryReader {
         private readonly documentId: string,
         private readonly summaryStorage: IGitManager,
         private readonly enableWholeSummaryUpload: boolean,
+        private readonly maxRetriesOnError: number = 6,
     ) {
         this.lumberProperties = getLumberBaseProperties(this.documentId, this.tenantId);
     }
@@ -44,13 +45,13 @@ export class SummaryReader implements ISummaryReader {
                     "readWholeSummary_getRef",
                     this.lumberProperties,
                     shouldRetryNetworkError,
-                    10);
+                    this.maxRetriesOnError);
                 const wholeFlatSummary = await requestWithRetry(
                     async() => this.summaryStorage.getSummary(existingRef.object.sha),
                     "readWholeSummary_getSummary",
                     this.lumberProperties,
                     shouldRetryNetworkError,
-                    10);
+                    this.maxRetriesOnError);
                 const normalizedSummary = convertWholeFlatSummaryToSnapshotTreeAndBlobs(wholeFlatSummary);
 
                 // Obtain IDs of specific fields from the downloaded summary
@@ -106,35 +107,35 @@ export class SummaryReader implements ISummaryReader {
                     "readSummary_getRef",
                     this.lumberProperties,
                     shouldRetryNetworkError,
-                    10);
+                    this.maxRetriesOnError);
                 const [attributesContent, scribeContent, deliContent, opsContent] = await Promise.all([
                     requestWithRetry(
                         async() => this.summaryStorage.getContent(existingRef.object.sha, ".protocol/attributes"),
                         "readSummary_getProtocolAttributesContent",
                         this.lumberProperties,
                         shouldRetryNetworkError,
-                        10
+                        this.maxRetriesOnError
                     ).catch(() => undefined),
                     requestWithRetry(
                         async() => this.summaryStorage.getContent(existingRef.object.sha, ".serviceProtocol/scribe"),
                         "readSummary_getServiceProtocolScribeContent",
                         this.lumberProperties,
                         shouldRetryNetworkError,
-                        10
+                        this.maxRetriesOnError
                     ).catch(() => undefined),
                     requestWithRetry(
                         async() => this.summaryStorage.getContent(existingRef.object.sha, ".serviceProtocol/deli"),
                         "readSummary_getServiceProtocolDeliContent",
                         this.lumberProperties,
                         shouldRetryNetworkError,
-                        10
+                        this.maxRetriesOnError
                     ).catch(() => undefined),
                     requestWithRetry(
                         async() => this.summaryStorage.getContent(existingRef.object.sha, ".logTail/logTail"),
                         "readSummary_getLogTailContent",
                         this.lumberProperties,
                         shouldRetryNetworkError,
-                        10
+                        this.maxRetriesOnError
                     ).catch(() => undefined),
                 ]);
 


### PR DESCRIPTION
Also:
* Adding request retries in some places under SummaryWriter, which were missing retries
* Setting default max number of retries in SummaryWriter and Reader. Since we currently use a back-off retry with increasing delays, a max retry count = 6 means that adding all the retries wait time would be close to 2 min. That is a lot and at that point we should probably fail the operation instead of waiting indefinitely. For SummaryReader, the default summary would be used, and that might be ok during connect document as clients could replay operations from storage. In summary writer, the summary failure (service or client) would not corrupt the document, and a later summary request might succeed. Also, telemetry indicates that the 99th percentile of max retries is 6, so that's the most we would usually expect.