### PR TITLE
Remove the `OpenBatchOnDisconnect` event

### DIFF
--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -570,21 +570,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     }
 
     private disconnectHandler(reason: string) {
-        if (this.messageBuffer.length > 0) {
-            // Behavior is not well defined here RE batches across connections / disconnect.
-            // DeltaManager overall policy - drop all ops on disconnection and rely on
-            // container runtime to deal with resubmitting any ops that did not make it through.
-            // So drop them, but also raise error event to look into details.
-            this.logger.sendTelemetryEvent({
-                eventName: "OpenBatchOnDisconnect",
-                length: this.messageBuffer.length,
-                reason: {
-                    value: reason,
-                    tag: TelemetryDataTag.PackageData,
-                },
-            });
-            this.messageBuffer.length = 0;
-        }
+        this.messageBuffer.length = 0;
         this.emit("disconnect", reason);
     }
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -25,7 +25,6 @@ import {
     normalizeError,
     logIfFalse,
     safeRaiseEvent,
-    TelemetryDataTag,
 } from "@fluidframework/telemetry-utils";
 import {
     IDocumentDeltaStorageService,


### PR DESCRIPTION
Closes https://github.com/microsoft/FluidFramework/issues/9184

With `FlushMode.TurnBased`, everything is pretty much a batch, so this event will be hit more often if the container is disconnected with ops in the pipeline. However, the ops will be replayed by the runtime anyway, so there is no need to track this in the `DeltaManager`.

This event has already been demoted from `error` in https://github.com/microsoft/FluidFramework/pull/8833 as it started firing when `FlushMode.TurnBased` was set as the default and causing test failures due to undeclared log errors.

There is no current (elegant) way that I know of to trigger a disconnect in the end-to-end tests to showcase the replays end to end, however, aside from testing this locally, the biggest piece of evidence that replays at the runtime level happen is the notorious reconnect loop triggered when the op payload exceeds the socket.io limit of 1MB.