### PR TITLE
Add support for multiple nack messages in deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -24,6 +24,7 @@ import {
     IContext,
     IControlMessage,
     IDeliState,
+    IDisableNackMessagesControlMessageContents,
     IMessage,
     INackMessage,
     IPartitionLambda,
@@ -178,8 +179,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
     // @ts-ignore
     private canClose = false;
 
-    // when set, messages will be nacked based on the provided info
-    private nackMessages: INackMessagesControlMessageContents | undefined;
+    // mapping of enabled nack message types. messages will be nacked based on the provided info
+    private nackMessages: Map<NackMessagesType, INackMessagesControlMessageContents>;
 
     // Session level properties
     private serviceSummaryGenerated: boolean = false;
@@ -225,7 +226,24 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
         this.durableSequenceNumber = lastCheckpoint.durableSequenceNumber;
         this.lastSentMSN = lastCheckpoint.lastSentMSN ?? 0;
         this.logOffset = lastCheckpoint.logOffset;
-        this.nackMessages = lastCheckpoint.nackMessages;
+
+        if (lastCheckpoint.nackMessages) {
+            if (Array.isArray(lastCheckpoint.nackMessages)) {
+                this.nackMessages = new Map(lastCheckpoint.nackMessages);
+            } else {
+                // backwards compat. nackMessages is a INackMessagesControlMessageContents
+                this.nackMessages = new Map();
+
+                // extra check for very old nack messages
+                const identifier = lastCheckpoint.nackMessages.identifier;
+                if (identifier !== undefined) {
+                    this.nackMessages.set(identifier, lastCheckpoint.nackMessages);
+                }
+            }
+        } else {
+            this.nackMessages = new Map();
+        }
+
         // Null coalescing for backward compatibility
         this.successfullyStartedLambdas = lastCheckpoint.successfullyStartedLambdas ?? [];
 
@@ -323,17 +341,18 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                 }
 
                 // Check if Deli is over the max ops since last summary nack limit
-                if (this.serviceConfiguration.deli.summaryNackMessages.enable && !this.nackMessages) {
+                if (this.serviceConfiguration.deli.summaryNackMessages.enable &&
+                    !this.nackMessages.has(NackMessagesType.SummaryMaxOps)) {
                     const opsSinceLastSummary = this.sequenceNumber - this.durableSequenceNumber;
                     if (opsSinceLastSummary > this.serviceConfiguration.deli.summaryNackMessages.maxOps) {
                         // this op brings us over the limit
                         // start nacking non-system ops and ops that are submitted by non-summarizers
-                        this.nackMessages = {
+                        this.nackMessages.set(NackMessagesType.SummaryMaxOps, {
                             identifier: NackMessagesType.SummaryMaxOps,
                             content: this.serviceConfiguration.deli.summaryNackMessages.nackContent,
                             allowSystemMessages: true,
                             allowedScopes: [ScopeType.SummaryWrite],
-                        };
+                        });
                     }
                 }
                 const sequencedMessage = ticketedMessage.message as ISequencedDocumentMessage;
@@ -478,7 +497,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
             this.sessionMetric,
             this.sequenceNumber,
             this.durableSequenceNumber,
-            this.nackMessages?.identifier,
+            this.nackMessages.size > 0 ? Array.from(this.nackMessages.keys())[0] : undefined,
         );
     }
 
@@ -493,37 +512,38 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
         const dataContent = this.extractDataContent(message);
 
         // Check if we should nack this message
-        const nackMessages = this.nackMessages;
-        if (nackMessages && this.serviceConfiguration.deli.enableNackMessages) {
+        if (this.nackMessages.size > 0 && this.serviceConfiguration.deli.enableNackMessages) {
             let shouldNack = true;
 
-            if (nackMessages.allowSystemMessages &&
-                (isServiceMessageType(message.operation.type) || !message.clientId)) {
-                // this is a system message. don't nack it
-                shouldNack = false;
-            } else if (nackMessages.allowedScopes) {
-                const clientId = message.clientId;
-                if (clientId) {
-                    const client = this.clientSeqManager.get(clientId);
-                    if (client) {
-                        for (const scope of nackMessages.allowedScopes) {
-                            if (client.scopes.includes(scope)) {
-                                // this client has an allowed scope. don't nack it
-                                shouldNack = false;
-                                break;
+            for (const nackMessages of this.nackMessages.values()) {
+                if (nackMessages.allowSystemMessages &&
+                    (isServiceMessageType(message.operation.type) || !message.clientId)) {
+                    // this is a system message. don't nack it
+                    shouldNack = false;
+                } else if (nackMessages.allowedScopes) {
+                    const clientId = message.clientId;
+                    if (clientId) {
+                        const client = this.clientSeqManager.get(clientId);
+                        if (client) {
+                            for (const scope of nackMessages.allowedScopes) {
+                                if (client.scopes.includes(scope)) {
+                                    // this client has an allowed scope. don't nack it
+                                    shouldNack = false;
+                                    break;
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            if (shouldNack) {
-                return this.createNackMessage(
-                    message,
-                    nackMessages.content.code,
-                    nackMessages.content.type,
-                    nackMessages.content.message,
-                    nackMessages.content.retryAfter);
+                if (shouldNack) {
+                    return this.createNackMessage(
+                        message,
+                        nackMessages.content.code,
+                        nackMessages.content.type,
+                        nackMessages.content.message,
+                        nackMessages.content.retryAfter);
+                }
             }
         }
 
@@ -738,7 +758,15 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                 }
 
                 case ControlMessageType.NackMessages: {
-                    this.nackMessages = controlMessage.contents;
+                    const controlContents: INackMessagesControlMessageContents |
+                        IDisableNackMessagesControlMessageContents = controlMessage.contents;
+
+                    if (controlContents.content !== undefined) {
+                        this.nackMessages.set(controlContents.identifier, controlContents);
+                    } else {
+                        this.nackMessages.delete(controlContents.identifier);
+                    }
+
                     break;
                 }
 
@@ -1056,7 +1084,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
             sequenceNumber: this.sequenceNumber,
             term: this.term,
             lastSentMSN: this.lastSentMSN,
-            nackMessages: this.nackMessages ? { ...this.nackMessages } : undefined,
+            nackMessages: Array.from(this.nackMessages),
             successfullyStartedLambdas: this.successfullyStartedLambdas,
         };
     }
@@ -1186,16 +1214,14 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
      * Checks if the nackMessages flag should be reset
      */
     private checkNackMessagesState() {
-        // note: "!this.nackMessages.identifier" is for backwards compat
-        if (this.serviceConfiguration.deli.summaryNackMessages.enable && this.nackMessages &&
-            (!this.nackMessages.identifier ||
-                this.nackMessages.identifier === NackMessagesType.SummaryMaxOps)) {
+        if (this.serviceConfiguration.deli.summaryNackMessages.enable &&
+            this.nackMessages.has(NackMessagesType.SummaryMaxOps)) {
             // Deli is nacking messages due to summary max ops
             // Check if this new dsn gets it out of that state
             const opsSinceLastSummary = this.sequenceNumber - this.durableSequenceNumber;
             if (opsSinceLastSummary <= this.serviceConfiguration.deli.summaryNackMessages.maxOps) {
                 // stop nacking future messages
-                this.nackMessages = undefined;
+                this.nackMessages.delete(NackMessagesType.SummaryMaxOps);
             }
         }
     }

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -513,9 +513,9 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 
         // Check if we should nack this message
         if (this.nackMessages.size > 0 && this.serviceConfiguration.deli.enableNackMessages) {
-            let shouldNack = true;
-
             for (const nackMessages of this.nackMessages.values()) {
+                let shouldNack = true;
+
                 if (nackMessages.allowSystemMessages &&
                     (isServiceMessageType(message.operation.type) || !message.clientId)) {
                     // this is a system message. don't nack it

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -180,7 +180,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
     private canClose = false;
 
     // mapping of enabled nack message types. messages will be nacked based on the provided info
-    private nackMessages: Map<NackMessagesType, INackMessagesControlMessageContents>;
+    private readonly nackMessages: Map<NackMessagesType, INackMessagesControlMessageContents>;
 
     // Session level properties
     private serviceSummaryGenerated: boolean = false;

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -75,7 +75,7 @@ export interface IDeliState {
     lastSentMSN: number | undefined;
 
     // Nack messages state
-    nackMessages: Array<[NackMessagesType, INackMessagesControlMessageContents]> |
+    nackMessages: [NackMessagesType, INackMessagesControlMessageContents][] |
     INackMessagesControlMessageContents | undefined;
 
     // List of successfully started lambdas at session start

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -7,7 +7,7 @@ import { ICommit, ICommitDetails } from "@fluidframework/gitresources";
 import { IProtocolState, ISummaryTree, ICommittedProposal } from "@fluidframework/protocol-definitions";
 import { IGitCache } from "@fluidframework/server-services-client";
 import { LambdaName } from "./lambdas";
-import { INackMessagesControlMessageContents } from "./messages";
+import { INackMessagesControlMessageContents, NackMessagesType } from "./messages";
 
 export interface IDocumentDetails {
     existing: boolean;
@@ -75,7 +75,8 @@ export interface IDeliState {
     lastSentMSN: number | undefined;
 
     // Nack messages state
-    nackMessages: INackMessagesControlMessageContents | undefined;
+    nackMessages: Array<[NackMessagesType, INackMessagesControlMessageContents]> |
+    INackMessagesControlMessageContents | undefined;
 
     // List of successfully started lambdas at session start
     successfullyStartedLambdas: LambdaName[];

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -181,11 +181,14 @@ export enum NackMessagesType {
     SummaryMaxOps = "summaryMaxOps",
 }
 
+/**
+ * Control message sent to enable a nack message
+ */
 export interface INackMessagesControlMessageContents {
     /**
      * Identifier for the type/reason for this nack messages
      */
-    identifier: NackMessagesType | undefined;
+    identifier: NackMessagesType;
 
     /**
      * The INackContent to send when nacking the message
@@ -202,6 +205,21 @@ export interface INackMessagesControlMessageContents {
      * Controls if system messages should be nacked
      */
     allowSystemMessages?: boolean;
+}
+
+/**
+ * Control message sent to disable a nack message
+ */
+export interface IDisableNackMessagesControlMessageContents {
+    /**
+     * Identifier for the type/reason for this nack messages
+     */
+    identifier: NackMessagesType;
+
+    /**
+     * The INackContent to send when nacking the message
+     */
+    content: undefined;
 }
 
 export interface ILambdaStartControlMessageContents {


### PR DESCRIPTION
Deli's `nackMessages` system currently supports 1 nack messages type at a time and it's currently used to set/unset the SummaryMaxOps type.

I need the ability to set more than one at a time. This means it needs to track each nack messages type separately. So I'm changing nackMessages to a Map. It will keep track of active nack messages that are enabled per nack message type.
The NackMessages control messages will allow arbitrary control of enabling/disabling nack message types.

My use case involves preventing deli from sequencing ops when there are certain backend things occurring, such as an SPO tenant/site/file being read-only. And I don't want that nack message type to interfere with the SummaryMaxOps nack message type. Related to issue #9000