### PR TITLE
Fixes the FlushMode validation in PendingStateManager which expected Immediate to be the default FlushMode (#9432)

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1128,6 +1128,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.pendingStateManager = new PendingStateManager(
             this,
             async (type, content) => this.applyStashedOp(type, content),
+            this._flushMode,
             context.pendingLocalState as IPendingLocalState);
 
         this.context.quorum.on("removeMember", (clientId: string) => {

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -18,9 +18,7 @@ import {
     ITestContainerConfig,
     DataObjectFactoryType,
 } from "@fluidframework/test-utils";
-import {
-    describeFullCompat,
-} from "@fluidframework/test-version-utils";
+import { describeFullCompat, describeNoCompat } from "@fluidframework/test-version-utils";
 
 const map1Id = "map1Key";
 const map2Id = "map2Key";
@@ -33,7 +31,50 @@ const testContainerConfig: ITestContainerConfig = {
     registry,
 };
 
-describeFullCompat("Batching", (getTestObjectProvider) => {
+// Function to yield a turn in the Javascript event loop.
+async function yieldJSTurn(): Promise<void> {
+    await new Promise<void>((resolve) => {
+        setTimeout(resolve);
+    });
+}
+
+function setupBatchMessageListener(dataStore: ITestFluidObject, receivedMessages: ISequencedDocumentMessage[]) {
+    dataStore.context.containerRuntime.on("op", (message: ISequencedDocumentMessage) => {
+        if (isRuntimeMessage(message)) {
+            receivedMessages.push(message);
+        }
+    });
+}
+
+function verifyBatchMetadata(batchMessages: ISequencedDocumentMessage[]) {
+    const batchCount = batchMessages.length;
+    assert(batchCount !== 0, "No messages in the batch");
+
+    const batchBeginMetadata = batchMessages[0].metadata?.batch;
+    const batchEndMetadata = batchMessages[batchCount - 1].metadata?.batch;
+    if (batchCount === 1) {
+        assert.equal(batchBeginMetadata, undefined, "Batch with one message should not have batch metadata");
+        return;
+    }
+
+    assert.equal(batchBeginMetadata, true, "Batch begin metadata not found");
+    assert.equal(batchEndMetadata, false, "Batch end metadata not found");
+}
+
+const filterDatastoreOps = (messages: ISequencedDocumentMessage[]) => {
+    return messages.filter((m) => m.type === ContainerMessageType.FluidDataStoreOp);
+};
+
+async function waitForCleanContainers(...dataStores: ITestFluidObject[]) {
+    return Promise.all(dataStores.map(async (dataStore) => {
+        const runtime = dataStore.context.containerRuntime as IContainerRuntime;
+        while (runtime.isDirty) {
+            await timeoutPromise((resolve) => runtime.once("batchEnd", resolve));
+        }
+    }));
+}
+
+describeFullCompat("Flushing ops", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
     beforeEach(() => {
         provider = getTestObjectProvider();
@@ -45,42 +86,6 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
     let dataObject1map2: SharedMap;
     let dataObject2map1: SharedMap;
     let dataObject2map2: SharedMap;
-
-    function setupBatchMessageListener(dataStore: ITestFluidObject, receivedMessages: ISequencedDocumentMessage[]) {
-        dataStore.context.containerRuntime.on("op", (message: ISequencedDocumentMessage) => {
-            if (isRuntimeMessage(message)) {
-                receivedMessages.push(message);
-            }
-        });
-    }
-
-    function verifyBatchMetadata(batchMessages: ISequencedDocumentMessage[]) {
-        const batchCount = batchMessages.length;
-        assert(batchCount !== 0, "No messages in the batch");
-
-        const batchBeginMetadata = batchMessages[0].metadata?.batch;
-        const batchEndMetadata = batchMessages[batchCount - 1].metadata?.batch;
-        if (batchCount === 1) {
-            assert.equal(batchBeginMetadata, undefined, "Batch with one message should not have batch metadata");
-            return;
-        }
-
-        assert.equal(batchBeginMetadata, true, "Batch begin metadata not found");
-        assert.equal(batchEndMetadata, false, "Batch end metadata not found");
-    }
-
-    const filterDatastoreOps = (messages: ISequencedDocumentMessage[]) => {
-        return messages.filter((m) => m.type === ContainerMessageType.FluidDataStoreOp);
-    };
-
-    async function waitForCleanContainers(...dataStores: ITestFluidObject[]) {
-        return Promise.all(dataStores.map(async (dataStore) => {
-            const runtime = dataStore.context.containerRuntime as IContainerRuntime;
-            while (runtime.isDirty) {
-                await timeoutPromise((resolve) => runtime.once("batchEnd", resolve));
-            }
-        }));
-    }
 
     beforeEach(async () => {
         // Create a Container for the first client.
@@ -101,7 +106,7 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
     });
 
-    describe("Local ops batch metadata verification", () => {
+    describe("Batch metadata verification when ops are flushed in batches", () => {
         let dataObject1BatchMessages: ISequencedDocumentMessage[] = [];
         let dataObject2BatchMessages: ISequencedDocumentMessage[] = [];
 
@@ -110,7 +115,7 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
             setupBatchMessageListener(dataObject2, dataObject2BatchMessages);
         });
 
-        describe("Automatic batches via orderSequentially", () => {
+        describe("Flushing of batches via orderSequentially", () => {
             it("can send and receive multiple batch ops correctly", async () => {
                 // Send messages in batch in the first dataStore.
                 dataObject1.context.containerRuntime.orderSequentially(() => {
@@ -159,16 +164,16 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
                     dataObject2map2.set("key2", "value2");
                 });
 
-                // Manually flush the ops so that they are sent as a batch.
-                (dataObject2.context.containerRuntime as IContainerRuntime).flush();
+                // Yield a turn so that in TurnBased mode, the ops are flushed.
+                await yieldJSTurn();
 
                 dataObject2.context.containerRuntime.orderSequentially(() => {
                     dataObject2map1.set("key3", "value3");
                     dataObject2map2.set("key4", "value4");
                 });
 
-                // Manually flush the ops so that they are sent as a batch.
-                (dataObject2.context.containerRuntime as IContainerRuntime).flush();
+                // Yield a turn so that in TurnBased mode, the ops are flushed.
+                await yieldJSTurn();
 
                 // Wait for the ops to get processed by both the containers.
                 await provider.ensureSynchronized();
@@ -233,17 +238,20 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
             });
         });
 
-        describe("Manually flushed batches", () => {
-            it("can send and receive multiple batch ops that are manually flushed", async () => {
+        describe("TurnBased flushing of batches", () => {
+            beforeEach(() => {
                 dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+            });
+
+            it("can send and receive multiple batch ops that are flushed on JS turn", async () => {
                 // Send the ops that are to be batched together.
                 dataObject1map1.set("key1", "value1");
                 dataObject1map2.set("key2", "value2");
                 dataObject1map1.set("key3", "value3");
                 dataObject1map2.set("key4", "value4");
 
-                // Manually flush the ops so that they are sent as a batch.
-                (dataObject1.context.containerRuntime as IContainerRuntime).flush();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Wait for the ops to get processed by both the containers.
                 await provider.ensureSynchronized();
@@ -257,10 +265,11 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
                 verifyBatchMetadata(dataObject2BatchMessages);
             });
 
-            it("can send and receive single batch op that is manually flushed", async () => {
-                dataObject2.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
-                dataObject2map1.set("key1", "value1");
-                (dataObject2.context.containerRuntime as IContainerRuntime).flush();
+            it("can send and receive single batch op that is flushed on JS turn", async () => {
+                dataObject1map1.set("key1", "value1");
+
+                // Yield a turn so that the op is flushed.
+                await yieldJSTurn();
 
                 // Wait for the ops to get processed by both the containers.
                 await provider.ensureSynchronized();
@@ -274,34 +283,32 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
                 verifyBatchMetadata(dataObject2BatchMessages);
             });
 
-            it("can send and receive consecutive batches that are manually flushed", async () => {
+            it("can send and receive consecutive batches that are flushed on JS turn", async () => {
                 /**
                  * This test verifies that among other things, the PendingStateManager's algorithm of handling
                  * consecutive batches is correct.
                  */
 
-                dataObject2.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
-
                 // Send the ops that are to be batched together.
-                dataObject2map1.set("key1", "value1");
-                dataObject2map2.set("key2", "value2");
+                dataObject1map1.set("key1", "value1");
+                dataObject1map2.set("key2", "value2");
 
-                // Manually flush the batch.
-                (dataObject2.context.containerRuntime as IContainerRuntime).flush();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Send the second set of ops that are to be batched together.
-                dataObject2map1.set("key3", "value3");
-                dataObject2map2.set("key4", "value4");
+                dataObject1map1.set("key3", "value3");
+                dataObject1map2.set("key4", "value4");
 
-                // Manually flush the batch.
-                (dataObject2.context.containerRuntime as IContainerRuntime).flush();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Send a third set of ops that are to be batched together.
-                dataObject2map1.set("key5", "value5");
-                dataObject2map2.set("key6", "value6");
+                dataObject1map1.set("key5", "value5");
+                dataObject1map2.set("key6", "value6");
 
-                // Manually flush the batch.
-                (dataObject2.context.containerRuntime as IContainerRuntime).flush();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Wait for the ops to get processed by both the containers.
                 await provider.ensureSynchronized();
@@ -323,20 +330,42 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
             });
         });
 
+        describe("Immediate flushing of ops", () => {
+            beforeEach(() => {
+                dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+            });
+
+            it("can send and receive ops that are flushed individually", async () => {
+                dataObject1map1.set("key1", "value1");
+                dataObject1map2.set("key2", "value2");
+
+                // Wait for the ops to get processed by both the containers.
+                await provider.ensureSynchronized();
+
+                assert.equal(filterDatastoreOps(dataObject1BatchMessages).length, 2,
+                    "Incorrect number of messages received on local client");
+                assert.equal(filterDatastoreOps(dataObject2BatchMessages).length, 2,
+                    "Incorrect number of messages received on remote client");
+
+                verifyBatchMetadata(dataObject1BatchMessages.slice(0, 1));
+                verifyBatchMetadata(dataObject1BatchMessages.slice(1, 2));
+            });
+        });
+
         afterEach(async () => {
             dataObject1BatchMessages = [];
             dataObject2BatchMessages = [];
         });
     });
 
-    describe("Document Dirty State", () => {
+    describe("Document Dirty State when batches are flushed", () => {
         // Verifies that the document dirty state for the given document is as expected.
         function verifyDocumentDirtyState(dataStore: ITestFluidObject, expectedState: boolean) {
             const dirty = (dataStore.context.containerRuntime as IContainerRuntime).isDirty;
             assert.equal(dirty, expectedState, "The document dirty state is not as expected");
         }
 
-        describe("Automatic batches via orderSequentially", () => {
+        describe("Automatic flushing of batches via orderSequentially", () => {
             it("should clean document dirty state after a batch with single message is sent", async () => {
                 // Send a batch with a single message.
                 dataObject1.context.containerRuntime.orderSequentially(() => {
@@ -423,85 +452,207 @@ describeFullCompat("Batching", (getTestObjectProvider) => {
             });
         });
 
-        describe("Manually flushed batches", () => {
+        describe("TurnBased flushing of batches", () => {
+            beforeEach(() => {
+                dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+            });
+
             it("should clean document dirty state after a batch with single message is flushed", async () => {
-                // Manually flush a single batch message.
                 dataObject1map1.set("key1", "value1");
-                (dataObject1.context.containerRuntime as IContainerRuntime).flush();
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
 
             it("should clean document dirty state after a batch with multiple messages is flushed", async () => {
-                // Manually flush a batch with multiple messages.
                 dataObject1map1.set("key1", "value1");
                 dataObject1map2.set("key2", "value2");
                 dataObject1map1.set("key3", "value3");
-                (dataObject1.context.containerRuntime as IContainerRuntime).flush();
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
 
             it("should clean document dirty state after consecutive batches are flushed", async () => {
-                // Flush a couple of batches consecutively.
                 dataObject1map1.set("key1", "value1");
-                (dataObject1.context.containerRuntime as IContainerRuntime).flush();
-
-                dataObject1map2.set("key2", "value2");
-                dataObject1map1.set("key3", "value3");
-                dataObject1map2.set("key4", "value4");
-                (dataObject1.context.containerRuntime as IContainerRuntime).flush();
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the op is flushed.
+                await yieldJSTurn();
+
+                dataObject1map2.set("key2", "value2");
+                dataObject1map1.set("key3", "value3");
+                dataObject1map2.set("key4", "value4");
+
+                // Verify that the document is correctly set to dirty.
+                verifyDocumentDirtyState(dataObject1, true);
+
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Check that the document dirty state is cleaned after the ops are processed.
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
 
             it("should clean document dirty state after batch and non-batch messages are flushed", async () => {
-                // Send a non-batch message.
+                // Send a single message and yield a turn so that it is flushed.
                 dataObject1map1.set("key1", "value1");
+                await yieldJSTurn();
 
-                // Flush a couple of batches consecutively.
+                // Flush a couple of batches consecutively and yield a turn so that they are flushed.
                 dataObject1map2.set("key2", "value2");
                 dataObject1map1.set("key3", "value3");
                 dataObject1map2.set("key4", "value4");
-                (dataObject1.context.containerRuntime as IContainerRuntime).flush();
+                await yieldJSTurn();
 
+                // Send a single message and yield a turn so that it is flushed.
                 dataObject1map1.set("key5", "value5");
-                (dataObject1.context.containerRuntime as IContainerRuntime).flush();
+                await yieldJSTurn();
 
-                // Send another non-batch message.
+                // Send a single message.
                 dataObject1map1.set("key5", "value5");
 
                 // Verify that the document is correctly set to dirty.
                 verifyDocumentDirtyState(dataObject1, true);
 
-                // Wait for the ops to get processed by both the containers.
-                await provider.ensureSynchronized();
+                // Yield a turn so that the ops are flushed.
+                await yieldJSTurn();
 
                 // Verify that the document dirty state is cleaned after the ops are processed.
+                await provider.ensureSynchronized();
                 verifyDocumentDirtyState(dataObject1, false);
             });
         });
+    });
+});
+
+describeNoCompat("Flushing ops in combination of TurnBased and Immediate", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+    let dataObject1: ITestFluidObject;
+    let dataObject1map1: SharedMap;
+    let dataObject1map2: SharedMap;
+    let dataObject1BatchMessages: ISequencedDocumentMessage[] = [];
+
+    beforeEach(async () => {
+        provider = getTestObjectProvider();
+        // Create a Container for the first client.
+        const container1 = await provider.makeTestContainer(testContainerConfig);
+        dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+        dataObject1map1 = await dataObject1.getSharedObject<SharedMap>(map1Id);
+        dataObject1map2 = await dataObject1.getSharedObject<SharedMap>(map2Id);
+
+        await waitForCleanContainers(dataObject1);
+        await provider.ensureSynchronized();
+        setupBatchMessageListener(dataObject1, dataObject1BatchMessages);
+    });
+
+    it("can send ops alternatively with Immediate and TurnBased modes starting with Immediate", async () => {
+        // Send couple of ops in Immediate FlushMode. These ops should not have batch metadata.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("key1", "value1");
+        dataObject1map2.set("key2", "value2");
+
+        // Send couple of ops in TurnBased FlushMode. These ops should be batched together. No need to yield
+        // after sending these ops because setting FlushMode to Immediate will flush these ops.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("key3", "value3");
+        dataObject1map2.set("key4", "value4");
+
+        // Send couple of ops in Immediate FlushMode. These ops should not have batch metadata.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("key5", "value5");
+        dataObject1map2.set("key6", "value6");
+
+        // Send couple of ops in TurnBased FlushMode. These ops should be batched together.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("key3", "value3");
+        dataObject1map2.set("key4", "value4");
+        await yieldJSTurn();
+
+        // Wait for the ops to get processed by both the containers.
+        await provider.ensureSynchronized();
+
+        assert.equal(
+            dataObject1BatchMessages.length, 8, "Incorrect number of messages received on local client");
+
+        // The first couple of ops in Immediate mode should have been sent individually without batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(0, 1));
+        verifyBatchMetadata(dataObject1BatchMessages.slice(1, 2));
+
+        // The next couple of ops in TurnBased mode should be in a batch have have batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(2, 4));
+
+        // The next couple of ops in Immediate mode should have been sent individually without batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(4, 5));
+        verifyBatchMetadata(dataObject1BatchMessages.slice(5, 6));
+
+        // The next couple of ops in TurnBased mode should be in a batch have have batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(6, 8));
+    });
+
+    it("can send ops alternatively with Immediate and TurnBased modes starting with TurnBased", async () => {
+        // Send couple of ops in TurnBased FlushMode. These ops should be batched together. No need to yield
+        // after sending these ops because setting FlushMode to Immediate will flush these ops.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("key1", "value1");
+        dataObject1map2.set("key2", "value2");
+
+        // Send couple of ops in Immediate FlushMode. These ops should not have batch metadata.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("key3", "value3");
+        dataObject1map2.set("key4", "value4");
+
+        // Send couple of ops in TurnBased FlushMode. These ops should be batched together. No need to yield
+        // after sending these ops because setting FlushMode to Immediate will flush these ops.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("key5", "value5");
+        dataObject1map2.set("key6", "value6");
+
+        // Send couple of ops in Immediate FlushMode. These ops should not have batch metadata.
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("key3", "value3");
+        dataObject1map2.set("key4", "value4");
+
+        // Wait for the ops to get processed by both the containers.
+        await provider.ensureSynchronized();
+
+        assert.equal(
+            dataObject1BatchMessages.length, 8, "Incorrect number of messages received on local client");
+
+        // The first couple of ops in TurnBased mode should be in a batch have have batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(0, 2));
+
+        // The next couple of ops in Immediate mode should have been sent individually without batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(2, 3));
+        verifyBatchMetadata(dataObject1BatchMessages.slice(3, 4));
+
+        // The next couple of ops in TurnBased mode should be in a batch have have batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(4, 6));
+
+        // The next couple of ops in Immediate mode should have been sent individually without batch metadata.
+        verifyBatchMetadata(dataObject1BatchMessages.slice(6, 7));
+        verifyBatchMetadata(dataObject1BatchMessages.slice(7, 8));
+    });
+
+    afterEach(() => {
+        dataObject1BatchMessages = [];
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
@@ -1,0 +1,109 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { Container } from "@fluidframework/container-loader";
+import { SharedMap } from "@fluidframework/map";
+import { FlushMode } from "@fluidframework/runtime-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import {
+    ITestFluidObject,
+    ChannelFactoryRegistry,
+    ITestObjectProvider,
+    ITestContainerConfig,
+    DataObjectFactoryType,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
+
+/**
+ * This test validates that changing the FlushMode does not hit any validation errors in PendingStateManager.
+ * It also validates the scenario in this bug - https://github.com/microsoft/FluidFramework/issues/9398.
+ */
+describeNoCompat("Flush mode validation", (getTestObjectProvider) => {
+    const map1Id = "map1Key";
+    const registry: ChannelFactoryRegistry = [
+        [map1Id, SharedMap.getFactory()],
+    ];
+    const testContainerConfig: ITestContainerConfig = {
+        fluidDataObjectType: DataObjectFactoryType.Test,
+        registry,
+    };
+
+    let provider: ITestObjectProvider;
+    let dataObject1: ITestFluidObject;
+    let dataObject1map1: SharedMap;
+
+    async function ensureContainerConnected(container: Container): Promise<void> {
+        if (!container.connected) {
+            return new Promise((resolve) => container.once("connected", () => resolve()));
+        }
+    }
+
+    before(function() {
+        provider = getTestObjectProvider();
+        if (provider.driver.type !== "local") {
+            this.skip();
+        }
+    });
+
+    beforeEach(async () => {
+        // Create a Container for the first client.
+        const container1 = await provider.makeTestContainer(testContainerConfig) as Container;
+        dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+        dataObject1map1 = await dataObject1.getSharedObject<SharedMap>(map1Id);
+        // Send an op in container1 so that it switches to "write" mode and wait for it to be connected.
+        dataObject1map1.set("key", "value");
+        await ensureContainerConnected(container1);
+        await provider.ensureSynchronized();
+    });
+
+    it("can set flush mode to Immediate and send ops", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("flushMode", "Immediate");
+        await provider.ensureSynchronized();
+
+        assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+    });
+
+    it("can set flush mode to TurnBased and send ops", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("flushMode", "TurnBased");
+        await provider.ensureSynchronized();
+
+        assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+    });
+
+    it("can set alternate flush modes and send ops", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("flushMode", "Immediate");
+        await provider.ensureSynchronized();
+
+        assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1map1.set("flushMode", "TurnBased");
+        await provider.ensureSynchronized();
+
+        assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1map1.set("flushMode", "Immediate");
+        await provider.ensureSynchronized();
+
+        assert.strictEqual(dataObject1map1.get("flushMode"), "Immediate", "container1's map did not get updated");
+    });
+
+    it("can set alternate flush modes without ops in between", async () => {
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.Immediate);
+        dataObject1.context.containerRuntime.setFlushMode(FlushMode.TurnBased);
+
+        dataObject1map1.set("flushMode", "TurnBased");
+        await provider.ensureSynchronized();
+
+        assert.strictEqual(dataObject1map1.get("flushMode"), "TurnBased", "container1's map did not get updated");
+    });
+});


### PR DESCRIPTION
Ported from main - https://github.com/microsoft/FluidFramework/pull/9432.

Fixes https://github.com/microsoft/FluidFramework/issues/9398.

The bug is that PendingStateManager's validation around FlushMode is based on the assumption that the starting FlushMode is always Immediate. However, that's not the case anymore. Fixed it as follows:

Update the PendingStateManager to always track FlushMode changes.
During batch begin validation, read through all FlushMode and flush states before a message. The last FlushMode set decides whether the next message is part of a batch.
Added tests that cover more scenarios for FlushMode validation and for batching.