### PR TITLE
[0.57] IFluidDependencySynthezier: Fix getProvider back compat

### DIFF
--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -82,6 +82,9 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
      * @deprecated - Needed for back compat
      */
     private getProvider(provider: string & keyof TMap) {
+        // this was removed, but some partners have trouble with back compat where they
+        // use invalid patterns with IFluidObject and IFluidDependencySynthesizer
+        // this is just for back compat until those are removed
         if(this.has(provider)) {
             if(this.providers.has(provider)) {
                 return this.providers.get(provider);
@@ -90,10 +93,10 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
                 if(parent instanceof DependencyContainer) {
                     return parent.getProvider(provider);
                 }else{
-                    // eslint-disable-next-line @typescript-eslint/dot-notation
-                    const maybeGetProvider = parent["getProvider"];
-                    if(typeof maybeGetProvider === "function") {
-                        return maybeGetProvider(provider);
+                    // older implementations of the IFluidDependencySynthesizer exposed getProvider
+                    const maybeGetProvider: {getProvider?(provider: string & keyof TMap)} = parent as any;
+                    if(maybeGetProvider?.getProvider !== undefined) {
+                        return maybeGetProvider.getProvider(provider);
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes getProvider back compat issues. These changes will be back ported to 0.56 and 0.57

Original PR: https://github.com/microsoft/FluidFramework/pull/9449

Incident: https://portal.microsofticm.com/imp/v3/incidents/details/294548714/home