### PR TITLE
Fixes the FlushMode validation in PendingStateManager which expected Immediate to be the default FlushMode

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1129,6 +1129,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.pendingStateManager = new PendingStateManager(
             this,
             async (type, content) => this.applyStashedOp(type, content),
+            this._flushMode,
             context.pendingLocalState as IPendingLocalState);
 
         this.context.quorum.on("removeMember", (clientId: string) => {

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -37,8 +37,8 @@ export interface IPendingFlushMode {
 }
 
 /**
- * This represents a manual flush and is added to the pending queue when `flush` is called on the ContainerRuntime to
- * flush any pending messages. This is applicable only when the FlushMode is Manual.
+ * This represents an explicit flush call and is added to the pending queue when flush is called on the ContainerRuntime
+ * to flush pending messages.
  */
 export interface IPendingFlush {
     type: "flush";
@@ -169,54 +169,27 @@ export class PendingStateManager implements IDisposable {
      * @param flushMode - The flushMode that was updated.
      */
     public onFlushModeUpdated(flushMode: FlushMode) {
-        if (flushMode === FlushMode.Immediate) {
-            const previousState = this.pendingStates.peekBack();
-
-            // We don't have to track a previous "flush" state because FlushMode.Immediate flushes the messages. So,
-            // just tracking this FlushMode.Immediate is enough.
-            if (previousState?.type === "flush") {
-                this.pendingStates.removeBack();
-            }
-
-            // If no messages were sent between FlushMode.TurnBased and FlushMode.Immediate,
-            // then we do not have to track both these states.
-            // Remove FlushMode.TurnBased from the pending queue and return.
-            if (previousState?.type === "flushMode" && previousState.flushMode === FlushMode.TurnBased) {
-                this.pendingStates.removeBack();
-                return;
-            }
-        }
-
-        const pendingFlushMode: IPendingFlushMode = {
-            type: "flushMode",
-            flushMode,
-        };
-        this.pendingStates.push(pendingFlushMode);
+        this.pendingStates.push({ type: "flushMode", flushMode });
     }
 
     /**
      * Called when flush() is called on the ContainerRuntime to manually flush messages.
      */
     public onFlush() {
-        // If the FlushMode is Immediate, we should not track this flush call as it is only applicable when FlushMode
-        // is TurnBased.
+        // If the FlushMode is Immediate, we don't need to track an explicit flush call because every message is
+        // automatically flushed. So, flush is a no-op.
         if (this.containerRuntime.flushMode === FlushMode.Immediate) {
             return;
         }
 
-        // If the previous state is not a message, we don't have to track this flush call as there is nothing to flush.
+        // If the previous state is not a message, flush is a no-op.
         const previousState = this.pendingStates.peekBack();
         if (previousState?.type !== "message") {
             return;
         }
 
-        // Note that because of the checks above and the checks in onFlushModeUpdated(), we can be sure that a "flush"
-        // state always has a "message" before and after it. So, it marks the end of a batch and the beginning of a
-        // new one.
-        const pendingFlush: IPendingFlush = {
-            type: "flush",
-        };
-        this.pendingStates.push(pendingFlush);
+        // An explicit flush is interesting and is tracked only if there are messages sent in TurnBased mode.
+        this.pendingStates.push({ type: "flush" });
     }
 
     /**
@@ -249,7 +222,7 @@ export class PendingStateManager implements IDisposable {
      * Processes a local message once it's ack'd by the server to verify that there was no data corruption and that
      * the batch information was preserved for batch messages. Also process remote messages that might have been
      * sent from a previous container.
-     * @param message - The messsage that got ack'd and needs to be processed.
+     * @param message - The message that got ack'd and needs to be processed.
      */
     public processMessage(message: ISequencedDocumentMessage, local: boolean) {
         // Do not process chunked ops until all pieces are available.
@@ -324,7 +297,7 @@ export class PendingStateManager implements IDisposable {
     /**
      * Processes a local message once its ack'd by the server. It verifies that there was no data corruption and that
      * the batch information was preserved for batch messages.
-     * @param message - The messsage that got ack'd and needs to be processed.
+     * @param message - The message that got ack'd and needs to be processed.
      */
     private processPendingLocalMessage(message: ISequencedDocumentMessage): unknown {
         // Pre-processing part - This may be the start of a batch.
@@ -353,9 +326,7 @@ export class PendingStateManager implements IDisposable {
         this.pendingMessagesCount--;
 
         // Post-processing part - If we are processing a batch then this could be the last message in the batch.
-        if (this.isProcessingBatch) {
-            this.maybeProcessBatchEnd(message);
-        }
+        this.maybeProcessBatchEnd(message);
 
         return pendingState.localOpMetadata;
     }
@@ -365,45 +336,77 @@ export class PendingStateManager implements IDisposable {
      * @param message - The message that is being processed.
      */
     private maybeProcessBatchBegin(message: ISequencedDocumentMessage) {
-        const pendingState = this.peekNextPendingState();
-        if (pendingState.type !== "flush" && pendingState.type !== "flushMode") {
+        // Tracks the last FlushMode that was set before this message was sent.
+        let pendingFlushMode: IPendingFlushMode | undefined;
+        // Tracks whether a flush was called before this message was sent.
+        let pendingFlush: boolean = false;
+
+        /**
+         * We are checking if the next message is the start of a batch. It can happen in the following scenarios:
+         * 1. The FlushMode was set to TurnBased before this message was sent.
+         * 2. The FlushMode was already TurnBased and a flush was called before this message was sent. This essentially
+         *    means that the flush marked the end of a previous batch and beginning of a new batch.
+         *
+         * Keep reading pending states from the queue until we encounter a message. It's possible that the FlushMode was
+         * updated a bunch of times without sending any messages.
+         */
+        let nextPendingState = this.peekNextPendingState();
+        while (nextPendingState.type !== "message") {
+            if (nextPendingState.type === "flushMode") {
+                pendingFlushMode = nextPendingState;
+            }
+            if (nextPendingState.type === "flush") {
+                pendingFlush = true;
+            }
+            this.pendingStates.shift();
+            nextPendingState = this.peekNextPendingState();
+        }
+
+        // If the FlushMode was set to Immediate before this message was sent, this message won't be a batch message
+        // because in Immediate mode, every message is flushed individually.
+        if (pendingFlushMode?.flushMode === FlushMode.Immediate) {
             return;
         }
 
-        // If the pending state is of type "flushMode", it must be Manual since Automatic flush mode is processed
-        // after a message is processed and not before.
-        if (pendingState.type === "flushMode") {
-            assert(pendingState.flushMode === FlushMode.TurnBased,
-                0x16a /* "Flush mode should be manual when processing batch begin" */);
+        /**
+         * This message is the first in a batch if before it was sent either the FlushMode was set to TurnBased or there
+         * was an explicit flush call. Note that a flush call is tracked only in TurnBased mode and it indicates the end
+         * of one batch and beginning of another.
+         */
+        if (pendingFlushMode?.flushMode === FlushMode.TurnBased || pendingFlush) {
+            // We should not already be processing a batch and there should be no pending batch begin message.
+            assert(!this.isProcessingBatch && this.pendingBatchBeginMessage === undefined,
+                0x16b /* "The pending batch state indicates we are already processing a batch" */);
+
+            // Set the pending batch state indicating we have started processing a batch.
+            this.pendingBatchBeginMessage = message;
+            this.isProcessingBatch = true;
         }
-
-        // We should not already be processing a batch and there should be no pending batch begin message.
-        assert(!this.isProcessingBatch && this.pendingBatchBeginMessage === undefined,
-            0x16b /* "The pending batch state indicates we are already processing a batch" */);
-
-        // Set the pending batch state indicating we have started processing a batch.
-        this.pendingBatchBeginMessage = message;
-        this.isProcessingBatch = true;
-
-        // Remove this pending state from the queue as we have processed it.
-        this.pendingStates.shift();
     }
 
+    /**
+     * This message could be the last message in batch. If so, clear batch state since the batch is complete.
+     * @param message - The message that is being processed.
+     */
     private maybeProcessBatchEnd(message: ISequencedDocumentMessage) {
-        const nextPendingState = this.peekNextPendingState();
-        if (nextPendingState.type !== "flush" && nextPendingState.type !== "flushMode") {
+        if (!this.isProcessingBatch) {
             return;
         }
 
-        // If the next pending state is of type "flushMode", it must be Immediate and if so, we need to remove it from
-        // the queue.
-        // Note that we do not remove the type "flush" from the queue because it indicates the end of one batch and the
-        // beginning of a new one. So, it will removed when the next batch begin is processed.
-        if (nextPendingState.type === "flushMode") {
-            assert(nextPendingState.flushMode === FlushMode.Immediate,
-                0x16c /* "Flush mode is set to TurnBased in the middle of processing a batch" */);
-            this.pendingStates.shift();
+        const nextPendingState = this.peekNextPendingState();
+        if (nextPendingState.type === "message") {
+            return;
         }
+
+        /**
+         * We are in the middle of processing a batch. The batch ends when we see an explicit flush. We should never see
+         * a FlushMode before flush. This is true because we track batches only when FlushMode is TurnBased and in this
+         * mode, a batch ends either by calling flush or by changing the mode to Immediate which also triggers a flush.
+         */
+        assert(
+            nextPendingState.type !== "flushMode",
+            "We should not see a pending FlushMode until we see a flush when processing a batch",
+        );
 
         // There should be a pending batch begin message.
         assert(this.pendingBatchBeginMessage !== undefined, 0x16d /* "There is no pending batch begin message" */);
@@ -470,23 +473,17 @@ export class PendingStateManager implements IDisposable {
             const pendingState = this.pendingStates.shift()!;
             switch (pendingState.type) {
                 case "message":
-                    {
-                        this.containerRuntime.reSubmitFn(
-                            pendingState.messageType,
-                            pendingState.content,
-                            pendingState.localOpMetadata,
-                            pendingState.opMetadata);
-                    }
+                    this.containerRuntime.reSubmitFn(
+                        pendingState.messageType,
+                        pendingState.content,
+                        pendingState.localOpMetadata,
+                        pendingState.opMetadata);
                     break;
                 case "flushMode":
-                    {
-                        this.containerRuntime.setFlushMode(pendingState.flushMode);
-                    }
+                    this.containerRuntime.setFlushMode(pendingState.flushMode);
                     break;
                 case "flush":
-                    {
-                        this.containerRuntime.flush();
-                    }
+                    this.containerRuntime.flush();
                     break;
                 default:
                     break;

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -485,6 +485,8 @@ export class PendingStateManager implements IDisposable {
         // Save the current FlushMode so that we can revert it back after replaying the states.
         const savedFlushMode = this.containerRuntime.flushMode;
 
+        // Set the last acked flush mode. This is the flush mode that the next set of messages should use before it is
+        // changed.
         this.containerRuntime.setFlushMode(this.lastAckedFlushMode);
 
         // Process exactly `pendingStatesCount` items in the queue as it represents the number of states that were

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -453,17 +453,21 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
         });
 
         describe("TurnBased flushing of batches", () => {
+            beforeEach(() => {
+                dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+            });
+
             it("should clean document dirty state after a batch with single message is flushed", async () => {
                 dataObject1map1.set("key1", "value1");
-                await yieldJSTurn();
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
 
@@ -471,62 +475,69 @@ describeFullCompat("Flushing ops", (getTestObjectProvider) => {
                 dataObject1map1.set("key1", "value1");
                 dataObject1map2.set("key2", "value2");
                 dataObject1map1.set("key3", "value3");
-                await yieldJSTurn();
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
 
             it("should clean document dirty state after consecutive batches are flushed", async () => {
-                // Flush a couple of batches consecutively.
                 dataObject1map1.set("key1", "value1");
+
+                // Verify that the document is correctly set to dirty.
+                verifyDocumentDirtyState(dataObject1, true);
+
+                // Yield a turn so that the op is flushed.
                 await yieldJSTurn();
 
                 dataObject1map2.set("key2", "value2");
                 dataObject1map1.set("key3", "value3");
                 dataObject1map2.set("key4", "value4");
-                await yieldJSTurn();
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Check that the document dirty state is cleaned after the ops are processed.
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
 
             it("should clean document dirty state after batch and non-batch messages are flushed", async () => {
-                // Send a non-batch message.
+                // Send a single message and yield a turn so that it is flushed.
                 dataObject1map1.set("key1", "value1");
+                await yieldJSTurn();
 
-                // Flush a couple of batches consecutively.
+                // Flush a couple of batches consecutively and yield a turn so that they are flushed.
                 dataObject1map2.set("key2", "value2");
                 dataObject1map1.set("key3", "value3");
                 dataObject1map2.set("key4", "value4");
                 await yieldJSTurn();
 
+                // Send a single message and yield a turn so that it is flushed.
                 dataObject1map1.set("key5", "value5");
                 await yieldJSTurn();
 
-                // Send another non-batch message.
+                // Send a single message.
                 dataObject1map1.set("key5", "value5");
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
         });

--- a/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
@@ -1,0 +1,111 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { Container } from "@fluidframework/container-loader";
+import { SharedMap } from "@fluidframework/map";
+import { FlushMode } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import {
+    ITestFluidObject,
+    ChannelFactoryRegistry,
+    ITestObjectProvider,
+    ITestContainerConfig,
+    DataObjectFactoryType,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
+
+/**
+ * This test validates that changing the FlushMode does not hit any validation errors in PendingStateManager.
+ * It also validates the scenario in this bug - https://github.com/microsoft/FluidFramework/issues/9398.
+ */
+describeNoCompat("Flush mode validation", (getTestObjectProvider) => {
+    const map1Id = "map1Key";
+    const registry: ChannelFactoryRegistry = [
+        [map1Id, SharedMap.getFactory()],
+    ];
+    const testContainerConfig: ITestContainerConfig = {
+        fluidDataObjectType: DataObjectFactoryType.Test,
+        registry,
+    };
+
+    let provider: ITestObjectProvider;
+    let dataObject1: ITestFluidObject;
+    let dataObject1map1: SharedMap;
+
+    async function ensureContainerConnected(container: Container): Promise<void> {
+        if (!container.connected) {
+            return new Promise((resolve) => container.once("connected", () => resolve()));
+        }
+    }
+
+    before(function() {
+        provider = getTestObjectProvider();
+        if (provider.driver.type !== "local") {
+            this.skip();
+        }
+    });
+
+    beforeEach(async () => {
+        // Create a Container for the first client.
+        const container1 = await provider.makeTestContainer(testContainerConfig) as Container;
+        dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+        dataObject1map1 = await dataObject1.getSharedObject<SharedMap>(map1Id);
+        // Send an op in container1 so that it switches to "write" mode and wait for it to be connected.
+        dataObject1map1.set("key", "value");
+        await ensureContainerConnected(container1);
+        await provider.ensureSynchronized();
+    });
+
+    describe("Flush Mode validation", () => {
+        it("can set flush mode to Immediate and send ops", async () => {
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+            dataObject1map1.set("flushMode", "Immediate");
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+        });
+
+        it("can set flush mode to TurnBased and send ops", async () => {
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+            dataObject1map1.set("flushMode", "TurnBased");
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+        });
+
+        it("can set alternate flush modes and send ops", async () => {
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+            dataObject1map1.set("flushMode", "Immediate");
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+            dataObject1map1.set("flushMode", "TurnBased");
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+            dataObject1map1.set("flushMode", "Immediate");
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+        });
+
+        it("can set alternate flush modes without ops in between", async () => {
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+
+            dataObject1map1.set("flushMode", "TurnBased");
+            await provider.ensureSynchronized();
+
+            assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+        });
+    });
+});

--- a/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
@@ -59,53 +59,51 @@ describeNoCompat("Flush mode validation", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
     });
 
-    describe("Flush Mode validation", () => {
-        it("can set flush mode to Immediate and send ops", async () => {
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
-            dataObject1map1.set("flushMode", "Immediate");
-            await provider.ensureSynchronized();
+    it("can set flush mode to Immediate and send ops", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("flushMode", "Immediate");
+        await provider.ensureSynchronized();
 
-            assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
-        });
+        assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+    });
 
-        it("can set flush mode to TurnBased and send ops", async () => {
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
-            dataObject1map1.set("flushMode", "TurnBased");
-            await provider.ensureSynchronized();
+    it("can set flush mode to TurnBased and send ops", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("flushMode", "TurnBased");
+        await provider.ensureSynchronized();
 
-            assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
-        });
+        assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+    });
 
-        it("can set alternate flush modes and send ops", async () => {
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
-            dataObject1map1.set("flushMode", "Immediate");
-            await provider.ensureSynchronized();
+    it("can set alternate flush modes and send ops", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("flushMode", "Immediate");
+        await provider.ensureSynchronized();
 
-            assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+        assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
 
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
-            dataObject1map1.set("flushMode", "TurnBased");
-            await provider.ensureSynchronized();
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("flushMode", "TurnBased");
+        await provider.ensureSynchronized();
 
-            assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+        assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
 
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
-            dataObject1map1.set("flushMode", "Immediate");
-            await provider.ensureSynchronized();
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("flushMode", "Immediate");
+        await provider.ensureSynchronized();
 
-            assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
-        });
+        assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+    });
 
-        it("can set alternate flush modes without ops in between", async () => {
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
-            dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+    it("can set alternate flush modes without ops in between", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
 
-            dataObject1map1.set("flushMode", "TurnBased");
-            await provider.ensureSynchronized();
+        dataObject1map1.set("flushMode", "TurnBased");
+        await provider.ensureSynchronized();
 
-            assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
-        });
+        assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
     });
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/FluidFramework/issues/9398.

The bug is that PendingStateManager's validation around FlushMode is based on the assumption that the starting FlushMode is always Immediate. However, that's not the case anymore. Fixed it as follows:
- Update the PendingStateManager to always track FlushMode changes.
- During batch begin validation, read through all FlushMode and flush states before a message. The last FlushMode set decides whether the next message is part of a batch.
- Added tests that cover more scenarios for FlushMode validation and for batching.