### PR TITLE
r11s-driver: handle node-fetch network errors

### DIFF
--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -64,8 +64,8 @@ export class RouterliciousRestWrapper extends RestWrapper {
 
         const response: Response = await this.rateLimiter.schedule(async () => fetch(...fetchRequestConfig)
             .catch(async (error) => {
-                // Fetch throws a TypeError on network error
-                const isNetworkError = error instanceof TypeError;
+                // Browser Fetch throws a TypeError on network error, `node-fetch` throws a FetchError
+                const isNetworkError = ["TypeError", "FetchError"].includes(error?.name);
                 throwR11sNetworkError(
                     isNetworkError ? `NetworkError: ${error.message}` : safeStringify(error));
             }));

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -105,6 +105,13 @@ describe("RouterliciousDriverRestWrapper", () => {
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
             });
         });
+        it("throws retriable error on Network Error", async () => {
+            nock(testHost).get(testPath).replyWithError({code: "ECONNRESET"});
+            await assert.rejects(restWrapper.get(testUrl), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
     });
 
     describe("post()", () => {
@@ -149,6 +156,13 @@ describe("RouterliciousDriverRestWrapper", () => {
             await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
                 canRetry: false,
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+            });
+        });
+        it("throws retriable error on Network Error", async () => {
+            nock(testHost).post(testPath).replyWithError({code: "ECONNRESET"});
+            await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
             });
         });
     });
@@ -197,6 +211,13 @@ describe("RouterliciousDriverRestWrapper", () => {
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
             });
         });
+        it("throws retriable error on Network Error", async () => {
+            nock(testHost).patch(testPath).replyWithError({code: "ECONNRESET"});
+            await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
+            });
+        });
     });
 
     describe("delete()", () => {
@@ -241,6 +262,13 @@ describe("RouterliciousDriverRestWrapper", () => {
             await assert.rejects(restWrapper.delete(testUrl), {
                 canRetry: false,
                 errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+            });
+        });
+        it("throws retriable error on Network Error", async () => {
+            nock(testHost).delete(testPath).replyWithError({code: "ECONNRESET"});
+            await assert.rejects(restWrapper.delete(testUrl), {
+                canRetry: true,
+                errorType: DriverErrorType.genericNetworkError,
             });
         });
     });


### PR DESCRIPTION
Browsers' built-in Fetch() (and [GitHub's WhatWG-Fetch Polyfill](https://github.com/github/fetch/blob/master/fetch.js#L535)) throw a `TypeError` when  a Network Error (like ECONNREFUSED) is encountered. However, `node-fetch` behaves differently and throws a `FetchError`. R11s-driver needs to handle both.