### PR TITLE
Handle errors in docs pipeline more gracefully

### DIFF
--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -67,6 +67,7 @@ steps:
 
 - task: AzureCLI@2
   displayName: 'Upload JSON'
+  continueOnError: true
   inputs:
     azureSubscription: 'fluid-docs'
     scriptType: bash
@@ -77,9 +78,10 @@ steps:
 - ${{ if eq(parameters.uploadAsLatest, true) }}:
   - task: AzureCLI@2
     displayName: 'Upload JSON as latest.tar.gz'
+    continueOnError: true
     inputs:
       azureSubscription: 'fluid-docs'
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --account-key ${{ parameters.STORAGE_KEY }} --verbose
+        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --account-key ${{ parameters.STORAGE_KEY }} --overwrite --verbose


### PR DESCRIPTION
The pipeline should not fail when uploading api-extractor json to Azure storage, because those are optional.

Also fixes the upload step to overwrite an existing file.