### PR TITLE
Add a comment with old error message for code search wherever error messages recently changed

### DIFF
--- a/examples/hosts/hosts-sample/src/codeDetailsView.ts
+++ b/examples/hosts/hosts-sample/src/codeDetailsView.ts
@@ -15,6 +15,7 @@ export const setupUI = (container: IContainer) => {
     // Observe container events to detect when it gets forcefully closed.
     container.once("closed", (error) => {
         if (
+            // pre-0.58 error message: ExistingContextDoesNotSatisfyIncomingProposal
             error?.message === "Existing context does not satisfy incoming proposal"
         ) {
             const reload = window.confirm(

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -305,6 +305,7 @@ export class DocumentDeltaConnection
         this.disposeCore(
             false, // socketProtocolError
             createGenericNetworkError(
+                // pre-0.58 error message: clientClosingConnection
                 "Client closing delta connection", { canRetry: true }, { driverVersion }));
     }
 

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -61,7 +61,7 @@ export async function createNewFluidFile(
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
         throw new NonRetryableError(
-            // pre-0.58 error message: createNewInvalidFilename
+            // pre-0.58 error message: Invalid filename
             "Invalid filename for createNew", OdspErrorType.invalidFileNameError, { driverVersion });
     }
 
@@ -155,6 +155,7 @@ export async function createNewEmptyFluidFile(
                 const content = fetchResponse.content;
                 if (!content || !content.id) {
                     throw new NonRetryableError(
+                        // pre-0.58 error message: ODSP CreateFile call returned no item ID
                         "ODSP CreateFile call returned no item ID (for empty file)",
                         DriverErrorType.incorrectServerResponse,
                         { driverVersion });

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -61,6 +61,7 @@ export async function createNewFluidFile(
     // Check for valid filename before the request to create file is actually made.
     if (isInvalidFileName(newFileInfo.filename)) {
         throw new NonRetryableError(
+            // pre-0.58 error message: createNewInvalidFilename
             "Invalid filename for createNew", OdspErrorType.invalidFileNameError, { driverVersion });
     }
 

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -10,6 +10,7 @@ import { IOdspSocketError } from "./contracts";
  * Returns network error based on error object from ODSP socket (IOdspSocketError)
  */
 export function errorObjectFromSocketError(socketError: IOdspSocketError, handler: string) {
+    // pre-0.58 error message prefix: OdspSocketError
     const message = `ODSP socket error (${handler}): ${socketError.message}`;
     const error = createOdspNetworkError(
         message,

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -110,12 +110,14 @@ export async function fetchHelper(
         // Let's assume we can retry.
         if (!response) {
             throw new NonRetryableError(
+                // pre-0.58 error message: No response from fetch call
                 "No response from ODSP fetch call",
                 DriverErrorType.incorrectServerResponse,
                 { driverVersion });
         }
         if (!response.ok || response.status < 200 || response.status >= 300) {
             throwOdspNetworkError(
+                // pre-0.58 error message prefix: odspFetchError
                 `ODSP fetch error [${response.status}]`, response.status, response, await response.text());
         }
 
@@ -156,6 +158,7 @@ export async function fetchHelper(
                 `ODSP fetch failure (Offline): ${errorText}`, DriverErrorType.offlineError, { driverVersion });
         } else {
             throw new RetryableError(
+                // pre-0.58 error message prefix: Fetch error
                 `ODSP fetch failure: ${errorText}`, DriverErrorType.fetchFailure, { driverVersion });
         }
     });
@@ -202,6 +205,7 @@ export async function fetchAndParseAsJSONHelper<T>(
         // succeeds on retry.
         // So do not log error object itself.
         throwOdspNetworkError(
+            // pre-0.58 error message: errorWhileParsingFetchResponse
             "Error while parsing fetch response",
             fetchIncorrectResponse,
             content, // response
@@ -304,6 +308,7 @@ export function toInstrumentedOdspTokenFetcher(
                 }
                 if (token === null && throwOnNullToken) {
                     throw new NonRetryableError(
+                        // pre-0.58 error message: Token is null for ${name} call
                         `The Host-provided token fetcher for ${name} call returned null`,
                         OdspErrorType.fetchTokenError,
                         { method: name, driverVersion });

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -155,6 +155,7 @@ export async function fetchHelper(
         //
         if (online === OnlineStatus.Offline) {
             throw new RetryableError(
+                // pre-0.58 error message prefix: Offline
                 `ODSP fetch failure (Offline): ${errorText}`, DriverErrorType.offlineError, { driverVersion });
         } else {
             throw new RetryableError(

--- a/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
+++ b/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
@@ -92,6 +92,7 @@ export class RetryErrorsStorageAdapter implements IDocumentStorageService, IDisp
 
     private checkStorageDisposed() {
         if (this._disposed) {
+            // pre-0.58 error message: storageServiceDisposedCannotRetry
             throw new LoggingError("Storage Service is disposed. Cannot retry", { canRetry: false });
         }
     }

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -96,6 +96,7 @@ export function throwR11sNetworkError(
  * Returns network error based on error object from R11s socket (IR11sSocketError)
  */
 export function errorObjectFromSocketError(socketError: IR11sSocketError, handler: string): R11sError {
+    // pre-0.58 error message prefix: R11sSocketError
     const message = `R11s socket error (${handler}): ${socketError.message}`;
     return createR11sNetworkError(
         message,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -258,6 +258,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 const mode: IContainerLoadMode = loadOptions.loadMode ?? defaultMode;
 
                 const onClosed = (err?: ICriticalContainerError) => {
+                    // pre-0.58 error message: containerClosedWithoutErrorDuringLoad
                     reject(err ?? new GenericError("Container closed without error during load"));
                 };
                 container.on("closed", onClosed);
@@ -780,6 +781,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     public async attach(request: IRequest): Promise<void> {
         await PerformanceEvent.timedExecAsync(this.mc.logger, { eventName: "Attach" }, async () => {
             if (this._lifecycleState !== "loaded") {
+                // pre-0.58 error message: containerNotValidForAttach
                 throw new UsageError(`The Container is not in a valid state for attach [${this._lifecycleState}]`);
             }
 
@@ -1014,6 +1016,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             return;
         }
 
+        // pre-0.58 error message: existingContextDoesNotSatisfyIncomingProposal
         this.close(new GenericError("Existing context does not satisfy incoming proposal"));
     }
 
@@ -1640,8 +1643,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             const client: ILocalSequencedClient | undefined =
                 this.getQuorum().getMember(message.clientId);
             if (client === undefined && message.type !== MessageType.ClientJoin) {
+                // pre-0.58 error message: messageClientIdMissingFromQuorum
                 errorMsg = "Remote message's clientId is missing from the quorum";
             } else if (client?.shouldHaveLeft === true && message.type !== MessageType.NoOp) {
+                // pre-0.58 error message: messageClientIdShouldHaveLeft
                 errorMsg = "Remote message's clientId already should have left";
             }
             if (errorMsg !== undefined) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -725,6 +725,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
                         // This looks like a data corruption but the culprit has been found instead
                         // to be the file being overwritten in storage.  See PR #5882.
                         const error = new NonRetryableError(
+                            // pre-0.58 error message: twoMessagesWithSameSeqNumAndDifferentPayload
                             "Found two messages with the same sequenceNumber but different payloads",
                             DriverErrorType.fileOverwrittenInStorage,
                             {
@@ -779,6 +780,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
         // Watch the minimum sequence number and be ready to update as needed
         if (this.minSequenceNumber > message.minimumSequenceNumber) {
+            // pre-0.58 error message: msnMovesBackwards
             throw new DataCorruptionError("Found a lower minimumSequenceNumber (msn) than previously recorded", {
                 ...extractSafePropertiesFromMessage(message),
                 clientId: this.connectionManager.clientId,
@@ -787,6 +789,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
         this.minSequenceNumber = message.minimumSequenceNumber;
 
         if (message.sequenceNumber !== this.lastProcessedSequenceNumber + 1) {
+            // pre-0.58 error message: nonSequentialSequenceNumber
             throw new DataCorruptionError("Found a non-Sequential sequenceNumber", {
                 ...extractSafePropertiesFromMessage(message),
                 clientId: this.connectionManager.clientId,

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -108,6 +108,7 @@ export class RetriableDocumentStorageService implements IDocumentStorageService,
 
     private checkStorageDisposed() {
         if (this._disposed) {
+            // pre-0.58 error message: storageServiceDisposedCannotRetry
             throw new GenericError("Storage Service is disposed. Cannot retry", { canRetry: false });
         }
         return undefined;

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -402,6 +402,7 @@ async function getSingleOpBatch(
                 // ops to storage quick enough, and possibly waiting for summaries, while summarizer can't get
                 // current as it can't get ops.
                 throw createGenericNetworkError(
+                    // pre-0.58 error message: failedToRetrieveOpsFromStorage:TooManyRetries
                     "Failed to retrieve ops from storage (Too Many Retries)",
                     { canRetry: false },
                     {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -780,6 +780,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             if (loadSequenceNumberVerification !== "bypass" && runtimeSequenceNumber !== protocolSequenceNumber) {
                 // "Load from summary, runtime metadata sequenceNumber !== initialSequenceNumber"
                 const error = new DataCorruptionError(
+                    // pre-0.58 error message: SummaryMetadataMismatch
                     "Summary metadata mismatch",
                     { runtimeSequenceNumber, protocolSequenceNumber },
                 );
@@ -1579,6 +1580,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.context.pendingLocalState = undefined;
             if (!this.shouldContinueReconnecting()) {
                 this.closeFn(new GenericError(
+                    // pre-0.58 error message: MaxReconnectsWithNoProgress
                     "Runtime detected too many reconnects with no progress syncing local ops",
                     undefined, // error
                     { attempts: this.consecutiveReconnects }));
@@ -1762,6 +1764,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this._orderSequentiallyCalls++;
             callback();
         } catch (error) {
+            // pre-0.58 error message: orderSequentiallyCallbackException
             this.closeFn(new GenericError("orderSequentially callback exception", error));
             throw error; // throw the original error for the consumer of the runtime
         } finally {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -194,6 +194,7 @@ export class DataStores implements IDisposable {
         if (this.alreadyProcessed(attachMessage.id)) {
             // TODO: dataStoreId may require a different tag from PackageData #7488
             const error = new DataCorruptionError(
+                // pre-0.58 error message: duplicateDataStoreCreatedWithExistingId
                 "Duplicate DataStore created with existing id",
                 {
                     ...extractSafePropertiesFromMessage(message),

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -131,6 +131,7 @@ export class RunningSummarizer implements IDisposable {
         this.pendingAckTimer = new PromiseTimer(
             maxAckWaitTime,
             () => {
+                // pre-0.58 error message: summaryAckWaitTimeout
                 this.raiseSummarizingError("Pending summary ack not received in time");
                 // Note: summarizeCount (from ChildLogger definition) may be 0,
                 // since this code path is hit when RunningSummarizer first starts up,

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -394,6 +394,7 @@ export class SummaryGenerator {
                 const message = summaryNack?.message;
                 const retryAfterSeconds = summaryNack?.retryAfter;
 
+                // pre-0.58 error message prefix: summaryNack
                 const error = new LoggingError(`Received summaryNack: ${message}`, { retryAfterSeconds });
                 logger.sendErrorEvent(
                     { eventName: "SummaryNack", ...summarizeTelemetryProps, retryAfterSeconds }, error);

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -102,6 +102,7 @@ export async function fetchTokens(
 
     if (accessToken === undefined || refreshToken === undefined) {
         throwOdspNetworkError(
+            // pre-0.58 error message: unableToGetAccessToken
             "Unable to get access token",
             tokens.error === "invalid_grant" ? 401 : result.status,
             result);

--- a/packages/utils/odsp-doclib-utils/src/odspDrives.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspDrives.ts
@@ -125,6 +125,7 @@ export async function getChildrenByDriveItem(
     do {
         const response = await getAsync(url, authRequestInfo);
         if (response.status !== 200) {
+            // pre-0.58 error message: unableToGetChildren
             throwOdspNetworkError("Unable to get driveItem children", response.status, response);
         }
         const getChildrenResult = await response.json();
@@ -143,6 +144,7 @@ async function getDriveItem(
     let response = await getAsync(getDriveItemUrl, authRequestInfo);
     if (response.status !== 200) {
         if (!create) {
+            // pre-0.58 error message: unableToGetDriveItemIdFromPath
             throwOdspNetworkError("Unable to get drive/item id from path", response.status, response);
         }
 
@@ -150,11 +152,13 @@ async function getDriveItem(
         const contentUri = `${getDriveItemUrl}/content`;
         const createResultResponse = await putAsync(contentUri, authRequestInfo);
         if (createResultResponse.status !== 201) {
+            // pre-0.58 error message: failedToCreateFile
             throwOdspNetworkError("Failed to create file", createResultResponse.status, createResultResponse);
         }
 
         response = await getAsync(getDriveItemUrl, authRequestInfo);
         if (response.status !== 200) {
+            // pre-0.58 error message: unableToGetDriveItemIdFromPath
             throwOdspNetworkError("Unable to get drive/item id from path after creating", response.status, response);
         }
     }
@@ -213,6 +217,7 @@ async function getDriveResponse(
     const response = await getAsync(getDriveUrl, authRequestInfo);
     if (response.status !== 200) {
         throwOdspNetworkError(
+            // pre-0.58 error message: failedToGetDriveResponse
             `Failed to get response from /${routeTail} endpoint`,
             response.status,
             response,


### PR DESCRIPTION
https://github.com/microsoft/FluidFramework/pull/9249 changed a bunch of error messages, and over the next few months while old error messages are still prevalent in telemetry, it's really difficult to look up errors we see when they don't appear in code search. So adding old messages in comments so when you search for them you find the new error.