### PR TITLE
Bump eslint version for release branch after release

### DIFF
--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.27.0",
+  "version": "0.27.1001",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": "https://github.com/microsoft/FluidFramework",


### PR DESCRIPTION
Mimicking the 1*** format here, though the just-released version is 0.27.0