### PR TITLE
Update CI/PR triggers for "next" branch

### DIFF
--- a/tools/pipelines/build-azure-local-service.yml
+++ b/tools/pipelines/build-azure-local-service.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -44,6 +45,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - tools/benchmark
@@ -42,6 +43,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - tools/build-tools
@@ -42,6 +43,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -10,6 +10,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-bundle-size-tools.yml
+++ b/tools/pipelines/build-bundle-size-tools.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - tools/bundle-size-tools
@@ -42,6 +43,7 @@ pr:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - tools/bundle-size-tools

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -32,6 +32,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -56,6 +57,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-docs-site.yml
+++ b/tools/pipelines/build-docs-site.yml
@@ -12,6 +12,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # build-docs pipeline
-# This pipeline builds the main branch docs each time the client packages are built
+# This pipeline builds the main/next branch docs each time the client packages are built
 
 name: $(Build.BuildId)
 
@@ -37,6 +37,7 @@ variables:
   - name: latestPipeline
     value: ${{ or(
       eq(variables['Build.SourceBranchName'], 'main'),
+      eq(variables['Build.SourceBranchName'], 'next'),
       eq(variables['Build.SourceBranchName'], 'pl-test')
       )}}
   - name: n1Branch
@@ -49,17 +50,20 @@ variables:
     value: ${{ or(variables.releasePipeline, variables.n1Pipeline, variables.latestPipeline) }}
   - name: Packaging.EnableSBOMSigning
     value: true
-  - name: isMain
-    value: ${{ eq(variables['Build.SourceBranchName'], 'main') }}
+  - name: isMainOrNext
+    value: ${{ or(
+      eq(variables['Build.SourceBranchName'], 'main'),
+      eq(variables['Build.SourceBranchName'], 'next')
+      )}}
   - name: shouldDeploy
     value: ${{ or(
       eq(parameters.deployOverride, 'force'),
-      and(eq(variables.isMain, true), eq(parameters.deployOverride, 'default'))
+      and(eq(variables.isMainOrNext, true), eq(parameters.deployOverride, 'default'))
       )}}
   - name: shouldRetainGuardianAssets
     value: ${{ or(
       eq(parameters.guardianAssetRetentionOverride, 'force'),
-      and(eq(variables.isMain, true), eq(parameters.guardianAssetRetentionOverride, 'default'))
+      and(eq(variables.isMainOrNext, true), eq(parameters.guardianAssetRetentionOverride, 'default'))
       )}}
   - name: arrow.releasedtoproduction
     value: eq(variables.shouldDeploy, true)
@@ -70,6 +74,7 @@ trigger:
     include:
     - release/*
     - main
+    - next
 pr: none
 
 resources:
@@ -92,6 +97,7 @@ resources:
       branches:
         include:
         - main
+        - next
         - docs/**
   - pipeline: server
     source: server-routerlicious
@@ -138,7 +144,7 @@ stages:
               parameters:
                 STORAGE_ACCOUNT: $(STORAGE_ACCOUNT)
                 STORAGE_KEY: $(STORAGE_KEY)
-                uploadAsLatest: ${{ variables.isMain }}
+                uploadAsLatest: ${{ variables.isMainOrNext }}
 
 - stage: site_build
   displayName: 'Build website'

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-generator-fluid.yml
+++ b/tools/pipelines/build-generator-fluid.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -44,6 +45,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -27,6 +27,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -45,6 +46,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - tools/test-tools
@@ -42,6 +43,7 @@ pr:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - tools/test-tools

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -44,6 +45,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/chart-copy-historian.yml
+++ b/tools/pipelines/chart-copy-historian.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - server/charts/historian

--- a/tools/pipelines/chart-copy-routerlicious.yml
+++ b/tools/pipelines/chart-copy-routerlicious.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - server/routerlicious/kubernetes/routerlicious

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -5,10 +5,12 @@
 
 trigger:
 - main
+- next
 - release/*
 
 pr:
 - main
+- next
 - release/*
 
 pool:

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - server/gitrest
@@ -43,6 +44,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - server/gitssh
@@ -40,6 +41,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -36,6 +36,7 @@ trigger:
   branches:
     include:
     - main
+    - next
   paths:
     include:
     - server/historian
@@ -56,6 +57,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -35,6 +35,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -58,6 +59,7 @@ pr:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -90,9 +90,14 @@ variables:
     value: $[variables.containerRegistryConnection]
   - name: containerTag
     value: $(containerRegistryUrl)/$(buildContainerName):$(containerTagSuffix)
-  - ${{ if or( eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/next')) }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     - name: latestContainerTagSuffix
       value: latest
+    - name: latestContainerTag
+      value: $(containerRegistryUrl)/$(buildContainerName):$(latestContainerTagSuffix)
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/next') }}:
+    - name: latestContainerTagSuffix
+      value: next
     - name: latestContainerTag
       value: $(containerRegistryUrl)/$(buildContainerName):$(latestContainerTagSuffix)
 # tag the git repo when we published the docker image if the releaseKind is docker,

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -90,7 +90,7 @@ variables:
     value: $[variables.containerRegistryConnection]
   - name: containerTag
     value: $(containerRegistryUrl)/$(buildContainerName):$(containerTagSuffix)
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if or( eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/next')) }}:
     - name: latestContainerTagSuffix
       value: latest
     - name: latestContainerTag

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -9,6 +9,7 @@ trigger:
   branches:
     include:
     - main
+    - next
     - release/*
   paths:
     include:
@@ -31,6 +32,7 @@ resources:
         include:
         - releases/*
         - main
+        - next
 
 variables:
 - group: prague-key-vault

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -16,6 +16,7 @@ resources:
       branches:
       - release/*
       - main
+      - next
 
 variables:
 - group: prague-key-vault

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -16,6 +16,7 @@ resources:
       branches:
       - release/*
       - main
+      - next
 
 variables:
 - group: prague-key-vault


### PR DESCRIPTION
Part 1 #9367

Update pipeline definitions to trigger CI/PR runs for changes made against the "next" branch, which functions as an active development branch parallel to "main".

- In all build cases, I added "next" as a trigger even if we shouldn't expect changes to those areas in "next".  This is to avoid potential late discovery of breaks in these areas if something does happen to get checked into "next
- I didn't update package/release checks/rules to allow this for "next".  I think this needs a bit more thought first on what we want to allow from there.
- I did update docs publishing/building to allow it out of "next".  Unsure if correct