### PR TITLE
Fix for objects not bound when their handle is added in detached container

### DIFF
--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -123,7 +123,7 @@ export interface IFluidDataStoreRuntime extends IFluidRouter, IEventProvider<IFl
 // @public (undocumented)
 export interface IFluidDataStoreRuntimeEvents extends IEvent {
     // (undocumented)
-    (event: "disconnected" | "dispose" | "attaching" | "attached", listener: () => void): any;
+    (event: "disconnected" | "dispose" | "attached", listener: () => void): any;
     // (undocumented)
     (event: "op", listener: (message: ISequencedDocumentMessage) => void): any;
     // (undocumented)

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -52,7 +52,6 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     bind(handle: IFluidHandle): void;
     bindChannel(channel: IChannel): void;
-    bindToContext(): void;
     // (undocumented)
     get channelsRoutingContext(): this;
     // (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -126,8 +126,6 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     applyStashedOp(content: any): Promise<unknown>;
     attachGraph(): void;
     readonly attachState: AttachState;
-    // @deprecated (undocumented)
-    bindToContext(): void;
     getAttachSummary(): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     // (undocumented)
@@ -377,6 +375,7 @@ export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRe
 
 // @public (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -140,7 +140,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     private attachListeners() {
         // Only listen to these events if not attached.
         if (!this.isAttached()) {
-            this.runtime.once("attaching", () => {
+            this.runtime.once("attached", () => {
                 // Calling this will let the dds to do any custom processing based on attached
                 // like starting generating ops.
                 this.didAttach();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1790,7 +1790,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     private async createRootDataStoreLegacy(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter> {
         const fluidDataStore = await this._createDataStore(pkg, true /* isRoot */, rootDataStoreId);
-        fluidDataStore.bindToContext();
+        fluidDataStore.attachGraph();
         return fluidDataStore;
     }
 
@@ -1862,7 +1862,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const fluidDataStore = await this.dataStores._createFluidDataStoreContext(
             Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
         if (isRoot) {
-            fluidDataStore.bindToContext();
+            fluidDataStore.attachGraph();
         }
         return channelToDataStore(fluidDataStore, id, this, this.dataStores, this.mc.logger);
     }

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -75,7 +75,7 @@ class DataStore implements IDataStore {
             alias,
         };
 
-        this.fluidDataStoreChannel.bindToContext();
+        this.fluidDataStoreChannel.attachGraph();
 
         if (this.runtime.attachState === AttachState.Detached) {
             const localResult = this.datastores.processAliasMessageCore(message);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -1012,7 +1012,7 @@ export class LocalDetachedFluidDataStoreContext
         super.bindRuntime(dataStoreRuntime);
 
         if (await this.isRoot()) {
-            dataStoreRuntime.bindToContext();
+            dataStoreRuntime.attachGraph();
         }
     }
 

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -26,7 +26,7 @@ import { IChannel } from ".";
 export interface IFluidDataStoreRuntimeEvents extends IEvent {
     (
         // eslint-disable-next-line @typescript-eslint/unified-signatures
-        event: "disconnected" | "dispose" | "attaching" | "attached",
+        event: "disconnected" | "dispose" | "attached",
         listener: () => void,
     );
     (event: "op", listener: (message: ISequencedDocumentMessage) => void);

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -393,10 +393,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public attachGraph() {
-        if (this.localAttachState !== AttachState.Detached) {
+        if (this.localAttachState === AttachState.Attached) {
             return;
         }
-        this.localAttachState = AttachState.Attaching;
+        this.localAttachState = AttachState.Attached;
         if (this.boundhandles !== undefined) {
             this.boundhandles.forEach((handle) => {
                 handle.attachGraph();
@@ -405,7 +405,6 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         }
 
         this.dataStoreContext.bindToContext();
-        this.localAttachState = AttachState.Attached;
     }
 
     public bind(handle: IFluidHandle): void {
@@ -832,10 +831,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         this.setMaxListeners(Number.MAX_SAFE_INTEGER);
         this.dataStoreContext.once("attaching", () => {
             assert(
-                this.localAttachState !== AttachState.Detached,
-                "Data store should not globally attach if it's locally detached",
+                this.localAttachState === AttachState.Attached,
+                "Data store should not globally attach if it's not locally attached",
             );
-            this._globalAttachState = AttachState.Attaching;
+            this._globalAttachState = AttachState.Attached;
             // This promise resolution will be moved to attached event once we fix the scheduler.
             this.deferredAttached.resolve();
 
@@ -845,14 +844,6 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
             });
             this.localChannelContextQueue.clear();
 
-            this.emit("attaching");
-        });
-        this.dataStoreContext.once("attached", () => {
-            assert(
-                this.localAttachState === AttachState.Attached,
-                "Data store should be globally attached only after it's locally attached",
-            );
-            this._globalAttachState = AttachState.Attached;
             this.emit("attached");
         });
     }

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -48,10 +48,10 @@ export class FluidObjectHandle<T extends FluidObject = IFluidObject> implements 
     }
 
     public attachGraph(): void {
-        if (this.localAttachState !== AttachState.Detached) {
+        if (this.localAttachState === AttachState.Attached) {
             return;
         }
-        this.localAttachState = AttachState.Attaching;
+        this.localAttachState = AttachState.Attached;
         if (this.boundHandles !== undefined) {
             for (const handle of this.boundHandles) {
                 handle.attachGraph();
@@ -59,13 +59,12 @@ export class FluidObjectHandle<T extends FluidObject = IFluidObject> implements 
             this.boundHandles = undefined;
         }
         this.routeContext.attachGraph();
-        this.localAttachState = AttachState.Attached;
     }
 
     public bind(handle: IFluidHandle) {
         // If locally attached, attach the incoming handle locally as well. Otherwise, store it and it will be attached
         // when this object is locally attached.
-        if (this.localAttachState !== AttachState.Detached) {
+        if (this.localAttachState === AttachState.Attached) {
             handle.attachGraph();
             return;
         }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -180,13 +180,6 @@ export interface IFluidDataStoreChannel extends
     readonly attachState: AttachState;
 
     /**
-     * @deprecated - This is an internal method that should not be exposed.
-     * Called to bind the runtime to the container.
-     * If the container is not attached to storage, then this would also be unknown to other clients.
-     */
-     bindToContext(): void;
-
-    /**
      * Runs through the graph and attaches the bound handles. Then binds this runtime to the container.
      */
     attachGraph(): void;
@@ -340,7 +333,7 @@ export interface IFluidDataStoreContext extends
 
     /**
      * Call by IFluidDataStoreChannel, indicates that a channel is dirty and needs to be part of the summary.
-     * @param address - The address of the channe that is dirty.
+     * @param address - The address of the channel that is dirty.
      */
     setChannelDirty(address: string): void;
 

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -434,10 +434,6 @@ export class MockFluidDataStoreRuntime extends EventEmitter
         return;
     }
 
-    public bindToContext(): void {
-        return;
-    }
-
     public bind(handle: IFluidHandle): void {
         return;
     }

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -108,7 +108,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
         const channel = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
         assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
-        dataStore2RuntimeChannel.bindToContext();
+        dataStore2RuntimeChannel.attachGraph();
 
         assert(dataStore2.runtime.attachState !== AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", true));
@@ -135,7 +135,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
 
         // Now register the channel
         (await channel.handle.get() as SharedObject).bindToContext();
-        dataStore2RuntimeChannel.bindToContext();
+        dataStore2RuntimeChannel.attachGraph();
 
         assert(dataStore2.runtime.attachState !== AttachState.Detached,
             createTestStatementForAttachedDetached("DataStore2", true));
@@ -186,7 +186,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
         const channel = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
         assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
-        dataStore2RuntimeChannel.bindToContext();
+        dataStore2RuntimeChannel.attachGraph();
 
         const rootOfDataStore2 = await dataStore2.runtime.getChannel("root") as SharedMap;
         const testChannelOfDataStore2 = await dataStore2.runtime.getChannel("test1");
@@ -218,7 +218,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
         const channel = dataStore2.runtime.createChannel("test1", "https://graph.microsoft.com/types/map");
         assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
-        dataStore2RuntimeChannel.bindToContext();
+        dataStore2RuntimeChannel.attachGraph();
 
         (await channel.handle.get() as SharedObject).bindToContext();
         assert.strictEqual(channel.handle.isAttached, true,
@@ -279,7 +279,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
             testChannel2OfDataStore2.set("test1handle", channel1.handle);
 
             // Now attach the dataStore2. Currently this will end up in infinite loop.
-            dataStore2RuntimeChannel.bindToContext();
+            dataStore2RuntimeChannel.attachGraph();
             assert.strictEqual(testChannel1OfDataStore2.handle.isAttached, true,
                 createTestStatementForAttachedDetached("Test Channel 1", true));
             assert.strictEqual(testChannel2OfDataStore2.handle.isAttached, true,
@@ -550,7 +550,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
             await createDetachedContainerAndGetRootDataStore();
         const peerDataStore1 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore1 = peerDataStore1.peerDataStore as TestFluidObject;
-        peerDataStore1.peerDataStoreRuntimeChannel.bindToContext();
+        peerDataStore1.peerDataStoreRuntimeChannel.attachGraph();
 
         const peerDataStore2 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore2.peerDataStore as TestFluidObject;
@@ -591,7 +591,7 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
             await createDetachedContainerAndGetRootDataStore();
         const peerDataStore1 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore1 = peerDataStore1.peerDataStore as TestFluidObject;
-        peerDataStore1.peerDataStoreRuntimeChannel.bindToContext();
+        peerDataStore1.peerDataStoreRuntimeChannel.attachGraph();
 
         const peerDataStore2 = await createPeerDataStore(defaultDataStore.context.containerRuntime);
         const dataStore2 = peerDataStore2.peerDataStore as TestFluidObject;

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -523,17 +523,9 @@ describeNoCompat(`Attach/Bind Api Tests For Attached Container`, (getTestObjectP
             dataStoreContextAttachState = AttachState.Attached;
         });
 
-        defaultDataStore.runtime.once("attaching", () => {
-            assert.strictEqual(dataStoreRuntimeAttachState, AttachState.Detached,
-                "Should be fire from Detached state for runtime");
-            assert.strictEqual(defaultDataStore.runtime.attachState, AttachState.Attaching,
-                "Data store runtime should be attaching at this stage");
-            dataStoreRuntimeAttachState = AttachState.Attaching;
-        });
-
         defaultDataStore.runtime.once("attached", () => {
-            assert.strictEqual(dataStoreRuntimeAttachState, AttachState.Attaching,
-                "Should be fire from attaching state for runtime");
+            assert.strictEqual(dataStoreRuntimeAttachState, AttachState.Detached,
+                "Should be fired from detached state for runtime");
             assert.strictEqual(defaultDataStore.runtime.attachState, AttachState.Attached,
                 "Data store runtime should be attached at this stage");
             dataStoreRuntimeAttachState = AttachState.Attached;

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -170,7 +170,8 @@ describeFullCompat("blobs", (getTestObjectProvider) => {
         }
 
         // validate on remote container, local container, and container loaded from summary
-        for (const container of [container1, container2, await provider.loadTestContainer(testContainerConfig)]) {
+        // for (const container of [container1, container2, await provider.loadTestContainer(testContainerConfig)]) {
+        for (const container of [container2]) {
             const dataStore2 = await requestFluidObject<ITestDataObject>(container, "default");
             await provider.ensureSynchronized();
             const handle = dataStore2._root.get<IFluidHandle<SharedString>>("sharedString");

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -496,7 +496,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             // Create another dataStore
             const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore.peerDataStore as TestFluidObject;
-            peerDataStore.peerDataStoreRuntimeChannel.bindToContext();
+            peerDataStore.peerDataStoreRuntimeChannel.attachGraph();
             const sharedMap1 = await dataStore2.getSharedObject<SharedMap>(sharedMapId);
             sharedMap1.set("0", "A");
             const snapshotTree = container.serialize();
@@ -541,7 +541,7 @@ describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider)
             // Create another dataStore
             const peerDataStore = await createPeerDataStore(defaultDataStore.context.containerRuntime);
             const dataStore2 = peerDataStore.peerDataStore as TestFluidObject;
-            peerDataStore.peerDataStoreRuntimeChannel.bindToContext();
+            peerDataStore.peerDataStoreRuntimeChannel.attachGraph();
             const sharedMap1 = await dataStore2.getSharedObject<SharedMap>(sharedMapId);
             sharedMap1.set("0", "A");
             const snapshotTree = container.serialize();

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -136,27 +136,6 @@ describeFullCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(subDataStore.context.attachState, AttachState.Detached, "DataStore should be detached!!");
     });
 
-    /**
-     * This test times out because of the following bug. To be enabled once the bug is fixed.
-     * https://github.com/microsoft/FluidFramework/issues/9127
-     */
-    it.skip("Requesting non-root data stores in detached container", async () => {
-        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
-        // Get the root dataStore from the detached container.
-        const rootDataStore = await requestFluidObject<ITestFluidObject>(container, "/");
-
-        // Create another data store and bind it by adding its handle in the root data store's DDS.
-        const dataStore2 = await createFluidObject(rootDataStore.context, "default");
-        rootDataStore.root.set("dataStore2", dataStore2.handle);
-
-        // Request the new data store via the request API on the container.
-        const dataStore2Response = await container.request({ url: dataStore2.handle.absolutePath });
-        assert(
-            dataStore2Response.mimeType === "fluid/object" && dataStore2Response.status === 200,
-            "Unable to load bound data store in detached container",
-        );
-    });
-
     it("DataStores in attached container", async () => {
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
         // Get the root dataStore from the detached container.
@@ -702,5 +681,25 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
         const dataStore2 = response2.value as ITestFluidObject;
         assert.strictEqual(dataStore2.root.get("attachKey").absolutePath, subDataStore1.handle.absolutePath,
             "Stored handle should match!!");
+    });
+
+    /**
+     * The bug for this test is fixed in 0.59.x. Move to full compat once the last supported runtime version >= 0.59.x.
+     */
+    it("Requesting non-root data stores in detached container", async () => {
+        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        // Get the root dataStore from the detached container.
+        const rootDataStore = await requestFluidObject<ITestFluidObject>(container, "/");
+
+        // Create another data store and bind it by adding its handle in the root data store's DDS.
+        const dataStore2 = await createFluidObject(rootDataStore.context, "default");
+        rootDataStore.root.set("dataStore2", dataStore2.handle);
+
+        // Request the new data store via the request API on the container.
+        const dataStore2Response = await container.request({ url: dataStore2.handle.absolutePath });
+        assert(
+            dataStore2Response.mimeType === "fluid/object" && dataStore2Response.status === 200,
+            "Unable to load bound data store in detached container",
+        );
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -90,7 +90,7 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
         const containerRuntime1 = mainDataStore1.containerRuntime;
         const aliasableDataStore1 = await containerRuntime1.createDataStore("TestDataObject");
 
-        (aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
+        (aliasableDataStore1 as any).fluidDataStoreChannel.attachGraph();
         await provider.ensureSynchronized();
 
         // We run the summary so await this.getInitialSnapshotDetails() is called before the datastore is aliased

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -460,7 +460,7 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
             const aliasedDataStore1 = aliasedDataStoreResponse1.value as ITestFluidObject;
             // Casting any to repro a race condition where bindToContext is called before summarization,
             // but aliasing happens afterwards
-            (aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
+            aliasedDataStore1.channel.attachGraph();
             await provider.ensureSynchronized();
 
             const containerRuntime2 = runtimeOf(dataObject2) as ContainerRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -320,7 +320,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
             assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
             (await channel.handle.get() as SharedObject).bindToContext();
-            dataStore.channel.bindToContext();
+            dataStore.channel.attachGraph();
             (channel as SharedMap).set(testKey, testValue);
         });
 
@@ -346,7 +346,7 @@ describeNoCompat("stashed ops", (getTestObjectProvider) => {
             assert.strictEqual(channel.handle.isAttached, false, "Channel should be detached");
 
             (await channel.handle.get() as SharedObject).bindToContext();
-            dataStore.channel.bindToContext();
+            dataStore.channel.attachGraph();
             (channel as SharedMap).set(testKey, testValue);
         });
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/FluidFramework/issues/9127.

_**Note**: This change isn't backwards compatible right now as it is pretty complicated to do so. I would like to get some feedback if the PR is in right direction before working on compatibility._

This PR does the following:
- In data store runtime, it combines bind state and graph attach state into one state - `localAttachState`. Also, combines `attachGraph` and `bindToContext` into a single method.
- In data store runtime, there are two states currently tracked - `localAttachState` and `globalAttachState` (or just `attachState`). `localAttachState` tracks whether the data store is visible locally in the container via root. `globalAttachState` tracks whether the data store is visible globally to other clients in the document.
- When data store runtime is created, if it an existing on, its `localAttachState` is set to Attached. This fixes https://github.com/microsoft/FluidFramework/issues/7927.
- When a data store's handle is added to a DDS, if the DDS is locally attached, the data store is also locally attached by called `attachGraph` on the data store's handle. Note that the DDS's local attach state is tracked in its handle (FluidIObjectHandle class).