### PR TITLE
Update bump-version tool to use 1 indexing for virtual patch

### DIFF
--- a/tools/build-tools/src/bumpVersion/README.md
+++ b/tools/build-tools/src/bumpVersion/README.md
@@ -30,7 +30,7 @@ For each package/monorepo that needs to be release, from the bottom of the depen
 
 #### Virtual patches
 
-The tool supports virtual patch versioning using the `--virtualPatch` flag.  The beta versioning scheme we use (0.x.x) does not have room to differentiate major/minor/patch because we only have 2 version components. We can simulate this by making the second component represent the major version, and combine minor and patch into the third by representing minor as a 1000 increment and patch as a 1 increment. This reserves number space (999 of them) between each minor version, allowing room for patches.  This mechanism is not needed outside of the beta versioning scheme.
+The tool supports virtual patch versioning using the `--virtualPatch` flag.  The beta versioning scheme we use (0.x.x) does not have room to differentiate major/minor/patch because we only have 2 version components. We can simulate this by making the second component represent the major version, and combine minor and patch into the third by representing minor as a 1000 increment and patch as a 1 increment. This reserves number space (999 of them) between each minor version, allowing room for patches.  Additionally, bumping the second version component also sets the third component to `1000`, skipping over `0`.  This ensures 4 digits in the third component because 0 padding is not allowed under semver.  This mechanism is not needed outside of the beta versioning scheme.
 
 ### Update dependencies across monorepo or independent packages
 

--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -80,9 +80,9 @@ export async function bumpVersion(context: Context, bump: string[], version: Ver
 /**
  * Translate a VersionChangeType for the virtual patch scenario where we overload a beta version number
  * to include all of major, minor, and patch.  Actual semver type is not translated
- * "major" maps to "minor" with "patch" = 1000 (<N + 1>.x.x -> x.<N + 1>.1000)
- * "minor" maps to "patch" * 1000 (x.<N + 1>.x -> x.x.<N + 1>00x)
- * "patch" is unchanged
+ * "major" maps to "minor" with "patch" = 1000 (<N + 1>.0.0 -> 0.<N + 1>.1000)
+ * "minor" maps to "patch" * 1000 (x.<N + 1>.0 -> 0.x.<N + 1>000)
+ * "patch" is unchanged (but remember the final patch number holds "minor" * 1000 + the incrementing "patch")
  */
 function translateVirtualVersion(
     versionBump: VersionChangeType,

--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -102,6 +102,9 @@ function translateVirtualVersion(
     if (!virtualVersion) {
         fatal("unable to deconstruct package version for virtual patch");
     }
+    if (virtualVersion.major !== 0) {
+        fatal("Can only use virtual patches before major version 0");
+    }
 
     switch (versionBump) {
         case "major": {

--- a/tools/build-tools/src/bumpVersion/bumpVersion.ts
+++ b/tools/build-tools/src/bumpVersion/bumpVersion.ts
@@ -103,7 +103,7 @@ function translateVirtualVersion(
         fatal("unable to deconstruct package version for virtual patch");
     }
     if (virtualVersion.major !== 0) {
-        fatal("Can only use virtual patches before major version 0");
+        fatal("Can only use virtual patches with major version 0");
     }
 
     switch (versionBump) {


### PR DESCRIPTION
Update the bump-version tooling to use 1 indexing for the minor component when bumping the major component for virtual patches.  This preserves 4 digits for the last version component (that holds minor and patch information) for all versions, and skips over the `x.x.0` version.  This avoids confusion around `x.x.1` and `x.x.1000` due to the differences in number of digits.  0 padding is not an option because it is not considered valid semver.