### PR TITLE
Added a deprecated interface to facilitate calling bindToContext on created data stores (#9326)

### DIFF
--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -10,6 +10,7 @@ import { FlushMode } from '@fluidframework/runtime-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
 import { IContainerRuntimeBaseEvents } from '@fluidframework/runtime-definitions';
+import { IDataStore } from '@fluidframework/runtime-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
@@ -66,6 +67,14 @@ export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     (event: "connected", listener: (clientId: string) => void): any;
     // (undocumented)
     (event: "localHelp", listener: (message: IHelpMessage) => void): any;
+}
+
+// @public @deprecated (undocumented)
+export interface IDataStoreWithBindToContext_Deprecated extends IDataStore {
+    // (undocumented)
+    fluidDataStoreChannel?: {
+        bindToContext?(): void;
+    };
 }
 
 // @public @deprecated (undocumented)

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -27,9 +27,17 @@ import {
     FlushMode,
     IContainerRuntimeBase,
     IContainerRuntimeBaseEvents,
+    IDataStore,
     IFluidDataStoreContextDetached,
     IProvideFluidDataStoreRegistry,
- } from "@fluidframework/runtime-definitions";
+} from "@fluidframework/runtime-definitions";
+
+/**
+ * @deprecated - This will be removed once https://github.com/microsoft/FluidFramework/issues/9127 is fixed.
+ */
+export interface IDataStoreWithBindToContext_Deprecated extends IDataStore {
+    fluidDataStoreChannel?: { bindToContext?(): void; };
+}
 
 /**
  * @deprecated - This will be removed in a later release.


### PR DESCRIPTION
Ported from main - https://github.com/microsoft/FluidFramework/pull/9326.

Added new deprecated interface derived from IDataStore. This is a workaround to bind data stores in detached container until https://github.com/microsoft/FluidFramework/issues/9127 is fixed. Once the above bug is fixed, this will be removed.
The usage is to cast the IDataStore to IDataStoreWithBindToContext_Deprecated and call fluidDataStoreChannel?.bindToContext() on it.