### PR TITLE
Update BREAKING.md format to include upcoming change notes

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,14 +1,22 @@
-## Adding breaking change notes
+# Adding breaking and upcoming change notes
 
-Notes on breaking and otherwise interesting changes go here.  They will be reviewed and published along with each release.  Published changelogs may be found on the docs site at fluidframework.com.
+Notes on breaking, upcoming, and otherwise interesting changes go here.  They will be reviewed and published along with each release.  Published changelogs may be found on the docs site at fluidframework.com.
 
-### Writing a change note
+Upcoming changes include anything expected to become a breaking change in the future.  It can include deprecations, optional to required transitions, etc.  They should be added to the section for the version in which they are being announced.
+
+Breaking changes include anything that a consumer upgrading to the specified version must account for as part of the upgrade process.  It can include expected compile time breaks, runtime compatibility breaks, etc.  They should typically be announced as an upcoming change in an earlier version before becoming a breaking change.
+
+## Writing a change note
 
 There are a few steps you can take to write a good change note and avoid needing to followup for clarification.
 - Provide a concise title.  It should make clear what the topic of the change is.
 - Ensure the affected packages are named or clearly identifiable within the body.
 - Provide guidance on how the change should be consumed if applicable, such as by specifying replacement APIs.
 - Consider providing code examples as part of guidance for non-trivial changes.
+
+# 0.58
+
+## 0.58 Upcoming changes
 
 ## 0.58 Breaking changes
 - [Move IntervalType from merge-tree to sequence package](#Move-IntervalType-from-merge-tree-to-sequence-package)
@@ -41,6 +49,10 @@ sometimes followed by a colon and an inner error message when applicable.
 ### Doing operations not allowed on deleted sub directory
 Users will not be allowed to do operations on a deleted directory. Users can subscribe to `disposed` event to know if a sub directory is deleted. Accessing deleted sub directory
 will throw `UsageError` exception now.
+
+# 0.57
+
+## 0.57 Upcoming changes
 
 ## 0.57 Breaking changes
 - [IFluidConfiguration removed](#IFluidConfiguration-removed)


### PR DESCRIPTION
Update the formatting for 0.58 section and the instructions to include upcoming change notes.  This is to be more explicit about upcoming breaking changes to help consumers with planning them, because currently they tend to get lost with the other breaking entries.  This is also to help build habits around announcing upcoming breaking changes instead of dumping them on consumers only when they actually break.