### PR TITLE
Fix container-runtime-definitions type compat tests

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2376,9 +2376,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.6",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.6.tgz",
-					"integrity": "sha512-kLzSc+uyxfsxTEWcvBA28m1mYSqDx2yEbkYCTJNCN2iqG6hkmiYH3xUshNtTnbveAnpufN+Vpo4F99gUfS4IVQ==",
+					"version": "0.56.7",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.7.tgz",
+					"integrity": "sha512-JqS+EcRCNJkASegydQO59jAYjepnVxTJM8yG58CZWkGKsgjJF3StWVy6OVL/3vDHhXDpcu3DMmpBJmD8lA4GOw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2427,9 +2427,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.57.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.57.0.tgz",
-					"integrity": "sha512-KVVyITvE/+mumkcMSjgobju2NGLkfMuBdB5rxJ0g3ce4/wkuFI5+eU06+kFwPGsHF8p6JKxqWCFtpAfrgZln6A==",
+					"version": "0.57.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.57.1.tgz",
+					"integrity": "sha512-CcqM2VGcq79UUQdIKUDMgi7nXSoBUwy3yYCLiYs0hEOhjq6oc/X5tUXjesGzG2GtdVU0IcDLc6d0kUucqvPwjw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2772,9 +2772,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.56.6",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.6.tgz",
-					"integrity": "sha512-kLzSc+uyxfsxTEWcvBA28m1mYSqDx2yEbkYCTJNCN2iqG6hkmiYH3xUshNtTnbveAnpufN+Vpo4F99gUfS4IVQ==",
+					"version": "0.56.7",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.56.7.tgz",
+					"integrity": "sha512-JqS+EcRCNJkASegydQO59jAYjepnVxTJM8yG58CZWkGKsgjJF3StWVy6OVL/3vDHhXDpcu3DMmpBJmD8lA4GOw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",
@@ -2823,9 +2823,9 @@
 					}
 				},
 				"@fluidframework/runtime-definitions": {
-					"version": "0.57.0",
-					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.57.0.tgz",
-					"integrity": "sha512-KVVyITvE/+mumkcMSjgobju2NGLkfMuBdB5rxJ0g3ce4/wkuFI5+eU06+kFwPGsHF8p6JKxqWCFtpAfrgZln6A==",
+					"version": "0.57.1",
+					"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.57.1.tgz",
+					"integrity": "sha512-CcqM2VGcq79UUQdIKUDMgi7nXSoBUwy3yYCLiYs0hEOhjq6oc/X5tUXjesGzG2GtdVU0IcDLc6d0kUucqvPwjw==",
 					"requires": {
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^0.32.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -156,16 +156,13 @@
       },
       "0.57.0": {
         "TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
-          "backCompat": true,
-          "forwardCompat": false
+          "backCompat": true
         },
         "InterfaceDeclaration_IProvideContainerRuntime": {
-          "backCompat": true,
-          "forwardCompat": false
+          "backCompat": true
         },
         "InterfaceDeclaration_IContainerRuntime": {
-          "backCompat": true,
-          "forwardCompat": false
+          "backCompat": true
         }
       }
     }

--- a/packages/runtime/container-runtime-definitions/src/test/types/validate0.57.0.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validate0.57.0.ts
@@ -43,7 +43,6 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: current.IContainerRuntime);
 use_current_InterfaceDeclaration_IContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -68,7 +67,6 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: current.IContainerRuntimeBaseWithCombinedEvents);
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
-    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -117,7 +115,6 @@ declare function get_old_InterfaceDeclaration_IProvideContainerRuntime():
 declare function use_current_InterfaceDeclaration_IProvideContainerRuntime(
     use: current.IProvideContainerRuntime);
 use_current_InterfaceDeclaration_IProvideContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideContainerRuntime());
 
 /*


### PR DESCRIPTION
It looks like the publishing of 57.1 caused the type compat tests to start failing in the pipeline.  I don't quite understand why, but the tests seem to think we were being overly-pessimistic about our compat here.