### PR TITLE
Enabled TurnBased flush mode for batch tests and added a scenario that currently fails

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { Container } from "@fluidframework/container-loader";
 import { ContainerMessageType, isRuntimeMessage } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { SharedMap } from "@fluidframework/map";
@@ -18,9 +19,8 @@ import {
     ITestContainerConfig,
     DataObjectFactoryType,
 } from "@fluidframework/test-utils";
-import {
-    describeFullCompat,
-} from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 
 const map1Id = "map1Key";
 const map2Id = "map2Key";
@@ -28,9 +28,15 @@ const registry: ChannelFactoryRegistry = [
     [map1Id, SharedMap.getFactory()],
     [map2Id, SharedMap.getFactory()],
 ];
+const configProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => {
+    return {
+        getRawConfig: (name: string): ConfigTypes => settings[name],
+    };
+});
 const testContainerConfig: ITestContainerConfig = {
     fluidDataObjectType: DataObjectFactoryType.Test,
     registry,
+    loaderProps: { configProvider: configProvider({ "Fluid.ContainerRuntime.FlushModeTurnBased": "true" }) },
 };
 
 describeFullCompat("Batching", (getTestObjectProvider) => {
@@ -39,6 +45,7 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
         provider = getTestObjectProvider();
     });
 
+    let container1: Container;
     let dataObject1: ITestFluidObject;
     let dataObject2: ITestFluidObject;
     let dataObject1map1: SharedMap;
@@ -82,23 +89,49 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
         }));
     }
 
+    async function ensureContainerConnected(container: Container): Promise<void> {
+        if (!container.connected) {
+            return new Promise((resolve) => container.once("connected", () => resolve()));
+        }
+    }
+
     beforeEach(async () => {
         // Create a Container for the first client.
-        const container1 = await provider.makeTestContainer(testContainerConfig);
+        container1 = await provider.makeTestContainer(testContainerConfig) as Container;
         dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
-        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
         dataObject1map1 = await dataObject1.getSharedObject<SharedMap>(map1Id);
         dataObject1map2 = await dataObject1.getSharedObject<SharedMap>(map2Id);
 
         // Load the Container that was created by the first client.
         const container2 = await provider.loadTestContainer(testContainerConfig);
         dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
-        dataObject2.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
         dataObject2map1 = await dataObject2.getSharedObject<SharedMap>(map1Id);
         dataObject2map2 = await dataObject2.getSharedObject<SharedMap>(map2Id);
 
         await waitForCleanContainers(dataObject1, dataObject2);
         await provider.ensureSynchronized();
+    });
+
+    describe("Flush Mode validation", () => {
+        beforeEach(async () => {
+            // Send an op in container1 so that it switches to "write" mode and wait for it to be connected.
+            dataObject1map1.set("key", "value");
+            await ensureContainerConnected(container1);
+            await provider.ensureSynchronized();
+        });
+
+        /**
+         * This test fails because of this bug - https://github.com/microsoft/FluidFramework/issues/9398.
+         * To be enabled once the above bug is fixed.
+         */
+        it.skip("can set flush mode to Immediate and send ops", async () => {
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+            dataObject1map1.set("key", "newValue");
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(dataObject2map1.get("key1"), "value1", "container1's map did not get updated");
+            assert.strictEqual(dataObject2map2.get("key1"), "value1", "container2's map did not get updated");
+        });
     });
 
     describe("Local ops batch metadata verification", () => {

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -20,7 +20,6 @@ import {
     DataObjectFactoryType,
 } from "@fluidframework/test-utils";
 import { describeFullCompat } from "@fluidframework/test-version-utils";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 
 const map1Id = "map1Key";
 const map2Id = "map2Key";
@@ -28,15 +27,9 @@ const registry: ChannelFactoryRegistry = [
     [map1Id, SharedMap.getFactory()],
     [map2Id, SharedMap.getFactory()],
 ];
-const configProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => {
-    return {
-        getRawConfig: (name: string): ConfigTypes => settings[name],
-    };
-});
 const testContainerConfig: ITestContainerConfig = {
     fluidDataObjectType: DataObjectFactoryType.Test,
     registry,
-    loaderProps: { configProvider: configProvider({ "Fluid.ContainerRuntime.FlushModeTurnBased": "true" }) },
 };
 
 describeFullCompat("Batching", (getTestObjectProvider) => {


### PR DESCRIPTION
Added the scenario that is failing in #9398 to end-to-end tests. The test is skipped now and should be enabled once the bug is fixed.
Things to note:
- The bug doesn't repro if the container is not in "write" mode before FlushMode is set to Immediate. The reason is that if the container is in "read" mode, on sending an op, the container reconnects in "write" mode. On reconnection, pending state is replayed including the setting of "FlushMode.Immediate" which removes it from the pending queue.
- The bug doesn't repro if the container is not connected before FlushMode is set to Immediate. The reason is the same as above.
