### PR TITLE
Replace node-fetch with cross-fetch in r11s-driver

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -4519,6 +4519,14 @@
 				"tslib": "~2.0.1"
 			},
 			"dependencies": {
+				"cross-fetch": {
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+					"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+					"requires": {
+						"node-fetch": "2.6.1"
+					}
+				},
 				"tslib": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
@@ -4647,6 +4655,14 @@
 				"tslib": "~2.0.1"
 			},
 			"dependencies": {
+				"cross-fetch": {
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+					"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+					"requires": {
+						"node-fetch": "2.6.1"
+					}
+				},
 				"tslib": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
@@ -19764,11 +19780,40 @@
 			}
 		},
 		"cross-fetch": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
 			"requires": {
-				"node-fetch": "2.6.1"
+				"node-fetch": "2.6.7"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				},
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
+				}
 			}
 		},
 		"cross-spawn": {
@@ -23299,50 +23344,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
 			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
-		},
-		"fetch-mock": {
-			"version": "9.11.0",
-			"resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
-			"integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
-			"requires": {
-				"@babel/core": "^7.0.0",
-				"@babel/runtime": "^7.0.0",
-				"core-js": "^3.0.0",
-				"debug": "^4.1.1",
-				"glob-to-regexp": "^0.4.0",
-				"is-subset": "^0.1.1",
-				"lodash.isequal": "^4.5.0",
-				"path-to-regexp": "^2.2.1",
-				"querystring": "^0.2.0",
-				"whatwg-url": "^6.5.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "3.20.2",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-					"integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
-				},
-				"glob-to-regexp": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-					"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-				},
-				"path-to-regexp": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-					"integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
-				},
-				"whatwg-url": {
-					"version": "6.5.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
-					}
-				}
-			}
 		},
 		"figgy-pudding": {
 			"version": "3.5.2",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -65,8 +65,8 @@
     "@fluidframework/protocol-definitions": "^0.1027.0-0",
     "@fluidframework/server-services-client": "^0.1035.0-0",
     "@fluidframework/telemetry-utils": "^0.58.1000",
+    "cross-fetch": "^3.1.5",
     "json-stringify-safe": "5.0.1",
-    "node-fetch": "^2.6.1",
     "socket.io-client": "^4.4.1",
     "url-parse": "^1.5.8",
     "uuid": "^8.3.1"
@@ -79,8 +79,6 @@
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^8.2.2",
     "@types/nock": "^9.3.0",
-    "@types/node-fetch": "^2.5.10",
-    "@types/sinon": "^7.0.13",
     "@types/socket.io-client": "^1.4.32",
     "@types/url-parse": "^1.4.4",
     "@types/uuid": "^8.3.0",
@@ -97,12 +95,10 @@
     "eslint-plugin-no-null": "~1.0.2",
     "eslint-plugin-react": "~7.28.0",
     "eslint-plugin-unicorn": "~40.0.0",
-    "fetch-mock": "^9.11.0",
     "mocha": "^8.4.0",
     "nock": "^10.0.1",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "sinon": "^7.4.2",
     "typescript": "~4.1.3",
     "typescript-formatter": "7.1.0"
   }

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -11,11 +11,7 @@ import {
     RestLessClient,
     RestWrapper,
 } from "@fluidframework/server-services-client";
-import {
-    default as nodeFetch,
-    RequestInfo as FetchRequestInfo,
-    RequestInit as FetchRequestInit,
-} from "node-fetch";
+import fetch from "cross-fetch";
 import type { AxiosRequestConfig, AxiosRequestHeaders } from "axios";
 import safeStringify from "json-stringify-safe";
 import { v4 as uuid } from "uuid";
@@ -23,13 +19,6 @@ import { throwR11sNetworkError } from "./errorUtils";
 import { ITokenProvider } from "./tokens";
 
 type AuthorizationHeaderGetter = (refresh?: boolean) => Promise<string | undefined>;
-
-// Borrowed from @fluidframework/odsp-driver's fetch.ts
-// The only purpose of this helper is to work around the slight misalignments between the
-// Browser's fetch API and the 'node-fetch' package by wrapping the call to the 'node-fetch' API
-// in the browser's types from 'lib.dom.d.ts'.
-export const fetch = async (request: RequestInfo, config?: RequestInit): Promise<Response> =>
-    nodeFetch(request as FetchRequestInfo, config as FetchRequestInit) as unknown as Response;
 
 const axiosRequestConfigToFetchRequestConfig = (requestConfig: AxiosRequestConfig): [RequestInfo, RequestInit] => {
     const requestInfo: string = requestConfig.baseURL !== undefined
@@ -78,7 +67,6 @@ export class RouterliciousRestWrapper extends RestWrapper {
                 // Fetch throws a TypeError on network error
                 const isNetworkError = error instanceof TypeError;
                 throwR11sNetworkError(
-                    "r11sFetchError",
                     isNetworkError ? `NetworkError: ${error.message}` : safeStringify(error));
             }));
 

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -7,10 +7,9 @@ import assert from "assert";
 import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { RateLimiter } from "@fluidframework/driver-utils";
+import nock from "nock";
 import { RouterliciousRestWrapper } from "../restWrapper";
 import { R11sErrorType } from "../errorUtils";
-// eslint-disable-next-line @typescript-eslint/no-require-imports,import/order
-import nock = require("nock");
 
 describe("RouterliciousDriverRestWrapper", () => {
     const rateLimiter = new RateLimiter(1);
@@ -59,7 +58,6 @@ describe("RouterliciousDriverRestWrapper", () => {
         await restWrapper.load();
     });
     after(() => {
-        // reset();
         nock.restore();
     });
 

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -7,33 +7,24 @@ import assert from "assert";
 import { TelemetryUTLogger } from "@fluidframework/telemetry-utils";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { RateLimiter } from "@fluidframework/driver-utils";
-import fetchMock from "fetch-mock";
-import * as nodeFetchModule from "node-fetch";
-import { reset, replace } from "sinon";
 import { RouterliciousRestWrapper } from "../restWrapper";
 import { R11sErrorType } from "../errorUtils";
+// eslint-disable-next-line @typescript-eslint/no-require-imports,import/order
+import nock = require("nock");
 
 describe("RouterliciousDriverRestWrapper", () => {
     const rateLimiter = new RateLimiter(1);
-    const testUrl = "https://contoso.com/api/protected";
+    const testHost = "http://localhost:3030";
+    const testPath = "/api/protected";
+    const testUrl = `${testHost}${testPath}`;
 
     // Set up mock request authentication
-    let validToken: string | undefined;
     const token1 = "1234-auth-token-abcd";
     const token2 = "9876-auth-token-zyxw";
     const token3 = "abc-auth-token-123";
     let tokenQueue: string[] = [];
     // Pop a token off tokenQueue to generate an auth header
     const getAuthHeader = async () => `Bearer ${tokenQueue.shift() || ""}`;
-    // Check if auth header token value matches current validToken
-    const isValidAuthHeader = (header: string | null) => header && header.replace(/^Bearer /, "") === validToken;
-    // Returns 200 on valid Authorization header; otherwise returns 401
-    const replyWithAuth = (_url, opts) => {
-        if (isValidAuthHeader(opts.headers?.Authorization)) {
-            return { status: 200, body: "OK" };
-        }
-        return { status: 401, body: "Not Allowed" };
-    };
 
     // Set up mock throttling
     let throttleDurationInMs: number;
@@ -41,33 +32,24 @@ describe("RouterliciousDriverRestWrapper", () => {
     const throttle = () => {
         throttledAt = Date.now();
     };
-    const replyWithThrottling = () => {
+    function replyWithThrottling() {
         const retryAfterSeconds = (throttleDurationInMs - Date.now() - throttledAt) / 1000;
         const throttled = retryAfterSeconds > 0;
         if (throttled) {
-            return { status: 429, body: { retryAfter: retryAfterSeconds } };
+            return [429, { retryAfter: retryAfterSeconds }];
         }
-        return { status: 200, body: "OK" };
-    };
+        return [200, "OK"];
+    }
 
     let restWrapper: RouterliciousRestWrapper;
 
-    const fetchMockSandbox = fetchMock.sandbox();
-    replace(
-        nodeFetchModule,
-        "default",
-        (fetchMockSandbox as unknown) as typeof nodeFetchModule.default,
-    );
-
     beforeEach(async () => {
         // reset auth mocking
-        validToken = undefined;
         tokenQueue = [token1, token2, token3];
         // reset throttling mocking
         throttledAt = 0;
         throttleDurationInMs = 50;
 
-        fetchMockSandbox.resetBehavior();
         restWrapper = new RouterliciousRestWrapper(
             new TelemetryUTLogger(),
             rateLimiter,
@@ -77,27 +59,30 @@ describe("RouterliciousDriverRestWrapper", () => {
         await restWrapper.load();
     });
     after(() => {
-        reset();
+        // reset();
+        nock.restore();
     });
 
     describe("get()", () => {
         it("sends a request with auth headers", async () => {
-            validToken = token1;
-            fetchMockSandbox.get(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).get(testPath).reply(200);
             await assert.doesNotReject(restWrapper.get(testUrl));
         });
         it("retries a request with fresh auth headers on 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.get(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).get(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).get(testPath).reply(200);
             await assert.doesNotReject(restWrapper.get(testUrl));
         });
         it("throws a non-retriable error on 2nd 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.get(testUrl, replyWithAuth);
-            await assert.doesNotReject(restWrapper.get(testUrl));
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).get(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).get(testPath).reply(401);
+            await assert.rejects(restWrapper.get(testUrl), {
+                canRetry: false,
+                errorType: DriverErrorType.authorizationError,
+            });
         });
         it("throws a retriable error on 500", async () => {
-            fetchMockSandbox.get(testUrl, 500);
+            nock(testHost).get(testPath).reply(500);
             await assert.rejects(restWrapper.get(testUrl), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
@@ -105,18 +90,18 @@ describe("RouterliciousDriverRestWrapper", () => {
         });
         it("retries with delay on 429 with retryAfter", async () => {
             throttle();
-            fetchMockSandbox.get(testUrl, replyWithThrottling);
+            nock(testHost).get(testPath).reply(replyWithThrottling);
             await assert.doesNotReject(restWrapper.get(testUrl));
         });
         it("throws a retriable error on 429 without retryAfter", async () => {
-            fetchMockSandbox.get(testUrl, { status: 429, body: { retryAfter: undefined } });
+            nock(testHost).get(testPath).reply(429, { retryAfter: undefined });
             await assert.rejects(restWrapper.get(testUrl), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
             });
         });
         it("throws a non-retriable error on 404", async () => {
-            fetchMockSandbox.get(testUrl, 404);
+            nock(testHost).get(testPath).reply(404);
             await assert.rejects(restWrapper.get(testUrl), {
                 canRetry: false,
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
@@ -126,22 +111,24 @@ describe("RouterliciousDriverRestWrapper", () => {
 
     describe("post()", () => {
         it("sends a request with auth headers", async () => {
-            validToken = token1;
-            fetchMockSandbox.post(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).post(testPath).reply(200);
             await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
         });
         it("retries a request with fresh auth headers on 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.post(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).post(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).post(testPath).reply(200);
             await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
         });
         it("throws a non-retriable error on 2nd 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.post(testUrl, replyWithAuth);
-            await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).post(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).post(testPath).reply(401);
+            await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
+                canRetry: false,
+                errorType: DriverErrorType.authorizationError,
+            });
         });
         it("throws a retriable error on 500", async () => {
-            fetchMockSandbox.post(testUrl, 500);
+            nock(testHost).post(testPath).reply(500);
             await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
@@ -149,18 +136,18 @@ describe("RouterliciousDriverRestWrapper", () => {
         });
         it("retries with delay on 429 with retryAfter", async () => {
             throttle();
-            fetchMockSandbox.post(testUrl, replyWithThrottling);
+            nock(testHost).post(testPath).reply(replyWithThrottling);
             await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
         });
         it("throws a retriable error on 429 without retryAfter", async () => {
-            fetchMockSandbox.post(testUrl, { status: 429, body: { retryAfter: undefined } });
+            nock(testHost).post(testPath).reply(429, { retryAfter: undefined });
             await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
             });
         });
         it("throws a non-retriable error on 404", async () => {
-            fetchMockSandbox.post(testUrl, 404);
+            nock(testHost).post(testPath).reply(404);
             await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
                 canRetry: false,
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
@@ -170,22 +157,24 @@ describe("RouterliciousDriverRestWrapper", () => {
 
     describe("patch()", () => {
         it("sends a request with auth headers", async () => {
-            validToken = token1;
-            fetchMockSandbox.patch(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).patch(testPath).reply(200);
             await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
         });
         it("retries a request with fresh auth headers on 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.patch(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).patch(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).patch(testPath).reply(200);
             await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
         });
         it("throws a non-retriable error on 2nd 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.patch(testUrl, replyWithAuth);
-            await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).patch(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).patch(testPath).reply(401);
+            await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
+                canRetry: false,
+                errorType: DriverErrorType.authorizationError,
+            });
         });
         it("throws a retriable error on 500", async () => {
-            fetchMockSandbox.patch(testUrl, 500);
+            nock(testHost).patch(testPath).reply(500);
             await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
@@ -193,18 +182,18 @@ describe("RouterliciousDriverRestWrapper", () => {
         });
         it("retries with delay on 429 with retryAfter", async () => {
             throttle();
-            fetchMockSandbox.patch(testUrl, replyWithThrottling);
+            nock(testHost).patch(testPath).reply(replyWithThrottling);
             await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
         });
         it("throws a retriable error on 429 without retryAfter", async () => {
-            fetchMockSandbox.patch(testUrl, { status: 429, body: { retryAfter: undefined } });
+            nock(testHost).patch(testPath).reply(429, { retryAfter: undefined });
             await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
             });
         });
         it("throws a non-retriable error on 404", async () => {
-            fetchMockSandbox.patch(testUrl, 404);
+            nock(testHost).patch(testPath).reply(404);
             await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
                 canRetry: false,
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
@@ -214,22 +203,24 @@ describe("RouterliciousDriverRestWrapper", () => {
 
     describe("delete()", () => {
         it("sends a request with auth headers", async () => {
-            validToken = token1;
-            fetchMockSandbox.delete(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).delete(testPath).reply(200);
             await assert.doesNotReject(restWrapper.delete(testUrl));
         });
         it("retries a request with fresh auth headers on 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.delete(testUrl, replyWithAuth);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).delete(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).delete(testPath).reply(200);
             await assert.doesNotReject(restWrapper.delete(testUrl));
         });
         it("throws a non-retriable error on 2nd 401", async () => {
-            validToken = token1;
-            fetchMockSandbox.delete(testUrl, replyWithAuth);
-            await assert.doesNotReject(restWrapper.delete(testUrl));
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token1}` }}).delete(testPath).reply(401);
+            nock(testHost, { reqheaders: { authorization: `Bearer ${token2}` }}).delete(testPath).reply(401);
+            await assert.rejects(restWrapper.delete(testUrl), {
+                canRetry: false,
+                errorType: DriverErrorType.authorizationError,
+            });
         });
         it("throws a retriable error on 500", async () => {
-            fetchMockSandbox.delete(testUrl, 500);
+            nock(testHost).delete(testPath).reply(500);
             await assert.rejects(restWrapper.delete(testUrl), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
@@ -237,18 +228,18 @@ describe("RouterliciousDriverRestWrapper", () => {
         });
         it("retries with delay on 429 with retryAfter", async () => {
             throttle();
-            fetchMockSandbox.delete(testUrl, replyWithThrottling);
+            nock(testHost).delete(testPath).reply(replyWithThrottling);
             await assert.doesNotReject(restWrapper.delete(testUrl));
         });
         it("throws a retriable error on 429 without retryAfter", async () => {
-            fetchMockSandbox.delete(testUrl, { status: 429, body: { retryAfter: undefined } });
+            nock(testHost).delete(testPath).reply(429, { retryAfter: undefined });
             await assert.rejects(restWrapper.delete(testUrl), {
                 canRetry: true,
                 errorType: DriverErrorType.genericNetworkError,
             });
         });
         it("throws a non-retriable error on 404", async () => {
-            fetchMockSandbox.delete(testUrl, 404);
+            nock(testHost).delete(testPath).reply(404);
             await assert.rejects(restWrapper.delete(testUrl), {
                 canRetry: false,
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,


### PR DESCRIPTION
Discussion in #8725 brought to light that node-fetch is not working in the browser when using bundlers that do not automatically include Node polyfills (Webpack 5, Vite, etc). Switching to `cross-fetch` is easy enough.

**cross-fetch vs isomorphic-fetch**
[cross-fetch](https://www.npmjs.com/package/cross-fetch)
-  ~11 million weekly downloads
- Last published 2 months ago
- [8kB (2.8kB gzipped)](https://bundlephobia.com/package/cross-fetch@3.1.5) bundle size

[isomorphic-fetch](https://www.npmjs.com/package/isomorphic-fetch)
- ~7 million weekly downloads
- Last published 1 year ago
- [9.2kB (3.1kB gzipped)](https://bundlephobia.com/package/isomorphic-fetch@3.0.0) bundle size