### PR TITLE
IFluidDependencySynthezier: Fix getProvider back compat

### DIFF
--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -81,19 +81,22 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
     /**
      * @deprecated - Needed for back compat
      */
-    private getProvider(provider: string & keyof TMap){
-        if(this.has(provider)){
-            if(this.providers.has(provider)){
+    private getProvider(provider: string & keyof TMap) {
+        // this was removed, but some partners have trouble with back compat where they
+        // use invalid patterns with IFluidObject and IFluidDependencySynthesizer
+        // this is just for back compat until those are removed
+        if(this.has(provider)) {
+            if(this.providers.has(provider)) {
                 return this.providers.get(provider);
             }
-            for(const parent of this.parents){
-                if(parent instanceof DependencyContainer){
+            for(const parent of this.parents) {
+                if(parent instanceof DependencyContainer) {
                     return parent.getProvider(provider);
-                }else{
-                    // eslint-disable-next-line @typescript-eslint/dot-notation
-                    const maybeGetProvider = parent["getProvider"];
-                    if(typeof maybeGetProvider === "function"){
-                        return maybeGetProvider(provider);
+                } else{
+                    // older implementations of the IFluidDependencySynthesizer exposed getProvider
+                    const maybeGetProvider: {getProvider?(provider: string & keyof TMap)} = parent as any;
+                    if(maybeGetProvider?.getProvider !== undefined) {
+                        return maybeGetProvider.getProvider(provider);
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes getProvider back compat issues. These changes will be back ported to 0.56 and 0.57

Original PR: https://github.com/microsoft/FluidFramework/pull/9449

Incident: https://portal.microsofticm.com/imp/v3/incidents/details/294548714/home