### PR TITLE
Run static web app deployment on linux, and guardian tasks in windows

### DIFF
--- a/docs/.gdnbaselines
+++ b/docs/.gdnbaselines
@@ -11,7 +11,9 @@
     "552baaa9d24596ed82e97b538dbef8abfcc9a0a8a9fdc8d3423424bf003b4fa7": {
       "signature": "552baaa9d24596ed82e97b538dbef8abfcc9a0a8a9fdc8d3423424bf003b4fa7",
       "alternativeSignatures": [
-        "b5f214e29b5462952a2841914ef8d1fc8141a9e8a69ea2b2be6c0cd409bf15d7"
+        "b5f214e29b5462952a2841914ef8d1fc8141a9e8a69ea2b2be6c0cd409bf15d7",
+        "f7352489c50aed5529c30f15f2d6e019dc840612ceb612ea5ffb44a0d994c641",
+        "956ef6761cd88e6cc39f6bd892c0e1e0719ac955d3e4bd5a52189ab9e64db97f"
       ],
       "target": "docs/themes/thxvscode/assets/js/bundle.js",
       "memberOf": [
@@ -27,7 +29,9 @@
     "0d4fa60d5f0b4f1d15e59fc8d68612e8f79f722ef23af4b073a0167ab4878fd6": {
       "signature": "0d4fa60d5f0b4f1d15e59fc8d68612e8f79f722ef23af4b073a0167ab4878fd6",
       "alternativeSignatures": [
-        "0c23128bddf2d4096ab21304a1026ea81637d87cf6c31a0ce9f56b97d03aad13"
+        "0c23128bddf2d4096ab21304a1026ea81637d87cf6c31a0ce9f56b97d03aad13",
+        "9ee87cd6cc4a7c3ee2b369ab55776beffe036908ab73e36bdc1ee30f78f925f4",
+        "b7a109924c97e48aae0751db9f9fae3963865ec0fcef79db223b22e1f72d8a20"
       ],
       "target": "docs/themes/thxvscode/assets/js/bundle.js",
       "memberOf": [
@@ -42,3 +46,38 @@
     }
   }
 }
+
+"results": {
+    "f7352489c50aed5529c30f15f2d6e019dc840612ceb612ea5ffb44a0d994c641": {
+      "signature": "f7352489c50aed5529c30f15f2d6e019dc840612ceb612ea5ffb44a0d994c641",
+      "alternativeSignatures": [
+        "956ef6761cd88e6cc39f6bd892c0e1e0719ac955d3e4bd5a52189ab9e64db97f"
+      ],
+      "target": "docs/themes/thxvscode/assets/js/bundle.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-inner-html",
+      "justification": "Comes from jquery dependency. Tracked by https://github.com/microsoft/FluidFramework/issues/9316.",
+      "createdDate": "2022-03-03 04:59:14Z",
+      "expirationDate": "2022-05-31 00:00:00Z",
+      "type": null
+    },
+    "9ee87cd6cc4a7c3ee2b369ab55776beffe036908ab73e36bdc1ee30f78f925f4": {
+      "signature": "9ee87cd6cc4a7c3ee2b369ab55776beffe036908ab73e36bdc1ee30f78f925f4",
+      "alternativeSignatures": [
+        "b7a109924c97e48aae0751db9f9fae3963865ec0fcef79db223b22e1f72d8a20"
+      ],
+      "target": "docs/themes/thxvscode/assets/js/bundle.js",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "eslint",
+      "ruleId": "@microsoft/sdl/no-html-method",
+      "justification": "Comes from jquery dependency. Tracked by https://github.com/microsoft/FluidFramework/issues/9316.",
+      "createdDate": "2022-03-03 04:59:14Z",
+      "expirationDate": "2022-05-31 00:00:00Z",
+      "type": null
+    }
+  }

--- a/docs/.gdnbaselines
+++ b/docs/.gdnbaselines
@@ -46,38 +46,3 @@
     }
   }
 }
-
-"results": {
-    "f7352489c50aed5529c30f15f2d6e019dc840612ceb612ea5ffb44a0d994c641": {
-      "signature": "f7352489c50aed5529c30f15f2d6e019dc840612ceb612ea5ffb44a0d994c641",
-      "alternativeSignatures": [
-        "956ef6761cd88e6cc39f6bd892c0e1e0719ac955d3e4bd5a52189ab9e64db97f"
-      ],
-      "target": "docs/themes/thxvscode/assets/js/bundle.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-inner-html",
-      "justification": "Comes from jquery dependency. Tracked by https://github.com/microsoft/FluidFramework/issues/9316.",
-      "createdDate": "2022-03-03 04:59:14Z",
-      "expirationDate": "2022-05-31 00:00:00Z",
-      "type": null
-    },
-    "9ee87cd6cc4a7c3ee2b369ab55776beffe036908ab73e36bdc1ee30f78f925f4": {
-      "signature": "9ee87cd6cc4a7c3ee2b369ab55776beffe036908ab73e36bdc1ee30f78f925f4",
-      "alternativeSignatures": [
-        "b7a109924c97e48aae0751db9f9fae3963865ec0fcef79db223b22e1f72d8a20"
-      ],
-      "target": "docs/themes/thxvscode/assets/js/bundle.js",
-      "memberOf": [
-        "default"
-      ],
-      "tool": "eslint",
-      "ruleId": "@microsoft/sdl/no-html-method",
-      "justification": "Comes from jquery dependency. Tracked by https://github.com/microsoft/FluidFramework/issues/9316.",
-      "createdDate": "2022-03-03 04:59:14Z",
-      "expirationDate": "2022-05-31 00:00:00Z",
-      "type": null
-    }
-  }

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -270,7 +270,7 @@ stages:
 
 - stage: deploy
   displayName: 'Deploy website'
-  dependsOn: build
+  dependsOn: [build, guardian]
   pool: Small
   jobs:
     - job: deploy_site
@@ -289,7 +289,7 @@ stages:
 
         - task: AzureStaticWebApp@0
           displayName: 'Deploy website to ASWA'
-          condition: eq(variables.shouldDeploy, true)
+          condition: and(in(stageDependencies.guardian.guardian_tasks.result, 'Succeeded', 'SucceededWithIssues'), eq(variables.shouldDeploy, true))
           inputs:
             skip_app_build: true # site was built in previous stage
             cwd: $(Build.SourcesDirectory)

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -15,6 +15,13 @@ parameters:
       - default
       - skip
       - force
+  - name: deployEnvironment
+    displayName: Static web app environment to deploy to
+    type: string
+    default: new
+    values:
+      - new
+      - old
   - name: guardianAssetRetentionOverride
     displayName: Guardian Asset Retention Override (default = based on branch)
     type: string
@@ -63,6 +70,11 @@ variables:
       )}}
   - name: arrow.releasedtoproduction
     value: eq(variables.shouldDeploy, true)
+  - name: deploymentToken
+    ${{ if eq( parameters['deployEnvironment'], 'new' ) }}:
+      value: "$(FLUID_WEBSITE_TORUS_API_TOKEN)"
+    ${{ if eq( parameters['deployEnvironment'], 'old') }}:
+      value: "$(AZURE_STATIC_WEB_APPS_API_TOKEN)"
 
 # no PR triggers
 trigger:
@@ -295,4 +307,4 @@ stages:
             cwd: $(Build.SourcesDirectory)
             app_location: 'docs/public'
             output_location: ''
-            azure_static_web_apps_api_token: $(AZURE_STATIC_WEB_APPS_API_TOKEN)
+            azure_static_web_apps_api_token: '${{ variables.deploymentToken }}'

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -269,12 +269,12 @@ stages:
 # END Secure development tasks
 
 - stage: deploy
-  displayName: 'Deploy site'
+  displayName: 'Deploy website'
   dependsOn: build
   pool: Small
   jobs:
     - job: deploy_site
-      displayName: 'Deploy site'
+      displayName: 'Deploy website'
       steps:
         - checkout: self
           submodules: false
@@ -288,7 +288,7 @@ stages:
             path: '$(Build.SourcesDirectory)/docs/public'
 
         - task: AzureStaticWebApp@0
-          displayName: 'Deploy site'
+          displayName: 'Deploy website to ASWA'
           condition: eq(variables.shouldDeploy, true)
           inputs:
             skip_app_build: true # site was built in previous stage

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -111,6 +111,7 @@ resources:
 stages:
 - stage: build
   displayName: 'Build website'
+  dependsOn: [] # run in parallel
   jobs:
     - job: debug_variables
       displayName: Show Variables
@@ -127,6 +128,7 @@ stages:
             echo latestPipeline ${{ variables.latestPipeline }}
             echo n1Pipeline ${{ variables.n1Pipeline }}
             echo repoToTrigger ${{ variables.repoToTrigger }}
+          displayName: Show Variables
 
     - job: component_detection
       displayName: Component Detection
@@ -208,23 +210,16 @@ stages:
   # BEGIN Secure development tasks
 - stage: guardian
   displayName: Guardian
+  dependsOn: [] # run in parallel
   pool:
     vmImage: windows-latest
   jobs:
     - job: guardian_tasks
       displayName: Guardian tasks
-      condition: in(stageDependencies.build.build_site.result, 'Succeeded', 'SucceededWithIssues')
       steps:
         - checkout: self
           submodules: false
           clean: true
-
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Copy fluidframework-docs to public folder'
-          inputs:
-            source: current
-            artifact: fluidframework-docs
-            path: '$(Build.SourcesDirectory)/docs/public'
 
         - task: UseNode@1
           displayName: 'Use Node 14.x'
@@ -282,6 +277,7 @@ stages:
 - stage: deploy
   displayName: 'Deploy website'
   pool: Small
+  dependsOn: ['build', 'guardian']
   jobs:
     - job: deploy_site
       displayName: 'Deploy website'

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -208,7 +208,6 @@ stages:
   # BEGIN Secure development tasks
 - stage: guardian
   displayName: Guardian
-  dependsOn: build
   pool:
     vmImage: windows-latest
   jobs:
@@ -282,7 +281,6 @@ stages:
 
 - stage: deploy
   displayName: 'Deploy website'
-  dependsOn: [build, guardian]
   pool: Small
   jobs:
     - job: deploy_site

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -97,44 +97,39 @@ resources:
     source: server-routerlicious
 
 stages:
-- stage: check
-  displayName: Checks
-  pool: Small
-  jobs:
-  - job: debug_variables
-    displayName: Component Detection
-    dependsOn: [] # run in parallel
-    steps:
-      - script: |
-          echo SourceBranchName: ${{ variables['Build.SourceBranchName'] }}
-          echo BASE_URL: $(BASE_URL)
-          echo RELEASE_VERSION: $(RELEASE_VERSION)
-          echo MAIN_BRANCH_VERSION: $(MAIN_BRANCH_VERSION)
-          echo N1_VERSION: $(N1_VERSION)
-          echo releasePipeline ${{ variables.releasePipeline }}
-          echo latestPipeline ${{ variables.latestPipeline }}
-          echo n1Pipeline ${{ variables.n1Pipeline }}
-          echo repoToTrigger ${{ variables.repoToTrigger }}
-        displayName: 'Show Variables'
-
-  - job: component_detection
-    displayName: Component Detection
-    dependsOn: [] # run in parallel
-    steps:
-      - task: ComponentGovernanceComponentDetection@0
-        displayName: Component Detection
-        inputs:
-          sourceScanPath: docs
-          verbosity: Verbose
-          scanType: Register
-          alertWarningLevel: High
-
 - stage: build
   displayName: 'Build website'
-  dependsOn: check
   jobs:
+    - job: debug_variables
+      displayName: Show Variables
+      dependsOn: [] # run in parallel
+      steps:
+        - script: |
+            echo SourceBranchName: ${{ variables['Build.SourceBranchName'] }}
+            echo BASE_URL: $(BASE_URL)
+            echo RELEASE_VERSION: $(RELEASE_VERSION)
+            echo MAIN_BRANCH_VERSION: $(MAIN_BRANCH_VERSION)
+            echo N1_VERSION: $(N1_VERSION)
+            echo releasePipeline ${{ variables.releasePipeline }}
+            echo latestPipeline ${{ variables.latestPipeline }}
+            echo n1Pipeline ${{ variables.n1Pipeline }}
+            echo repoToTrigger ${{ variables.repoToTrigger }}
+
+    - job: component_detection
+      displayName: Component Detection
+      dependsOn: [] # run in parallel
+      steps:
+        - task: ComponentGovernanceComponentDetection@0
+          displayName: Component Detection
+          inputs:
+            sourceScanPath: docs
+            verbosity: Verbose
+            scanType: Register
+            alertWarningLevel: High
+
     - deployment: upload_json
       displayName: 'Combine api-extractor JSON'
+      dependsOn: [] # run in parallel
       environment: 'fluid-docs-env'
       strategy:
         runOnce:
@@ -145,6 +140,7 @@ stages:
                 STORAGE_ACCOUNT: $(STORAGE_ACCOUNT)
                 STORAGE_KEY: $(STORAGE_KEY)
                 uploadAsLatest: ${{ variables.isMain }}
+
     - job: build_site
       displayName: 'Build site'
       dependsOn: upload_json

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -131,6 +131,7 @@ stages:
 
 - stage: build
   displayName: 'Build website'
+  dependsOn: check
   jobs:
     - deployment: upload_json
       displayName: 'Combine api-extractor JSON'
@@ -197,11 +198,12 @@ stages:
   # BEGIN Secure development tasks
 - stage: guardian
   displayName: Guardian
+  dependsOn: build
   pool:
     vmImage: windows-latest
   jobs:
     - job: guardian_tasks
-      condition: in(stageDependencies.json.upload_json.result, 'Succeeded', 'SucceededWithIssues')
+      condition: in(stageDependencies.build.build_site.result, 'Succeeded', 'SucceededWithIssues')
       steps:
         - checkout: self
           submodules: false
@@ -271,10 +273,10 @@ stages:
 
 - stage: deploy
   displayName: 'Deploy website'
+  dependsOn: build
   jobs:
     - job: deploy_site
       displayName: 'Build site'
-      dependsOn: upload_json
       steps:
         - checkout: self
           submodules: false

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -103,6 +103,7 @@ stages:
     - job: debug_variables
       displayName: Show Variables
       dependsOn: [] # run in parallel
+      pool: Small
       steps:
         - script: |
             echo SourceBranchName: ${{ variables['Build.SourceBranchName'] }}
@@ -118,6 +119,7 @@ stages:
     - job: component_detection
       displayName: Component Detection
       dependsOn: [] # run in parallel
+      pool: Small
       steps:
         - task: ComponentGovernanceComponentDetection@0
           displayName: Component Detection
@@ -131,6 +133,7 @@ stages:
       displayName: 'Combine api-extractor JSON'
       dependsOn: [] # run in parallel
       environment: 'fluid-docs-env'
+      pool: Large
       strategy:
         runOnce:
           deploy:
@@ -144,6 +147,7 @@ stages:
     - job: build_site
       displayName: 'Build site'
       dependsOn: upload_json
+      pool: Large
       steps:
         - checkout: self
           submodules: false
@@ -270,6 +274,7 @@ stages:
 - stage: deploy
   displayName: 'Deploy site'
   dependsOn: build
+  pool: Small
   jobs:
     - job: deploy_site
       displayName: 'Deploy site'

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -280,15 +280,12 @@ stages:
           submodules: false
           clean: true
 
-        - download: current
-          artifact: fluidframework-docs
-          path: '$(Pipeline.Workspace)'
-
-        - task: CopyFiles@2
+        - task: DownloadPipelineArtifact@2
           displayName: 'Copy fluidframework-docs to public folder'
           inputs:
-            contents: '$(Pipeline.Workspace)/fluidframework-docs/**'
-            targetFolder: '$(Build.SourcesDirectory)/docs/public'
+            source: current
+            artifact: fluidframework-docs
+            path: '$(Build.SourcesDirectory)/docs/public'
 
         - task: AzureStaticWebApp@0
           displayName: 'Deploy site'

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -268,11 +268,11 @@ stages:
 # END Secure development tasks
 
 - stage: deploy
-  displayName: 'Deploy website'
+  displayName: 'Deploy site'
   dependsOn: build
   jobs:
     - job: deploy_site
-      displayName: 'Build site'
+      displayName: 'Deploy site'
       steps:
         - checkout: self
           submodules: false

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -118,6 +118,7 @@ stages:
       dependsOn: [] # run in parallel
       pool: Small
       steps:
+        - checkout: none
         - script: |
             echo SourceBranchName: ${{ variables['Build.SourceBranchName'] }}
             echo BASE_URL: $(BASE_URL)
@@ -128,6 +129,8 @@ stages:
             echo latestPipeline ${{ variables.latestPipeline }}
             echo n1Pipeline ${{ variables.n1Pipeline }}
             echo repoToTrigger ${{ variables.repoToTrigger }}
+            echo shouldDeploy ${{ variables.shouldDeploy }}
+            echo shouldRetainGuardianAssets ${{ variables.shouldRetainGuardianAssets }}
           displayName: Show Variables
 
     - job: component_detection

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -145,7 +145,7 @@ stages:
                 uploadAsLatest: ${{ variables.isMain }}
 
     - job: build_site
-      displayName: 'Build site'
+      displayName: 'Build website'
       dependsOn: upload_json
       pool: Large
       steps:

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -299,7 +299,7 @@ stages:
 
         - task: AzureStaticWebApp@0
           displayName: 'Deploy website to ASWA'
-          condition: and(in(stageDependencies.guardian.guardian_tasks.result, 'Succeeded', 'SucceededWithIssues'), eq(variables.shouldDeploy, true))
+          condition: eq(variables.shouldDeploy, true)
           inputs:
             skip_app_build: true # site was built in previous stage
             cwd: $(Build.SourcesDirectory)

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -203,6 +203,7 @@ stages:
     vmImage: windows-latest
   jobs:
     - job: guardian_tasks
+      displayName: Guardian tasks
       condition: in(stageDependencies.build.build_site.result, 'Succeeded', 'SucceededWithIssues')
       steps:
         - checkout: self

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -250,6 +250,7 @@ stages:
         - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
           displayName: 'Guardian Break'
           condition: succeededOrFailed()
+          continueOnError: false
           inputs:
             GdnBreakPolicyMinSev: Warning
             GdnBreakAllTools: true
@@ -258,7 +259,6 @@ stages:
             GdnBreakGdnToolESLintSeverity: Warning
             GdnBreakPolicy: M365
             GdnBreakOutputBaselineFile: '$(Build.ArtifactStagingDirectory)\'
-          continueOnError: true
 
         - task: PublishPipelineArtifact@1
           displayName: 'Publish Baselines'

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -155,6 +155,7 @@ stages:
 
         - download: current
           artifact: api-extractor-combined
+          path: '$(Pipeline.Workspace)'
 
         - task: CopyFiles@2
           displayName: 'Copy api-extractor JSON to staging folder'
@@ -212,6 +213,7 @@ stages:
 
         - download: current
           artifact: fluidframework-docs
+          path: '$(Pipeline.Workspace)'
 
         - task: CopyFiles@2
           displayName: 'Copy fluidframework-docs to public folder'
@@ -286,6 +288,7 @@ stages:
 
         - download: current
           artifact: fluidframework-docs
+          path: '$(Pipeline.Workspace)'
 
         - task: CopyFiles@2
           displayName: 'Copy fluidframework-docs to public folder'

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -101,34 +101,39 @@ stages:
   displayName: Checks
   pool: Small
   jobs:
-  - job:
+  - job: debug_variables
     displayName: Component Detection
+    dependsOn: [] # run in parallel
     steps:
-    - script: |
-        echo SourceBranchName: ${{ variables['Build.SourceBranchName'] }}
-        echo BASE_URL: $(BASE_URL)
-        echo RELEASE_VERSION: $(RELEASE_VERSION)
-        echo MAIN_BRANCH_VERSION: $(MAIN_BRANCH_VERSION)
-        echo N1_VERSION: $(N1_VERSION)
-        echo releasePipeline ${{ variables.releasePipeline }}
-        echo latestPipeline ${{ variables.latestPipeline }}
-        echo n1Pipeline ${{ variables.n1Pipeline }}
-        echo repoToTrigger ${{ variables.repoToTrigger }}
-      displayName: 'Show Variables'
-    - task: ComponentGovernanceComponentDetection@0
-      displayName: Component Detection
-      inputs:
-        sourceScanPath: docs
-        verbosity: Verbose
-        scanType: Register
-        alertWarningLevel: High
+      - script: |
+          echo SourceBranchName: ${{ variables['Build.SourceBranchName'] }}
+          echo BASE_URL: $(BASE_URL)
+          echo RELEASE_VERSION: $(RELEASE_VERSION)
+          echo MAIN_BRANCH_VERSION: $(MAIN_BRANCH_VERSION)
+          echo N1_VERSION: $(N1_VERSION)
+          echo releasePipeline ${{ variables.releasePipeline }}
+          echo latestPipeline ${{ variables.latestPipeline }}
+          echo n1Pipeline ${{ variables.n1Pipeline }}
+          echo repoToTrigger ${{ variables.repoToTrigger }}
+        displayName: 'Show Variables'
 
-- stage: json
-  displayName: 'Combine API Extractor JSON'
-  dependsOn: [] # run in parallel
+  - job: component_detection
+    displayName: Component Detection
+    dependsOn: [] # run in parallel
+    steps:
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Detection
+        inputs:
+          sourceScanPath: docs
+          verbosity: Verbose
+          scanType: Register
+          alertWarningLevel: High
+
+- stage: build
+  displayName: 'Build website'
   jobs:
     - deployment: upload_json
-      displayName: 'Upload combined api-extractor JSON'
+      displayName: 'Combine api-extractor JSON'
       environment: 'fluid-docs-env'
       strategy:
         runOnce:
@@ -139,118 +144,157 @@ stages:
                 STORAGE_ACCOUNT: $(STORAGE_ACCOUNT)
                 STORAGE_KEY: $(STORAGE_KEY)
                 uploadAsLatest: ${{ variables.isMain }}
-
-- stage: site_build
-  displayName: 'Build website'
-  dependsOn: json
-  jobs:
     - job: build_site
-      condition: in(stageDependencies.json.upload_json.result, 'Succeeded', 'SucceededWithIssues')
-      pool:
-        vmImage: windows-latest
+      displayName: 'Build site'
+      dependsOn: upload_json
       steps:
-      - checkout: self
-        submodules: false
-        clean: true
+        - checkout: self
+          submodules: false
+          clean: true
 
-      - download: current
-        artifact: api-extractor-combined
+        - download: current
+          artifact: api-extractor-combined
 
-      - task: CopyFiles@2
-        displayName: 'Copy api-extractor JSON to staging folder'
-        inputs:
-          contents: '$(Pipeline.Workspace)/api-extractor-combined/**'
-          targetFolder: '$(Build.SourcesDirectory)/_api-extractor-temp'
+        - task: CopyFiles@2
+          displayName: 'Copy api-extractor JSON to staging folder'
+          inputs:
+            contents: '$(Pipeline.Workspace)/api-extractor-combined/**'
+            targetFolder: '$(Build.SourcesDirectory)/_api-extractor-temp'
 
-      - task: UseNode@1
-        displayName: 'Use Node 14.x'
-        inputs:
-          version: 14.x
+        - task: UseNode@1
+          displayName: 'Use Node 14.x'
+          inputs:
+            version: 14.x
 
-      # BEGIN Secure development tasks
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core 3.x'
-        condition: succeededOrFailed()
-        inputs:
-          packageType: sdk
-          version: 3.x
+        - task: Npm@1
+          displayName: npm ci
+          inputs:
+            command: 'custom'
+            workingDir: '$(Build.SourcesDirectory)/docs'
+            customCommand: 'ci'
 
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-eslint.ESLint@1
-        displayName: 'Run ESLint'
-        condition: succeededOrFailed()
+        - task: Npm@1
+          displayName: npm run build
+          inputs:
+            command: 'custom'
+            workingDir: '$(Build.SourcesDirectory)/docs'
+            customCommand: 'run build'
 
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
-        displayName: 'Publish Guardian Artifacts - All Tools'
-        condition: succeededOrFailed()
-        inputs:
-          ArtifactType: M365
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Generate SBOM'
+          inputs:
+            BuildDropPath: '$(Build.SourcesDirectory)/docs/public'
+            PackageName: 'fluidframework-docs'
+            PackageVersion: '$(Build.BuildId)'
 
-      - task: AssetRetention@3
-        displayName: Guardian Asset Retention
-        condition: and(succeeded(), eq(variables.shouldRetainGuardianAssets, true))
-        inputs:
-          ArrowServiceConnection: 'Arrow_FluidFramework_internal'
-          AssetGroupName: 'fluidframework_$(System.TeamProject)_$(Build.DefinitionName)'
-          AssetNumber: '$(Build.BuildId)'
-          IsShipped: false # based on value of arrow.releasedtoproduction variable
-          DropsToRetain: 'CodeAnalysisLogs'
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish site build artifact'
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)/docs/public'
+            ArtifactName: 'fluidframework-docs'
+            publishLocation: 'Container'
 
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
-        displayName: 'Guardian Break'
-        condition: succeededOrFailed()
-        inputs:
-          GdnBreakPolicyMinSev: Warning
-          GdnBreakAllTools: true
-          GdnBreakBaselineFiles: '$(Build.SourcesDirectory)/docs/.gdnbaselines'
-          GdnBreakGdnToolESLint: true
-          GdnBreakGdnToolESLintSeverity: Warning
-          GdnBreakPolicy: M365
-          GdnBreakOutputBaselineFile: '$(Build.ArtifactStagingDirectory)\'
-        continueOnError: true
+  # BEGIN Secure development tasks
+- stage: guardian
+  displayName: Guardian
+  pool:
+    vmImage: windows-latest
+  jobs:
+    - job: guardian_tasks
+      condition: in(stageDependencies.json.upload_json.result, 'Succeeded', 'SucceededWithIssues')
+      steps:
+        - checkout: self
+          submodules: false
+          clean: true
 
-      - task: PublishPipelineArtifact@1
-        displayName: 'Publish Baselines'
-        condition: eq('${{ parameters.publishGuardianBaselines }}', 'true')
-        inputs:
-          targetPath: '$(Build.ArtifactStagingDirectory)\.gdnbaselines'
-          artifact: .gdn
+        - download: current
+          artifact: fluidframework-docs
 
-      # END Secure development tasks
+        - task: CopyFiles@2
+          displayName: 'Copy fluidframework-docs to public folder'
+          inputs:
+            contents: '$(Pipeline.Workspace)/fluidframework-docs/**'
+            targetFolder: '$(Build.SourcesDirectory)/docs/public'
 
-      - task: Npm@1
-        displayName: npm ci
-        inputs:
-          command: 'custom'
-          workingDir: '$(Build.SourcesDirectory)/docs'
-          customCommand: 'ci'
+        - task: UseNode@1
+          displayName: 'Use Node 14.x'
+          inputs:
+            version: 14.x
 
-      - task: Npm@1
-        displayName: npm run build
-        inputs:
-          command: 'custom'
-          workingDir: '$(Build.SourcesDirectory)/docs'
-          customCommand: 'run build'
+        - task: UseDotNet@2
+          displayName: 'Use .NET Core 3.x'
+          condition: succeededOrFailed()
+          inputs:
+            packageType: sdk
+            version: 3.x
 
-      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        displayName: 'Generate SBOM'
-        inputs:
-          BuildDropPath: '$(Build.SourcesDirectory)/docs/public'
-          PackageName: 'fluidframework-docs'
-          PackageVersion: '$(Build.BuildId)'
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-eslint.ESLint@1
+          displayName: 'Run ESLint'
+          condition: succeededOrFailed()
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish site build artifact'
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)/docs/public'
-          ArtifactName: 'fluidframework-docs'
-          publishLocation: 'Container'
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
+          displayName: 'Publish Guardian Artifacts - All Tools'
+          condition: succeededOrFailed()
+          inputs:
+            ArtifactType: M365
 
-      - task: AzureStaticWebApp@0
-        displayName: 'Deploy site'
-        condition: eq(variables.shouldDeploy, true)
-        inputs:
-          skip_app_build: true # site was built in previous step
-          cwd: $(Build.SourcesDirectory)
-          app_location: 'docs/public'
-          output_location: ''
-          azure_static_web_apps_api_token: $(AZURE_STATIC_WEB_APPS_API_TOKEN)
+        - task: AssetRetention@3
+          displayName: Guardian Asset Retention
+          condition: and(succeeded(), eq(variables.shouldRetainGuardianAssets, true))
+          inputs:
+            ArrowServiceConnection: 'Arrow_FluidFramework_internal'
+            AssetGroupName: 'fluidframework_$(System.TeamProject)_$(Build.DefinitionName)'
+            AssetNumber: '$(Build.BuildId)'
+            IsShipped: false # based on value of arrow.releasedtoproduction variable
+            DropsToRetain: 'CodeAnalysisLogs'
+
+        - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
+          displayName: 'Guardian Break'
+          condition: succeededOrFailed()
+          inputs:
+            GdnBreakPolicyMinSev: Warning
+            GdnBreakAllTools: true
+            GdnBreakBaselineFiles: '$(Build.SourcesDirectory)/docs/.gdnbaselines'
+            GdnBreakGdnToolESLint: true
+            GdnBreakGdnToolESLintSeverity: Warning
+            GdnBreakPolicy: M365
+            GdnBreakOutputBaselineFile: '$(Build.ArtifactStagingDirectory)\'
+          continueOnError: true
+
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish Baselines'
+          condition: eq('${{ parameters.publishGuardianBaselines }}', 'true')
+          inputs:
+            targetPath: '$(Build.ArtifactStagingDirectory)\.gdnbaselines'
+            artifact: .gdn
+# END Secure development tasks
+
+- stage: deploy
+  displayName: 'Deploy website'
+  jobs:
+    - job: deploy_site
+      displayName: 'Build site'
+      dependsOn: upload_json
+      steps:
+        - checkout: self
+          submodules: false
+          clean: true
+
+        - download: current
+          artifact: fluidframework-docs
+
+        - task: CopyFiles@2
+          displayName: 'Copy fluidframework-docs to public folder'
+          inputs:
+            contents: '$(Pipeline.Workspace)/fluidframework-docs/**'
+            targetFolder: '$(Build.SourcesDirectory)/docs/public'
+
+        - task: AzureStaticWebApp@0
+          displayName: 'Deploy site'
+          condition: eq(variables.shouldDeploy, true)
+          inputs:
+            skip_app_build: true # site was built in previous stage
+            cwd: $(Build.SourcesDirectory)
+            app_location: 'docs/public'
+            output_location: ''
+            azure_static_web_apps_api_token: $(AZURE_STATIC_WEB_APPS_API_TOKEN)

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -172,7 +172,7 @@ stages:
           inputs:
             source: current
             artifact: api-extractor-combined
-            path: '$(Build.SourcesDirectory)/_api-extractor-temp'
+            path: '$(Build.SourcesDirectory)/_api-extractor-temp/doc-models'
 
         - task: UseNode@1
           displayName: 'Use Node 14.x'

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -133,7 +133,7 @@ stages:
       displayName: 'Combine api-extractor JSON'
       dependsOn: [] # run in parallel
       environment: 'fluid-docs-env'
-      pool: Large
+      pool: Small
       strategy:
         runOnce:
           deploy:

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -153,15 +153,12 @@ stages:
           submodules: false
           clean: true
 
-        - download: current
-          artifact: api-extractor-combined
-          path: '$(Pipeline.Workspace)'
-
-        - task: CopyFiles@2
+        - task: DownloadPipelineArtifact@2
           displayName: 'Copy api-extractor JSON to staging folder'
           inputs:
-            contents: '$(Pipeline.Workspace)/api-extractor-combined/**'
-            targetFolder: '$(Build.SourcesDirectory)/_api-extractor-temp'
+            source: current
+            artifact: api-extractor-combined
+            path: '$(Build.SourcesDirectory)/_api-extractor-temp'
 
         - task: UseNode@1
           displayName: 'Use Node 14.x'
@@ -211,15 +208,12 @@ stages:
           submodules: false
           clean: true
 
-        - download: current
-          artifact: fluidframework-docs
-          path: '$(Pipeline.Workspace)'
-
-        - task: CopyFiles@2
+        - task: DownloadPipelineArtifact@2
           displayName: 'Copy fluidframework-docs to public folder'
           inputs:
-            contents: '$(Pipeline.Workspace)/fluidframework-docs/**'
-            targetFolder: '$(Build.SourcesDirectory)/docs/public'
+            source: current
+            artifact: fluidframework-docs
+            path: '$(Build.SourcesDirectory)/docs/public'
 
         - task: UseNode@1
           displayName: 'Use Node 14.x'


### PR DESCRIPTION
The guardian SDL tools require Windows (they have a prerelease Linux version), but the Azure Static Web Apps deployment requires Linux... Which I didn't know when I merged the SDL tool changes originally.

This PR updates the pipeline to have three stages:

1. Run basic checks (like CG) and build the site, then publish as a pipeline artifact.
2. Run Guardian tasks (windows).
3. Deploy the site (linux).

<img width="379" alt="image" src="https://user-images.githubusercontent.com/19589/157146643-0eb2ac6b-4047-4f6e-811a-de8478c7e53a.png">

The stages are run serially so if the guardian tasks fail (or any earlier task, for that matter), the deployment won't happen.

By default the site will be deployed to our new Static Web App environment, but this is configurable using a parameter when running the pipeline.