### PR TITLE
[GitRest] Adding isomorphic-git implementation of git functionality

### DIFF
--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -2954,6 +2954,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
+    "async-lock": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.3.1.tgz",
+      "integrity": "sha512-zK7xap9UnttfbE23JmcrNIyueAn6jWshihJqA33U/hEnKprF/lVGBDsBv/bqLm2YMMl1DnpHhUY044eA0t1TUw=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3227,6 +3232,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
     },
     "clean-regexp": {
       "version": "1.0.0",
@@ -3634,6 +3644,21 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -3720,6 +3745,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
+    },
+    "diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha1-1OXDpM305f4SEatC5pP8tDIVgPw="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -5859,8 +5889,7 @@
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "ignore-walk": {
       "version": "3.0.4",
@@ -6132,6 +6161,36 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isomorphic-git": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.14.0.tgz",
+      "integrity": "sha512-YO9PPLnLLSZRQ/BMwnGZ78eAftaEzhoAAhCiI6zrgUq7NZF2V/lNYVtf2ypes7Bj8+SgOn/HCv1ssIaPw/PYsA==",
+      "requires": {
+        "async-lock": "^1.1.0",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -6772,6 +6831,14 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "minipass": {
       "version": "2.9.0",
@@ -7815,6 +7882,11 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7872,6 +7944,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "pluralize": {
       "version": "8.0.0",
@@ -8439,6 +8516,21 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
       "integrity": "sha1-z9mIWOJJhnE0d3Xv47tRQfRsh9Y="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -40,6 +40,7 @@
     "cors": "^2.8.5",
     "debug": "^4.1.1",
     "express": "^4.16.4",
+    "isomorphic-git": "^1.14.0",
     "json-stringify-safe": "^5.0.1",
     "morgan": "^1.9.1",
     "nconf": "^0.11.0",

--- a/server/gitrest/src/runnerFactory.ts
+++ b/server/gitrest/src/runnerFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import fsPromises from "fs/promises";
+import fs from "fs";
 import { Provider } from "nconf";
 import * as services from "@fluidframework/server-services-shared";
 import * as core from "@fluidframework/server-services-core";
@@ -36,7 +36,7 @@ export class GitrestResources implements core.IResources {
 export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestResources> {
     public async create(config: Provider): Promise<GitrestResources> {
         const port = normalizePort(process.env.PORT || "3000");
-        const fileSystemManager = fsPromises;
+        const fileSystemManager = fs;
         const externalStorageManager = new ExternalStorageManager(config);
         const storageDirectory = config.get("storageDir");
         const gitLibrary: string | undefined = config.get("git:lib:name");

--- a/server/gitrest/src/runnerFactory.ts
+++ b/server/gitrest/src/runnerFactory.ts
@@ -10,7 +10,12 @@ import * as core from "@fluidframework/server-services-core";
 import { normalizePort } from "@fluidframework/server-services-utils";
 import { ExternalStorageManager } from "./externalStorageManager";
 import { GitrestRunner } from "./runner";
-import { IFileSystemManager, IRepositoryManagerFactory, NodegitRepositoryManagerFactory } from "./utils";
+import {
+    IFileSystemManager,
+    IRepositoryManagerFactory,
+    IsomorphicGitManagerFactory,
+    NodegitRepositoryManagerFactory,
+} from "./utils";
 
 export class GitrestResources implements core.IResources {
     public webServerFactory: core.IWebServerFactory;
@@ -41,6 +46,11 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
                     storageDirectory,
                     fileSystemManager,
                     externalStorageManager,
+                );
+            } else if (gitLibrary === "isomorphic-git") {
+                return new IsomorphicGitManagerFactory(
+                    storageDirectory,
+                    fileSystemManager,
                 );
             }
             throw new Error("Invalid git library name.");

--- a/server/gitrest/src/test/routes.spec.ts
+++ b/server/gitrest/src/test/routes.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "assert";
-import fsPromises from "fs/promises";
+import fs from "fs";
 import {
     ICreateBlobParams,
     ICreateBlobResponse,
@@ -150,7 +150,7 @@ describe("GitRest", () => {
         const externalStorageManager = new ExternalStorageManager(testUtils.defaultProvider);
         const getRepoManagerFactory = () => new NodegitRepositoryManagerFactory(
             testUtils.defaultProvider.get("storageDir"),
-            fsPromises,
+            fs,
             externalStorageManager,
         );
 
@@ -160,7 +160,7 @@ describe("GitRest", () => {
         let supertest: request.SuperTest<request.Test>;
         beforeEach(() => {
             const repoManagerFactory = getRepoManagerFactory();
-            const testApp = app.create(testUtils.defaultProvider, fsPromises, repoManagerFactory);
+            const testApp = app.create(testUtils.defaultProvider, fs, repoManagerFactory);
             supertest = request(testApp);
         });
 

--- a/server/gitrest/src/utils/definitions.ts
+++ b/server/gitrest/src/utils/definitions.ts
@@ -33,7 +33,7 @@ export interface IRepositoryManager {
 /**
  * Subset of Node.js `fs/promises` API.
  */
-export interface IFileSystemManager {
+export interface IFileSystemPromises {
     readFile: typeof fsPromises.readFile;
     writeFile: typeof fsPromises.writeFile;
     unlink: typeof fsPromises.unlink;
@@ -46,6 +46,13 @@ export interface IFileSystemManager {
     symlink: typeof fsPromises.symlink;
     chmod: typeof fsPromises.chmod;
     rm: typeof fsPromises.rm;
+}
+
+/**
+ * A filesystem representation.
+ */
+export interface IFileSystemManager {
+    promises: IFileSystemPromises;
 }
 
 export interface IRepositoryManagerFactory {

--- a/server/gitrest/src/utils/helpers.ts
+++ b/server/gitrest/src/utils/helpers.ts
@@ -37,7 +37,7 @@ export async function exists(
     fileOrDirectoryPath: PathLike,
 ): Promise<Stats | false> {
     try {
-        const fileOrDirectoryStats = await fileSystemManager.stat(fileOrDirectoryPath);
+        const fileOrDirectoryStats = await fileSystemManager.promises.stat(fileOrDirectoryPath);
         return fileOrDirectoryStats;
     } catch (error) {
         if (error?.code === "ENOENT") {
@@ -58,11 +58,11 @@ export async function persistLatestFullSummaryInStorage(
 ): Promise<void> {
     const directoryExists = await exists(fileSystemManager, storageDirectoryPath);
     if (directoryExists === false) {
-        await fileSystemManager.mkdir(storageDirectoryPath, { recursive: true });
+        await fileSystemManager.promises.mkdir(storageDirectoryPath, { recursive: true });
     } else if (!directoryExists.isDirectory()) {
         throw new NetworkError(400, "Document storage directory path is not a directory");
     }
-    await fileSystemManager.writeFile(
+    await fileSystemManager.promises.writeFile(
         getLatestFullSummaryFilePath(storageDirectoryPath),
         JSON.stringify(latestFullSummary),
     );
@@ -73,7 +73,7 @@ export async function retrieveLatestFullSummaryFromStorage(
     storageDirectoryPath: string,
 ): Promise<IWholeFlatSummary | undefined> {
     try {
-        const summaryFile = await fileSystemManager.readFile(
+        const summaryFile = await fileSystemManager.promises.readFile(
             getLatestFullSummaryFilePath(storageDirectoryPath),
         );
         // TODO: This will be converted back to a JSON string for the HTTP response

--- a/server/gitrest/src/utils/helpers.ts
+++ b/server/gitrest/src/utils/helpers.ts
@@ -4,6 +4,7 @@
  */
 
 import { PathLike, Stats } from "fs";
+import * as path from "path";
 import { IGetRefParamsExternal, IWholeFlatSummary, NetworkError } from "@fluidframework/server-services-client";
 import { IExternalWriterConfig, IFileSystemManager } from "./definitions";
 
@@ -86,4 +87,20 @@ export async function retrieveLatestFullSummaryFromStorage(
         }
         throw error;
     }
+}
+
+/**
+ * Retrieves the full repository path. Or throws an error if not valid.
+ */
+export function getRepoPath(owner: string, name: string) {
+    // Verify that both inputs are valid folder names
+    const parsedOwner = path.parse(owner);
+    const parsedName = path.parse(name);
+    const repoPath = `${owner}/${name}`;
+
+    if (parsedName.dir !== "" || parsedOwner.dir !== "") {
+        throw new NetworkError(400, `Invalid repo name ${repoPath}`);
+    }
+
+    return repoPath;
 }

--- a/server/gitrest/src/utils/index.ts
+++ b/server/gitrest/src/utils/index.ts
@@ -5,5 +5,6 @@
 
 export * from "./definitions";
 export * from "./helpers";
+export * from "./isomorphicgitManager";
 export * from "./nodegitManager";
 export * from "./gitWholeSummaryManager";

--- a/server/gitrest/src/utils/index.ts
+++ b/server/gitrest/src/utils/index.ts
@@ -5,4 +5,5 @@
 
 export * from "./definitions";
 export * from "./helpers";
+export * from "./isomorphicgitManager";
 export * from "./nodegitManager";

--- a/server/gitrest/src/utils/isomorphicgitConversions.ts
+++ b/server/gitrest/src/utils/isomorphicgitConversions.ts
@@ -31,7 +31,7 @@ function oidToCommitHash(oid: string): resources.ICommitHash {
 }
 
 /**
- * Helper function to convert from a nodegit commit to our resource representation
+ * Helper function to convert an `isomorphic-git` ReadCommitResult to our resource representation
  */
 export function commitToICommit(commitResult: isomorphicGit.ReadCommitResult): resources.ICommit {
     return {
@@ -57,6 +57,10 @@ export function commitToICommit(commitResult: isomorphicGit.ReadCommitResult): r
     };
 }
 
+/**
+ * Helper function to convert our Create Commit parameters to
+ * `isomorphic-git`'s CommitObject type.
+ */
 export function iCreateCommitParamsToCommitObject(
     commitParams: resources.ICreateCommitParams): isomorphicGit.CommitObject {
     const date = Date.parse(commitParams.author.date);
@@ -88,6 +92,9 @@ export function iCreateCommitParamsToCommitObject(
     };
 }
 
+/**
+ * Helper function to convert an `isomorphic-git` ReadBlobResult to our resource representation
+ */
 export function blobToIBlob(
     readBlobResponse: isomorphicGit.ReadBlobResult,
     owner: string,
@@ -105,6 +112,9 @@ export function blobToIBlob(
     };
 }
 
+/**
+ * Helper function to convert reference-related parameters into our resource representation.
+ */
 export function refToIRef(resolvedRef: string, expandedRef: string): resources.IRef {
     return {
         object: {
@@ -118,7 +128,7 @@ export function refToIRef(resolvedRef: string, expandedRef: string): resources.I
 }
 
 /**
- * Helper function to convert from an isomorphic-git TreeEntry to our ITreeEntry
+ * Helper function to convert an `isomorphic-git` TreeEntry to our resource representation ITreeEntry
  */
 export function treeEntryToITreeEntry(treeEntry: isomorphicGit.TreeEntry): resources.ITreeEntry {
     return {
@@ -133,7 +143,7 @@ export function treeEntryToITreeEntry(treeEntry: isomorphicGit.TreeEntry): resou
 }
 
 /**
- * Helper function to convert from our ICreateTreeEntry to an isomorphic-git TreeEntry
+ * Helper function to convert our Create Tree Entry to an `isomorphic-git` TreeEntry
  */
 export function iCreateTreeEntryToTreeEntry(createTreeEntry: resources.ICreateTreeEntry): isomorphicGit.TreeEntry {
     return {
@@ -144,6 +154,9 @@ export function iCreateTreeEntryToTreeEntry(createTreeEntry: resources.ICreateTr
     };
 }
 
+/**
+ * Helper function to convert an `isomorphic-git` ReadTagResult to our resource representation of a tag
+ */
 export async function tagToITag(tagResult: isomorphicGit.ReadTagResult): Promise<resources.ITag> {
     return {
         message: tagResult.tag.message,
@@ -163,6 +176,9 @@ export async function tagToITag(tagResult: isomorphicGit.ReadTagResult): Promise
     };
 }
 
+/**
+ * Helper function to convert our Create Tag parameters to an `isomorphic-git` TagObject
+ */
 export function iCreateTagParamsToTagObject(
     tagParams: resources.ICreateTagParams): isomorphicGit.TagObject {
     const date = Date.parse(tagParams.tagger.date);

--- a/server/gitrest/src/utils/isomorphicgitConversions.ts
+++ b/server/gitrest/src/utils/isomorphicgitConversions.ts
@@ -10,8 +10,6 @@ import { NetworkError } from "@fluidframework/server-services-client";
 type IsomorphicGitTreeEntryType = "commit" | "blob" | "tree";
 type IsomorphicGitTagObjectType = IsomorphicGitTreeEntryType | "tag";
 
-
-
 function ensureIsomorphicGitTreeEntryType(originalITreeEntryType: string): IsomorphicGitTreeEntryType {
     if (!["commit", "blob", "tree"].includes(originalITreeEntryType)) {
         throw new NetworkError(400, "Invalid TreeEntry type.");
@@ -42,13 +40,11 @@ export function commitToICommit(commitResult: isomorphicGit.ReadCommitResult): r
             email: commitResult.commit.author.email,
             name: commitResult.commit.author.name,
         },
-        //author:// authorToIAuthor(commit.author(), commit.date()),
         committer: {
             date: new Date(commitResult.commit.committer.timestamp * 1000).toISOString(),
             email: commitResult.commit.committer.email,
             name: commitResult.commit.committer.name,
         },
-        //committer: committerToICommitter(commit.committer(), commit.date()),
         message: commitResult.commit.message,
         parents: commitResult.commit.parent && commitResult.commit.parent.length > 0 ?
             commitResult.commit.parent.map((parent) => oidToCommitHash(parent)) : null,
@@ -70,7 +66,7 @@ export function iCreateCommitParamsToCommitObject(
 
     // Date.parse() returns a value in milliseconds, and Isomorphic-Git expects
     // a timestamp number time in seconds (UTC Unix timestamp)
-    const timestamp = Math.floor(date/1000);
+    const timestamp = Math.floor(date / 1000);
     const parent = commitParams.parents && commitParams.parents.length > 0 ? commitParams.parents : null;
 
     return {
@@ -81,14 +77,14 @@ export function iCreateCommitParamsToCommitObject(
             name: commitParams.author.name,
             email: commitParams.author.email,
             timestamp,
-            timezoneOffset: 0
+            timezoneOffset: 0,
         },
         committer: {
             name: commitParams.author.name,
             email: commitParams.author.email,
             timestamp,
-            timezoneOffset: 0
-        }
+            timezoneOffset: 0,
+        },
     };
 }
 
@@ -176,7 +172,7 @@ export function iCreateTagParamsToTagObject(
 
     // Date.parse() returns a value in milliseconds, and Isomorphic-Git expects
     // a timestamp number time in seconds (UTC Unix timestamp)
-    const timestamp = Math.floor(date/1000);
+    const timestamp = Math.floor(date / 1000);
 
     return {
         object: tagParams.object,
@@ -187,7 +183,7 @@ export function iCreateTagParamsToTagObject(
             name: tagParams.tagger.name,
             email: tagParams.tagger.email,
             timestamp,
-            timezoneOffset: 0
+            timezoneOffset: 0,
         },
     };
 }

--- a/server/gitrest/src/utils/isomorphicgitConversions.ts
+++ b/server/gitrest/src/utils/isomorphicgitConversions.ts
@@ -1,0 +1,193 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as isomorphicGit from "isomorphic-git";
+import * as resources from "@fluidframework/gitresources";
+import { NetworkError } from "@fluidframework/server-services-client";
+
+type IsomorphicGitTreeEntryType = "commit" | "blob" | "tree";
+type IsomorphicGitTagObjectType = IsomorphicGitTreeEntryType | "tag";
+
+
+
+function ensureIsomorphicGitTreeEntryType(originalITreeEntryType: string): IsomorphicGitTreeEntryType {
+    if (!["commit", "blob", "tree"].includes(originalITreeEntryType)) {
+        throw new NetworkError(400, "Invalid TreeEntry type.");
+    }
+
+    return originalITreeEntryType as IsomorphicGitTreeEntryType;
+}
+
+function ensureIsomorphicGitTagObjectType(originalITagType: string): IsomorphicGitTagObjectType {
+    if (!["commit", "blob", "tree", "tag"].includes(originalITagType)) {
+        throw new NetworkError(400, "Invalid Tag Object type.");
+    }
+
+    return originalITagType as IsomorphicGitTagObjectType;
+}
+
+function oidToCommitHash(oid: string): resources.ICommitHash {
+    return { sha: oid, url: "" };
+}
+
+/**
+ * Helper function to convert from a nodegit commit to our resource representation
+ */
+export function commitToICommit(commitResult: isomorphicGit.ReadCommitResult): resources.ICommit {
+    return {
+        author: {
+            date: new Date(commitResult.commit.author.timestamp * 1000).toISOString(),
+            email: commitResult.commit.author.email,
+            name: commitResult.commit.author.name,
+        },
+        //author:// authorToIAuthor(commit.author(), commit.date()),
+        committer: {
+            date: new Date(commitResult.commit.committer.timestamp * 1000).toISOString(),
+            email: commitResult.commit.committer.email,
+            name: commitResult.commit.committer.name,
+        },
+        //committer: committerToICommitter(commit.committer(), commit.date()),
+        message: commitResult.commit.message,
+        parents: commitResult.commit.parent && commitResult.commit.parent.length > 0 ?
+            commitResult.commit.parent.map((parent) => oidToCommitHash(parent)) : null,
+        sha: commitResult.oid,
+        tree: {
+            sha: commitResult.commit.tree,
+            url: "",
+        },
+        url: "",
+    };
+}
+
+export function iCreateCommitParamsToCommitObject(
+    commitParams: resources.ICreateCommitParams): isomorphicGit.CommitObject {
+    const date = Date.parse(commitParams.author.date);
+    if (isNaN(date)) {
+        throw new NetworkError(400, "Invalid input");
+    }
+
+    // Date.parse() returns a value in milliseconds, and Isomorphic-Git expects
+    // a timestamp number time in seconds (UTC Unix timestamp)
+    const timestamp = Math.floor(date/1000);
+    const parent = commitParams.parents && commitParams.parents.length > 0 ? commitParams.parents : null;
+
+    return {
+        message: commitParams.message,
+        tree: commitParams.tree,
+        parent,
+        author: {
+            name: commitParams.author.name,
+            email: commitParams.author.email,
+            timestamp,
+            timezoneOffset: 0
+        },
+        committer: {
+            name: commitParams.author.name,
+            email: commitParams.author.email,
+            timestamp,
+            timezoneOffset: 0
+        }
+    };
+}
+
+export function blobToIBlob(
+    readBlobResponse: isomorphicGit.ReadBlobResult,
+    owner: string,
+    repo: string,
+    ): resources.IBlob {
+    const buffer = Buffer.from(readBlobResponse.blob).toString("base64");
+    const sha = readBlobResponse.oid;
+
+    return {
+        content: buffer,
+        encoding: "base64",
+        sha,
+        size: buffer.length,
+        url: `/repos/${owner}/${repo}/git/blobs/${sha}`,
+    };
+}
+
+export function refToIRef(resolvedRef: string, expandedRef: string): resources.IRef {
+    return {
+        object: {
+            sha: resolvedRef,
+            type: "",
+            url: "",
+        },
+        ref: expandedRef,
+        url: "",
+    };
+}
+
+/**
+ * Helper function to convert from an isomorphic-git TreeEntry to our ITreeEntry
+ */
+export function treeEntryToITreeEntry(treeEntry: isomorphicGit.TreeEntry): resources.ITreeEntry {
+    return {
+        // remove leading 0s from hexadecimal mode string coming from isomorphic-git
+        mode: parseInt(treeEntry.mode, 16).toString(16),
+        path: treeEntry.path,
+        sha: treeEntry.oid,
+        size: 0,
+        type: treeEntry.type,
+        url: "",
+    };
+}
+
+/**
+ * Helper function to convert from our ICreateTreeEntry to an isomorphic-git TreeEntry
+ */
+export function iCreateTreeEntryToTreeEntry(createTreeEntry: resources.ICreateTreeEntry): isomorphicGit.TreeEntry {
+    return {
+        mode: createTreeEntry.mode,
+        path: createTreeEntry.path,
+        oid: createTreeEntry.sha,
+        type: ensureIsomorphicGitTreeEntryType(createTreeEntry.type),
+    };
+}
+
+export async function tagToITag(tagResult: isomorphicGit.ReadTagResult): Promise<resources.ITag> {
+    return {
+        message: tagResult.tag.message,
+        object: {
+            sha: tagResult.tag.object,
+            type:tagResult.tag.type,
+            url: "",
+        },
+        sha: tagResult.oid,
+        tag: tagResult.tag.tag,
+        tagger: {
+            date: new Date(tagResult.tag.tagger.timestamp * 1000).toISOString(),
+            email: tagResult.tag.tagger.email,
+            name: tagResult.tag.tagger.name,
+        },
+        url: "",
+    };
+}
+
+export function iCreateTagParamsToTagObject(
+    tagParams: resources.ICreateTagParams): isomorphicGit.TagObject {
+    const date = Date.parse(tagParams.tagger.date);
+    if (isNaN(date)) {
+        throw new NetworkError(400, "Invalid input");
+    }
+
+    // Date.parse() returns a value in milliseconds, and Isomorphic-Git expects
+    // a timestamp number time in seconds (UTC Unix timestamp)
+    const timestamp = Math.floor(date/1000);
+
+    return {
+        object: tagParams.object,
+        type: ensureIsomorphicGitTagObjectType(tagParams.type),
+        tag: tagParams.tag,
+        message: tagParams.message,
+        tagger: {
+            name: tagParams.tagger.name,
+            email: tagParams.tagger.email,
+            timestamp,
+            timezoneOffset: 0
+        },
+    };
+}

--- a/server/gitrest/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/src/utils/isomorphicgitManager.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { PathLike } from "fs";
 import * as path from "path";
 import * as isomorphicGit from "isomorphic-git";
 import winston from "winston";
@@ -18,15 +17,6 @@ import {
     IRepositoryManager,
     IFileSystemManager,
 } from "./definitions";
-
-const exists = async (fileSystemManager: IFileSystemManager, fileOrDirectoryPath: PathLike): Promise<boolean> => {
-    try {
-        await fileSystemManager.stat(fileOrDirectoryPath);
-        return true;
-    } catch (e) {
-        return false;
-    }
-};
 
 export class IsomorphicGitRepositoryManager implements IRepositoryManager {
     constructor(
@@ -388,7 +378,7 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
         const directoryPath = `${this.baseDir}/${repoPath}`;
 
         if (!(this.repositoryCache.has(repoPath))) {
-            const repoExists = await exists(this.fileSystemManager, directoryPath);
+            const repoExists = await helpers.exists(this.fileSystemManager, directoryPath);
             if (!repoExists) {
                 winston.info(`Repo does not exist ${directoryPath}`);
                 // services-client/getOrCreateRepository depends on a 400 response code

--- a/server/gitrest/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/src/utils/isomorphicgitManager.ts
@@ -45,13 +45,13 @@ export class IsomorphicGitRepositoryManager implements IRepositoryManager {
     ): Promise<resources.ICommitDetails[]> {
         try {
             const commits = await isomorphicGit.log({
-                    fs: this.fileSystemManager,
-                    gitdir: this.directory,
-                    ref: sha,
-                    depth: count,
-                });
+                fs: this.fileSystemManager,
+                gitdir: this.directory,
+                ref: sha,
+                depth: count,
+            });
 
-             return commits.map((rawCommit) => {
+            return commits.map((rawCommit) => {
                 const gitCommit = conversions.commitToICommit(rawCommit);
                 const result: resources.ICommitDetails =
                 {
@@ -71,7 +71,7 @@ export class IsomorphicGitRepositoryManager implements IRepositoryManager {
             });
         } catch (err) {
             winston.info(`getCommits error: ${err}`);
-            return Promise.reject(err);
+            throw new NetworkError(500, "Unable to get commits.");
         }
     }
 
@@ -274,7 +274,7 @@ export class IsomorphicGitRepositoryManager implements IRepositoryManager {
             return conversions.refToIRef(resolvedRef, expandedRef);
         } catch (err) {
             winston.error(`getRef error: ${safeStringify(err, undefined, 2)} repo: ${this.repoName} ref: ${refId}`);
-            return Promise.reject(err);
+            throw new NetworkError(500, "Unable to get ref.");
         }
     }
 
@@ -375,7 +375,7 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
 
         if (!(this.repositoryCache.has(repoPath))) {
             const repoExists = await helpers.exists(this.fileSystemManager, directoryPath);
-            if (!repoExists) {
+            if (!repoExists || !repoExists.isDirectory()) {
                 winston.info(`Repo does not exist ${directoryPath}`);
                 // services-client/getOrCreateRepository depends on a 400 response code
                 throw new NetworkError(400, `Repo does not exist ${directoryPath}`);

--- a/server/gitrest/src/utils/nodegitManager.ts
+++ b/server/gitrest/src/utils/nodegitManager.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import * as path from "path";
 import nodegit from "nodegit";
 import winston from "winston";
 import safeStringify from "json-stringify-safe";
@@ -340,7 +339,7 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
 
     public async create(owner: string, name: string): Promise<NodegitRepositoryManager> {
         // Verify that both inputs are valid folder names
-        const repoPath = this.getRepoPath(owner, name);
+        const repoPath = helpers.getRepoPath(owner, name);
 
         // Create and then cache the repository
         const isBare = 1;
@@ -359,7 +358,7 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
     }
 
     public async open(owner: string, name: string): Promise<NodegitRepositoryManager> {
-        const repoPath = this.getRepoPath(owner, name);
+        const repoPath = helpers.getRepoPath(owner, name);
 
         if (!(repoPath in this.repositoryPCache)) {
             const directory = `${this.baseDir}/${repoPath}`;
@@ -381,21 +380,5 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
             repository,
             this.externalStorageManager);
         return repoManager;
-    }
-
-    /**
-     * Retrieves the full repository path. Or throws an error if not valid.
-     */
-    private getRepoPath(owner: string, name: string) {
-        // Verify that both inputs are valid folder names
-        const parsedOwner = path.parse(owner);
-        const parsedName = path.parse(name);
-        const repoPath = `${owner}/${name}`;
-
-        if (parsedName.dir !== "" || parsedOwner.dir !== "") {
-            throw new NetworkError(400, `Invalid repo name ${repoPath}`);
-        }
-
-        return repoPath;
     }
 }


### PR DESCRIPTION
Adding `isomorphic-git` as an alternative way of handling Git data (instead of `node-git`). `isomorphic-git` is interesting because:
* most importantly: it allows the developer to provide their own implementation of a filesystem. `nodegit`, on the other hand, is not as flexible and will always use the OS/local filesystem
* it is isomorphic
* it is pure JavaScript, unlike `nodegit` which is based on `libgit2` native code. That means that investigating issues related to the Git library could be potentially simpler as it would involve only one programming language/environment
* `isomorphic-git` code has fewer lines of code that `libgit2` (different order of magnitude), so that can potentially help speed up understanding/ramp up

This PR:
* introduces new `IRepositoryManager` and `IRepositoryManagerFactory` implementations based on `isomorphic-git`
* provides helper `conversions` functions to convert FluidFramework types to `isomorphic-git` types and vice-versa
* updates `IFileSystemManager` to match Node.js's `fs` instead of `fs/promises`. [That is because `isomorphic-git` expects the `fs` argument to have a `promises` property](https://github.com/isomorphic-git/isomorphic-git/blob/f654d79303b90930136fc112ae535d6e62bbedd7/src/models/FileSystem.js#L14), which was not the case if we used that directly.

Testing strategy:
1. Debugged `IsomorphicGitManager` comparing returned values with those returned by `NodegitRepositoryManager` and confirmed parity
2. Ran r11s with `nodegit`-based GitRest, created a few documents, stopped r11s, and then started it again but with an `isomorphic-git`-based GitRest. Opened the documents originally created by `nodegit` (opened successfully), generated a few more summaries. Also generated new documents in `isomorphic-git`. Switched back to `nodegit`, opening the first set of documents again, and the new set of documents created with `isomorphic-git`. Throughout the testing, validated the documents did not present any data loss or corruption, and that all microservices behaved properly. This initial test was something like N -> I -> N -> I, but I also performed tests like I -> N -> I -> N.
3. Tests run when `enableWholeSummaryUpload` was both `true` and `false` in r11s.