### PR TITLE
Update build tools version to get virtual patch feature

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -82,16 +82,16 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.44827",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.44827.tgz",
-      "integrity": "sha512-gU6nYhF9ZhchZCZ092dABKI7AY3brO4+BQzhmH9vakZdmQ43kL7GcjHgR5N2N6idoqcCGIulzYxoXxYxhnTrMQ==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
-        "commander": "^2.20.0",
-        "danger": "^10.4.1",
+        "commander": "^6.2.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -108,6 +108,12 @@
         "ts-morph": "^7.1.2"
       },
       "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -302,177 +308,31 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.3.tgz",
-      "integrity": "sha512-OGjrhdVgTT2TAAj/2RrdXjwxaDoTm16c2LfAzrta1xIFe6/XhgQIYDmeRN/RptQoZQBX8e9Vv2JoQq+TbghJmw==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
+      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
-        "@oclif/config": "^1.15.1",
+        "@oclif/config": "^1.18.2",
         "@oclif/errors": "^1.3.5",
-        "@oclif/parser": "^3.8.5",
-        "@oclif/plugin-help": "^3.2.4",
+        "@oclif/help": "^1.0.1",
+        "@oclif/parser": "^3.8.6",
         "debug": "^4.1.1",
         "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "@oclif/plugin-help": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.5.tgz",
-          "integrity": "sha512-fjkZTstvacCPicF2oaa3Lc+Yw3ocKEaW6x6O7doVqMLuoMUX6wBOQ+f1a3VFzO1fErqNeFPDlUlVUhwq9yMzQg==",
-          "dev": true,
-          "requires": {
-            "@oclif/command": "^1.8.3",
-            "@oclif/config": "^1.17.1",
-            "@oclif/errors": "^1.3.5",
-            "chalk": "^4.1.0",
-            "indent-string": "^4.0.0",
-            "lodash": "^4.17.21",
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "widest-line": "^3.1.0",
-            "wrap-ansi": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
-          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "color-convert": {
-              "version": "1.9.3",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-              "dev": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            },
-            "color-name": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        }
       }
     },
     "@oclif/config": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.1.tgz",
-      "integrity": "sha512-UqV5qsN2np96TNlJspSNlRl7CpFmxYSrB0iLe3XV9NDkbFEE5prGP++h6w6xOR/FL3QV7BoqrbwGuJdJdFbidw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
-        "@oclif/parser": "^3.8.6",
+        "@oclif/errors": "^1.3.5",
+        "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -518,6 +378,114 @@
         }
       }
     },
+    "@oclif/help": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
+      "integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
+      "dev": true,
+      "requires": {
+        "@oclif/config": "1.18.2",
+        "@oclif/errors": "1.3.5",
+        "chalk": "^4.1.2",
+        "indent-string": "^4.0.0",
+        "lodash": "^4.17.21",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "@oclif/linewrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
@@ -525,15 +493,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -784,16 +752,16 @@
       }
     },
     "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -1730,9 +1698,9 @@
       }
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-retry": {
@@ -2214,9 +2182,9 @@
       }
     },
     "danger": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
-      "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2232,7 +2200,7 @@
         "https-proxy-agent": "^2.2.1",
         "hyperlinker": "^1.0.0",
         "json5": "^2.1.0",
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "^5.0.0",
         "jsonwebtoken": "^8.4.0",
         "lodash.find": "^4.6.0",
         "lodash.includes": "^4.3.0",
@@ -2243,13 +2211,13 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
         "parse-git-config": "^2.0.3",
         "parse-github-url": "^1.0.2",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "pinpoint": "^1.1.0",
         "prettyjson": "^1.2.1",
         "readline-sync": "^1.4.9",
@@ -2292,9 +2260,9 @@
           "dev": true
         },
         "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
           "dev": true
         }
       }
@@ -3895,9 +3863,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsonwebtoken": {
@@ -4223,12 +4191,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "merge2": {
@@ -4342,10 +4310,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "noms": {
       "version": "0.0.0",
@@ -4815,9 +4786,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dev": true,
       "requires": {
         "xtend": "~4.0.1"
@@ -4884,13 +4855,21 @@
       "dev": true
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -4939,9 +4918,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -5181,6 +5160,26 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5197,19 +5196,25 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.2.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
-          "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
+            "string-width": "^4.2.3",
             "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
+            "yargs-parser": "^21.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "dev": true
         }
       }
     },
@@ -5380,9 +5385,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {
@@ -5696,13 +5701,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -5815,9 +5817,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
     "universal-url": {
@@ -5828,6 +5830,34 @@
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "universal-user-agent": {
@@ -5897,20 +5927,19 @@
       "dev": true
     },
     "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -40,7 +40,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.44827",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/common-definitions-0.20.0": "npm:@fluidframework/common-definitions@0.20.0",
     "@fluidframework/eslint-config-fluid": "^0.26.0-0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -456,16 +456,16 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -1369,17 +1369,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -1457,6 +1457,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1515,6 +1529,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -1535,15 +1555,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1830,42 +1850,11 @@
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         },
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-          "dev": true
-        },
         "universal-user-agent": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
           "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
           "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
         }
       }
     },
@@ -4370,9 +4359,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -4399,7 +4388,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -9799,12 +9788,12 @@
       }
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "merge-deep": {
@@ -10288,10 +10277,37 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -11788,9 +11804,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/common-utils-0.32.1": "npm:@fluidframework/common-utils@0.32.1",
     "@fluidframework/eslint-config-fluid": "^0.26.0-0",
     "@microsoft/api-extractor": "^7.16.1",

--- a/common/lib/container-definitions/package-lock.json
+++ b/common/lib/container-definitions/package-lock.json
@@ -82,16 +82,16 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -625,17 +625,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -689,6 +689,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -738,6 +752,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -758,15 +778,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1060,15 +1080,6 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -2502,9 +2513,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2531,7 +2542,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -4464,12 +4475,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "merge2": {
@@ -4580,10 +4591,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "noms": {
       "version": "0.0.0",
@@ -5455,9 +5469,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -5615,9 +5629,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/container-definitions-0.39.8": "npm:@fluidframework/container-definitions@0.39.8",
     "@fluidframework/container-definitions-0.40.0": "npm:@fluidframework/container-definitions@0.40.0",
     "@fluidframework/container-definitions-0.41.0": "npm:@fluidframework/container-definitions@0.41.0",

--- a/common/lib/core-interfaces/package-lock.json
+++ b/common/lib/core-interfaces/package-lock.json
@@ -82,16 +82,16 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -358,17 +358,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -422,6 +422,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -471,6 +485,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -491,15 +511,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -793,15 +813,6 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -2229,9 +2240,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2258,7 +2269,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -4191,12 +4202,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "merge2": {
@@ -4307,10 +4318,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "noms": {
       "version": "0.0.0",
@@ -5182,9 +5196,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -5342,9 +5356,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {

--- a/common/lib/core-interfaces/package.json
+++ b/common/lib/core-interfaces/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/core-interfaces-0.39.8": "npm:@fluidframework/core-interfaces@0.39.8",
     "@fluidframework/core-interfaces-0.40.0": "npm:@fluidframework/core-interfaces@0.40.0",
     "@fluidframework/core-interfaces-0.41.0": "npm:@fluidframework/core-interfaces@0.41.0",

--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -82,16 +82,16 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -514,17 +514,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -578,6 +578,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -627,6 +641,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -647,15 +667,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -949,15 +969,6 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -2379,9 +2390,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2408,7 +2419,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -4341,12 +4352,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "merge2": {
@@ -4457,10 +4468,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "noms": {
       "version": "0.0.0",
@@ -5332,9 +5346,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -5492,9 +5506,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/driver-definitions-0.39.8": "npm:@fluidframework/driver-definitions@0.39.8",
     "@fluidframework/driver-definitions-0.40.0": "npm:@fluidframework/driver-definitions@0.40.0",
     "@fluidframework/driver-definitions-0.41.0": "npm:@fluidframework/driver-definitions@0.41.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -82,16 +82,16 @@
       "dev": true
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -366,17 +366,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -430,6 +430,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -479,6 +493,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -499,15 +519,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -801,15 +821,6 @@
             "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
           }
         },
         "universal-user-agent": {
@@ -1349,9 +1360,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
-      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -2237,9 +2248,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -2266,7 +2277,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -4199,12 +4210,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "merge2": {
@@ -4315,10 +4326,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "noms": {
       "version": "0.0.0",
@@ -5190,9 +5204,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -5350,9 +5364,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/eslint-config-fluid": "^0.26.0-0",
     "@fluidframework/protocol-definitions-0.1024.0": "npm:@fluidframework/protocol-definitions@0.1024.0",
     "@fluidframework/protocol-definitions-0.1025.1": "npm:@fluidframework/protocol-definitions@0.1025.1",

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1918,16 +1918,16 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.49276",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-			"integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+			"version": "0.2.54658",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+			"integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
 				"async": "^3.2.0",
 				"chalk": "^2.4.2",
 				"commander": "^6.2.1",
-				"danger": "^10.4.1",
+				"danger": "^10.9.0",
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.3",
 				"ignore": "^5.1.8",
@@ -2376,9 +2376,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.6",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.6.tgz",
-					"integrity": "sha512-kLzSc+uyxfsxTEWcvBA28m1mYSqDx2yEbkYCTJNCN2iqG6hkmiYH3xUshNtTnbveAnpufN+Vpo4F99gUfS4IVQ==",
+					"version": "0.56.7",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.7.tgz",
+					"integrity": "sha512-JqS+EcRCNJkASegydQO59jAYjepnVxTJM8yG58CZWkGKsgjJF3StWVy6OVL/3vDHhXDpcu3DMmpBJmD8lA4GOw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2772,9 +2772,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.6",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.6.tgz",
-					"integrity": "sha512-kLzSc+uyxfsxTEWcvBA28m1mYSqDx2yEbkYCTJNCN2iqG6hkmiYH3xUshNtTnbveAnpufN+Vpo4F99gUfS4IVQ==",
+					"version": "0.56.7",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.7.tgz",
+					"integrity": "sha512-JqS+EcRCNJkASegydQO59jAYjepnVxTJM8yG58CZWkGKsgjJF3StWVy6OVL/3vDHhXDpcu3DMmpBJmD8lA4GOw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -8477,17 +8477,17 @@
 			}
 		},
 		"@oclif/config": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-			"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+			"integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
 			"dev": true,
 			"requires": {
-				"@oclif/errors": "^1.3.3",
+				"@oclif/errors": "^1.3.5",
 				"@oclif/parser": "^3.8.0",
 				"debug": "^4.1.1",
 				"globby": "^11.0.1",
 				"is-wsl": "^2.1.1",
-				"tslib": "^2.0.0"
+				"tslib": "^2.3.1"
 			},
 			"dependencies": {
 				"tslib": {
@@ -8565,6 +8565,20 @@
 				"wrap-ansi": "^6.2.0"
 			},
 			"dependencies": {
+				"@oclif/config": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+					"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+					"dev": true,
+					"requires": {
+						"@oclif/errors": "^1.3.3",
+						"@oclif/parser": "^3.8.0",
+						"debug": "^4.1.1",
+						"globby": "^11.0.1",
+						"is-wsl": "^2.1.1",
+						"tslib": "^2.0.0"
+					}
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -8646,6 +8660,12 @@
 						"has-flag": "^4.0.0"
 					}
 				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"dev": true
+				},
 				"wrap-ansi": {
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -8666,15 +8686,15 @@
 			"dev": true
 		},
 		"@oclif/parser": {
-			"version": "3.8.6",
-			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-			"integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+			"integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
 			"dev": true,
 			"requires": {
-				"@oclif/errors": "^1.2.2",
+				"@oclif/errors": "^1.3.5",
 				"@oclif/linewrap": "^1.0.0",
 				"chalk": "^4.1.0",
-				"tslib": "^2.0.0"
+				"tslib": "^2.3.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -19361,9 +19381,9 @@
 			}
 		},
 		"danger": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-			"integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+			"integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -19390,7 +19410,7 @@
 				"memfs-or-file-map-to-github-branch": "^1.1.0",
 				"micromatch": "^4.0.4",
 				"node-cleanup": "^2.1.2",
-				"node-fetch": "2.6.1",
+				"node-fetch": "^2.6.7",
 				"override-require": "^1.1.1",
 				"p-limit": "^2.1.0",
 				"parse-diff": "^0.7.0",
@@ -19444,6 +19464,15 @@
 						"picomatch": "^2.2.3"
 					}
 				},
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				},
 				"to-regex-range": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -19451,6 +19480,28 @@
 					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
+					}
+				},
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+					"dev": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
 					}
 				}
 			}
@@ -30719,12 +30770,12 @@
 			}
 		},
 		"memfs-or-file-map-to-github-branch": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-			"integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+			"integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
 			"dev": true,
 			"requires": {
-				"@octokit/rest": "^16.43.1"
+				"@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
 			}
 		},
 		"memoize-one": {
@@ -37866,9 +37917,9 @@
 					}
 				},
 				"yargs-parser": {
-					"version": "21.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-					"integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+					"version": "21.0.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,16 +57,16 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -3007,17 +3007,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -3095,6 +3095,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3176,6 +3190,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -3196,15 +3216,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5521,9 +5541,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -5550,7 +5570,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -5569,6 +5589,15 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
         }
       }
     },
@@ -6576,9 +6605,9 @@
       },
       "dependencies": {
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         }
       }
@@ -7333,9 +7362,9 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         },
         "is-callable": {
@@ -8326,12 +8355,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "meow": {
@@ -10168,9 +10197,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -11113,9 +11142,9 @@
       },
       "dependencies": {
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         }
       }
@@ -11392,9 +11421,9 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         },
         "is-callable": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack:profile": "lerna run --no-sort webpack:profile --stream"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/test-tools": "^0.2.3074",
     "@microsoft/api-documenter": "^7.12.7",
     "@microsoft/api-extractor": "^7.16.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/container-runtime-definitions-0.51.1": "npm:@fluidframework/container-runtime-definitions@0.51.1",
     "@fluidframework/container-runtime-definitions-0.52.0": "npm:@fluidframework/container-runtime-definitions@0.52.0",
     "@fluidframework/container-runtime-definitions-0.53.0": "npm:@fluidframework/container-runtime-definitions@0.53.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/datastore-definitions-0.51.1": "npm:@fluidframework/datastore-definitions@0.51.1",
     "@fluidframework/datastore-definitions-0.52.0": "npm:@fluidframework/datastore-definitions@0.52.0",
     "@fluidframework/datastore-definitions-0.53.0": "npm:@fluidframework/datastore-definitions@0.53.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/eslint-config-fluid": "^0.26.0-0",
     "@fluidframework/runtime-definitions-0.51.1": "npm:@fluidframework/runtime-definitions@0.51.1",
     "@fluidframework/runtime-definitions-0.52.0": "npm:@fluidframework/runtime-definitions@0.52.0",

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -315,16 +315,16 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.49276",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-			"integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+			"version": "0.2.54658",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+			"integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
 				"async": "^3.2.0",
 				"chalk": "^2.4.2",
 				"commander": "^6.2.1",
-				"danger": "^10.4.1",
+				"danger": "^10.9.0",
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.3",
 				"ignore": "^5.1.8",
@@ -3273,17 +3273,17 @@
 			}
 		},
 		"@oclif/config": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-			"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+			"integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
 			"dev": true,
 			"requires": {
-				"@oclif/errors": "^1.3.3",
+				"@oclif/errors": "^1.3.5",
 				"@oclif/parser": "^3.8.0",
 				"debug": "^4.1.1",
 				"globby": "^11.0.1",
 				"is-wsl": "^2.1.1",
-				"tslib": "^2.0.0"
+				"tslib": "^2.3.1"
 			},
 			"dependencies": {
 				"tslib": {
@@ -3367,6 +3367,20 @@
 				"wrap-ansi": "^6.2.0"
 			},
 			"dependencies": {
+				"@oclif/config": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+					"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+					"dev": true,
+					"requires": {
+						"@oclif/errors": "^1.3.3",
+						"@oclif/parser": "^3.8.0",
+						"debug": "^4.1.1",
+						"globby": "^11.0.1",
+						"is-wsl": "^2.1.1",
+						"tslib": "^2.0.0"
+					}
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3416,6 +3430,12 @@
 						"has-flag": "^4.0.0"
 					}
 				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"dev": true
+				},
 				"wrap-ansi": {
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -3436,15 +3456,15 @@
 			"dev": true
 		},
 		"@oclif/parser": {
-			"version": "3.8.6",
-			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-			"integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+			"integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
 			"dev": true,
 			"requires": {
-				"@oclif/errors": "^1.2.2",
+				"@oclif/errors": "^1.3.5",
 				"@oclif/linewrap": "^1.0.0",
 				"chalk": "^4.1.0",
-				"tslib": "^2.0.0"
+				"tslib": "^2.3.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7307,9 +7327,9 @@
 			}
 		},
 		"danger": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-			"integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+			"integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -7336,7 +7356,7 @@
 				"memfs-or-file-map-to-github-branch": "^1.1.0",
 				"micromatch": "^4.0.4",
 				"node-cleanup": "^2.1.2",
-				"node-fetch": "2.6.1",
+				"node-fetch": "^2.6.7",
 				"override-require": "^1.1.1",
 				"p-limit": "^2.1.0",
 				"parse-diff": "^0.7.0",
@@ -7355,6 +7375,15 @@
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
 					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 					"dev": true
+				},
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
 				}
 			}
 		},
@@ -11659,12 +11688,12 @@
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"memfs-or-file-map-to-github-branch": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-			"integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+			"integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
 			"dev": true,
 			"requires": {
-				"@octokit/rest": "^16.43.1"
+				"@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
 			}
 		},
 		"memory-pager": {
@@ -14600,9 +14629,9 @@
 					}
 				},
 				"yargs-parser": {
-					"version": "21.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-					"integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+					"version": "21.0.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
 					"dev": true
 				}
 			}

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -300,16 +300,16 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -2745,17 +2745,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -2839,6 +2839,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2888,6 +2902,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -2908,15 +2928,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6562,9 +6582,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -6591,7 +6611,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -6603,6 +6623,17 @@
         "readline-sync": "^1.4.9",
         "require-from-string": "^2.0.2",
         "supports-hyperlinks": "^1.0.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "dargs": {
@@ -9287,9 +9318,9 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         },
         "is-callable": {
@@ -10257,12 +10288,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "meow": {
@@ -12935,9 +12966,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -14415,9 +14446,9 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         },
         "is-callable": {

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -44,7 +44,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@fluidframework/eslint-config-fluid": "^0.26.0-0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/compression": "0.0.36",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -330,16 +330,16 @@
 			"integrity": "sha512-2Uz+rKTApwDIez+e9mx+UDAFK74Rh1r+emsHVpo0t29jECqa0f5NlkdmFREpjjexRS4+W/uLTKB5wN3fgN/f9w=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.2.49276",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-			"integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+			"version": "0.2.54658",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+			"integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
 			"dev": true,
 			"requires": {
 				"@fluidframework/bundle-size-tools": "^0.0.8505",
 				"async": "^3.2.0",
 				"chalk": "^2.4.2",
 				"commander": "^6.2.1",
-				"danger": "^10.4.1",
+				"danger": "^10.9.0",
 				"fs-extra": "^9.0.1",
 				"glob": "^7.1.3",
 				"ignore": "^5.1.8",
@@ -3566,17 +3566,17 @@
 			}
 		},
 		"@oclif/config": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-			"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+			"integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
 			"dev": true,
 			"requires": {
-				"@oclif/errors": "^1.3.3",
+				"@oclif/errors": "^1.3.5",
 				"@oclif/parser": "^3.8.0",
 				"debug": "^4.1.1",
 				"globby": "^11.0.1",
 				"is-wsl": "^2.1.1",
-				"tslib": "^2.0.0"
+				"tslib": "^2.3.1"
 			},
 			"dependencies": {
 				"is-wsl": {
@@ -3669,6 +3669,20 @@
 				"wrap-ansi": "^6.2.0"
 			},
 			"dependencies": {
+				"@oclif/config": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+					"integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+					"dev": true,
+					"requires": {
+						"@oclif/errors": "^1.3.3",
+						"@oclif/parser": "^3.8.0",
+						"debug": "^4.1.1",
+						"globby": "^11.0.1",
+						"is-wsl": "^2.1.1",
+						"tslib": "^2.0.0"
+					}
+				},
 				"ansi-regex": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3727,6 +3741,15 @@
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
+				"is-wsl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+					"dev": true,
+					"requires": {
+						"is-docker": "^2.0.0"
+					}
+				},
 				"string-width": {
 					"version": "4.2.3",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3756,6 +3779,12 @@
 						"has-flag": "^4.0.0"
 					}
 				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"dev": true
+				},
 				"wrap-ansi": {
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -3776,15 +3805,15 @@
 			"dev": true
 		},
 		"@oclif/parser": {
-			"version": "3.8.6",
-			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-			"integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+			"integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
 			"dev": true,
 			"requires": {
-				"@oclif/errors": "^1.2.2",
+				"@oclif/errors": "^1.3.5",
 				"@oclif/linewrap": "^1.0.0",
 				"chalk": "^4.1.0",
-				"tslib": "^2.0.0"
+				"tslib": "^2.3.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4256,15 +4285,6 @@
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
-				},
-				"node-fetch": {
-					"version": "2.6.7",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-					"dev": true,
-					"requires": {
-						"whatwg-url": "^5.0.0"
-					}
 				},
 				"universal-user-agent": {
 					"version": "6.0.0",
@@ -8261,9 +8281,9 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"danger": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-			"integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+			"integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
 			"dev": true,
 			"requires": {
 				"@babel/polyfill": "^7.2.5",
@@ -8290,7 +8310,7 @@
 				"memfs-or-file-map-to-github-branch": "^1.1.0",
 				"micromatch": "^4.0.4",
 				"node-cleanup": "^2.1.2",
-				"node-fetch": "2.6.1",
+				"node-fetch": "^2.6.7",
 				"override-require": "^1.1.1",
 				"p-limit": "^2.1.0",
 				"parse-diff": "^0.7.0",
@@ -13339,12 +13359,12 @@
 			}
 		},
 		"memfs-or-file-map-to-github-branch": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-			"integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+			"integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
 			"dev": true,
 			"requires": {
-				"@octokit/rest": "^16.43.1"
+				"@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
 			}
 		},
 		"memory-fs": {
@@ -14566,10 +14586,13 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
 		},
 		"node-gyp": {
 			"version": "5.1.1",
@@ -16931,9 +16954,9 @@
 					}
 				},
 				"yargs-parser": {
-					"version": "21.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-					"integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+					"version": "21.0.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
 					"dev": true
 				}
 			}

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -278,16 +278,16 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.2.49276",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.49276.tgz",
-      "integrity": "sha512-UCGUALBrYHJGkj2ZnJEsJ1L1wEBKbFKJqUl8t3ofgfs/TQf+WQ8hwRxcoyDuDiihP0zY5CmwtU7Fdr40ccDRXg==",
+      "version": "0.2.54658",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.2.54658.tgz",
+      "integrity": "sha512-gnlzidsR+vSStZNu9LjY/wOQ+4Mk7F5FgOu81zQbwL7DUgB6NEF67BoCQVHbOo7CU7VRneiqjph6kOcauxWbqA==",
       "dev": true,
       "requires": {
         "@fluidframework/bundle-size-tools": "^0.0.8505",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
         "commander": "^6.2.1",
-        "danger": "^10.4.1",
+        "danger": "^10.9.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.3",
         "ignore": "^5.1.8",
@@ -2980,17 +2980,17 @@
       }
     },
     "@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
+      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.3.3",
+        "@oclif/errors": "^1.3.5",
         "@oclif/parser": "^3.8.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
@@ -3074,6 +3074,20 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
+          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
+          "dev": true,
+          "requires": {
+            "@oclif/errors": "^1.3.3",
+            "@oclif/parser": "^3.8.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-wsl": "^2.1.1",
+            "tslib": "^2.0.0"
+          }
+        },
         "ansi-regex": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3161,6 +3175,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -3181,15 +3201,15 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.6.tgz",
-      "integrity": "sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
+      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "^1.2.2",
+        "@oclif/errors": "^1.3.5",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5462,9 +5482,9 @@
       }
     },
     "danger": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/danger/-/danger-10.8.0.tgz",
-      "integrity": "sha512-s4Ge4jKQdENdVhGndHpnXnUmfR60IHQeIxkZlHIupHKmYiMYWYCazlTtTS1ieApYhhKPrtEgZYXF7zQ6SBg9lw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-10.9.0.tgz",
+      "integrity": "sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==",
       "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
@@ -5491,7 +5511,7 @@
         "memfs-or-file-map-to-github-branch": "^1.1.0",
         "micromatch": "^4.0.4",
         "node-cleanup": "^2.1.2",
-        "node-fetch": "2.6.1",
+        "node-fetch": "^2.6.7",
         "override-require": "^1.1.1",
         "p-limit": "^2.1.0",
         "parse-diff": "^0.7.0",
@@ -5503,6 +5523,17 @@
         "readline-sync": "^1.4.9",
         "require-from-string": "^2.0.2",
         "supports-hyperlinks": "^1.0.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "dargs": {
@@ -6612,9 +6643,9 @@
       },
       "dependencies": {
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         }
       }
@@ -7385,9 +7416,9 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         },
         "is-callable": {
@@ -8323,12 +8354,12 @@
       "dev": true
     },
     "memfs-or-file-map-to-github-branch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
-      "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.1.tgz",
+      "integrity": "sha512-I/hQzJ2a/pCGR8fkSQ9l5Yx+FQ4e7X6blNHyWBm2ojeFLT3GVzGkTj7xnyWpdclrr7Nq4dmx3xrvu70m3ypzAQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^16.43.1"
+        "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
     "meow": {
@@ -10549,9 +10580,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -11850,9 +11881,9 @@
           }
         },
         "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         },
         "is-callable": {

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/build-tools": "^0.2.49276",
+    "@fluidframework/build-tools": "^0.2.54658",
     "@microsoft/api-documenter": "^7.4.6",
     "@microsoft/api-extractor": "^7.16.1",
     "concurrently": "^6.2.0",


### PR DESCRIPTION
Update to use the latest build-tools so virtual patches are available for the 0.58 release and version bumps