### PR TITLE
gitrest: add FS Manager interface

### DIFF
--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -1840,9 +1840,9 @@
       "integrity": "sha512-Qh0/DWkz7fQm5h+IPFBIO5ixaFdv86V6gpbA8TPA1hhgXYtzGviv9yriqN1B+KTtmLweemKZD5XxY1cTAQPNMg=="
     },
     "@types/node": {
-      "version": "12.19.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.3.tgz",
-      "integrity": "sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg=="
+      "version": "14.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
+      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
     },
     "@types/nodegit": {
       "version": "0.27.3",

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -59,7 +59,7 @@
     "@types/mocha": "^8.2.2",
     "@types/morgan": "^1.7.32",
     "@types/nconf": "^0.10.0",
-    "@types/node": "^12.12.54",
+    "@types/node": "^14.18.12",
     "@types/nodegit": "^0.27.3",
     "@types/rimraf": "^2.0.2",
     "@types/supertest": "^2.0.7",

--- a/server/gitrest/src/app.ts
+++ b/server/gitrest/src/app.ts
@@ -13,7 +13,7 @@ import winston from "winston";
 import { bindCorrelationId } from "@fluidframework/server-services-utils";
 import { IExternalStorageManager } from "./externalStorageManager";
 import * as routes from "./routes";
-import { NodegitRepositoryManagerFactory } from "./utils";
+import { IFileSystemManager, NodegitRepositoryManagerFactory } from "./utils";
 
 /**
  * Basic stream logging interface for libraries that require a stream to pipe output to
@@ -24,6 +24,7 @@ const stream = split().on("data", (message) => {
 
 export function create(
     store: nconf.Provider,
+    fileSystemManager: IFileSystemManager,
     externalStorageManager: IExternalStorageManager,
 ) {
     // Express app configuration
@@ -55,7 +56,11 @@ export function create(
     app.use(bindCorrelationId());
 
     app.use(cors());
-    const repoManagerFactory = new NodegitRepositoryManagerFactory(store.get("storageDir"), externalStorageManager);
+    const repoManagerFactory = new NodegitRepositoryManagerFactory(
+        store.get("storageDir"),
+        fileSystemManager,
+        externalStorageManager,
+    );
     const apiRoutes = routes.create(store, repoManagerFactory);
     app.use(apiRoutes.git.blobs);
     app.use(apiRoutes.git.refs);

--- a/server/gitrest/src/app.ts
+++ b/server/gitrest/src/app.ts
@@ -11,9 +11,8 @@ import nconf from "nconf";
 import split from "split";
 import winston from "winston";
 import { bindCorrelationId } from "@fluidframework/server-services-utils";
-import { IExternalStorageManager } from "./externalStorageManager";
 import * as routes from "./routes";
-import { IFileSystemManager, NodegitRepositoryManagerFactory } from "./utils";
+import { IRepositoryManagerFactory } from "./utils";
 
 /**
  * Basic stream logging interface for libraries that require a stream to pipe output to
@@ -24,8 +23,7 @@ const stream = split().on("data", (message) => {
 
 export function create(
     store: nconf.Provider,
-    fileSystemManager: IFileSystemManager,
-    externalStorageManager: IExternalStorageManager,
+    repositoryManagerFactory: IRepositoryManagerFactory,
 ) {
     // Express app configuration
     const app: Express = express();
@@ -56,12 +54,8 @@ export function create(
     app.use(bindCorrelationId());
 
     app.use(cors());
-    const repoManagerFactory = new NodegitRepositoryManagerFactory(
-        store.get("storageDir"),
-        fileSystemManager,
-        externalStorageManager,
-    );
-    const apiRoutes = routes.create(store, repoManagerFactory);
+
+    const apiRoutes = routes.create(store, repositoryManagerFactory);
     app.use(apiRoutes.git.blobs);
     app.use(apiRoutes.git.refs);
     app.use(apiRoutes.git.repos);

--- a/server/gitrest/src/runner.ts
+++ b/server/gitrest/src/runner.ts
@@ -8,8 +8,7 @@ import { IWebServer, IWebServerFactory, IRunner } from "@fluidframework/server-s
 import { Provider } from "nconf";
 import * as winston from "winston";
 import * as app from "./app";
-import { IExternalStorageManager } from "./externalStorageManager";
-import { IFileSystemManager } from "./utils";
+import { IRepositoryManagerFactory } from "./utils";
 
 export class GitrestRunner implements IRunner {
     private server: IWebServer;
@@ -19,14 +18,13 @@ export class GitrestRunner implements IRunner {
         private readonly serverFactory: IWebServerFactory,
         private readonly config: Provider,
         private readonly port: string | number,
-        private readonly fileSystemManager: IFileSystemManager,
-        private readonly externalStorageManager: IExternalStorageManager) {
+        private readonly repositoryManagerFactory: IRepositoryManagerFactory) {
     }
 
     public async start(): Promise<void> {
         this.runningDeferred = new Deferred<void>();
         // Create the gitrest app
-        const gitrest = app.create(this.config, this.fileSystemManager, this.externalStorageManager);
+        const gitrest = app.create(this.config, this.repositoryManagerFactory);
         gitrest.set("port", this.port);
 
         this.server = this.serverFactory.create(gitrest);

--- a/server/gitrest/src/runner.ts
+++ b/server/gitrest/src/runner.ts
@@ -9,6 +9,7 @@ import { Provider } from "nconf";
 import * as winston from "winston";
 import * as app from "./app";
 import { IExternalStorageManager } from "./externalStorageManager";
+import { IFileSystemManager } from "./utils";
 
 export class GitrestRunner implements IRunner {
     private server: IWebServer;
@@ -18,13 +19,14 @@ export class GitrestRunner implements IRunner {
         private readonly serverFactory: IWebServerFactory,
         private readonly config: Provider,
         private readonly port: string | number,
+        private readonly fileSystemManager: IFileSystemManager,
         private readonly externalStorageManager: IExternalStorageManager) {
     }
 
     public async start(): Promise<void> {
         this.runningDeferred = new Deferred<void>();
         // Create the gitrest app
-        const gitrest = app.create(this.config, this.externalStorageManager);
+        const gitrest = app.create(this.config, this.fileSystemManager, this.externalStorageManager);
         gitrest.set("port", this.port);
 
         this.server = this.serverFactory.create(gitrest);

--- a/server/gitrest/src/runnerFactory.ts
+++ b/server/gitrest/src/runnerFactory.ts
@@ -3,12 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import fsPromises from "fs/promises";
 import { Provider } from "nconf";
 import * as services from "@fluidframework/server-services-shared";
 import * as core from "@fluidframework/server-services-core";
 import { normalizePort } from "@fluidframework/server-services-utils";
 import { ExternalStorageManager, IExternalStorageManager } from "./externalStorageManager";
 import { GitrestRunner } from "./runner";
+import { IFileSystemManager } from "./utils";
 
 export class GitrestResources implements core.IResources {
     public webServerFactory: core.IWebServerFactory;
@@ -16,6 +18,7 @@ export class GitrestResources implements core.IResources {
     constructor(
         public readonly config: Provider,
         public readonly port: string | number,
+        public readonly fileSystemManager: IFileSystemManager,
         public readonly externalStorageManager: IExternalStorageManager) {
         this.webServerFactory = new services.BasicWebServerFactory();
     }
@@ -28,9 +31,10 @@ export class GitrestResources implements core.IResources {
 export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestResources> {
     public async create(config: Provider): Promise<GitrestResources> {
         const port = normalizePort(process.env.PORT || "3000");
+        const localFileSystemManager = fsPromises;
         const externalStorageManager = new ExternalStorageManager(config);
 
-        return new GitrestResources(config, port, externalStorageManager);
+        return new GitrestResources(config, port, localFileSystemManager, externalStorageManager);
     }
 }
 
@@ -40,6 +44,7 @@ export class GitrestRunnerFactory implements core.IRunnerFactory<GitrestResource
             resources.webServerFactory,
             resources.config,
             resources.port,
+            resources.fileSystemManager,
             resources.externalStorageManager);
     }
 }

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -30,7 +30,6 @@ const commitEmail = "kurtb@microsoft.com";
 const commitName = "Kurt Berglund";
 
 async function createRepo(supertest: request.SuperTest<request.Test>, owner: string, name: string) {
-    console.log("Entered create repo");
     return supertest
         .post(`/${owner}/repos`)
         .set("Accept", "application/json")
@@ -149,7 +148,7 @@ describe("GitRest", () => {
         };
 
         const externalStorageManager = new ExternalStorageManager(testUtils.defaultProvider);
-        const repoManagerFactory = new NodegitRepositoryManagerFactory(
+        const getRepoManagerFactory = () => new NodegitRepositoryManagerFactory(
             testUtils.defaultProvider.get("storageDir"),
             fsPromises,
             externalStorageManager,
@@ -160,6 +159,7 @@ describe("GitRest", () => {
         // Create the git repo before and after each test
         let supertest: request.SuperTest<request.Test>;
         beforeEach(() => {
+            const repoManagerFactory = getRepoManagerFactory();
             const testApp = app.create(testUtils.defaultProvider, repoManagerFactory);
             supertest = request(testApp);
         });
@@ -423,6 +423,7 @@ describe("GitRest", () => {
                 const MaxParagraphs = 200;
 
                 await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
+                const repoManagerFactory = getRepoManagerFactory();
                 const repoManager = await repoManagerFactory.open(testOwnerName, testRepoName);
 
                 let lastCommit;

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -149,13 +149,18 @@ describe("GitRest", () => {
         };
 
         const externalStorageManager = new ExternalStorageManager(testUtils.defaultProvider);
+        const repoManagerFactory = new NodegitRepositoryManagerFactory(
+            testUtils.defaultProvider.get("storageDir"),
+            fsPromises,
+            externalStorageManager,
+        );
 
         testUtils.initializeBeforeAfterTestHooks(testUtils.defaultProvider);
 
         // Create the git repo before and after each test
         let supertest: request.SuperTest<request.Test>;
         beforeEach(() => {
-            const testApp = app.create(testUtils.defaultProvider, fsPromises, externalStorageManager);
+            const testApp = app.create(testUtils.defaultProvider, repoManagerFactory);
             supertest = request(testApp);
         });
 
@@ -418,11 +423,6 @@ describe("GitRest", () => {
                 const MaxParagraphs = 200;
 
                 await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
-                const repoManagerFactory = new NodegitRepositoryManagerFactory(
-                    testUtils.defaultProvider.get("storageDir"),
-                    fsPromises,
-                    externalStorageManager,
-                );
                 const repoManager = await repoManagerFactory.open(testOwnerName, testRepoName);
 
                 let lastCommit;

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import assert from "assert";
+import fsPromises from "fs/promises";
 import {
     ICreateBlobParams,
     ICreateBlobResponse,
@@ -154,7 +155,7 @@ describe("GitRest", () => {
         // Create the git repo before and after each test
         let supertest: request.SuperTest<request.Test>;
         beforeEach(() => {
-            const testApp = app.create(testUtils.defaultProvider, externalStorageManager);
+            const testApp = app.create(testUtils.defaultProvider, fsPromises, externalStorageManager);
             supertest = request(testApp);
         });
 
@@ -419,6 +420,7 @@ describe("GitRest", () => {
                 await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
                 const repoManagerFactory = new NodegitRepositoryManagerFactory(
                     testUtils.defaultProvider.get("storageDir"),
+                    fsPromises,
                     externalStorageManager,
                 );
                 const repoManager = await repoManagerFactory.open(testOwnerName, testRepoName);

--- a/server/gitrest/src/utils/definitions.ts
+++ b/server/gitrest/src/utils/definitions.ts
@@ -35,9 +35,15 @@ export interface IRepositoryManager {
 export interface IFileSystemManager {
     readFile: typeof fsPromises.readFile;
     writeFile: typeof fsPromises.writeFile;
+    unlink: typeof fsPromises.unlink;
+    readdir: typeof fsPromises.readdir;
     mkdir: typeof fsPromises.mkdir;
     rmdir: typeof fsPromises.rmdir;
     stat: typeof fsPromises.stat;
+    lstat: typeof fsPromises.lstat;
+    readlink: typeof fsPromises.readlink;
+    symlink: typeof fsPromises.symlink;
+    chmod: typeof fsPromises.chmod;
     rm: typeof fsPromises.rm;
 }
 

--- a/server/gitrest/src/utils/definitions.ts
+++ b/server/gitrest/src/utils/definitions.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import fsPromises from "fs/promises";
 import * as git from "@fluidframework/gitresources";
 
 export interface IExternalWriterConfig {
@@ -26,6 +27,18 @@ export interface IRepositoryManager {
     deleteRef(refId: string): Promise<void>;
     getTag(tagId: string): Promise<git.ITag>;
     createTag(tagParams: git.ICreateTagParams): Promise<git.ITag>;
+}
+
+/**
+ * Subset of Node.js `fs/promises` API.
+ */
+export interface IFileSystemManager {
+    readFile: typeof fsPromises.readFile;
+    writeFile: typeof fsPromises.writeFile;
+    mkdir: typeof fsPromises.mkdir;
+    rmdir: typeof fsPromises.rmdir;
+    stat: typeof fsPromises.stat;
+    rm: typeof fsPromises.rm;
 }
 
 export interface IRepositoryManagerFactory {

--- a/server/gitrest/src/utils/nodegitManager.ts
+++ b/server/gitrest/src/utils/nodegitManager.ts
@@ -370,7 +370,8 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
         if (!(repoPath in this.repositoryPCache)) {
             const directory = `${this.baseDir}/${repoPath}`;
 
-            if (!await exists(this.fileSystemManager, directory)) {
+            const repoExists = await exists(this.fileSystemManager, directory);
+            if (!repoExists) {
                 winston.info(`Repo does not exist ${directory}`);
                 // services-client/getOrCreateRepository depends on a 400 response code
                 throw new NetworkError(400, `Repo does not exist ${directory}`);

--- a/server/gitrest/src/utils/nodegitManager.ts
+++ b/server/gitrest/src/utils/nodegitManager.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as fs from "fs";
+import { PathLike } from "fs";
 import * as path from "path";
-import * as util from "util";
 import nodegit from "nodegit";
 import winston from "winston";
 import safeStringify from "json-stringify-safe";
@@ -14,9 +13,22 @@ import { NetworkError } from "@fluidframework/server-services-client";
 import { IExternalStorageManager } from "../externalStorageManager";
 import * as helpers from "./helpers";
 import * as conversions from "./nodegitConversions";
-import { IRepositoryManagerFactory, GitObjectType, IExternalWriterConfig, IRepositoryManager } from "./definitions";
+import {
+    IRepositoryManagerFactory,
+    GitObjectType,
+    IExternalWriterConfig,
+    IRepositoryManager,
+    IFileSystemManager,
+} from "./definitions";
 
-const exists = util.promisify(fs.exists);
+const exists = async (fileSystemManager: IFileSystemManager, fileOrDirectoryPath: PathLike): Promise<boolean> => {
+    try {
+        await fileSystemManager.stat(fileOrDirectoryPath);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
 
 export class NodegitRepositoryManager implements IRepositoryManager {
     constructor(
@@ -325,7 +337,11 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
     // Cache repositories to allow for reuse
     private repositoryPCache: { [key: string]: Promise<nodegit.Repository> } = {};
 
-    constructor(private readonly baseDir, private readonly externalStorageManager: IExternalStorageManager) {
+    constructor(
+        private readonly baseDir,
+        private readonly fileSystemManager: IFileSystemManager,
+        private readonly externalStorageManager: IExternalStorageManager,
+    ) {
     }
 
     public async create(owner: string, name: string): Promise<NodegitRepositoryManager> {
@@ -338,7 +354,11 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
         this.repositoryPCache[repoPath] = repositoryP;
 
         const repository = await this.repositoryPCache[repoPath];
-        const repoManager = new NodegitRepositoryManager(owner, name, repository, this.externalStorageManager);
+        const repoManager = new NodegitRepositoryManager(
+            owner,
+            name,
+            repository,
+            this.externalStorageManager);
         winston.info(`Created a new repo for owner ${owner} reponame: ${name}`);
 
         return repoManager;
@@ -350,7 +370,7 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
         if (!(repoPath in this.repositoryPCache)) {
             const directory = `${this.baseDir}/${repoPath}`;
 
-            if (!await exists(directory)) {
+            if (!await exists(this.fileSystemManager, directory)) {
                 winston.info(`Repo does not exist ${directory}`);
                 // services-client/getOrCreateRepository depends on a 400 response code
                 throw new NetworkError(400, `Repo does not exist ${directory}`);
@@ -360,7 +380,11 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
         }
 
         const repository = await this.repositoryPCache[repoPath];
-        const repoManager = new NodegitRepositoryManager(owner, name, repository, this.externalStorageManager);
+        const repoManager = new NodegitRepositoryManager(
+            owner,
+            name,
+            repository,
+            this.externalStorageManager);
         return repoManager;
     }
 


### PR DESCRIPTION
Adding a FileSystemManager interface (simply a subset of the Node.js `fs/promises` module) and hoisting the RepoManager configuration to the ResourceFactory. This allows for alternate filesystem (e.g. remote blob storage) and/or an alternate Git implementation (e.g. isomorphic-git).

Will have a follow-up PR to utilize the FS Manager to persist pre-computed FullSummaries (see #9490).