### PR TITLE
Fix virtualPatch option for branch command in bump-version tool

### DIFF
--- a/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersionCli.ts
@@ -124,7 +124,7 @@ function parseOptions(argv: string[]) {
         if (arg === "--branch") {
             paramBranch = true;
             paramClean = true;
-            break;
+            continue;
         }
         if (arg === "--local") {
             paramLocal = false;


### PR DESCRIPTION
The `branch` command was short-circuiting when parsing options and not picking up the `virtualPatch` option.  Remove the short-circuit so additional options may be parsed.  There is already a later check for conflicting options that will exit if `branch` commands pick up additional unwanted options as a result of this change.