### PR TITLE
Add globaldb mongomanager into riddler 

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -61,7 +61,7 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
         if (globalDbEnabled) {
             const globalDbMongoUrl = config.get("mongo:globalDbEndpoint") as string;
             const globalDbMongoFactory = new services.MongoDbFactory(globalDbMongoUrl, bufferMaxEntries);
-            globalDbMongoManager = new MongoManager(globalDbMongoFactory, false);
+            globalDbMongoManager = new MongoManager(globalDbMongoFactory);
         }
 
         const mongoManager = globalDbEnabled ? globalDbMongoManager : operationsDbMongoManager;

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -8,6 +8,7 @@ import { getOrCreateRepository } from "@fluidframework/server-services-client";
 import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import {
     MongoManager,
+    IDb,
     ISecretManager,
     IResources,
     IResourcesFactory,
@@ -49,13 +50,23 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
         // Database connection
         const mongoUrl = config.get("mongo:operationsDbEndpoint") as string;
         const bufferMaxEntries = config.get("mongo:bufferMaxEntries") as number | undefined;
-        const mongoFactory = new services.MongoDbFactory(mongoUrl, bufferMaxEntries);
-        const mongoManager = new MongoManager(mongoFactory);
+        const operationsDbMongoFactory = new services.MongoDbFactory(mongoUrl, bufferMaxEntries);
+        const operationsDbMongoManager = new MongoManager(operationsDbMongoFactory);
         const tenantsCollectionName = config.get("mongo:collectionNames:tenants");
         const secretManager = new services.SecretManager();
 
         // Load configs for default tenants
-        const db = await mongoManager.getDatabase();
+        let globalDbMongoManager;
+        const globalDbEnabled = config.get("mongo:globalDbEnabled") as boolean;
+        if (globalDbEnabled) {
+            const globalDbMongoUrl = config.get("mongo:globalDbEndpoint") as string;
+            const globalDbMongoFactory = new services.MongoDbFactory(globalDbMongoUrl, bufferMaxEntries);
+            globalDbMongoManager = new MongoManager(globalDbMongoFactory, false);
+        }
+
+        const mongoManager = globalDbEnabled ? globalDbMongoManager : operationsDbMongoManager;
+        const db: IDb = await mongoManager.getDatabase();
+
         const collection = db.collection<ITenantDocument>(tenantsCollectionName);
         const tenants = config.get("tenantConfig") as any[];
         const upsertP = tenants.map(async (tenant) => {


### PR DESCRIPTION
This PR adds the option to use the globaldb mongo manager in riddler. If globaldb is enabled, then the TenantManager in riddler will consume it and use the global database to read and write tenant data. If it is not enabled, then it would use the operations db (i.e. local db). 