### PR TITLE
Move getLongClientId from passing though merge tree to snapshotV1.ts

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -294,9 +294,6 @@ export function extend<T>(base: MapLike<T>, extension: MapLike<T> | undefined, c
 export function extendIfUndefined<T>(base: MapLike<T>, extension: MapLike<T> | undefined): MapLike<T>;
 
 // @public (undocumented)
-export function glc(mergeTree: MergeTree, id: number): string;
-
-// @public (undocumented)
 export class Heap<T> {
     constructor(a: T[], comp: Comparer<T>);
     // (undocumented)
@@ -997,8 +994,6 @@ export class MergeTree {
     // (undocumented)
     getLength(refSeq: number, clientId: number): number;
     // (undocumented)
-    getLongClientId?: (id: number) => string;
-    // (undocumented)
     getMarkerFromId(id: string): ISegment | undefined;
     // (undocumented)
     getPosition(node: MergeNode, refSeq: number, clientId: number): number;
@@ -1028,8 +1023,6 @@ export class MergeTree {
     // (undocumented)
     mergeTreeMaintenanceCallback?: MergeTreeMaintenanceCallback;
     // (undocumented)
-    nodeToString(block: IMergeBlock, strbuf: string, indentCount?: number): string;
-    // (undocumented)
     options?: PropertySet | undefined;
     // (undocumented)
     static readonly options: {
@@ -1053,8 +1046,6 @@ export class MergeTree {
     setMinSeq(minSeq: number): void;
     // (undocumented)
     startCollaboration(localClientId: number, minSeq: number, currentSeq: number): void;
-    // (undocumented)
-    toString(): string;
     // (undocumented)
     walkAllSegments<TClientData>(block: IMergeBlock, action: (segment: ISegment, accum?: TClientData) => boolean, accum?: TClientData): boolean;
     }

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -101,7 +101,6 @@ export class Client {
         options?: PropertySet,
     ) {
         this.mergeTree = new MergeTree(options);
-        this.mergeTree.getLongClientId = (id) => this.getLongClientId(id);
     }
 
     /**
@@ -889,7 +888,7 @@ export class Client {
             assert(
                 catchUpMsgs === undefined || catchUpMsgs.length === 0,
                 0x03f /* "New format should not emit catchup ops" */);
-            const snap = new SnapshotV1(this.mergeTree, this.logger);
+            const snap = new SnapshotV1(this.mergeTree, this.logger, (id)=>this.getLongClientId(id));
             snap.extractSync();
             return snap.emit(serializer, handle);
         } else {

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -48,6 +48,7 @@ export class SnapshotV1 {
     constructor(
         public mergeTree: MergeTree,
         logger: ITelemetryLogger,
+        private readonly getLongClientId: (id: number) => string,
         public filename?: string,
         public onCompletion?: () => void,
     ) {
@@ -209,8 +210,7 @@ export class SnapshotV1 {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 if (segment.seq! > minSeq) {
                     raw.seq = segment.seq;
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    raw.client = mergeTree.getLongClientId!(segment.clientId);
+                    raw.client = this.getLongClientId(segment.clientId);
                 }
                 // We have already dispensed with removed segments below the MSN and removed segments with unassigned
                 // sequence numbers.  Any remaining removal info should be preserved.
@@ -219,7 +219,7 @@ export class SnapshotV1 {
                         0x065 /* "On removal info preservation, segment has invalid removed sequence number!" */);
                     raw.removedSeq = segment.removedSeq;
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    raw.removedClient = mergeTree.getLongClientId!(segment.removedClientId!);
+                    raw.removedClient = this.getLongClientId(segment.removedClientId!);
                 }
 
             // Sanity check that we are preserving either the seq < minSeq or a removed segment's info.

--- a/packages/dds/merge-tree/src/test/snapshot.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.spec.ts
@@ -77,7 +77,11 @@ class TestString {
     }
 
     public getSummary() {
-        const snapshot = new SnapshotV1(this.client.mergeTree, this.client.logger);
+        const snapshot = new SnapshotV1(
+            this.client.mergeTree,
+            this.client.logger,
+            (id)=>this.client.getLongClientId(id));
+
         snapshot.extractSync();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return snapshot.emit(TestClient.serializer, undefined!).summary;


### PR DESCRIPTION
This is an unnecessary passthrough that forces non-null assertions. this change just passes it where it is needed.