### PR TITLE
Enhance authorization for document creation workflow

### DIFF
--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -99,6 +99,8 @@ export interface IRouterliciousDriverPolicies {
 
 // @public
 export interface ITokenProvider {
+    // (undocumented)
+    documentPostCreateCallback?(documentId: string, creationToken: string): any;
     fetchOrdererToken(tenantId: string, documentId?: string, refresh?: boolean): Promise<ITokenResponse>;
     fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
 }

--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -99,8 +99,7 @@ export interface IRouterliciousDriverPolicies {
 
 // @public
 export interface ITokenProvider {
-    // (undocumented)
-    documentPostCreateCallback?(documentId: string, creationToken: string): any;
+    documentPostCreateCallback?(documentId: string, creationToken: string): Promise<void>;
     fetchOrdererToken(tenantId: string, documentId?: string, refresh?: boolean): Promise<ITokenResponse>;
     fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
 }

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -95,6 +95,8 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         const documentPostCreateCallback = this.tokenProvider.documentPostCreateCallback;
 
         // the backend responds with the actual document ID associated with the new container.
+
+        // @TODO: Remove returned "string" type when removing back-compat code
         const res = await ordererRestWrapper.post<{ id: string, token?: string } | string>(
             `/documents/${tenantId}`,
             {
@@ -107,6 +109,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 
         // For supporting backward compatibility, when the request has generateToken === true, it will return
         // an object instead of string
+        // @TODO: Remove the logic when no need to support back-compat
 
         let documentId: string;
         let token: string | undefined;
@@ -118,6 +121,8 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             token = res.token;
         }
 
+        // @TODO: Remove token from the condition, checking the documentPostCreateCallback !== undefined
+        // is sufficient to determine if the token will be undefined or not.
         if (token && documentPostCreateCallback !== undefined) {
             await documentPostCreateCallback(documentId, token);
         }

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -92,8 +92,6 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             resolvedUrl.endpoints.ordererUrl,
         );
 
-        const { documentPostCreateCallback } = this.tokenProvider;
-
         // the backend responds with the actual document ID associated with the new container.
 
         // @TODO: Remove returned "string" type when removing back-compat code
@@ -103,7 +101,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 summary: convertSummaryToCreateNewSummary(appSummary),
                 sequenceNumber: documentAttributes.sequenceNumber,
                 values: quorumValues,
-                generateToken: documentPostCreateCallback !== undefined,
+                generateToken: this.tokenProvider.documentPostCreateCallback !== undefined,
             },
         );
 
@@ -123,8 +121,8 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 
         // @TODO: Remove token from the condition, checking the documentPostCreateCallback !== undefined
         // is sufficient to determine if the token will be undefined or not.
-        if (token && documentPostCreateCallback !== undefined) {
-            await documentPostCreateCallback(documentId, token);
+        if (token && this.tokenProvider.documentPostCreateCallback !== undefined) {
+            await this.tokenProvider.documentPostCreateCallback (documentId, token);
         }
 
         parsedUrl.set("pathname", replaceDocumentIdInPath(parsedUrl.pathname, documentId));

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -92,7 +92,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             resolvedUrl.endpoints.ordererUrl,
         );
 
-        const documentPostCreateCallback = this.tokenProvider.documentPostCreateCallback;
+        const { documentPostCreateCallback } = this.tokenProvider;
 
         // the backend responds with the actual document ID associated with the new container.
 

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -92,6 +92,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
             resolvedUrl.endpoints.ordererUrl,
         );
         // the backend responds with the actual document ID associated with the new container.
+
         const { id: documentId, token } = await ordererRestWrapper.post<{id: string, token: string}>(
             `/documents/${tenantId}`,
             {
@@ -100,14 +101,15 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
                 values: quorumValues,
             },
         );
-         if (this.tokenProvider.documentPostCreateCallback !== undefined) {
+
+        if (this.tokenProvider.documentPostCreateCallback !== undefined) {
             try {
                 await this.tokenProvider.documentPostCreateCallback(documentId, token);
-            } catch (e) {
-                // TODO: logging to console for now
-                console.error(e);
+            } catch (error) {
+                logger2.sendErrorEvent({eventName: "catchDocumentPostCreateCallback" }, error);
             }
         }
+
         parsedUrl.set("pathname", replaceDocumentIdInPath(parsedUrl.pathname, documentId));
         const deltaStorageUrl = resolvedUrl.endpoints.deltaStorageUrl;
         if (!deltaStorageUrl) {

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -93,7 +93,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
         );
 
         // the backend responds with the actual document ID associated with the new container.
-        const res = await ordererRestWrapper.post<{ id: string, token: string } | string>(
+        const res = await ordererRestWrapper.post<{ id: string, token?: string } | string>(
             `/documents/${tenantId}`,
             {
                 summary: convertSummaryToCreateNewSummary(appSummary),

--- a/packages/drivers/routerlicious-driver/src/tokens.ts
+++ b/packages/drivers/routerlicious-driver/src/tokens.ts
@@ -49,7 +49,10 @@ export interface ITokenProvider {
      * A callback triggered directly after creating the document. In this callback the client has the opportunity, to
      * verify against an authorization service, if the user who claims to create the document is the same user who
      * created it.
-     * Any exception thrown in the callback would fail the creation workflow.
+     *
+     * Note:
+     * * Using the callback may have performance impact on the document creation process.
+     * * Any exceptions thrown in the callback would fail the creation workflow.
      * @param documentId - Document ID.
      * @param creationToken - A special token that doesn't provide any kind of access, but it has the user's payload
      * and document id. It can be used to validate the identity of the document creator.

--- a/packages/drivers/routerlicious-driver/src/tokens.ts
+++ b/packages/drivers/routerlicious-driver/src/tokens.ts
@@ -45,7 +45,6 @@ export interface ITokenProvider {
      */
     fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
 
-
     /**
      * A callback triggered directly after creating the document.
      * @param documentId - Document ID.

--- a/packages/drivers/routerlicious-driver/src/tokens.ts
+++ b/packages/drivers/routerlicious-driver/src/tokens.ts
@@ -46,7 +46,10 @@ export interface ITokenProvider {
     fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
 
     /**
-     * A callback triggered directly after creating the document.
+     * A callback triggered directly after creating the document. In this callback the client has the opportunity, to
+     * verify against an authorization service, if the user who claims to create the document is the same user who
+     * created it.
+     * Any exception thrown in the callback would fail the creation workflow.
      * @param documentId - Document ID.
      * @param creationToken - A special token that doesn't provide any kind of access, but it has the user's payload
      * and document id. It can be used to validate the identity of the document creator.

--- a/packages/drivers/routerlicious-driver/src/tokens.ts
+++ b/packages/drivers/routerlicious-driver/src/tokens.ts
@@ -44,4 +44,13 @@ export interface ITokenProvider {
      * whether token came from cache.
      */
     fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
+
+
+    /**
+     * A callback triggered directly after creating the document.
+     * @param documentId - Document ID.
+     * @param creationToken - A special token that doesn't provide any kind of access, but it has the user's payload
+     * and document id. It can be used to validate the identity of the document creator.
+     */
+    documentPostCreateCallback?(documentId: string, creationToken: string): Promise<void>;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -111,9 +111,7 @@ export function create(
                         id,
                         token: getCreationToken(token, key, id),
                     }
-                    : {
-                        id,
-                    };
+                    : id;
             }), response, undefined, 201);
         });
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -111,7 +111,9 @@ export function create(
                         id,
                         token: getCreationToken(token, key, id),
                     }
-                    : id;
+                    : {
+                        id,
+                    };
             }), response, undefined, 201);
         });
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -98,7 +98,6 @@ export function create(
                 crypto.randomBytes(4).toString("hex"),
                 values);
 
-
             // Generate creation token given a jwt from header
             const authorizationHeader = request.header("Authorization");
             const tokenRegex = /Basic (.+)/;
@@ -107,11 +106,11 @@ export function create(
 
             const tenantKeyP = tenantManager.getKey(tenantId);
 
-            handleResponse(Promise.all([createP,tenantKeyP]).then((values) => {
+            handleResponse(Promise.all([createP, tenantKeyP]).then(([_, key]) => {
                 return {
                     id,
-                    token: getCreationToken(token, values[1], id)
-                }
+                    token: getCreationToken(token, key, id),
+                };
             }), response, undefined, 201);
         });
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -106,6 +106,7 @@ export function create(
             const tenantKeyP = tenantManager.getKey(tenantId);
 
             handleResponse(Promise.all([createP, tenantKeyP]).then(([_, key]) => {
+                // @TODO: Modify it to return an object only, it returns string for back-compat.
                 return generateToken
                     ? {
                         id,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -86,8 +86,7 @@ export function create(
             const summary = request.body.summary;
 
             // Protocol state
-            const sequenceNumber = request.body.sequenceNumber;
-            const values = request.body.values;
+            const { sequenceNumber, values, generateToken = false } = request.body;
 
             const createP = storage.createDocument(
                 tenantId,
@@ -107,10 +106,12 @@ export function create(
             const tenantKeyP = tenantManager.getKey(tenantId);
 
             handleResponse(Promise.all([createP, tenantKeyP]).then(([_, key]) => {
-                return {
-                    id,
-                    token: getCreationToken(token, key, id),
-                };
+                return generateToken
+                    ? {
+                        id,
+                        token: getCreationToken(token, key, id),
+                    }
+                    : id;
             }), response, undefined, 201);
         });
 

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -44,6 +44,24 @@ export function validateTokenClaims(
     return claims;
 }
 
+export function getCreationToken(token: string, key: string, documentId: string) {
+ // Current time in seconds
+ const now = Math.round((new Date()).getTime() / 1000);
+ const tokenClaims = jwt.decode(token) as ITokenClaims;
+
+ const claims: ITokenClaims = {
+     documentId,
+     tenantId: tokenClaims.tenantId,
+     user: tokenClaims.user,
+     scopes: [],
+     iat: now,
+     exp: now + 5 * 60,
+     ver: "1.0",
+ };
+
+ return jwt.sign(claims, key, { jwtid: uuid()});
+}
+
 /**
  * Generates a JWT token to authorize routerlicious. This function uses a large auth library (jsonwebtoken)
  * and should only be used in server context.

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -44,22 +44,17 @@ export function validateTokenClaims(
     return claims;
 }
 
-export function getCreationToken(token: string, key: string, documentId: string) {
+/**
+ * Generates a document creation JWT token, this token doesn't provide any sort of authorization to the user.
+ * But it can be used by other services to validate the document creator identity upon creating a document.
+ */
+export function getCreationToken(token: string, key: string, documentId: string, lifetime = 5) {
  // Current time in seconds
- const now = Math.round((new Date()).getTime() / 1000);
  const tokenClaims = jwt.decode(token) as ITokenClaims;
 
- const claims: ITokenClaims = {
-     documentId,
-     tenantId: tokenClaims.tenantId,
-     user: tokenClaims.user,
-     scopes: [],
-     iat: now,
-     exp: now + 5 * 60,
-     ver: "1.0",
- };
+ const { tenantId, user } = tokenClaims;
 
- return jwt.sign(claims, key, { jwtid: uuid()});
+ return generateToken(tenantId, documentId, key, [], user, lifetime);
 }
 
 /**

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -48,7 +48,7 @@ export function validateTokenClaims(
  * Generates a document creation JWT token, this token doesn't provide any sort of authorization to the user.
  * But it can be used by other services to validate the document creator identity upon creating a document.
  */
-export function getCreationToken(token: string, key: string, documentId: string, lifetime = 5) {
+export function getCreationToken(token: string, key: string, documentId: string, lifetime = 5 * 60) {
  // Current time in seconds
  const tokenClaims = jwt.decode(token) as ITokenClaims;
 


### PR DESCRIPTION
**Problem Description:**
When a document is created this is currently done by invoking an endpoint on the service (with a generic JWT token). The service will then create the document and return the ID of the document. The client is now expected to provide a new signed JWT for this new document.

This problem occur, when having an authorizaiton service that manages documents access control. It needs a way to confirm/validate that the user who created a document is the same user who is claiming to be creating the document against the authorizaiton service prior creating the ACL entry. 

**Proposal**
Modify the service to return a special JWT token (Creation token) in addition to the document ID. This token doesn't provide the user with any kind of access, but it will have the user's payload and documentId. E.g.:
```
{
  "documentId": "02f0c7fb-2e15-4d7f-82ea-b825ee65d778",
  "tenantId": "tenant_example",
  "user": {     // Optional user's payload
    "userId": "some_user",
    "creationId": "f9b7cda7-f5b9-4e55-aa81-91a7fc57ef3c" // Provided by the authorization service
  },
  "scopes": [],
  "iat": 1646662277,
  "exp": 1646662577,
  "ver": "1.0",
  "jti": "98b54f53-150e-493d-a084-dd77800e0974"
}
```

For making the usage of this token cleaner in the code,  the proposal extends `ITokenProvider ` with optional callback `documentPostCreateCallback` to consume this token, this callback is triggered immediately after creating the document, and could be used to call authorization service with the creation token and document id. E.g. 
```
 documentPostCreateCallback: async (documentId: string, creationToken: string) => {
      await authorizationService.createContainer(someAccessToken, documentId, creationToken);
  };
```


