### PR TITLE
Always log DeltaConnectionFailureToConnect

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -107,6 +107,9 @@ export function buildSnapshotTree(entries: ITreeEntry[], blobMap: Map<string, Ar
 // @public
 export const canRetryOnError: (error: any) => boolean;
 
+// @public (undocumented)
+export function checkConnectionType(): string | undefined;
+
 // @public
 export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolSummary: ISummaryTree): ISummaryTree;
 

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -188,10 +188,10 @@ export function getDocAttributesFromProtocolSummary(protocolSummary: ISummaryTre
 // @public
 export function getQuorumValuesFromProtocolSummary(protocolSummary: ISummaryTree): [string, ICommittedProposal][];
 
-// @public (undocumented)
+// @public
 export const getRetryDelayFromError: (error: any) => number | undefined;
 
-// @public (undocumented)
+// @public
 export const getRetryDelaySecondsFromError: (error: any) => number | undefined;
 
 // @public

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -107,9 +107,6 @@ export function buildSnapshotTree(entries: ITreeEntry[], blobMap: Map<string, Ar
 // @public
 export const canRetryOnError: (error: any) => boolean;
 
-// @public (undocumented)
-export function checkConnectionType(): string | undefined;
-
 // @public
 export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolSummary: ISummaryTree): ISummaryTree;
 

--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "0.27.0",
+  "version": "0.27.2000",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -232,16 +232,10 @@ export class OdspDocumentService implements IDocumentService {
         failedConnectionStep: string,
         separateTokenRequest: boolean,
     ): IFluidErrorBase {
-        const normalizedError = normalizeError(error, { props: {
+        return normalizeError(error, { props: {
             failedConnectionStep,
             separateTokenRequest,
         }});
-
-        // We need to preserve these properties which are used in a non-typesafe way throughout driver code
-        const { canRetry, retryAfterSeconds } = error;
-        Object.assign(normalizeError, { canRetry, retryAfterSeconds });
-
-        return normalizedError;
     }
 
     /**

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -7,6 +7,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { performance } from "@fluidframework/common-utils";
 import {
     ChildLogger,
+    IFluidErrorBase,
     loggerToMonitoringContext,
     MonitoringContext,
     normalizeError,
@@ -225,6 +226,19 @@ export class OdspDocumentService implements IDocumentService {
         );
     }
 
+    /** Annotate the given error indicated which connection step failed */
+    private annotateConnectionError(error: any, step: string): IFluidErrorBase {
+        const normalizedError = normalizeError(error, { props: {
+            failedStep: step,
+        }});
+
+        // We need to preserve these properties which are used in a non-typesafe way throughout driver code
+        const { canRetry, retryAfterSeconds } = error;
+        Object.assign(normalizeError, { canRetry, retryAfterSeconds });
+
+        return normalizedError;
+    }
+
     /**
      * Connects to a delta stream endpoint for emitting ops.
      *
@@ -240,25 +254,16 @@ export class OdspDocumentService implements IDocumentService {
                 ? Promise.resolve(null)
                 : this.getWebsocketToken!(options);
 
-            // Annotates the error with the given step and then rethrows, preserving canRetry and retryAfterSeconds
-            const annotateConnectionError = (step: string) => (error: any) => {
-                const normalizedError = normalizeError(error, { props: {
-                    failedStep: step,
-                }});
-
-                // We need to preserve these properties which are used in a non-typesafe way throughout driver code
-                const { canRetry, retryAfterSeconds } = error;
-                Object.assign(normalizeError, { canRetry, retryAfterSeconds });
-
-                throw normalizedError;
+            const annotateAndRethrowConnectionError = (step: string) => (error: any) => {
+                throw this.annotateConnectionError(error, step);
             };
 
             const joinSessionPromise = this.joinSession(requestWebsocketTokenFromJoinSession, options);
             const [websocketEndpoint, websocketToken, io] =
                 await Promise.all([
-                    joinSessionPromise.catch(annotateConnectionError("joinSession")),
-                    websocketTokenPromise.catch(annotateConnectionError("getWebsocketToken")),
-                    this.socketIoClientFactory().catch(annotateConnectionError("socketIoClientFactory")),
+                    joinSessionPromise.catch(annotateAndRethrowConnectionError("joinSession")),
+                    websocketTokenPromise.catch(annotateAndRethrowConnectionError("getWebsocketToken")),
+                    this.socketIoClientFactory().catch(annotateAndRethrowConnectionError("socketIoClientFactory")),
                 ]);
 
             const finalWebsocketToken = websocketToken ?? (websocketEndpoint.socketToken || null);
@@ -293,10 +298,12 @@ export class OdspDocumentService implements IDocumentService {
                 return connection;
             } catch (error) {
                 this.cache.sessionJoinCache.remove(this.joinSessionKey);
+
+                const normalizedError = this.annotateConnectionError(error, "connectToDeltaStreamWithRetry");
                 if (typeof error === "object" && error !== null) {
-                    error.socketDocumentId = websocketEndpoint.id;
+                    normalizedError.addTelemetryProperties({socketDocumentId: websocketEndpoint.id});
                 }
-                throw error;
+                throw normalizedError;
             }
         });
     }

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -226,10 +226,10 @@ export class OdspDocumentService implements IDocumentService {
         );
     }
 
-    /** Annotate the given error indicated which connection step failed */
+    /** Annotate the given error indicating which connection step failed */
     private annotateConnectionError(error: any, step: string): IFluidErrorBase {
         const normalizedError = normalizeError(error, { props: {
-            failedStep: step,
+            failedConnectionStep: step,
         }});
 
         // We need to preserve these properties which are used in a non-typesafe way throughout driver code
@@ -268,10 +268,13 @@ export class OdspDocumentService implements IDocumentService {
 
             const finalWebsocketToken = websocketToken ?? (websocketEndpoint.socketToken || null);
             if (finalWebsocketToken === null) {
-                throw new NonRetryableError(
-                    "Websocket token is null",
-                    OdspErrorType.fetchTokenError,
-                    { driverVersion });
+                throw this.annotateConnectionError(
+                    new NonRetryableError(
+                        "Websocket token is null",
+                        OdspErrorType.fetchTokenError,
+                        { driverVersion },
+                    ),
+                    "getWebsocketToken");
             }
             try {
                 const connection = await this.connectToDeltaStreamWithRetry(

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -47,20 +47,21 @@ export async function fetchJoinSession(
 ): Promise<ISocketStorageDiscovery> {
     const token = await getStorageToken(options, "JoinSession");
 
+    const tokenRefreshProps = options.refresh
+        ? { hasClaims: !!options.claims, hasTenantId: !!options.tenantId }
+        : {};
     const details: ITelemetryProperties = {
         refreshedToken: options.refresh,
         requestSocketToken,
+        ...tokenRefreshProps,
     };
-    if (options.refresh) {
-        details.hasClaims = !!options.claims;
-        details.hasTenantId = !!options.tenantId;
-    }
 
     return PerformanceEvent.timedExecAsync(
         logger, {
             eventName: "JoinSession",
             attempts: options.refresh ? 2 : 1,
             details: JSON.stringify(details),
+            ...tokenRefreshProps,
         },
         async (event) => {
             const siteOrigin = getOrigin(urlParts.siteUrl);

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -25,11 +25,11 @@ import {
 } from "@fluidframework/driver-definitions";
 import {
     canRetryOnError,
+    checkConnectionType,
     createWriteError,
     createGenericNetworkError,
     getRetryDelayFromError,
     IAnyDriverError,
-    logNetworkFailure,
     waitForConnectedState,
     DeltaStreamConnectionForbiddenError,
 } from "@fluidframework/driver-utils";
@@ -490,13 +490,13 @@ export class ConnectionManager implements IConnectionManager {
                     throw error;
                 }
 
-                logNetworkFailure(
-                    this.logger,
+                this.logger.sendTelemetryEvent(
                     {
                         attempts: connectRepeatCount,
                         delay: delayMs, // milliseconds
                         eventName: "DeltaConnectionFailureToConnect",
                         duration: TelemetryLogger.formatTick(performance.now() - connectStartTime),
+                        connectionType: checkConnectionType(),
                     },
                     origError);
 
@@ -519,6 +519,7 @@ export class ConnectionManager implements IConnectionManager {
                     eventName: "MultipleDeltaConnectionFailures",
                     attempts: connectRepeatCount,
                     duration: TelemetryLogger.formatTick(performance.now() - connectStartTime),
+                    connectionType: checkConnectionType(),
                 },
                 lastError,
             );

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -490,18 +490,15 @@ export class ConnectionManager implements IConnectionManager {
                     throw error;
                 }
 
-                // Log error once - we get too many errors in logs when we are offline,
-                // and unfortunately there is no reliable way to detect that.
-                if (connectRepeatCount === 1) {
-                    logNetworkFailure(
-                        this.logger,
-                        {
-                            delay: delayMs, // milliseconds
-                            eventName: "DeltaConnectionFailureToConnect",
-                            duration: TelemetryLogger.formatTick(performance.now() - connectStartTime),
-                        },
-                        origError);
-                }
+                logNetworkFailure(
+                    this.logger,
+                    {
+                        attempts: connectRepeatCount,
+                        delay: delayMs, // milliseconds
+                        eventName: "DeltaConnectionFailureToConnect",
+                        duration: TelemetryLogger.formatTick(performance.now() - connectStartTime),
+                    },
+                    origError);
 
                 lastError = origError;
 

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -160,8 +160,10 @@ export function createGenericNetworkError(
  */
 export const canRetryOnError = (error: any): boolean => error?.canRetry === true;
 
+/** Check retryAfterSeconds property on error */
 export const getRetryDelaySecondsFromError = (error: any): number | undefined =>
     error?.retryAfterSeconds as number | undefined;
 
+/** Check retryAfterSeconds property on error and convert to ms */
 export const getRetryDelayFromError = (error: any): number | undefined => error?.retryAfterSeconds !== undefined ?
     error.retryAfterSeconds * 1000 : undefined;

--- a/packages/loader/driver-utils/src/networkUtils.ts
+++ b/packages/loader/driver-utils/src/networkUtils.ts
@@ -6,33 +6,24 @@
 import { ITelemetryErrorEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { isOnline, OnlineStatus, canRetryOnError } from "./network";
 
-export function checkConnectionType() {
+export function logNetworkFailure(logger: ITelemetryLogger, event: ITelemetryErrorEvent, error?: any) {
+    const newEvent = { ...event };
+
+    const errorOnlineProp = error.online;
+    newEvent.online = typeof errorOnlineProp === "string"
+        ? errorOnlineProp
+        : OnlineStatus[isOnline()];
+
     if (typeof navigator === "object" && navigator !== null) {
         const nav = navigator as any;
         const connection = nav.connection ?? nav.mozConnection ?? nav.webkitConnection;
         if (connection !== null && typeof connection === "object") {
-            return String(connection.type);
+            newEvent.connectionType = connection.type;
         }
     }
-    return undefined;
-}
 
-export function logNetworkFailure(logger: ITelemetryLogger, event: ITelemetryErrorEvent, error?: any) {
-    const newEvent = { ...event };
-    newEvent.online = isOnline();
-    if (error?.online !== undefined) {
-        newEvent.online = error.online as string;
-    }
-    const connectionType = checkConnectionType();
-    if (connectionType !== undefined) {
-        newEvent.connectionType = connectionType;
-    }
-
-    // If we are online, log it as an error, such that we look at it ASAP.
-    // But if we are offline, log non-error event - we will remove
-    // it in the future once confident it's right thing to do.
-    // Note: Unfortunately false positives happen in here (i.e. cable disconnected, but it reports true)!
-    newEvent.category = (newEvent.online === OnlineStatus.Online || !canRetryOnError(error)) ? "error" : "generic";
+    // non-retryable errors are fatal and should be logged as errors
+    newEvent.category = canRetryOnError(error) ? "generic" : "error";
     logger.sendTelemetryEvent(newEvent, error);
 }
 

--- a/packages/loader/driver-utils/src/networkUtils.ts
+++ b/packages/loader/driver-utils/src/networkUtils.ts
@@ -6,18 +6,26 @@
 import { ITelemetryErrorEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { isOnline, OnlineStatus, canRetryOnError } from "./network";
 
+export function checkConnectionType() {
+    if (typeof navigator === "object" && navigator !== null) {
+        const nav = navigator as any;
+        const connection = nav.connection ?? nav.mozConnection ?? nav.webkitConnection;
+        if (connection !== null && typeof connection === "object") {
+            return String(connection.type);
+        }
+    }
+    return undefined;
+}
+
 export function logNetworkFailure(logger: ITelemetryLogger, event: ITelemetryErrorEvent, error?: any) {
     const newEvent = { ...event };
     newEvent.online = isOnline();
     if (error?.online !== undefined) {
         newEvent.online = error.online as string;
     }
-    if (typeof navigator === "object" && navigator !== null) {
-        const nav = navigator as any;
-        const connection = nav.connection ?? nav.mozConnection ?? nav.webkitConnection;
-        if (connection !== null && typeof connection === "object") {
-            newEvent.connectionType = connection.type;
-        }
+    const connectionType = checkConnectionType();
+    if (connectionType !== undefined) {
+        newEvent.connectionType = connectionType;
     }
 
     // If we are online, log it as an error, such that we look at it ASAP.

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -419,6 +419,7 @@ async function getSingleOpBatch(
 
             const retryAfter = getRetryDelayFromError(error);
 
+            // This will log to error table only if the error is non-retryable
             logNetworkFailure(
                 logger,
                 {

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -126,6 +126,14 @@ export function normalizeError(
         untrustedOrigin: 1, // This will let us filter to errors not originated by our own code
     });
 
+    // We need to preserve these properties which are used in a non-typesafe way throughout driver code (see #8743)
+    // Anywhere they are set should be on a valid Fluid Error that would have been returned above,
+    // but we can't prove it with the types, so adding this defensive measure.
+    if (typeof error === "object" && error !== null) {
+        const { canRetry, retryAfterSeconds } = error as any;
+        Object.assign(normalizeError, { canRetry, retryAfterSeconds });
+    }
+
     if (typeof(error) !== "object") {
         // This is only interesting for non-objects
         fluidError.addTelemetryProperties({ typeofError: typeof(error) });


### PR DESCRIPTION
When analyzing sessions that fail to connect, we don't have the luxury of the "MultipleDeltaConnectionFailures" telemetry event.  We are already logging JoinSession_end over and over again (only once every 8 seconds!) so also logging "DeltaConnectionFailureToConnect" every time (instead of just once) feels ok.

This also adds additional context of which step failed (JoinSession, GetWebsocketToken, or initializing socket.io).  And makes a small tweak to how JoinSession logs extra props to reduce extra columns in our tables.

Also fixes #9185