### PR TITLE
r11s-driver: make 502 errors retriable

### DIFF
--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -71,6 +71,7 @@ export function createR11sNetworkError(
             return createGenericNetworkError(
                 errorMessage, { canRetry: true, retryAfterMs }, props);
         case 500:
+        case 502:
             return new GenericNetworkError(errorMessage, true, props);
         default:
             const retryInfo = { canRetry: retryAfterMs !== undefined, retryAfterMs };


### PR DESCRIPTION
502 (Bad Gateway) errors are thrown from Azure Fluid Relay when a service connection times out. These should be retriable.