### PR TITLE
gitrest: persist pre-computed full summaries in storage

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -26,8 +26,8 @@ data:
         },
         "git": {
             "lib": {
-                "name": "{{ .Values.gitrest.git.lib.name }}",
-                "persistLatestFullSummary": {{ .Values.gitrest.git.lib.persistLatestFullSummary }}
-            }
+                "name": "{{ .Values.gitrest.git.lib.name }}"
+            },
+            "persistLatestFullSummary": {{ .Values.gitrest.git.persistLatestFullSummary }}
         }
     }

--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -23,5 +23,11 @@ data:
         "externalStorage": {
           "enabled": false,
           "endpoint": "http://externalStorage:3005"
+        },
+        "git": {
+            "lib": {
+                "name": "{{ .Values.gitrest.git.lib.name }}",
+                "persistLatestFullSummary": {{ .Values.gitrest.git.lib.persistLatestFullSummary }}
+            }
         }
     }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -39,7 +39,7 @@ gitrest:
   git:
     lib:
       name: nodegit
-      persistLatestFullSummary: false
+    persistLatestFullSummary: false
 
 gitssh:
   name: gitssh

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -36,6 +36,10 @@ gitrest:
     storageClass: managed-premium
     size: 4094Gi
     accessMode: ReadWriteOnce
+  git:
+    lib:
+      name: nodegit
+      persistLatestFullSummary: false
 
 gitssh:
   name: gitssh

--- a/server/gitrest/config.json
+++ b/server/gitrest/config.json
@@ -14,8 +14,8 @@
     },
     "git": {
         "lib": {
-            "name": "nodegit",
-            "persistLatestFullSummary": false
-        }
+            "name": "nodegit"
+        },
+        "persistLatestFullSummary": false
     }
 }

--- a/server/gitrest/config.json
+++ b/server/gitrest/config.json
@@ -11,5 +11,11 @@
     "externalStorage": {
         "enabled": false,
         "endpoint": "http://externalStorage:3005"
+    },
+    "git": {
+        "lib": {
+            "name": "nodegit",
+            "persistLatestFullSummary": false
+        }
     }
 }

--- a/server/gitrest/src/app.ts
+++ b/server/gitrest/src/app.ts
@@ -12,7 +12,7 @@ import split from "split";
 import winston from "winston";
 import { bindCorrelationId } from "@fluidframework/server-services-utils";
 import * as routes from "./routes";
-import { IRepositoryManagerFactory } from "./utils";
+import { IFileSystemManager, IRepositoryManagerFactory } from "./utils";
 
 /**
  * Basic stream logging interface for libraries that require a stream to pipe output to
@@ -23,6 +23,7 @@ const stream = split().on("data", (message) => {
 
 export function create(
     store: nconf.Provider,
+    fileSystemManager: IFileSystemManager,
     repositoryManagerFactory: IRepositoryManagerFactory,
 ) {
     // Express app configuration
@@ -55,7 +56,7 @@ export function create(
 
     app.use(cors());
 
-    const apiRoutes = routes.create(store, repositoryManagerFactory);
+    const apiRoutes = routes.create(store, fileSystemManager, repositoryManagerFactory);
     app.use(apiRoutes.git.blobs);
     app.use(apiRoutes.git.refs);
     app.use(apiRoutes.git.repos);

--- a/server/gitrest/src/routes/index.ts
+++ b/server/gitrest/src/routes/index.ts
@@ -5,7 +5,7 @@
 
 import { Router } from "express";
 import nconf from "nconf";
-import { IRepositoryManagerFactory } from "../utils";
+import { IFileSystemManager, IRepositoryManagerFactory } from "../utils";
 /* eslint-disable import/no-internal-modules */
 import * as blobs from "./git/blobs";
 import * as commits from "./git/commits";
@@ -36,6 +36,7 @@ export interface IRoutes {
 
 export function create(
     store: nconf.Provider,
+    fileSystemManager: IFileSystemManager,
     repoManagerFactory: IRepositoryManagerFactory,
 ): IRoutes {
     return {
@@ -51,6 +52,6 @@ export function create(
             commits: repositoryCommits.create(store, repoManagerFactory),
             contents: contents.create(store, repoManagerFactory),
         },
-        summaries: summaries.create(store, repoManagerFactory),
+        summaries: summaries.create(store, fileSystemManager, repoManagerFactory),
     };
 }

--- a/server/gitrest/src/routes/summaries.ts
+++ b/server/gitrest/src/routes/summaries.ts
@@ -11,14 +11,134 @@ import {
 } from "@fluidframework/server-services-client";
 import { Router } from "express";
 import { Provider } from "nconf";
-import { getExternalWriterParams, IRepositoryManagerFactory } from "../utils";
+import winston from "winston";
+import safeStringify from "json-stringify-safe";
+import {
+    getExternalWriterParams,
+    IExternalWriterConfig,
+    IRepositoryManagerFactory,
+    latestSummarySha,
+    GitWholeSummaryManager,
+    retrieveLatestFullSummaryFromStorage,
+    persistLatestFullSummaryInStorage,
+    isContainerSummary,
+    IRepositoryManager,
+    IFileSystemManager,
+} from "../utils";
 import { handleResponse } from "./utils";
+
+function getDocumentStorageDirectory(repoManager: IRepositoryManager, documentId: string): string {
+    return `${repoManager.path}/${documentId}`;
+}
+
+async function getSummary(
+    repoManager: IRepositoryManager,
+    fileSystemManager: IFileSystemManager,
+    sha: string,
+    documentId: string,
+    tenantId: string,
+    externalWriterConfig?: IExternalWriterConfig,
+    persistLatestFullSummary = false,
+): Promise<IWholeFlatSummary> {
+    if (persistLatestFullSummary && sha === latestSummarySha) {
+        try {
+            const latestFullSummaryFromStorage = await retrieveLatestFullSummaryFromStorage(
+                fileSystemManager,
+                getDocumentStorageDirectory(repoManager, documentId),
+            );
+            if (latestFullSummaryFromStorage !== undefined) {
+                return latestFullSummaryFromStorage;
+            }
+        } catch (e) {
+            // This read is for optimization purposes, so on failure
+            // we can try to read the summary in typical fashion.
+            winston.error(`Failed to read latest full summary from storage: ${safeStringify(e)}`, {
+                documentId,
+                tenantId,
+            });
+        }
+    }
+
+    const wholeSummaryManager = new GitWholeSummaryManager(
+        documentId,
+        repoManager,
+        externalWriterConfig?.enabled ?? false,
+    );
+    return wholeSummaryManager.readSummary(sha);
+}
+
+async function createSummary(
+    repoManager: IRepositoryManager,
+    fileSystemManager: IFileSystemManager,
+    payload: IWholeSummaryPayload,
+    documentId: string,
+    tenantId: string,
+    externalWriterConfig?: IExternalWriterConfig,
+    persistLatestFullSummary = false,
+): Promise<IWriteSummaryResponse | IWholeFlatSummary> {
+    const wholeSummaryManager = new GitWholeSummaryManager(
+        documentId,
+        repoManager,
+        externalWriterConfig?.enabled ?? false,
+    );
+    const {isNew, writeSummaryResponse} = await wholeSummaryManager.writeSummary(payload);
+
+    // Waiting to pre-compute and persist latest summary would slow down document creation,
+    // so skip this step if it is a new document.
+    if (!isNew && isContainerSummary(payload)) {
+        const latestFullSummary: IWholeFlatSummary | undefined = await wholeSummaryManager.readSummary(
+            writeSummaryResponse.id,
+        ).catch((err) => {
+            // This read is for Historian caching purposes, so it should be ignored on failure.
+            winston.error(`Failed to read latest summary after writing container summary: ${safeStringify(err)}`, {
+                documentId,
+                tenantId,
+            });
+            return undefined;
+        });
+        if (latestFullSummary) {
+            if (persistLatestFullSummary) {
+                try {
+                    // TODO: does this fail if file is open and still being written to from a previous request?
+                    await persistLatestFullSummaryInStorage(
+                        fileSystemManager,
+                        getDocumentStorageDirectory(repoManager, documentId),
+                        latestFullSummary,
+                    );
+                } catch(e) {
+                    winston.error(`Failed to persist latest full summary to storage: ${safeStringify(e)}`, {
+                        documentId,
+                        tenantId,
+                    });
+                    // TODO: Find and add more information about this failure so that Scribe can retry as necessary.
+                    throw new NetworkError(500, "Failed to persist latest full summary to storage");
+                }
+            }
+            return latestFullSummary;
+        }
+    }
+
+    return writeSummaryResponse;
+}
+
+async function deleteSummary(
+    repoManager: IRepositoryManager,
+    fileSystemManager: IFileSystemManager,
+    documentId: string,
+    tenantId: string,
+    softDelete: boolean,
+    externalWriterConfig?: IExternalWriterConfig,
+    persistLatestFullSummary = false): Promise<boolean> {
+    throw new NetworkError(501, "Not Implemented");
+}
 
 export function create(
     store: Provider,
+    fileSystemManager: IFileSystemManager,
     repoManagerFactory: IRepositoryManagerFactory,
 ): Router {
     const router: Router = Router();
+    const persistLatestFullSummary: boolean = store.get("git:persistLatestFullSummary") ?? false;
 
     /**
      * Retrieves a summary.
@@ -26,7 +146,7 @@ export function create(
      */
     router.get("/repos/:owner/:repo/git/summaries/:sha", async (request, response) => {
         const storageRoutingId: string = request.get("Storage-Routing-Id");
-        const [,documentId] = storageRoutingId.split(":");
+        const [tenantId,documentId] = storageRoutingId.split(":");
         if (!documentId) {
             handleResponse(Promise.reject(new NetworkError(400, "Invalid Storage-Routing-Id header")), response);
             return;
@@ -34,10 +154,14 @@ export function create(
         const resultP = repoManagerFactory.open(
             request.params.owner,
             request.params.repo,
-        ).then(async (repoManager) => repoManager.getSummary(
+        ).then(async (repoManager) => getSummary(
+            repoManager,
+            fileSystemManager,
             request.params.sha,
             documentId,
+            tenantId,
             getExternalWriterParams(request.query?.config as string | undefined),
+            persistLatestFullSummary,
         ));
         handleResponse(resultP, response);
     });
@@ -47,7 +171,7 @@ export function create(
      */
     router.post("/repos/:owner/:repo/git/summaries", async (request, response) => {
         const storageRoutingId: string = request.get("Storage-Routing-Id");
-        const [,documentId] = storageRoutingId.split(":");
+        const [tenantId,documentId] = storageRoutingId.split(":");
         if (!documentId) {
             handleResponse(Promise.reject(new NetworkError(400, "Invalid Storage-Routing-Id header")), response);
             return;
@@ -56,14 +180,15 @@ export function create(
         const resultP = repoManagerFactory.open(
             request.params.owner,
             request.params.repo,
-        ).then(async (repoManager): Promise<IWriteSummaryResponse | IWholeFlatSummary> => {
-            const writeSummaryResponse = await repoManager.createSummary(
-                wholeSummaryPayload,
-                documentId,
-                getExternalWriterParams(request.query?.config as string | undefined),
-            );
-            return writeSummaryResponse;
-        });
+        ).then(async (repoManager): Promise<IWriteSummaryResponse | IWholeFlatSummary> => createSummary(
+            repoManager,
+            fileSystemManager,
+            wholeSummaryPayload,
+            documentId,
+            tenantId,
+            getExternalWriterParams(request.query?.config as string | undefined),
+            persistLatestFullSummary,
+        ));
         handleResponse(resultP, response, 201);
     });
 
@@ -73,7 +198,7 @@ export function create(
      */
     router.delete("/repos/:owner/:repo/git/summaries", async (request, response) => {
         const storageRoutingId: string = request.get("Storage-Routing-Id");
-        const [,documentId] = storageRoutingId.split(":");
+        const [tenantId,documentId] = storageRoutingId.split(":");
         if (!documentId) {
             handleResponse(Promise.reject(new NetworkError(400, "Invalid Storage-Routing-Id header")), response);
             return;
@@ -82,7 +207,15 @@ export function create(
         const resultP = repoManagerFactory.open(
             request.params.owner,
             request.params.repo,
-        ).then(async (repoManager) => repoManager.deleteSummary(documentId, softDelete));
+        ).then(async (repoManager) => deleteSummary(
+            repoManager,
+            fileSystemManager,
+            documentId,
+            tenantId,
+            softDelete,
+            getExternalWriterParams(request.query?.config as string | undefined),
+            persistLatestFullSummary,
+        ));
         handleResponse(resultP, response, 204);
     });
 

--- a/server/gitrest/src/routes/summaries.ts
+++ b/server/gitrest/src/routes/summaries.ts
@@ -4,350 +4,15 @@
  */
 
 import {
-    ICreateCommitParams,
-    ICreateTreeEntry,
-} from "@fluidframework/gitresources";
-import { getGitMode, getGitType } from "@fluidframework/protocol-base";
-import { SummaryObject, SummaryType } from "@fluidframework/protocol-definitions";
-import {
     IWholeFlatSummary,
-    IWholeFlatSummaryBlob,
-    IWholeFlatSummaryTreeEntry,
-    IWholeSummaryBlob,
     IWholeSummaryPayload,
-    IWholeSummaryTree,
-    IWholeSummaryTreeHandleEntry,
-    IWholeSummaryTreeValueEntry,
     IWriteSummaryResponse,
     NetworkError,
-    WholeSummaryTreeEntry,
 } from "@fluidframework/server-services-client";
 import { Router } from "express";
 import { Provider } from "nconf";
-import winston from "winston";
-import { getExternalWriterParams, IRepositoryManager, IRepositoryManagerFactory } from "../utils";
+import { getExternalWriterParams, IRepositoryManagerFactory } from "../utils";
 import { handleResponse } from "./utils";
-
-interface ISummaryVersion {
-    id: string;
-    treeId: string;
-}
-
-export class WholeSummaryReadGitManager {
-    constructor(
-        private readonly documentId: string,
-        private readonly repoManager: IRepositoryManager,
-        private readonly externalStorageEnabled = true,
-    ) {}
-
-    public async readSummary(sha: string): Promise<IWholeFlatSummary> {
-        let version: ISummaryVersion;
-        if (sha === "latest") {
-            version = await this.getLatestVersion();
-        } else {
-            const commit = await this.repoManager.getCommit(sha);
-            version = { id: commit.sha, treeId: commit.tree.sha };
-        }
-        const rawTree = await this.repoManager.getTree(version.treeId, true /* recursive */);
-        const wholeFlatSummaryTreeEntries: IWholeFlatSummaryTreeEntry[] = [];
-        const wholeFlatSummaryBlobPs: Promise<IWholeFlatSummaryBlob>[] = [];
-        rawTree.tree.forEach((treeEntry) => {
-            if (treeEntry.type === "blob") {
-                wholeFlatSummaryTreeEntries.push({
-                    type: "blob",
-                    id: treeEntry.sha,
-                    path: treeEntry.path,
-                });
-                wholeFlatSummaryBlobPs.push(
-                    this.getBlob(
-                        treeEntry.sha,
-                    ),
-                );
-            } else {
-                wholeFlatSummaryTreeEntries.push({
-                    type: "tree",
-                    path: treeEntry.path,
-                });
-            }
-        });
-        const wholeFlatSummaryBlobs = await Promise.all(wholeFlatSummaryBlobPs);
-        return {
-            id: version.id,
-            trees: [
-                {
-                    id: rawTree.sha,
-                    entries: wholeFlatSummaryTreeEntries,
-                    // We don't store sequence numbers in git
-                    sequenceNumber: undefined,
-                },
-            ],
-            blobs: wholeFlatSummaryBlobs,
-        };
-    }
-
-    private async getBlob(sha: string): Promise<IWholeFlatSummaryBlob> {
-        const blob = await this.repoManager.getBlob(
-            sha,
-        );
-        return {
-            content: blob.content,
-            encoding: blob.encoding === "base64" ? "base64" : "utf-8",
-            id: blob.sha,
-            size: blob.size,
-        };
-    }
-
-    private async getLatestVersion(): Promise<ISummaryVersion> {
-        const commitDetails = await this.repoManager.getCommits(
-            this.documentId,
-            1,
-            { enabled: this.externalStorageEnabled },
-        );
-        return {
-            id: commitDetails[0].sha,
-            treeId: commitDetails[0].commit.tree.sha,
-        };
-    }
-}
-
-function getSummaryObjectFromWholeSummaryTreeEntry(entry: WholeSummaryTreeEntry): SummaryObject {
-    if ((entry as IWholeSummaryTreeHandleEntry).id !== undefined) {
-        return {
-            type: SummaryType.Handle,
-            handleType: entry.type === "tree" ? SummaryType.Tree : SummaryType.Blob,
-            handle: (entry as IWholeSummaryTreeHandleEntry).id,
-        };
-    }
-    if (entry.type === "blob") {
-        return {
-            type: SummaryType.Blob,
-            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
-            content: "",
-        };
-    }
-    if (entry.type === "tree") {
-        return {
-            type: SummaryType.Tree,
-            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
-            tree: {},
-            unreferenced: (entry as IWholeSummaryTreeValueEntry).unreferenced,
-        };
-    }
-    throw new NetworkError(400, `Unknown entry type: ${entry.type}`);
-}
-
-export class WholeSummaryWriteGitManager {
-    private readonly entryHandleToObjectShaCache: Map<string, string> = new Map();
-
-    constructor(
-        private readonly documentId: string,
-        private readonly repoManager: IRepositoryManager,
-        private readonly externalStorageEnabled = true,
-    ) {}
-
-    public async writeSummary(payload: IWholeSummaryPayload): Promise<IWholeFlatSummary | IWriteSummaryResponse> {
-        if (payload.type === "channel") {
-            const summaryTreeHandle = await this.writeChannelSummary(payload);
-            return {
-                id: summaryTreeHandle,
-            };
-        }
-        if (payload.type === "container") {
-            const wholeFlatSummary = await this.writeContainerSummary(payload);
-            return wholeFlatSummary;
-        }
-        throw new NetworkError(400, `Unknown Summary Type: ${payload.type}`);
-    }
-
-    private async writeChannelSummary(payload: IWholeSummaryPayload): Promise<string> {
-        return this.writeSummaryTreeCore(payload.entries);
-    }
-
-    private async writeContainerSummary(
-        payload: IWholeSummaryPayload,
-    ): Promise<IWriteSummaryResponse> {
-        const treeHandle = await this.writeSummaryTreeCore(
-            payload.entries,
-            "",
-        );
-        const existingRef = await this.repoManager.getRef(
-            `refs/heads/${this.documentId}`,
-            { enabled: this.externalStorageEnabled },
-        ).catch(() => undefined);
-        let commitParams: ICreateCommitParams;
-        if (!existingRef && payload.sequenceNumber === 0) {
-            // Create new document
-            commitParams = {
-                author: {
-                    date: new Date().toISOString(),
-                    email: "dummy@microsoft.com",
-                    name: "GitRest Service",
-                },
-                message: "New document",
-                parents: [],
-                tree: treeHandle,
-            };
-        } else {
-            // Update existing document
-            commitParams = {
-                author: {
-                    date: new Date().toISOString(),
-                    email: "dummy@microsoft.com",
-                    name: "GitRest Service",
-                },
-                // TODO: How to know if Service/Client Summary?
-                // .app handle embedded=true looks to be an indicator. Is it worth checking?
-                message: `Service/Client Summary @${payload.sequenceNumber}`,
-                parents: existingRef ? [existingRef.object.sha] : [],
-                tree: treeHandle,
-            };
-        }
-        const commit = await this.repoManager.createCommit(commitParams);
-        if (existingRef) {
-            await this.repoManager.patchRef(
-                `refs/heads/${this.documentId}`,
-                {
-                    force: true,
-                    sha: commit.sha,
-                },
-                { enabled: this.externalStorageEnabled },
-            );
-        } else {
-            await this.repoManager.createRef(
-                {
-                    ref: `refs/heads/${this.documentId}`,
-                    sha: commit.sha,
-                },
-                { enabled: this.externalStorageEnabled },
-            );
-        }
-        return {
-            id: commit.sha,
-        };
-    }
-
-    private async writeSummaryTreeCore(
-        wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
-        currentPath: string = "",
-    ): Promise<string> {
-        const entries: ICreateTreeEntry[] = await Promise.all(wholeSummaryTreeEntries.map(async (entry) => {
-            const summaryObject = getSummaryObjectFromWholeSummaryTreeEntry(entry);
-            const type = getGitType(summaryObject);
-            const path = entry.path;
-            const fullPath = currentPath ? `${currentPath}/${entry.path}` : entry.path;
-            const pathHandle = await this.writeSummaryTreeObject(
-                entry,
-                summaryObject,
-                fullPath,
-            );
-            return {
-                mode: getGitMode(summaryObject),
-                path,
-                sha: pathHandle,
-                type,
-            };
-        }));
-
-        const createdTree = await this.repoManager.createTree(
-            { tree: entries },
-        );
-        return createdTree.sha;
-    }
-
-    private async writeSummaryTreeObject(
-        wholeSummaryTreeEntry: WholeSummaryTreeEntry,
-        summaryObject: SummaryObject,
-        currentPath: string,
-    ): Promise<string> {
-        switch(summaryObject.type) {
-            case SummaryType.Blob:
-                return this.writeSummaryBlob(
-                    ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryBlob),
-                );
-            case SummaryType.Tree:
-                return this.writeSummaryTreeCore(
-                    ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryTree).entries ?? [],
-                    currentPath,
-                );
-            case SummaryType.Handle:
-                return this.getShaFromTreeHandleEntry(wholeSummaryTreeEntry as IWholeSummaryTreeHandleEntry);
-            default:
-                throw new NetworkError(501, "Not Implemented");
-        }
-    }
-
-    private async writeSummaryBlob(blob: IWholeSummaryBlob): Promise<string> {
-        const blobResponse = await this.repoManager.createBlob(
-            {
-                content: blob.content,
-                encoding: blob.encoding,
-            },
-        );
-        return blobResponse.sha;
-    }
-
-    private async getShaFromTreeHandleEntry(entry: IWholeSummaryTreeHandleEntry): Promise<string> {
-        if (!entry.id) {
-            throw new NetworkError(400, `Empty summary tree handle`);
-        }
-        if (entry.id.split("/").length === 1) {
-            // The entry id is already a sha, so just return it
-            return entry.id;
-        }
-
-        const cachedSha = this.entryHandleToObjectShaCache.get(entry.id);
-        if (cachedSha) {
-            return cachedSha;
-        }
-
-        // The entry id is in the format { id: `<parent commit sha>/<tree path>`, path: `<tree path>` }
-        const parentHandle = entry.id.split("/")[0];
-        const parentCommit = await this.repoManager.getCommit(parentHandle);
-        const parentTree = await this.repoManager.getTree(parentCommit.tree.sha, true /* recursive */);
-        for (const treeEntry of parentTree.tree) {
-            this.entryHandleToObjectShaCache.set(`${parentHandle}/${treeEntry.path}`, treeEntry.sha);
-        }
-        const sha = this.entryHandleToObjectShaCache.get(entry.id);
-        if (!sha) {
-            throw new NetworkError(404, `Summary tree handle object not found: id: ${entry.id}, path: ${entry.path}`);
-        }
-        return sha;
-    }
-}
-
-export async function getSummary(
-    repoManager: IRepositoryManager,
-    sha: string,
-    documentId: string,
-    externalStorageEnabled: boolean,
-): Promise<IWholeFlatSummary> {
-    const wholeSummaryReadGitManager = new WholeSummaryReadGitManager(
-        documentId,
-        repoManager,
-        externalStorageEnabled,
-    );
-    return wholeSummaryReadGitManager.readSummary(sha);
-}
-
-export async function createSummary(
-    repoManager: IRepositoryManager,
-    payload: IWholeSummaryPayload,
-    documentId: string,
-    externalStorageEnabled: boolean,
-): Promise<IWholeFlatSummary | IWriteSummaryResponse> {
-    const wholeSummaryWriteGitManager = new WholeSummaryWriteGitManager(
-        documentId,
-        repoManager,
-        externalStorageEnabled,
-    );
-    return wholeSummaryWriteGitManager.writeSummary(payload);
-}
-
-export async function deleteSummary(
-    repoManager: IRepositoryManager,
-    softDelete: boolean): Promise<boolean> {
-    throw new NetworkError(501, "Not Implemented");
-}
 
 export function create(
     store: Provider,
@@ -369,11 +34,10 @@ export function create(
         const resultP = repoManagerFactory.open(
             request.params.owner,
             request.params.repo,
-        ).then(async (repoManager) => getSummary(
-            repoManager,
+        ).then(async (repoManager) => repoManager.getSummary(
             request.params.sha,
             documentId,
-            getExternalWriterParams(request.query?.config as string | undefined)?.enabled ?? false,
+            getExternalWriterParams(request.query?.config as string | undefined),
         ));
         handleResponse(resultP, response);
     });
@@ -383,7 +47,7 @@ export function create(
      */
     router.post("/repos/:owner/:repo/git/summaries", async (request, response) => {
         const storageRoutingId: string = request.get("Storage-Routing-Id");
-        const [tenantId,documentId] = storageRoutingId.split(":");
+        const [,documentId] = storageRoutingId.split(":");
         if (!documentId) {
             handleResponse(Promise.reject(new NetworkError(400, "Invalid Storage-Routing-Id header")), response);
             return;
@@ -393,46 +57,32 @@ export function create(
             request.params.owner,
             request.params.repo,
         ).then(async (repoManager): Promise<IWriteSummaryResponse | IWholeFlatSummary> => {
-            const externalStorageEnabled =
-                getExternalWriterParams(request.query?.config as string | undefined)?.enabled ?? false;
-            const writeSummaryResponse = await createSummary(
-                repoManager,
+            const writeSummaryResponse = await repoManager.createSummary(
                 wholeSummaryPayload,
                 documentId,
-                externalStorageEnabled,
+                getExternalWriterParams(request.query?.config as string | undefined),
             );
-            if (wholeSummaryPayload.type === "container") {
-                try {
-                    const wholeFlatSummary = await getSummary(
-                        repoManager,
-                        writeSummaryResponse.id,
-                        documentId,
-                        externalStorageEnabled,
-                    );
-                    return wholeFlatSummary;
-                } catch (e) {
-                    // This read is for Historian caching purposes, so it should be ignored on failure.
-                    winston.error("Failed to read latest summary after writing container summary", {
-                        documentId,
-                        tenantId,
-                    });
-                }
-            }
             return writeSummaryResponse;
         });
         handleResponse(resultP, response, 201);
     });
 
     /**
-     * Deletes the latest summary for the owner/repo.
+     * Deletes the latest summary for the given document.
      * If header Soft-Delete="true", only flags summary as deleted.
      */
-    router.delete("/repos/:owner/:repo/git/summaries/:sha", async (request, response) => {
+    router.delete("/repos/:owner/:repo/git/summaries", async (request, response) => {
+        const storageRoutingId: string = request.get("Storage-Routing-Id");
+        const [,documentId] = storageRoutingId.split(":");
+        if (!documentId) {
+            handleResponse(Promise.reject(new NetworkError(400, "Invalid Storage-Routing-Id header")), response);
+            return;
+        }
         const softDelete = request.get("Soft-Delete")?.toLowerCase() === "true";
         const resultP = repoManagerFactory.open(
             request.params.owner,
             request.params.repo,
-        ).then(async (repoManager) => deleteSummary(repoManager, softDelete));
+        ).then(async (repoManager) => repoManager.deleteSummary(documentId, softDelete));
         handleResponse(resultP, response, 204);
     });
 

--- a/server/gitrest/src/runner.ts
+++ b/server/gitrest/src/runner.ts
@@ -8,7 +8,7 @@ import { IWebServer, IWebServerFactory, IRunner } from "@fluidframework/server-s
 import { Provider } from "nconf";
 import * as winston from "winston";
 import * as app from "./app";
-import { IRepositoryManagerFactory } from "./utils";
+import { IFileSystemManager, IRepositoryManagerFactory } from "./utils";
 
 export class GitrestRunner implements IRunner {
     private server: IWebServer;
@@ -18,13 +18,14 @@ export class GitrestRunner implements IRunner {
         private readonly serverFactory: IWebServerFactory,
         private readonly config: Provider,
         private readonly port: string | number,
+        private readonly fileSystemManager: IFileSystemManager,
         private readonly repositoryManagerFactory: IRepositoryManagerFactory) {
     }
 
     public async start(): Promise<void> {
         this.runningDeferred = new Deferred<void>();
         // Create the gitrest app
-        const gitrest = app.create(this.config, this.repositoryManagerFactory);
+        const gitrest = app.create(this.config, this.fileSystemManager, this.repositoryManagerFactory);
         gitrest.set("port", this.port);
 
         this.server = this.serverFactory.create(gitrest);

--- a/server/gitrest/src/runnerFactory.ts
+++ b/server/gitrest/src/runnerFactory.ts
@@ -10,7 +10,7 @@ import * as core from "@fluidframework/server-services-core";
 import { normalizePort } from "@fluidframework/server-services-utils";
 import { ExternalStorageManager } from "./externalStorageManager";
 import { GitrestRunner } from "./runner";
-import { IRepositoryManagerFactory, NodegitRepositoryManagerFactory } from "./utils";
+import { IFileSystemManager, IRepositoryManagerFactory, NodegitRepositoryManagerFactory } from "./utils";
 
 export class GitrestResources implements core.IResources {
     public webServerFactory: core.IWebServerFactory;
@@ -18,6 +18,7 @@ export class GitrestResources implements core.IResources {
     constructor(
         public readonly config: Provider,
         public readonly port: string | number,
+        public readonly fileSystemManager: IFileSystemManager,
         public readonly repositoryManagerFactory: IRepositoryManagerFactory) {
         this.webServerFactory = new services.BasicWebServerFactory();
     }
@@ -34,24 +35,19 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
         const externalStorageManager = new ExternalStorageManager(config);
         const storageDirectory = config.get("storageDir");
         const gitLibrary: string | undefined = config.get("git:lib:name");
-        const persistLatestFullSummary: boolean =
-            config.get("git:persistLatestFullSummary") ?? false;
         const getRepositoryManagerFactory = () => {
             if (!gitLibrary || gitLibrary === "nodegit") {
                 return new NodegitRepositoryManagerFactory(
                     storageDirectory,
                     fileSystemManager,
                     externalStorageManager,
-                    {
-                        persistLatestFullSummary,
-                    },
                 );
             }
             throw new Error("Invalid git library name.");
         };
         const repositoryManagerFactory = getRepositoryManagerFactory();
 
-        return new GitrestResources(config, port, repositoryManagerFactory);
+        return new GitrestResources(config, port, fileSystemManager, repositoryManagerFactory);
     }
 }
 
@@ -61,6 +57,7 @@ export class GitrestRunnerFactory implements core.IRunnerFactory<GitrestResource
             resources.webServerFactory,
             resources.config,
             resources.port,
+            resources.fileSystemManager,
             resources.repositoryManagerFactory);
     }
 }

--- a/server/gitrest/src/runnerFactory.ts
+++ b/server/gitrest/src/runnerFactory.ts
@@ -48,7 +48,7 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
                 );
             }
             throw new Error("Invalid git library name.");
-        }
+        };
         const repositoryManagerFactory = getRepositoryManagerFactory();
 
         return new GitrestResources(config, port, repositoryManagerFactory);

--- a/server/gitrest/src/runnerFactory.ts
+++ b/server/gitrest/src/runnerFactory.ts
@@ -35,7 +35,7 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
         const storageDirectory = config.get("storageDir");
         const gitLibrary: string | undefined = config.get("git:lib:name");
         const persistLatestFullSummary: boolean =
-            config.get("git:lib:persistLatestFullSummary") ?? false;
+            config.get("git:persistLatestFullSummary") ?? false;
         const getRepositoryManagerFactory = () => {
             if (!gitLibrary || gitLibrary === "nodegit") {
                 return new NodegitRepositoryManagerFactory(

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -152,6 +152,7 @@ describe("GitRest", () => {
             testUtils.defaultProvider.get("storageDir"),
             fsPromises,
             externalStorageManager,
+            { persistLatestFullSummary: true }
         );
 
         testUtils.initializeBeforeAfterTestHooks(testUtils.defaultProvider);

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -152,7 +152,6 @@ describe("GitRest", () => {
             testUtils.defaultProvider.get("storageDir"),
             fsPromises,
             externalStorageManager,
-            { persistLatestFullSummary: true },
         );
 
         testUtils.initializeBeforeAfterTestHooks(testUtils.defaultProvider);
@@ -161,7 +160,7 @@ describe("GitRest", () => {
         let supertest: request.SuperTest<request.Test>;
         beforeEach(() => {
             const repoManagerFactory = getRepoManagerFactory();
-            const testApp = app.create(testUtils.defaultProvider, repoManagerFactory);
+            const testApp = app.create(testUtils.defaultProvider, fsPromises, repoManagerFactory);
             supertest = request(testApp);
         });
 

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -152,7 +152,7 @@ describe("GitRest", () => {
             testUtils.defaultProvider.get("storageDir"),
             fsPromises,
             externalStorageManager,
-            { persistLatestFullSummary: true }
+            { persistLatestFullSummary: true },
         );
 
         testUtils.initializeBeforeAfterTestHooks(testUtils.defaultProvider);

--- a/server/gitrest/src/utils/definitions.ts
+++ b/server/gitrest/src/utils/definitions.ts
@@ -5,13 +5,13 @@
 
 import fsPromises from "fs/promises";
 import * as git from "@fluidframework/gitresources";
-import { IWholeFlatSummary, IWholeSummaryPayload, IWriteSummaryResponse } from "@fluidframework/server-services-client";
 
 export interface IExternalWriterConfig {
     enabled: boolean;
 }
 
 export interface IRepositoryManager {
+    path: string;
     getCommit(sha: string): Promise<git.ICommit>;
     getCommits(sha: string, count: number, externalWriterConfig?: IExternalWriterConfig): Promise<git.ICommitDetails[]>;
     getTree(root: string, recursive: boolean): Promise<git.ITree>;
@@ -28,11 +28,6 @@ export interface IRepositoryManager {
     deleteRef(refId: string): Promise<void>;
     getTag(tagId: string): Promise<git.ITag>;
     createTag(tagParams: git.ICreateTagParams): Promise<git.ITag>;
-    // eslint-disable-next-line max-len
-    getSummary(sha: string, documentId: string, externalWriterConfig?: IExternalWriterConfig): Promise<IWholeFlatSummary>;
-    // eslint-disable-next-line max-len
-    createSummary(payload: IWholeSummaryPayload, documentId: string, externalWriterConfig?: IExternalWriterConfig): Promise<IWriteSummaryResponse | IWholeFlatSummary>;
-    deleteSummary(documentId: string, softDelete: boolean): Promise<boolean>;
 }
 
 /**

--- a/server/gitrest/src/utils/definitions.ts
+++ b/server/gitrest/src/utils/definitions.ts
@@ -5,6 +5,7 @@
 
 import fsPromises from "fs/promises";
 import * as git from "@fluidframework/gitresources";
+import { IWholeFlatSummary, IWholeSummaryPayload, IWriteSummaryResponse } from "@fluidframework/server-services-client";
 
 export interface IExternalWriterConfig {
     enabled: boolean;
@@ -27,6 +28,11 @@ export interface IRepositoryManager {
     deleteRef(refId: string): Promise<void>;
     getTag(tagId: string): Promise<git.ITag>;
     createTag(tagParams: git.ICreateTagParams): Promise<git.ITag>;
+    // eslint-disable-next-line max-len
+    getSummary(sha: string, documentId: string, externalWriterConfig?: IExternalWriterConfig): Promise<IWholeFlatSummary>;
+    // eslint-disable-next-line max-len
+    createSummary(payload: IWholeSummaryPayload, documentId: string, externalWriterConfig?: IExternalWriterConfig): Promise<IWriteSummaryResponse | IWholeFlatSummary>;
+    deleteSummary(documentId: string, softDelete: boolean): Promise<boolean>;
 }
 
 /**

--- a/server/gitrest/src/utils/helpers.ts
+++ b/server/gitrest/src/utils/helpers.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IGetRefParamsExternal } from "@fluidframework/server-services-client";
-import { IExternalWriterConfig } from "./definitions";
+import { IGetRefParamsExternal, IWholeFlatSummary } from "@fluidframework/server-services-client";
+import { PathLike } from "fs";
+import { IExternalWriterConfig, IFileSystemManager } from "./definitions";
 
 /**
  * Validates that the input encoding is valid
@@ -29,4 +30,55 @@ export function getExternalWriterParams(params: string | undefined): IExternalWr
         return getRefParams.config;
     }
     return undefined;
+}
+
+export async function exists(fileSystemManager: IFileSystemManager, fileOrDirectoryPath: PathLike): Promise<boolean> {
+    try {
+        await fileSystemManager.stat(fileOrDirectoryPath);
+        return true;
+    } catch (error) {
+        if (error?.code === "ENOENT") {
+            // File/Directory does not exist.
+            return false;
+        }
+        throw error;
+    }
+};
+
+const latestFullSummaryFilename = "latestFullSummary";
+const getLatestFullSummaryFilePath = (dir: string) => `${dir}/${latestFullSummaryFilename}`
+
+export async function persistLatestFullSummaryInStorage(
+    fileSystemManager: IFileSystemManager,
+    storageDirectoryPath: string,
+    latestFullSummary: IWholeFlatSummary,
+): Promise<void> {
+    const directoryExists = await exists(fileSystemManager, storageDirectoryPath);
+    if (!directoryExists) {
+        await fileSystemManager.mkdir(storageDirectoryPath);
+    }
+    await fileSystemManager.writeFile(
+        getLatestFullSummaryFilePath(storageDirectoryPath),
+        JSON.stringify(latestFullSummary),
+    );
+}
+
+export async function retrieveLatestFullSummaryFromStorage(
+    fileSystemManager: IFileSystemManager,
+    storageDirectoryPath: string,
+): Promise<IWholeFlatSummary | undefined> {
+    try {
+        const summaryFile = await fileSystemManager.readFile(
+            getLatestFullSummaryFilePath(storageDirectoryPath),
+        );
+        // TODO: This will be converted back to a JSON string for the HTTP response
+        const summary: IWholeFlatSummary = JSON.parse(summaryFile.toString());
+        return summary;
+    } catch (error) {
+        if (error?.code === "ENOENT") {
+            // File does not exist.
+            return undefined
+        }
+        throw error;
+    }
 }

--- a/server/gitrest/src/utils/helpers.ts
+++ b/server/gitrest/src/utils/helpers.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IGetRefParamsExternal, IWholeFlatSummary } from "@fluidframework/server-services-client";
 import { PathLike } from "fs";
+import { IGetRefParamsExternal, IWholeFlatSummary } from "@fluidframework/server-services-client";
 import { IExternalWriterConfig, IFileSystemManager } from "./definitions";
 
 /**
@@ -43,10 +43,10 @@ export async function exists(fileSystemManager: IFileSystemManager, fileOrDirect
         }
         throw error;
     }
-};
+}
 
 const latestFullSummaryFilename = "latestFullSummary";
-const getLatestFullSummaryFilePath = (dir: string) => `${dir}/${latestFullSummaryFilename}`
+const getLatestFullSummaryFilePath = (dir: string) => `${dir}/${latestFullSummaryFilename}`;
 
 export async function persistLatestFullSummaryInStorage(
     fileSystemManager: IFileSystemManager,
@@ -77,7 +77,7 @@ export async function retrieveLatestFullSummaryFromStorage(
     } catch (error) {
         if (error?.code === "ENOENT") {
             // File does not exist.
-            return undefined
+            return undefined;
         }
         throw error;
     }

--- a/server/gitrest/src/utils/index.ts
+++ b/server/gitrest/src/utils/index.ts
@@ -6,3 +6,4 @@
 export * from "./definitions";
 export * from "./helpers";
 export * from "./nodegitManager";
+export * from "./gitWholeSummaryManager";

--- a/server/gitrest/src/utils/wholeSummaryManagers.ts
+++ b/server/gitrest/src/utils/wholeSummaryManagers.ts
@@ -1,0 +1,312 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ICreateCommitParams,
+    ICreateTreeEntry,
+} from "@fluidframework/gitresources";
+import { getGitMode, getGitType } from "@fluidframework/protocol-base";
+import { SummaryObject, SummaryType } from "@fluidframework/protocol-definitions";
+import {
+    IWholeFlatSummary,
+    IWholeFlatSummaryBlob,
+    IWholeFlatSummaryTreeEntry,
+    IWholeSummaryBlob,
+    IWholeSummaryPayload,
+    IWholeSummaryTree,
+    IWholeSummaryTreeHandleEntry,
+    IWholeSummaryTreeValueEntry,
+    IWriteSummaryResponse,
+    NetworkError,
+    WholeSummaryTreeEntry,
+} from "@fluidframework/server-services-client";
+import { IRepositoryManager } from "../utils";
+
+interface ISummaryVersion {
+    id: string;
+    treeId: string;
+}
+
+export const latestSummarySha = "latest";
+
+export class WholeSummaryReadGitManager {
+    constructor(
+        private readonly documentId: string,
+        private readonly repoManager: IRepositoryManager,
+        private readonly externalStorageEnabled = true,
+    ) {}
+
+    public async readSummary(sha: string): Promise<IWholeFlatSummary> {
+        let version: ISummaryVersion;
+        if (sha === latestSummarySha) {
+            version = await this.getLatestVersion();
+        } else {
+            const commit = await this.repoManager.getCommit(sha);
+            version = { id: commit.sha, treeId: commit.tree.sha };
+        }
+        const rawTree = await this.repoManager.getTree(version.treeId, true /* recursive */);
+        const wholeFlatSummaryTreeEntries: IWholeFlatSummaryTreeEntry[] = [];
+        const wholeFlatSummaryBlobPs: Promise<IWholeFlatSummaryBlob>[] = [];
+        rawTree.tree.forEach((treeEntry) => {
+            if (treeEntry.type === "blob") {
+                wholeFlatSummaryTreeEntries.push({
+                    type: "blob",
+                    id: treeEntry.sha,
+                    path: treeEntry.path,
+                });
+                wholeFlatSummaryBlobPs.push(
+                    this.getBlob(
+                        treeEntry.sha,
+                    ),
+                );
+            } else {
+                wholeFlatSummaryTreeEntries.push({
+                    type: "tree",
+                    path: treeEntry.path,
+                });
+            }
+        });
+        const wholeFlatSummaryBlobs = await Promise.all(wholeFlatSummaryBlobPs);
+        return {
+            id: version.id,
+            trees: [
+                {
+                    id: rawTree.sha,
+                    entries: wholeFlatSummaryTreeEntries,
+                    // We don't store sequence numbers in git
+                    sequenceNumber: undefined,
+                },
+            ],
+            blobs: wholeFlatSummaryBlobs,
+        };
+    }
+
+    private async getBlob(sha: string): Promise<IWholeFlatSummaryBlob> {
+        const blob = await this.repoManager.getBlob(
+            sha,
+        );
+        return {
+            content: blob.content,
+            encoding: blob.encoding === "base64" ? "base64" : "utf-8",
+            id: blob.sha,
+            size: blob.size,
+        };
+    }
+
+    private async getLatestVersion(): Promise<ISummaryVersion> {
+        const commitDetails = await this.repoManager.getCommits(
+            this.documentId,
+            1,
+            { enabled: this.externalStorageEnabled },
+        );
+        return {
+            id: commitDetails[0].sha,
+            treeId: commitDetails[0].commit.tree.sha,
+        };
+    }
+}
+
+function getSummaryObjectFromWholeSummaryTreeEntry(entry: WholeSummaryTreeEntry): SummaryObject {
+    if ((entry as IWholeSummaryTreeHandleEntry).id !== undefined) {
+        return {
+            type: SummaryType.Handle,
+            handleType: entry.type === "tree" ? SummaryType.Tree : SummaryType.Blob,
+            handle: (entry as IWholeSummaryTreeHandleEntry).id,
+        };
+    }
+    if (entry.type === "blob") {
+        return {
+            type: SummaryType.Blob,
+            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
+            content: "",
+        };
+    }
+    if (entry.type === "tree") {
+        return {
+            type: SummaryType.Tree,
+            // We don't use this in the code below. We mostly just care about summaryObject for type inference.
+            tree: {},
+            unreferenced: (entry as IWholeSummaryTreeValueEntry).unreferenced,
+        };
+    }
+    throw new NetworkError(400, `Unknown entry type: ${entry.type}`);
+}
+
+export class WholeSummaryWriteGitManager {
+    private readonly entryHandleToObjectShaCache: Map<string, string> = new Map();
+
+    constructor(
+        private readonly documentId: string,
+        private readonly repoManager: IRepositoryManager,
+        private readonly externalStorageEnabled = true,
+    ) {}
+
+    public async writeSummary(payload: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
+        if (payload.type === "channel") {
+            const summaryTreeHandle = await this.writeChannelSummary(payload);
+            return {
+                id: summaryTreeHandle,
+            };
+        }
+        if (payload.type === "container") {
+            const writeSummaryResponse = await this.writeContainerSummary(payload);
+            return writeSummaryResponse;
+        }
+        throw new NetworkError(400, `Unknown Summary Type: ${payload.type}`);
+    }
+
+    private async writeChannelSummary(payload: IWholeSummaryPayload): Promise<string> {
+        return this.writeSummaryTreeCore(payload.entries);
+    }
+
+    private async writeContainerSummary(payload: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
+        const treeHandle = await this.writeSummaryTreeCore(
+            payload.entries,
+            "",
+        );
+        const existingRef = await this.repoManager.getRef(
+            `refs/heads/${this.documentId}`,
+            { enabled: this.externalStorageEnabled },
+        ).catch(() => undefined);
+        let commitParams: ICreateCommitParams;
+        if (!existingRef && payload.sequenceNumber === 0) {
+            // Create new document
+            commitParams = {
+                author: {
+                    date: new Date().toISOString(),
+                    email: "dummy@microsoft.com",
+                    name: "GitRest Service",
+                },
+                message: "New document",
+                parents: [],
+                tree: treeHandle,
+            };
+        } else {
+            // Update existing document
+            commitParams = {
+                author: {
+                    date: new Date().toISOString(),
+                    email: "dummy@microsoft.com",
+                    name: "GitRest Service",
+                },
+                // TODO: How to know if Service/Client Summary?
+                // .app handle embedded=true looks to be an indicator. Is it worth checking?
+                message: `Service/Client Summary @${payload.sequenceNumber}`,
+                parents: existingRef ? [existingRef.object.sha] : [],
+                tree: treeHandle,
+            };
+        }
+        const commit = await this.repoManager.createCommit(commitParams);
+        if (existingRef) {
+            await this.repoManager.patchRef(
+                `refs/heads/${this.documentId}`,
+                {
+                    force: true,
+                    sha: commit.sha,
+                },
+                { enabled: this.externalStorageEnabled },
+            );
+        } else {
+            await this.repoManager.createRef(
+                {
+                    ref: `refs/heads/${this.documentId}`,
+                    sha: commit.sha,
+                },
+                { enabled: this.externalStorageEnabled },
+            );
+        }
+        return {
+            id: commit.sha,
+        };
+    }
+
+    private async writeSummaryTreeCore(
+        wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
+        currentPath: string = "",
+    ): Promise<string> {
+        const entries: ICreateTreeEntry[] = await Promise.all(wholeSummaryTreeEntries.map(async (entry) => {
+            const summaryObject = getSummaryObjectFromWholeSummaryTreeEntry(entry);
+            const type = getGitType(summaryObject);
+            const path = entry.path;
+            const fullPath = currentPath ? `${currentPath}/${entry.path}` : entry.path;
+            const pathHandle = await this.writeSummaryTreeObject(
+                entry,
+                summaryObject,
+                fullPath,
+            );
+            return {
+                mode: getGitMode(summaryObject),
+                path,
+                sha: pathHandle,
+                type,
+            };
+        }));
+
+        const createdTree = await this.repoManager.createTree(
+            { tree: entries },
+        );
+        return createdTree.sha;
+    }
+
+    private async writeSummaryTreeObject(
+        wholeSummaryTreeEntry: WholeSummaryTreeEntry,
+        summaryObject: SummaryObject,
+        currentPath: string,
+    ): Promise<string> {
+        switch(summaryObject.type) {
+            case SummaryType.Blob:
+                return this.writeSummaryBlob(
+                    ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryBlob),
+                );
+            case SummaryType.Tree:
+                return this.writeSummaryTreeCore(
+                    ((wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry).value as IWholeSummaryTree).entries ?? [],
+                    currentPath,
+                );
+            case SummaryType.Handle:
+                return this.getShaFromTreeHandleEntry(wholeSummaryTreeEntry as IWholeSummaryTreeHandleEntry);
+            default:
+                throw new NetworkError(501, "Not Implemented");
+        }
+    }
+
+    private async writeSummaryBlob(blob: IWholeSummaryBlob): Promise<string> {
+        const blobResponse = await this.repoManager.createBlob(
+            {
+                content: blob.content,
+                encoding: blob.encoding,
+            },
+        );
+        return blobResponse.sha;
+    }
+
+    private async getShaFromTreeHandleEntry(entry: IWholeSummaryTreeHandleEntry): Promise<string> {
+        if (!entry.id) {
+            throw new NetworkError(400, `Empty summary tree handle`);
+        }
+        if (entry.id.split("/").length === 1) {
+            // The entry id is already a sha, so just return it
+            return entry.id;
+        }
+
+        const cachedSha = this.entryHandleToObjectShaCache.get(entry.id);
+        if (cachedSha) {
+            return cachedSha;
+        }
+
+        // The entry id is in the format { id: `<parent commit sha>/<tree path>`, path: `<tree path>` }
+        const parentHandle = entry.id.split("/")[0];
+        const parentCommit = await this.repoManager.getCommit(parentHandle);
+        const parentTree = await this.repoManager.getTree(parentCommit.tree.sha, true /* recursive */);
+        for (const treeEntry of parentTree.tree) {
+            this.entryHandleToObjectShaCache.set(`${parentHandle}/${treeEntry.path}`, treeEntry.sha);
+        }
+        const sha = this.entryHandleToObjectShaCache.get(entry.id);
+        if (!sha) {
+            throw new NetworkError(404, `Summary tree handle object not found: id: ${entry.id}, path: ${entry.path}`);
+        }
+        return sha;
+    }
+}


### PR DESCRIPTION
Optional ability to persist the latest pre-computed full summary in storage on write. Disabled by default. More relevant for remote filesystems than local.

Highlights:
- Move `WholeSummaryManager` classes to their own file and rename as single class `GitWholeSummaryManager`
- ~~Add `createSummary` and `readSummary` to `IRepositoryManager`~~
- ~~Consume `WholeSummaryManager`s within RepositoryManager instead of within summaries routes file (all FS operations for a given document must be done within a given repo path, which only the RepositoryManager knows)~~
- Add (optional) plumbing for future transition to [isomorphic-git](https://github.com/isomorphic-git/isomorphic-git) from nodegit.