### PR TITLE
Remove GC from odspCache implementation.

### DIFF
--- a/packages/drivers/odsp-driver/src/odspCache.ts
+++ b/packages/drivers/odsp-driver/src/odspCache.ts
@@ -24,12 +24,12 @@ export interface IPersistedFileCache {
  * Default local-only implementation of IPersistedCache,
  * used if no persisted cache is provided by the host
  */
- export class LocalPersistentCache implements IPersistedCache {
+export class LocalPersistentCache implements IPersistedCache {
     private readonly cache = new Map<string, any>();
     // For every document id there will be a single expiration entry inspite of the number of cache entries.
     private readonly docIdExpirationMap = new Map<string, ReturnType<typeof setTimeout>>();
 
-    public constructor(private readonly snapshotExpiryPolicy = 3600 * 1000) {}
+    public constructor(private readonly snapshotExpiryPolicy = 3600 * 1000) { }
 
     async get(entry: ICacheEntry): Promise<any> {
         const key = this.keyFromEntry(entry);
@@ -48,17 +48,17 @@ export interface IPersistedFileCache {
     }
 
     private removeDocIdEntriesFromCache(docId: string) {
-         return Array.from(this.cache)
-         .filter(([cachekey]) => {
-            const docIdFromKey = cachekey.split("_");
-            if (docIdFromKey[0] === docId) {
-                return true;
-            }
-        })
-        .map(([cachekey]) => {
-            this.cache.delete(cachekey);
-        });
-     }
+        return Array.from(this.cache)
+            .filter(([cachekey]) => {
+                const docIdFromKey = cachekey.split("_");
+                if (docIdFromKey[0] === docId) {
+                    return true;
+                }
+            })
+            .map(([cachekey]) => {
+                this.cache.delete(cachekey);
+            });
+    }
 
     private removeExpirationEntry(docId: string) {
         const timeout = this.docIdExpirationMap.get(docId);
@@ -99,7 +99,8 @@ export interface INonPersistentCache {
     /**
      * Cache of joined/joining session info
      */
-    readonly sessionJoinCache: PromiseCache<string, { entryTime: number, joinSessionResponse: ISocketStorageDiscovery }>;
+    readonly sessionJoinCache: PromiseCache<string,
+        { entryTime: number, joinSessionResponse: ISocketStorageDiscovery }>;
 
     /**
      * Cache of resolved/resolving file URLs

--- a/packages/drivers/odsp-driver/src/odspCache.ts
+++ b/packages/drivers/odsp-driver/src/odspCache.ts
@@ -29,7 +29,7 @@ export class LocalPersistentCache implements IPersistedCache {
 
     public constructor(private readonly snapshotExpiryPolicy = 30 * 1000) {
         this.pc = new PromiseCache<string, any>(
-            { expiry: { policy: "absolute", durationMs: this.snapshotExpiryPolicy } });
+            { expiry: { policy: "sliding", durationMs: this.snapshotExpiryPolicy } });
     }
 
     async get(entry: ICacheEntry): Promise<any> {

--- a/packages/drivers/odsp-driver/src/odspCache.ts
+++ b/packages/drivers/odsp-driver/src/odspCache.ts
@@ -48,6 +48,7 @@ export class LocalPersistentCache implements IPersistedCache {
     }
 
     private removeDocIdEntriesFromCache(docId: string) {
+        this.removeExpirationEntry(docId);
         return Array.from(this.cache)
             .filter(([cachekey]) => {
                 const docIdFromKey = cachekey.split("_");
@@ -75,7 +76,6 @@ export class LocalPersistentCache implements IPersistedCache {
             setTimeout(
                 () => {
                     this.removeDocIdEntriesFromCache(docId);
-                    this.removeExpirationEntry(docId);
                 },
                 this.snapshotExpiryPolicy,
             ),

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -15,7 +15,7 @@ import { INewFileInfo, createCacheSnapshotKey, ISnapshotContents } from "../odsp
 import { LocalPersistentCache } from "../odspCache";
 import { mockFetchOk } from "./mockFetch";
 
-const createUtLocalCache = () => new LocalPersistentCache(2000);
+const createUtLocalCache = () => new LocalPersistentCache();
 
 describe("Create New Utils Tests", () => {
     const documentAttributes: api.IDocumentAttributes = {
@@ -127,6 +127,7 @@ describe("Create New Utils Tests", () => {
                 );
         const snapshot = await epochTracker.get(createCacheSnapshotKey(odspResolvedUrl));
         test(snapshot);
+        await epochTracker.removeEntries().catch(() => {});
     });
 
     it("Should save share link information received during createNewFluidFile", async () => {
@@ -201,5 +202,6 @@ describe("Create New Utils Tests", () => {
             link: undefined,
             error: mockError,
         });
+        await epochTracker.removeEntries().catch(() => {});
     });
 });

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -17,7 +17,7 @@ import { getHashedDocumentId } from "../odspPublicUtils";
 import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts";
 import { mockFetchOk, mockFetchSingle, createResponse } from "./mockFetch";
 
-const createUtLocalCache = () => new LocalPersistentCache(2000);
+const createUtLocalCache = () => new LocalPersistentCache();
 
 describe("Tests for Epoch Tracker", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
@@ -42,6 +42,10 @@ describe("Tests for Epoch Tracker", () => {
                 resolvedUrl,
             },
             new TelemetryNullLogger());
+    });
+
+    afterEach(async () => {
+        await epochTracker.removeEntries().catch(() => {});
     });
 
     it("Cache, old versions", async () => {

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -49,7 +49,7 @@ describe("Tests for Epoch Tracker With Redemption", () => {
     beforeEach(() => {
         const resolvedUrl = ({ siteUrl, driveId, itemId, odspResolvedUrl: true } as any) as IOdspResolvedUrl;
         epochTracker = new EpochTrackerWithRedemption(
-            new LocalPersistentCache(2000),
+            new LocalPersistentCache(),
             {
                 docId: hashedDocumentId,
                 resolvedUrl,
@@ -57,6 +57,10 @@ describe("Tests for Epoch Tracker With Redemption", () => {
             new TelemetryUTLogger());
         epochCallback = new DeferralWithCallback();
         (epochTracker as any).treesLatestDeferral = epochCallback;
+    });
+
+    afterEach(async () => {
+        await epochTracker.removeEntries().catch(() => {});
     });
 
     it.skip("joinSession call should succeed on retrying after snapshot cached read succeeds", async () => {

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -17,7 +17,7 @@ import { getHashedDocumentId } from "../odspPublicUtils";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 
-const createUtLocalCache = () => new LocalPersistentCache(2000);
+const createUtLocalCache = () => new LocalPersistentCache();
 
 describe("Tests for snapshot fetch headers", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
@@ -88,6 +88,10 @@ describe("Tests for snapshot fetch headers", () => {
             epochTracker,
             async () => { return {}; },
             );
+    });
+
+    afterEach(async () => {
+        await epochTracker.removeEntries().catch(() => {});
     });
 
     it("Mds limit check in fetch snapshot", async () => {

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -24,7 +24,7 @@ import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { OdspDocumentStorageService } from "../odspDocumentStorageManager";
 import { mockFetchSingle, notFound, createResponse } from "./mockFetch";
 
-const createUtLocalCache = () => new LocalPersistentCache(2000);
+const createUtLocalCache = () => new LocalPersistentCache();
 
 describe("Tests for snapshot fetch", () => {
     const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
@@ -118,6 +118,10 @@ describe("Tests for snapshot fetch", () => {
             epochTracker,
             async () => { return {}; },
             );
+    });
+
+    afterEach(async () => {
+        await epochTracker.removeEntries().catch(() => {});
     });
 
     it("cache fetch throws and network fetch succeeds", async () => {


### PR DESCRIPTION
Fix #4500 
@markfields @andre4i   this is the change I was planning to remove the GarbageCollector from the odspCache. It depends on the getEntries method being added to the PromiseCache implementation.

The idea is to remove the local cache + GarbageCollector by replacing it with a PromiseCache.