### PR TITLE
Integrate latest prerelease of protocol-definitions into routerlicious and gitrest

### DIFF
--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -370,9 +370,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0.tgz",
-      "integrity": "sha512-dDjLGrpZd02NU9oXEzgQlW50EDt75v2CSU90xhg4S1VkHHuNrQfc/jEEeYNAVqac9duPutcDK4pP1n4AESYjlw==",
+      "version": "0.1027.0-51404",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1027.0-51404.tgz",
+      "integrity": "sha512-eHDMcWhmCT7cM7ozFAZ0RIA78qX5u9zXtW2jXViaJdVPO/OqHlenDuoUzr6a+0CdhOfPoflXm2Tac4gUAJw/ww==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
       }

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -25,7 +25,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1033.0",
     "@fluidframework/protocol-base": "^0.1033.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-client": "^0.1033.0",
     "@fluidframework/server-services-core": "^0.1033.0",
     "@fluidframework/server-services-shared": "^0.1033.0",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -465,9 +465,9 @@
 			}
 		},
 		"@fluidframework/protocol-definitions": {
-			"version": "0.1026.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1026.0.tgz",
-			"integrity": "sha512-dDjLGrpZd02NU9oXEzgQlW50EDt75v2CSU90xhg4S1VkHHuNrQfc/jEEeYNAVqac9duPutcDK4pP1n4AESYjlw==",
+			"version": "0.1027.0-51404",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1027.0-51404.tgz",
+			"integrity": "sha512-eHDMcWhmCT7cM7ozFAZ0RIA78qX5u9zXtW2jXViaJdVPO/OqHlenDuoUzr6a+0CdhOfPoflXm2Tac4gUAJw/ww==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.0"
 			}

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -23,7 +23,7 @@
     "tsfmt:fix": "tsfmt --replace"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-core": "^0.1035.0"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -51,7 +51,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
     "@fluidframework/protocol-base": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-lambdas-driver": "^0.1035.0",
     "@fluidframework/server-services-client": "^0.1035.0",
     "@fluidframework/server-services-core": "^0.1035.0",

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -259,8 +259,6 @@ export class ScribeLambda implements IPartitionLambda {
                                 await this.sendSummaryNack(
                                     {
                                         message: "Failed to summarize the document.",
-                                        // errorMessage in ISummaryNack will be deprecated soon
-                                        errorMessage: "Failed to summarize the document.",
                                         summaryProposal: {
                                             summarySequenceNumber: value.operation.sequenceNumber,
                                         },

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -106,8 +106,6 @@ export class SummaryWriter implements ISummaryWriter {
                     return {
                         message: {
                             message: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef ? existingRef.object.sha : "n/a"}".`,
-                            // errorMessage in ISummaryNack will be deprecated soon
-                            errorMessage: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef ? existingRef.object.sha : "n/a"}".`,
                             summaryProposal: {
                                 summarySequenceNumber: op.sequenceNumber,
                             },
@@ -120,8 +118,6 @@ export class SummaryWriter implements ISummaryWriter {
                 return {
                     message: {
                         message: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef.object.sha}".`,
-                        // errorMessage in ISummaryNack will be deprecated soon
-                        errorMessage: `Proposed parent summary "${content.head}" does not match actual parent summary "${existingRef.object.sha}".`,
                         summaryProposal: {
                             summarySequenceNumber: op.sequenceNumber,
                         },
@@ -142,8 +138,6 @@ export class SummaryWriter implements ISummaryWriter {
                     return {
                         message: {
                             message: "One or more parent summaries are invalid",
-                            // errorMessage in ISummaryNack will be deprecated soon
-                            errorMessage: "One or more parent summaries are invalid",
                             summaryProposal: {
                                 summarySequenceNumber: op.sequenceNumber,
                             },
@@ -159,8 +153,6 @@ export class SummaryWriter implements ISummaryWriter {
                 return {
                     message: {
                         message: `Proposed summary reference sequence number ${op.referenceSequenceNumber} is less than current sequence number ${checkpoint.protocolState.sequenceNumber}`,
-                        // errorMessage in ISummaryNack will be deprecated soon
-                        errorMessage: `Proposed summary reference sequence number ${op.referenceSequenceNumber} is less than current sequence number ${checkpoint.protocolState.sequenceNumber}`,
                         summaryProposal: {
                             summarySequenceNumber: op.sequenceNumber,
                         },
@@ -291,8 +283,6 @@ export class SummaryWriter implements ISummaryWriter {
                     return {
                         message: {
                             message: `A non-fatal error happened when trying to write client summary. Error: ${safeStringify(networkError.details)}`,
-                            // errorMessage in ISummaryNack will be deprecated soon
-                            errorMessage: `A non-fatal error happened when trying to write client summary. Error: ${safeStringify(networkError.details)}`,
                             summaryProposal: {
                                 summarySequenceNumber: op.sequenceNumber,
                             },

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-lambdas": "^0.1035.0",
     "@fluidframework/server-memory-orderer": "^0.1035.0",
     "@fluidframework/server-services-client": "^0.1035.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/protocol-base": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-lambdas": "^0.1035.0",
     "@fluidframework/server-services-client": "^0.1035.0",
     "@fluidframework/server-services-core": "^0.1035.0",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -9,7 +9,6 @@ import cloneDeep from "lodash/cloneDeep";
 import { assert, Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
     ICommittedProposal,
-    IPendingProposal,
     IQuorum,
     IQuorumClients,
     IQuorumClientsEvents,
@@ -366,7 +365,7 @@ export class Quorum extends TypedEventEmitter<IQuorumEvents> implements IQuorum 
         });
 
         this.quorumProposals = new QuorumProposals({ proposals, values }, sendProposal);
-        this.quorumProposals.on("addProposal", (proposal: IPendingProposal) => {
+        this.quorumProposals.on("addProposal", (proposal: ISequencedProposal) => {
             this.emit("addProposal", proposal);
         });
         this.quorumProposals.on(

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-kafka-orderer": "^0.1035.0",
     "@fluidframework/server-lambdas": "^0.1035.0",
     "@fluidframework/server-lambdas-driver": "^0.1035.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-kafka-orderer": "^0.1035.0",
     "@fluidframework/server-lambdas": "^0.1035.0",
     "@fluidframework/server-lambdas-driver": "^0.1035.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -56,7 +56,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
     "@fluidframework/protocol-base": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "axios": "^0.26.0",
     "crc-32": "1.2.0",
     "debug": "^4.1.1",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-client": "^0.1035.0",
     "@fluidframework/server-services-telemetry": "^0.1035.0",
     "@types/nconf": "^0.10.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
     "@fluidframework/protocol-base": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-client": "^0.1035.0",
     "@fluidframework/server-services-core": "^0.1035.0",
     "@fluidframework/server-services-telemetry": "^0.1035.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -47,7 +47,7 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-client": "^0.1035.0",
     "@fluidframework/server-services-core": "^0.1035.0",
     "@fluidframework/server-services-telemetry": "^0.1035.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fluidframework/common-utils": "^0.32.1",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-client": "^0.1035.0",
     "@fluidframework/server-services-core": "^0.1035.0",
     "@fluidframework/server-services-ordering-kafkanode": "^0.1035.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/common-utils": "^0.32.1",
     "@fluidframework/gitresources": "^0.1035.0",
     "@fluidframework/protocol-base": "^0.1035.0",
-    "@fluidframework/protocol-definitions": "^0.1026.0",
+    "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-client": "^0.1035.0",
     "@fluidframework/server-services-core": "^0.1035.0",
     "@fluidframework/server-services-telemetry": "^0.1035.0",


### PR DESCRIPTION
Since the client packages, historian, and tinylicious also import routerlicious packages, I'll want to issue a prerelease of routerlicious first to keep everything aligned.