### PR TITLE
Update rootiness for aliased datastores (#9312)

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -1,0 +1,117 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    ContainerRuntimeFactoryWithDefaultDataStore,
+    DataObjectFactory,
+} from "@fluidframework/aqueduct";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
+import {
+    IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime";
+import { IContainerRuntimeBase, } from "@fluidframework/runtime-definitions";
+import { TestDataObject } from "./mockSummarizerClient";
+import { mockConfigProvider } from "./mockConfigProivder";
+
+/**
+ * Validates this scenario: When a datastore is aliased that it is considered a root datastore and always referenced
+ */
+describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+    const dataObjectFactory = new DataObjectFactory(
+        "TestDataObject",
+        TestDataObject,
+        [],
+        []);
+
+    const runtimeOptions: IContainerRuntimeOptions = {
+        summaryOptions: {
+            disableSummaries: true,
+        },
+        gcOptions: {
+            gcAllowed: true,
+        },
+    };
+    const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+        runtime.IFluidHandleContext.resolveHandle(request);
+    const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+        dataObjectFactory,
+        [
+            [dataObjectFactory.type, Promise.resolve(dataObjectFactory)],
+        ],
+        undefined,
+        [innerRequestHandler],
+        runtimeOptions,
+    );
+    
+    // Enable config provider setting to write GC data at the root.
+    const settings = { "Fluid.GarbageCollection.LogUnknownOutboundRoutes": "true" };
+    const configProvider = mockConfigProvider(settings);
+
+    let container1: IContainer;
+    let container2: IContainer;
+    let mainDataStore1: TestDataObject;
+    let mainDataStore2: TestDataObject;
+
+     async function summarizeOnContainer(container: IContainer) {
+        const dataStore = await requestFluidObject<TestDataObject>(container, "default");
+        return dataStore.containerRuntime.summarize({runGC: true, trackState: false});
+    }
+
+    const createContainer = async (): Promise<IContainer> => {
+        return provider.createContainer(runtimeFactory, { configProvider });
+    }
+    const loadContainer = async (): Promise<IContainer> => {
+        return provider.loadContainer(runtimeFactory, { configProvider });
+    };
+    beforeEach(async () => {
+        provider = getTestObjectProvider();
+
+        // Create a Container for the first client.
+        container1 = await createContainer();
+        container2 = await loadContainer();
+
+        mainDataStore1 = await requestFluidObject<TestDataObject>(container1, "default");
+        mainDataStore2 = await requestFluidObject<TestDataObject>(container2, "default");
+        await provider.ensureSynchronized();
+    });
+
+    // TODO: fully validate that GC is notified. Currently this tests the race condition
+    // where a remote datastore is summarized before the alias op arrives when trySetAlias is called.
+    it("GC is notified when datastores are aliased.", async () => {
+        await summarizeOnContainer(container2);
+        const containerRuntime1 = mainDataStore1.containerRuntime;
+        const aliasableDataStore1 = await containerRuntime1.createDataStore("TestDataObject");
+
+        (aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
+        await provider.ensureSynchronized();
+
+        // We run the summary so await this.getInitialSnapshotDetails() is called before the datastore is aliased
+        // and after the datastore is attached. This sets the isRootDataStore. This should be passing as there is 
+        // further GC work that will require this test to pass https://github.com/microsoft/FluidFramework/issues/8859
+        await summarizeOnContainer(container2);
+
+        // Alias a datastore
+        const alias = "alias";
+        const aliasResult1 = await aliasableDataStore1.trySetAlias(alias);
+        assert(aliasResult1 === "Success", `Expected an successful aliasing. Got: ${aliasResult1}`);
+        await provider.ensureSynchronized();
+        
+        // Should be able to retrieve root datastore from remote
+        const containerRuntime2 = mainDataStore2.containerRuntime;
+        const aliasableDataStore2 = await containerRuntime2.getRootDataStore(alias);
+        const aliasedDataStoreResponse2 = await aliasableDataStore2.request({url:"/"});
+        const aliasedDataStore2 = aliasedDataStoreResponse2.value as TestDataObject;
+        assert(aliasedDataStore2._context.baseSnapshot?.unreferenced !== true, "datastore should be referenced");
+        
+        await summarizeOnContainer(container2);
+        // TODO: Check GC is notified
+    });
+}); 

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockConfigProivder.ts
@@ -6,6 +6,7 @@
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 
 export const mockConfigProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => {
+    settings["Fluid.ContainerRuntime.UseDataStoreAliasing"] = "true";
     return {
         getRawConfig: (name: string): ConfigTypes => settings[name],
     };

--- a/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/mockSummarizerClient.ts
@@ -37,6 +37,10 @@ export class TestDataObject extends DataObject {
     public get containerRuntime(): ContainerRuntime {
         return this.context.containerRuntime as ContainerRuntime;
     }
+
+    public get _context() {
+        return this.context;
+    }
 }
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -426,6 +426,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
          * above scenario.
          */
         it("Aliasing a bound datastore marks it as root correctly", async () => {
+            await reset();
             await setupContainers({
                 ... testContainerConfig,
                 runtimeOptions: {

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -417,5 +417,56 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             assert.equal(aliasResult3, "Conflict");
             assert.ok(await getRootDataStore(dataObject3, alias));
         });
+
+        /**
+         * Aliasing datastores summarized before the alias op is sent and after the attach op is sent
+         * does not cause a datastore corruption issue
+         * 
+         * This test validates a bug where the rootiness of a datastore was not set to true in the
+         * above scenario.
+         */
+        it("Aliasing a bound datastore marks it as root correctly", async () => {
+            await setupContainers({
+                ... testContainerConfig,
+                runtimeOptions: {
+                    summaryOptions: {
+                        disableSummaries: true,
+                    },
+                    gcOptions: {
+                        gcAllowed: true,
+                    },
+                },
+            });
+
+            const containerRuntime1 = runtimeOf(dataObject1);
+            const aliasableDataStore1 = await containerRuntime1.createDataStore(packageName);
+            const aliasedDataStoreResponse1 = await aliasableDataStore1.request({url:"/"});
+            const aliasedDataStore1 = aliasedDataStoreResponse1.value as ITestFluidObject;
+            // Casting any to repro a race condition where bindToContext is called before summarization,
+            // but aliasing happens afterwards
+            (aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
+            await provider.ensureSynchronized();
+            
+            const containerRuntime2 = runtimeOf(dataObject2) as ContainerRuntime;
+            let callFailed = false;
+            try{
+                // This executes getInitialSnapshotDetails, a LazyPromise, before the alias op is sent to update
+                // the isRootDataStore property in the dataStoreContext
+                await containerRuntime2.getRootDataStore(aliasedDataStore1.runtime.id);
+            }catch(e){
+                callFailed = true;
+            }
+            assert(callFailed, "Expected getRootDataStore to fail as the datastore is not yet a root datastore");
+            
+            // Alias a datastore
+            const alias = "alias";
+            const aliasResult1 = await aliasableDataStore1.trySetAlias(alias);
+            assert(aliasResult1 === "Success", `Expected an successful aliasing. Got: ${aliasResult1}`);
+            await provider.ensureSynchronized();
+            
+            // Should be able to retrieve root datastore from remote
+            assert.doesNotThrow(async () => 
+                await containerRuntime2.getRootDataStore(alias), "An aliased datastore should be a root datastore");
+        });
     });
 });


### PR DESCRIPTION
* Update rootiness for aliased datastores, 
* Resolves a race condition where aliased datastores were not recognized as root datastores.

Relevant issue: #9286 
Main PR: https://github.com/microsoft/FluidFramework/pull/9312