### PR TITLE
Fix spellings in MergeTree and Sequence

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -111,7 +111,6 @@ export class Client {
     cloneFromSegments(): Client;
     // (undocumented)
     createTextHelper(): MergeTreeTextHelper;
-    findReconnectionPostition(segment: ISegment, localSeq: number): number;
     // (undocumented)
     findTile(startPos: number, tileLabel: string, preceding?: boolean): {
         tile: ReferencePosition;
@@ -1028,8 +1027,6 @@ export class MergeTree {
     // (undocumented)
     mergeTreeMaintenanceCallback?: MergeTreeMaintenanceCallback;
     // (undocumented)
-    nodeToString(block: IMergeBlock, strbuf: string, indentCount?: number): string;
-    // (undocumented)
     options?: PropertySet | undefined;
     // (undocumented)
     static readonly options: {
@@ -1053,8 +1050,6 @@ export class MergeTree {
     setMinSeq(minSeq: number): void;
     // (undocumented)
     startCollaboration(localClientId: number, minSeq: number, currentSeq: number): void;
-    // (undocumented)
-    toString(): string;
     // (undocumented)
     walkAllSegments<TClientData>(block: IMergeBlock, action: (segment: ISegment, accum?: TClientData) => boolean, accum?: TClientData): boolean;
     }

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -111,6 +111,7 @@ export class Client {
     cloneFromSegments(): Client;
     // (undocumented)
     createTextHelper(): MergeTreeTextHelper;
+    protected findReconnectionPosition(segment: ISegment, localSeq: number): number;
     // (undocumented)
     findTile(startPos: number, tileLabel: string, preceding?: boolean): {
         tile: ReferencePosition;
@@ -291,9 +292,6 @@ export function extend<T>(base: MapLike<T>, extension: MapLike<T> | undefined, c
 
 // @public (undocumented)
 export function extendIfUndefined<T>(base: MapLike<T>, extension: MapLike<T> | undefined): MapLike<T>;
-
-// @public (undocumented)
-export function glc(mergeTree: MergeTree, id: number): string;
 
 // @public (undocumented)
 export class Heap<T> {

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -76,7 +76,7 @@ export class PermutationSegment extends BaseSegment {
         // it is included if the undo stack continues to unwind to the original insertion.
         //
         // Out of paranoia we link and unlink in separate loops to avoid mutating the underlying
-        // set during enumeration.  In pratice, this is unlikely to matter since there should be
+        // set during enumeration.  In practice, this is unlikely to matter since there should be
         // exactly 0 or 1 items in the enumeration.
         for (const group of this.trackingCollection.trackingGroups) {
             group.link(destination);
@@ -282,9 +282,9 @@ export class PermutationVector extends Client {
         // containing this position and use 'findReconnectionPosition' to adjust for the local ops that
         // have not yet been submitted.
 
-        // eslint-disable-next-line max-len
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
-        return this.findReconnectionPostition(containingSegment, localSeq) + containingOffset!;
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this.findReconnectionPosition(containingSegment, localSeq) + containingOffset!;
     }
 
     // Constructs an ISummaryTreeWithStats for the cell data.
@@ -331,7 +331,7 @@ export class PermutationVector extends Client {
             case MergeTreeDeltaType.INSERT:
                 // Pass 1: Perform any internal maintenance first to avoid reentrancy.
                 for (const { segment, position } of ranges) {
-                    // HACK: We need to include the allocated handle in the segment's JSON reperesntation
+                    // HACK: We need to include the allocated handle in the segment's JSON representation
                     //       for snapshots, but need to ignore the remote client's handle allocations when
                     //       processing remote ops.
                     segment.reset();

--- a/packages/dds/merge-tree/src/base.ts
+++ b/packages/dds/merge-tree/src/base.ts
@@ -14,7 +14,7 @@ export interface QProperty<TKey, TData> {
 }
 
 export interface PropertyAction<TKey, TData> {
-    // eslint-disable-next-line @typescript-eslint/prefer-function-type
+
     <TAccum>(p: Property<TKey, TData>, accum?: TAccum): boolean;
 }
 
@@ -35,7 +35,7 @@ export interface SortedDictionary<TKey, TData> extends Dictionary<TKey, TData> {
 }
 
 export interface KeyComparer<TKey> {
-    // eslint-disable-next-line @typescript-eslint/prefer-function-type
+
     (a: TKey, b: TKey): number;
 }
 /**

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -647,7 +647,7 @@ export class Client {
      * @param segment - The segment to find the position for
      * @param localSeq - The localSeq to find the position of the segment at
      */
-    private findReconnectionPosition(segment: ISegment, localSeq: number) {
+    protected findReconnectionPosition(segment: ISegment, localSeq: number) {
         assert(localSeq <= this.mergeTree.collabWindow.localSeq, 0x032 /* "localSeq greater than collab window" */);
         let segmentPosition = 0;
         /*

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -126,7 +126,7 @@ export class Client {
     }
 
     /**
-     * Annotate a maker and call the callback on consensus.
+     * Annotate a marker and call the callback on consensus.
      * @param marker - The marker to annotate
      * @param props - The properties to annotate the marker with
      * @param consensusCallback - The callback called when consensus is reached

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -126,7 +126,7 @@ export class Client {
     }
 
     /**
-     * Annotate a maker and call the callback on concensus.
+     * Annotate a maker and call the callback on consensus.
      * @param marker - The marker to annotate
      * @param props - The properties to annotate the marker with
      * @param consensusCallback - The callback called when consensus is reached
@@ -285,7 +285,7 @@ export class Client {
     }
 
     /**
-     * Serializes the data required for garbage collection. The IFluidHandles stored in all segements that haven't
+     * Serializes the data required for garbage collection. The IFluidHandles stored in all segments that haven't
      * been removed represent routes to other objects. We serialize the data in these segments using the passed in
      * serializer which keeps track of all serialized handles.
      */
@@ -647,7 +647,7 @@ export class Client {
      * @param segment - The segment to find the position for
      * @param localSeq - The localSeq to find the position of the segment at
      */
-    public findReconnectionPostition(segment: ISegment, localSeq: number) {
+    private findReconnectionPosition(segment: ISegment, localSeq: number) {
         assert(localSeq <= this.mergeTree.collabWindow.localSeq, 0x032 /* "localSeq greater than collab window" */);
         let segmentPosition = 0;
         /*
@@ -694,12 +694,12 @@ export class Client {
         // The reason they need them sorted, as they have the same local sequence number and which means
         // farther segments will  take into account nearer segments when calculating their position.
         // By sorting we ensure the nearer segment will be applied and sequenced before the father segments
-        // so their recalulated positions will be correct.
+        // so their recalculated positions will be correct.
         for (const segment of segmentGroup.segments.sort((a, b) => a.ordinal < b.ordinal ? -1 : 1)) {
             const segmentSegGroup = segment.segmentGroups.dequeue();
             assert(segmentGroup === segmentSegGroup,
                 0x035 /* "Segment group not at head of segment pending queue" */);
-            const segmentPosition = this.findReconnectionPostition(segment, segmentGroup.localSeq);
+            const segmentPosition = this.findReconnectionPosition(segment, segmentGroup.localSeq);
             let newOp: IMergeTreeDeltaOp | undefined;
             switch (resetOp.type) {
                 case MergeTreeDeltaType.ANNOTATE:

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -180,7 +180,7 @@ export class Heap<T> {
         const x = this.L[1];
         this.L[1] = this.L[this.count()];
         this.L.pop();
-        this.fixdown(1);
+        this.fixDown(1);
         return x;
     }
 
@@ -199,7 +199,7 @@ export class Heap<T> {
         }
     }
 
-    private fixdown(k: number) {
+    private fixDown(k: number) {
         let _k = k;
         while ((_k << 1) <= (this.count())) {
             let j = _k << 1;

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -912,14 +912,6 @@ const LRUSegmentComparer: Comparer<LRUSegment> = {
     compare: (a, b) => a.maxSeq - b.maxSeq,
 };
 
-export function glc(mergeTree: MergeTree, id: number) {
-    if (mergeTree.getLongClientId) {
-        return mergeTree.getLongClientId(id);
-    } else {
-        return id.toString();
-    }
-}
-
 export interface SegmentAccumulator {
     segments: ISegment[];
 }
@@ -2113,7 +2105,7 @@ export class MergeTree {
             if (pos === 0) {
                 // normalize the seq numbers
                 // if the new seg is local (UnassignedSequenceNumber) give it the highest possible
-                // seq for comparision, as it will get a seq higher than any other seq once sequences
+                // seq for comparison, as it will get a seq higher than any other seq once sequences
                 // if the current seg is local (UnassignedSequenceNumber) give it the second highest
                 // possible seq, as the highest is reserved for the previous.
                 const newSeq = seq === UnassignedSequenceNumber ? Number.MAX_SAFE_INTEGER : seq;
@@ -2605,46 +2597,6 @@ export class MergeTree {
             }
         }
         this.nodeMap(this.root, actions, 0, refSeq, clientId, accum, start, end);
-    }
-
-    public nodeToString(block: IMergeBlock, strbuf: string, indentCount = 0) {
-        let _strbuf = strbuf;
-        _strbuf += internedSpaces(indentCount);
-        // eslint-disable-next-line max-len
-        _strbuf += `Node (len ${block.cachedLength}) p len (${block.parent ? block.parent.cachedLength : 0}) ord ${ordinalToArray(block.ordinal)} with ${block.childCount} segs:\n`;
-        if (MergeTree.blockUpdateMarkers) {
-            _strbuf += internedSpaces(indentCount);
-            _strbuf += (<IHierBlock>block).hierToString(indentCount);
-        }
-        if (this.collabWindow.collaborating) {
-            _strbuf += internedSpaces(indentCount);
-            _strbuf += `${block.partialLengths!.toString((id) => glc(this, id), indentCount)}\n`;
-        }
-        const children = block.children;
-        for (let childIndex = 0; childIndex < block.childCount; childIndex++) {
-            const child = children[childIndex];
-            if (!child.isLeaf()) {
-                _strbuf = this.nodeToString(child, _strbuf, indentCount + 4);
-            } else {
-                const segment = child;
-                _strbuf += internedSpaces(indentCount + 4);
-                // eslint-disable-next-line max-len
-                _strbuf += `cli: ${glc(this, segment.clientId)} seq: ${segment.seq} ord: ${ordinalToArray(segment.ordinal)}`;
-                const removalInfo: IRemovalInfo = segment;
-                if (removalInfo.removedSeq !== undefined) {
-                    _strbuf += ` rcli: ${glc(this, removalInfo.removedClientId!)} rseq: ${removalInfo.removedSeq}`;
-                }
-                _strbuf += "\n";
-                _strbuf += internedSpaces(indentCount + 4);
-                _strbuf += segment.toString();
-                _strbuf += "\n";
-            }
-        }
-        return _strbuf;
-    }
-
-    public toString() {
-        return this.nodeToString(this.root, "", 0);
     }
 
     public incrementalBlockMap<TContext>(stateStack: Stack<IncrementalMapState<TContext>>) {

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -75,7 +75,6 @@ export interface IMergeTreeClientSequenceArgs {
 export type MergeTreeDeltaCallback =
     (opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs) => void;
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IMergeTreeMaintenanceCallbackArgs extends IMergeTreeDeltaCallbackArgs<MergeTreeMaintenanceType> { }
 
 export type MergeTreeMaintenanceCallback =

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -177,8 +177,8 @@ export class PartialSequenceLengths {
                     // Find next earliest sequence number
                     if (indices[k] < childPartialsCounts[k]) {
                         const cpLen = childPartials[k].partialLengths[indices[k]];
-                        // eslint-disable-next-line max-len
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         if ((outerIndexOfEarliest < 0) || (cpLen.seq < earliestPartialLength!.seq)) {
                             outerIndexOfEarliest = k;
                             earliestPartialLength = cpLen;
@@ -186,8 +186,8 @@ export class PartialSequenceLengths {
                     }
                 }
                 if (outerIndexOfEarliest >= 0) {
-                    // eslint-disable-next-line max-len
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     addNext(earliestPartialLength!);
                     indices[outerIndexOfEarliest]++;
                 }
@@ -263,9 +263,9 @@ export class PartialSequenceLengths {
         }
     }
 
-    private static getOverlapClients(overlapClientids: number[], seglen: number) {
+    private static getOverlapClients(overlapClientIds: number[], seglen: number) {
         const bst = new RedBlackTree<number, IOverlapClient>(compareNumbers);
-        for (const clientId of overlapClientids) {
+        for (const clientId of overlapClientIds) {
             bst.put(clientId, { clientId, seglen });
         }
         return bst;
@@ -277,11 +277,11 @@ export class PartialSequenceLengths {
         seglen: number) {
         if (partialLength.overlapRemoveClients) {
             for (const clientId of overlapRemoveClientIds) {
-                const ovlapClientNode = partialLength.overlapRemoveClients.get(clientId);
-                if (!ovlapClientNode) {
+                const overlapClientNode = partialLength.overlapRemoveClients.get(clientId);
+                if (!overlapClientNode) {
                     partialLength.overlapRemoveClients.put(clientId, { clientId, seglen });
                 } else {
-                    ovlapClientNode.data.seglen += seglen;
+                    overlapClientNode.data.seglen += seglen;
                 }
             }
         } else {
@@ -367,7 +367,7 @@ export class PartialSequenceLengths {
             }
         }
         if (seqPartialLen === undefined) {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+
             seqPartialLen = {
                 clientId,
                 seglen: seqSeglen,
@@ -453,14 +453,14 @@ export class PartialSequenceLengths {
     public getPartialLength(refSeq: number, clientId: number) {
         let pLen = this.minLength;
         const seqIndex = latestLEQ(this.partialLengths, refSeq);
-        const cliLatestindex = this.cliLatest(clientId);
+        const cliLatestIndex = this.cliLatest(clientId);
         const cliSeq = this.clientSeqNumbers[clientId];
         if (seqIndex >= 0) {
             // Add the partial length up to refSeq
             pLen += this.partialLengths[seqIndex].len;
 
-            if (cliLatestindex >= 0) {
-                const cliLatest = cliSeq[cliLatestindex];
+            if (cliLatestIndex >= 0) {
+                const cliLatest = cliSeq[cliLatestIndex];
 
                 if (cliLatest.seq > refSeq) {
                     // The client has local edits after refSeq, add in the length adjustments
@@ -474,8 +474,8 @@ export class PartialSequenceLengths {
         } else {
             // RefSeq is before any of the partial lengths
             // so just add in all local edits of that client (which should all be after the refSeq)
-            if (cliLatestindex >= 0) {
-                const cliLatest = cliSeq[cliLatestindex];
+            if (cliLatestIndex >= 0) {
+                const cliLatest = cliSeq[cliLatestIndex];
                 pLen += cliLatest.len;
             }
         }
@@ -488,7 +488,7 @@ export class PartialSequenceLengths {
             buf += `(${partial.seq},${partial.len}) `;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-for-in-array, no-restricted-syntax
+        // eslint-disable-next-line @typescript-eslint/no-for-in-array
         for (const clientId in this.clientSeqNumbers) {
             if (this.clientSeqNumbers[clientId].length > 0) {
                 buf += `Client `;
@@ -530,7 +530,7 @@ export class PartialSequenceLengths {
             return minLength;
         }
         this.minLength += copyDown(this.partialLengths);
-        // eslint-disable-next-line @typescript-eslint/no-for-in-array, guard-for-in, no-restricted-syntax
+        // eslint-disable-next-line @typescript-eslint/no-for-in-array, guard-for-in
         for (const clientId in this.clientSeqNumbers) {
             const cliPartials = this.clientSeqNumbers[clientId];
             if (cliPartials) {

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -33,7 +33,7 @@ export class PropertiesManager {
                     0x05c /* "Trying to update more annotate props than do exist!" */);
                 this.pendingKeyUpdateCount[key]--;
                 if (this.pendingKeyUpdateCount?.[key] === 0) {
-                    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+
                     delete this.pendingKeyUpdateCount[key];
                 }
             }
@@ -72,12 +72,12 @@ export class PropertiesManager {
             if (collaborating && seq === UnassignedSequenceNumber) {
                 this.pendingRewriteCount++;
             }
-            // We are re-writting so delete all the properties
+            // We are re-writing so delete all the properties
             // not in the new props
             for (const key of Object.keys(oldProps)) {
                 if (!newProps[key] && shouldModifyKey(key)) {
                     deltas[key] = oldProps[key];
-                    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+
                     delete oldProps[key];
                 }
             }
@@ -105,7 +105,7 @@ export class PropertiesManager {
                 newValue = newProps[key];
             }
             if (newValue === null) {
-                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+
                 delete oldProps[key];
             } else {
                 oldProps[key] = newValue;
@@ -122,7 +122,7 @@ export class PropertiesManager {
     ): PropertySet | undefined {
         if (oldProps) {
             if (!newProps) {
-                // eslint-disable-next-line no-param-reassign
+
                 newProps = createMap<any>();
             }
             if (!newManager) {

--- a/packages/dds/merge-tree/src/snapshotChunks.ts
+++ b/packages/dds/merge-tree/src/snapshotChunks.ts
@@ -94,7 +94,7 @@ export function serializeAsMinSupportedVersion(
     switch (chunk.version) {
         case undefined:
             targetChuck = chunk as MergeTreeChunkLegacy;
-            targetChuck.headerMetadata = buildHeaderMetadataForLegecyChunk(path, targetChuck, options);
+            targetChuck.headerMetadata = buildHeaderMetadataForLegacyChunk(path, targetChuck, options);
             break;
 
         case "1":
@@ -143,7 +143,7 @@ export function toLatestVersion(
                 version: "1",
                 length: chunkLegacy.chunkLengthChars,
                 segmentCount: chunkLegacy.chunkSegmentCount,
-                headerMetadata: buildHeaderMetadataForLegecyChunk(path, chunkLegacy, options),
+                headerMetadata: buildHeaderMetadataForLegacyChunk(path, chunkLegacy, options),
                 segments: chunkLegacy.segmentTexts,
                 startIndex: chunkLegacy.chunkStartSegmentIndex,
             };
@@ -156,7 +156,7 @@ export function toLatestVersion(
     }
 }
 
-function buildHeaderMetadataForLegecyChunk(
+function buildHeaderMetadataForLegacyChunk(
     path: string, chunk: MergeTreeChunkLegacy, options: PropertySet | undefined): MergeTreeHeaderMetadata | undefined {
     if (path === SnapshotLegacy.header) {
         if (chunk.headerMetadata !== undefined) {

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -10,37 +10,37 @@ import { ISegment } from "./mergeTree";
  *
  * This differs from a normal sorted set in that the keys are not fixed.
  * The segments are sorted via their ordinals which can change as the merge tree is modified.
- * Eventhough the values of the ordinals can change their ordering and uniqueness cannot, so the order of a set of
+ * Even though the values of the ordinals can change their ordering and uniqueness cannot, so the order of a set of
  * segments ordered by their ordinals will always have the same order even if the ordinal values on
- * the segments changes. This invarient allows ensure the segments stay ordered and unique, and that new segments
+ * the segments changes. This invariant allows ensure the segments stay ordered and unique, and that new segments
  * can be inserted into that order.
  */
 export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment } = ISegment> {
-    private readonly oridinalSortedItems: T[] = [];
+    private readonly ordinalSortedItems: T[] = [];
 
     public get size(): number {
-        return this.oridinalSortedItems.length;
+        return this.ordinalSortedItems.length;
     }
 
     public get items(): readonly T[] {
-        return this.oridinalSortedItems;
+        return this.ordinalSortedItems;
     }
 
     public addOrUpdate(newItem: T, update?: (existingItem: T, newItem: T) => T) {
         const position = this.findOrdinalPosition(this.getOrdinal(newItem));
         if (position.exists) {
             if (update) {
-                update(this.oridinalSortedItems[position.index], newItem);
+                update(this.ordinalSortedItems[position.index], newItem);
             }
         } else {
-            this.oridinalSortedItems.splice(position.index, 0, newItem);
+            this.ordinalSortedItems.splice(position.index, 0, newItem);
         }
     }
 
     public remove(item: T): boolean {
         const position = this.findOrdinalPosition(this.getOrdinal(item));
         if (position.exists) {
-            this.oridinalSortedItems.splice(position.index, 1);
+            this.ordinalSortedItems.splice(position.index, 1);
             return true;
         }
         return false;
@@ -62,19 +62,19 @@ export class SortedSegmentSet<T extends ISegment | { readonly segment: ISegment 
     }
 
     private findOrdinalPosition(ordinal: string, start?: number, end?: number): { exists: boolean, index: number } {
-        if (this.oridinalSortedItems.length === 0) {
+        if (this.ordinalSortedItems.length === 0) {
             return { exists: false, index: 0 };
         }
         if (start === undefined || end === undefined) {
-            return this.findOrdinalPosition(ordinal, 0, this.oridinalSortedItems.length - 1);
+            return this.findOrdinalPosition(ordinal, 0, this.ordinalSortedItems.length - 1);
         }
         const index = start + Math.floor((end - start) / 2);
-        if (this.getOrdinal(this.oridinalSortedItems[index]) > ordinal) {
+        if (this.getOrdinal(this.ordinalSortedItems[index]) > ordinal) {
             if (start === index) {
                 return { exists: false, index };
             }
             return this.findOrdinalPosition(ordinal, start, index - 1);
-        } else if (this.getOrdinal(this.oridinalSortedItems[index]) < ordinal) {
+        } else if (this.getOrdinal(this.ordinalSortedItems[index]) < ordinal) {
             if (index === end) {
                 return { exists: false, index: index + 1 };
             }

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -66,7 +66,6 @@ describe("MergeTree.Client", () => {
     // Generate a list of single character client names, support up to 69 clients
     const clientNames = generateClientNames();
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
     doOverRange(opts.minLength, opts.growthFunc, (minLength) => {
         it(`ConflictFarm_${minLength}`, async () => {
             const mt = random.engines.mt19937();

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -88,7 +88,7 @@ export function runMergeTreeOperationRunner(
     apply = applyMessages) {
     let seq = startingSeq;
     const results: ReplayGroup[] = [];
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+
     doOverRange(config.opsPerRoundRange, config.growthFunc, (opsPerRound) => {
         if (config.incrementalLog) {
             console.log(`MinLength: ${minLength} Clients: ${clients.length} Ops: ${opsPerRound} Seq: ${seq}`);
@@ -164,7 +164,7 @@ export function generateOperationMessagesForClients(
             }
         }
         if (op !== undefined) {
-            // Precheck to avoid logger.toString() in the string template
+            // Pre-check to avoid logger.toString() in the string template
             if (sg === client.mergeTree.pendingSegments.last()) {
                 assert.notEqual(
                     sg,
@@ -192,7 +192,6 @@ export function generateClientNames(): string[] {
     addClientNames("A", 26);
     addClientNames("a", 26);
     addClientNames("0", 17);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return clientNames;
 }
 

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -31,11 +31,11 @@ export class TextSegment extends BaseSegment {
     }
 
     public static make(text: string, props?: PropertySet) {
-        const tseg = new TextSegment(text);
+        const seg = new TextSegment(text);
         if (props) {
-            tseg.addProperties(props);
+            seg.addProperties(props);
         }
-        return tseg;
+        return seg;
     }
 
     public static fromJSONObject(spec: any) {

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -18,9 +18,7 @@ import {
     IntervalNode,
     IntervalTree,
     LocalReference,
-    MergeTree,
     MergeTreeDeltaType,
-    ordinalToArray,
     PropertiesManager,
     PropertySet,
     RedBlackTree,
@@ -195,7 +193,6 @@ export class Interval implements ISerializableInterval {
 export class SequenceInterval implements ISerializableInterval {
     public properties: PropertySet;
     public propertyManager: PropertiesManager;
-    private readonly checkMergeTree: MergeTree;
 
     constructor(
         public start: LocalReference,
@@ -260,9 +257,6 @@ export class SequenceInterval implements ISerializableInterval {
     public overlaps(b: SequenceInterval) {
         const result = (this.start.compare(b.end) < 0) &&
             (this.end.compare(b.start) >= 0);
-        if (this.checkMergeTree) {
-            this.checkOverlaps(b, result);
-        }
         return result;
     }
 
@@ -298,24 +292,6 @@ export class SequenceInterval implements ISerializableInterval {
         const startPos = this.start.toPosition();
         const endPos = this.start.toPosition();
         return (endPos > bstart) && (startPos < bend);
-    }
-
-    private checkOverlaps(b: SequenceInterval, result: boolean) {
-        const astart = this.start.toPosition();
-        const bstart = b.start.toPosition();
-        const aend = this.end.toPosition();
-        const bend = b.end.toPosition();
-        const checkResult = ((astart < bend) && (bstart < aend));
-        if (checkResult !== result) {
-            // eslint-disable-next-line max-len
-            console.log(`check mismatch: res ${result} ${this.start.segment === b.end.segment} ${b.start.segment === this.end.segment}`);
-            console.log(`as ${astart} ae ${aend} bs ${bstart} be ${bend}`);
-            console.log(`as ${ordinalToArray(this.start.segment.ordinal)}@${this.start.offset}`);
-            console.log(`ae ${ordinalToArray(this.end.segment.ordinal)}@${this.end.offset}`);
-            console.log(`bs ${ordinalToArray(b.start.segment.ordinal)}@${b.start.offset}`);
-            console.log(`be ${ordinalToArray(b.end.segment.ordinal)}@${b.end.offset}`);
-            console.log(this.checkMergeTree.nodeToString(b.start.segment.parent, ""));
-        }
     }
 
     public modify(label: string, start: number, end: number) {

--- a/packages/dds/sequence/src/localValues.ts
+++ b/packages/dds/sequence/src/localValues.ts
@@ -248,8 +248,6 @@ export class LocalValueMaker {
         if (!valueType) {
             throw new Error(`Unknown type '${type}' specified`);
         }
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return valueType.factory.load(emitter, params);
     }
 }

--- a/packages/dds/sequence/src/mapKernel.ts
+++ b/packages/dds/sequence/src/mapKernel.ts
@@ -168,7 +168,7 @@ export class MapKernel implements IValueTypeCreator {
     private readonly pendingKeys: Map<string, number> = new Map();
 
     /**
-     * This is used to assign a unique id to every outgoing operation and helps in tracking unack'd ops.
+     * This is used to assign a unique id to every outgoing operation and helps in tracking unacked ops.
      */
     private pendingMessageId: number = -1;
 
@@ -636,14 +636,14 @@ export class MapKernel implements IValueTypeCreator {
         if (this.pendingClearMessageId !== -1) {
             if (local) {
                 assert(localOpMetadata !== undefined && localOpMetadata as number < this.pendingClearMessageId,
-                    0x1f1 /* "Received out of order op when there is an unackd clear message" */);
+                    0x1f1 /* "Received out of order op when there is an unacked clear message" */);
             }
-            // If we have an unack'd clear, we can ignore all ops.
+            // If we have an unacked clear, we can ignore all ops.
             return false;
         }
 
         if (this.pendingKeys.has(op.key)) {
-            // Found an unack'd op. Clear it from the map if the pendingMessageId in the map matches this message's
+            // Found an unacked op. Clear it from the map if the pendingMessageId in the map matches this message's
             // and don't process the op.
             if (local) {
                 assert(localOpMetadata !== undefined,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -156,7 +156,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
     protected client: Client;
     // Deferred that triggers once the object is loaded
     protected loadedDeferred = new Deferred<void>();
-    // cache out going ops created when parital loading
+    // cache out going ops created when partial loading
     private readonly loadedDeferredOutgoingOps:
         [IMergeTreeOp, SegmentGroup | SegmentGroup[]][] = [];
     // cache incoming ops that arrive when partial loading
@@ -544,7 +544,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
                     this.loadFinished(error);
                 });
             if (this.dataStoreRuntime.options?.sequenceInitializeFromHeaderOnly !== true) {
-                // if we not doing parital load, await the catch up ops,
+                // if we not doing partial load, await the catch up ops,
                 // and the finalization of the load
                 await loadCatchUpOps;
             }
@@ -600,14 +600,14 @@ export abstract class SharedSegmentSequence<T extends ISegment>
         const message = parseHandles(rawMessage, this.serializer);
 
         const ops: IMergeTreeDeltaOp[] = [];
-        function transfromOps(event: SequenceDeltaEvent) {
+        function transformOps(event: SequenceDeltaEvent) {
             ops.push(...SharedSegmentSequence.createOpsFromDelta(event));
         }
         const needsTransformation = message.referenceSequenceNumber !== message.sequenceNumber - 1;
         let stashMessage: Readonly<ISequencedDocumentMessage> = message;
         if (this.runtime.options?.newMergeTreeSnapshotFormat !== true) {
             if (needsTransformation) {
-                this.on("sequenceDelta", transfromOps);
+                this.on("sequenceDelta", transformOps);
             }
         }
 
@@ -615,7 +615,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 
         if (this.runtime.options?.newMergeTreeSnapshotFormat !== true) {
             if (needsTransformation) {
-                this.removeListener("sequenceDelta", transfromOps);
+                this.removeListener("sequenceDelta", transformOps);
                 // shallow clone the message as we only overwrite top level properties,
                 // like referenceSequenceNumber and content only
                 stashMessage = {
@@ -660,7 +660,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
                 throw error;
             } else {
                 // it is important this series remains synchronous
-                // first we stop defering incoming ops, and apply then all
+                // first we stop deferring incoming ops, and apply then all
                 this.deferIncomingOps = false;
                 while (this.loadedDeferredIncomingOps.length > 0) {
                     this.processCore(this.loadedDeferredIncomingOps.shift(), false, undefined);

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -94,10 +94,10 @@ export class SharedObjectSequenceFactory implements IChannelFactory {
      * For more info, please see [Github issue 8526](https://github.com/microsoft/FluidFramework/issues/8526)
      */
     public static segmentFromSpec(segSpec: IJSONSegment) {
-        // eslint-disable-next-line @typescript-eslint/ban-types
+
         const runSegment = segSpec as IJSONRunSegment<object>;
         if (runSegment.items) {
-            // eslint-disable-next-line @typescript-eslint/ban-types
+
             const seg = new SubSequence<object>(runSegment.items);
             if (runSegment.props) {
                 seg.addProperties(runSegment.props);
@@ -133,7 +133,7 @@ export class SharedObjectSequenceFactory implements IChannelFactory {
         id: string,
         services: IChannelServices,
         attributes: IChannelAttributes): Promise<ISharedObject> {
-        // eslint-disable-next-line @typescript-eslint/ban-types
+
         const sharedSeq = new SharedObjectSequence<object>(runtime, id, attributes);
         await sharedSeq.load(services);
         return sharedSeq;

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -172,7 +172,7 @@ export class SharedIntervalCollection<TInterval extends ISerializableInterval = 
 
     /**
      * Creates the full path of the intervalCollection label
-     * @param label - the incoming lable
+     * @param label - the incoming label
      */
     protected getIntervalCollectionPath(label: string): string {
         return label;

--- a/packages/dds/sequence/src/sharedObjectSequence.ts
+++ b/packages/dds/sequence/src/sharedObjectSequence.ts
@@ -27,7 +27,7 @@ export class SharedObjectSequence<T> extends SharedSequence<T> {
      * @deprecated SharedObjectSequence is not recommended for use and will be removed in an upcoming release.
      * For more info, please see [Github issue 8526](https://github.com/microsoft/FluidFramework/issues/8526)
      */
-    // eslint-disable-next-line @typescript-eslint/no-shadow
+
     public static create<T>(runtime: IFluidDataStoreRuntime, id?: string) {
         return runtime.createChannel(id, SharedObjectSequenceFactory.Type) as SharedObjectSequence<T>;
     }

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -28,7 +28,7 @@ export interface ISharedString extends SharedSegmentSequence<SharedStringSegment
      * Inserts the text at the position.
      * @param pos - The position to insert the text at
      * @param text - The text to insert
-     * @param props - The properties of tex
+     * @param props - The properties of the text
      */
     insertText(pos: number, text: string, props?: PropertySet): void;
 

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-unassigned-import
-import { } from "@fluidframework/core-interfaces";
 import {
     ICombiningOp,
     IMergeTreeInsertMsg,
@@ -30,7 +28,7 @@ export interface ISharedString extends SharedSegmentSequence<SharedStringSegment
      * Inserts the text at the position.
      * @param pos - The position to insert the text at
      * @param text - The text to insert
-     * @param props - The properties of text
+     * @param props - The properties of tex
      */
     insertText(pos: number, text: string, props?: PropertySet): void;
 

--- a/packages/dds/sequence/src/sparsematrix.ts
+++ b/packages/dds/sequence/src/sparsematrix.ts
@@ -159,7 +159,7 @@ export class RunSegment extends SubSequence<SparseMatrixItem> {
     }
 
     public getTag(pos: number) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
         return this.tags[pos];
     }
 
@@ -276,13 +276,13 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 
     public getItem(row: number, col: number):
         // The return type is defined explicitly here to prevent TypeScript from generating dynamic imports
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+
         Jsonable<string | number | boolean | IFluidHandle<IFluidObject & FluidObject & IFluidLoadable>> {
         const pos = rowColToPosition(row, col);
         const { segment, offset } =
             this.getContainingSegment(pos);
         if (RunSegment.is(segment)) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
             return segment.items[offset];
         } else if (PaddingSegment.is(segment)) {
             return undefined;
@@ -294,7 +294,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     public getTag(row: number, col: number) {
         const { segment, offset } = this.getSegment(row, col);
         if (RunSegment.is(segment)) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
             return segment.getTag(offset);
         }
         return undefined;


### PR DESCRIPTION
There were a bunch of spelling errors in these packages, along with some unused exports. This PR is just cleaning that up. No functional changes.