### PR TITLE
Simplified the attach / bind states in data store runtime. Fixed bug #9127.

### DIFF
--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -44,7 +44,6 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     get absolutePath(): string;
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
-    // (undocumented)
     attachGraph(): void;
     // (undocumented)
     get attachState(): AttachState;
@@ -88,6 +87,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     static load(context: IFluidDataStoreContext, sharedObjectRegistry: ISharedObjectRegistry, existing: boolean): FluidDataStoreRuntime;
     // (undocumented)
     readonly logger: ITelemetryLogger;
+    makeVisibleAndAttachGraph(): void;
     // (undocumented)
     get objectsRoutingContext(): this;
     // (undocumented)
@@ -139,7 +139,7 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
     readonly routeContext: IFluidHandleContext;
     // (undocumented)
     protected readonly value: T;
-}
+    }
 
 // @public (undocumented)
 export interface ISharedObjectRegistry {

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -28,6 +28,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
+import { VisibilityState as VisibilityState_2 } from '@fluidframework/runtime-definitions';
 
 // @public (undocumented)
 export enum DataStoreMessageType {
@@ -115,6 +116,8 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
+    // (undocumented)
+    visibilityState: VisibilityState_2;
     waitAttached(): Promise<void>;
 }
 

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -125,6 +125,7 @@ export interface IEnvelope {
 export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
+    // @deprecated (undocumented)
     attachGraph(): void;
     readonly attachState: AttachState;
     // @deprecated (undocumented)
@@ -133,6 +134,7 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     // (undocumented)
     readonly id: string;
+    makeVisibleAndAttachGraph?(): void;
     process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processSignal(message: any, local: boolean): void;
     reSubmit(type: string, content: any, localOpMetadata: unknown): any;
@@ -147,6 +149,7 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     readonly attachState: AttachState;
     // (undocumented)
     readonly baseSnapshot: ISnapshotTree | undefined;
+    // @deprecated (undocumented)
     bindToContext(): void;
     // (undocumented)
     readonly clientDetails: IClientDetails;
@@ -175,6 +178,7 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     readonly isLocalDataStore: boolean;
     // (undocumented)
     readonly logger: ITelemetryBaseLogger;
+    makeVisible?(): void;
     // (undocumented)
     readonly options: ILoaderOptions;
     readonly packagePath: readonly string[];
@@ -186,6 +190,8 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     submitSignal(type: string, content: any): void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
+    // (undocumented)
+    readonly visibilityState?: VisibilityState_2;
 }
 
 // @public (undocumented)
@@ -378,6 +384,16 @@ export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRe
 
 // @public (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
+
+// @public
+enum VisibilityState_2 {
+    CompatGraphAttached = "CompatGraphAttached",
+    GloballyVisible = "GloballyVisible",
+    LocallyVisible = "LocallyVisible",
+    NotVisible = "NotVisible"
+}
+
+export { VisibilityState_2 as VisibilityState }
 
 
 // (No @packageDocumentation comment for this package)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -178,7 +178,7 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     readonly isLocalDataStore: boolean;
     // (undocumented)
     readonly logger: ITelemetryBaseLogger;
-    makeVisible?(): void;
+    makeLocallyVisible?(): void;
     // (undocumented)
     readonly options: ILoaderOptions;
     readonly packagePath: readonly string[];

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -386,11 +386,14 @@ export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRe
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Promise<ISummarizeInternalResult>;
 
 // @public
-enum VisibilityState_2 {
-    GloballyVisible = "GloballyVisible",
-    LocallyVisible = "LocallyVisible",
-    NotVisible = "NotVisible"
-}
+const VisibilityState_2: {
+    NotVisible: string;
+    LocallyVisible: string;
+    GloballyVisible: string;
+};
+
+// @public (undocumented)
+type VisibilityState_2 = typeof VisibilityState_2[keyof typeof VisibilityState_2];
 
 export { VisibilityState_2 as VisibilityState }
 

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -387,7 +387,6 @@ export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean) => Pr
 
 // @public
 enum VisibilityState_2 {
-    CompatGraphAttached = "CompatGraphAttached",
     GloballyVisible = "GloballyVisible",
     LocallyVisible = "LocallyVisible",
     NotVisible = "NotVisible"

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -141,6 +141,8 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     setConnectionState(connected: boolean, clientId?: string): any;
     summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;
+    // (undocumented)
+    readonly visibilityState?: VisibilityState_2;
 }
 
 // @public
@@ -190,8 +192,6 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     submitSignal(type: string, content: any): void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
-    // (undocumented)
-    readonly visibilityState?: VisibilityState_2;
 }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1832,7 +1832,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     private async createRootDataStoreLegacy(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter> {
         const fluidDataStore = await this._createDataStore(pkg, true /* isRoot */, rootDataStoreId);
-        // back-compat 0.58.2000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel. For
+        // back-compat 0.58.3000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel. For
         // older versions, we still have to call bindToContext.
         if (fluidDataStore.makeVisibleAndAttachGraph !== undefined) {
             fluidDataStore.makeVisibleAndAttachGraph();
@@ -1910,7 +1910,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const fluidDataStore = await this.dataStores._createFluidDataStoreContext(
             Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
         if (isRoot) {
-            // back-compat 0.58.2000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel.
+            // back-compat 0.58.3000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel.
             // For older versions, we still have to call bindToContext.
             if (fluidDataStore.makeVisibleAndAttachGraph !== undefined) {
                 fluidDataStore.makeVisibleAndAttachGraph();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1832,7 +1832,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     private async createRootDataStoreLegacy(pkg: string | string[], rootDataStoreId: string): Promise<IFluidRouter> {
         const fluidDataStore = await this._createDataStore(pkg, true /* isRoot */, rootDataStoreId);
-        fluidDataStore.bindToContext();
+        // back-compat 0.58.2000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel. For
+        // older versions, we still have to call bindToContext.
+        if (fluidDataStore.makeVisibleAndAttachGraph !== undefined) {
+            fluidDataStore.makeVisibleAndAttachGraph();
+        } else {
+            fluidDataStore.bindToContext();
+        }
         return fluidDataStore;
     }
 
@@ -1904,7 +1910,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const fluidDataStore = await this.dataStores._createFluidDataStoreContext(
             Array.isArray(pkg) ? pkg : [pkg], id, isRoot, props).realize();
         if (isRoot) {
-            fluidDataStore.bindToContext();
+            // back-compat 0.58.2000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel.
+            // For older versions, we still have to call bindToContext.
+            if (fluidDataStore.makeVisibleAndAttachGraph !== undefined) {
+                fluidDataStore.makeVisibleAndAttachGraph();
+            } else {
+                fluidDataStore.bindToContext();
+            }
             this.logger.sendTelemetryEvent({
                 eventName: "Root datastore with props",
                 hasProps: props !== undefined,

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -75,7 +75,13 @@ class DataStore implements IDataStore {
             alias,
         };
 
-        this.fluidDataStoreChannel.bindToContext();
+        // back-compat 0.58.2000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel. For
+        // older versions, we still have to call bindToContext.
+        if (this.fluidDataStoreChannel.makeVisibleAndAttachGraph !== undefined) {
+            this.fluidDataStoreChannel.makeVisibleAndAttachGraph();
+        } else {
+            this.fluidDataStoreChannel.bindToContext();
+        }
 
         if (this.runtime.attachState === AttachState.Detached) {
             const localResult = this.datastores.processAliasMessageCore(message);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -283,8 +283,8 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
             this.containerRuntime.attachState : AttachState.Detached;
 
         /**
-         * If existing flag is false, this is a new data store and is not visible.
-         * The existing flag can be true in two conditions:
+         * If existing flag is false, this is a new data store and is not visible. The existing flag can be true in two
+         * conditions:
          * 1. It's a local data store that is created when a detached container is rehydrated. In this case, the data
          *    store is locally visible because the snapshot it is loaded from contains locally visible data stores only.
          * 2. It's a remote data store that is created when an attached container is loaded is loaded from snapshot or

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -1050,7 +1050,7 @@ export class LocalDetachedFluidDataStoreContext
         super.bindRuntime(dataStoreChannel);
 
         if (await this.isRoot()) {
-            // back-compat 0.58.2000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel.
+            // back-compat 0.58.3000 - makeVisibleAndAttachGraph was added in this version to IFluidDataStoreChannel.
             // For older versions, we still have to call bindToContext.
             if (dataStoreChannel.makeVisibleAndAttachGraph !== undefined) {
                 dataStoreChannel.makeVisibleAndAttachGraph();

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -156,7 +156,7 @@ export class DataStores implements IDisposable {
                         key,
                         { type: CreateSummarizerNodeSource.FromSummary },
                     ),
-                    makeVisibleFn: () => this.makeDataStoreVisible(key),
+                    makeLocallyVisibleFn: () => this.makeDataStoreLocallyVisible(key),
                     snapshotTree,
                     isRootDataStore: undefined,
                     writeGCDataAtRoot: this.writeGCDataAtRoot,
@@ -291,11 +291,11 @@ export class DataStores implements IDisposable {
     }
 
     /**
-     * Makes the data store with the given id visible in the container graph by moving the data store context from
-     * unbound to bound list. This data store can now be reached from the root.
+     * Make the data stores locally visible in the container graph by moving the data store context from unbound to
+     * bound list. This data store can now be reached from the root.
      * @param id - The id of the data store context to make visible.
      */
-    public makeDataStoreVisible(id: string): void {
+    private makeDataStoreLocallyVisible(id: string): void {
         const localContext = this.contexts.getUnbound(id);
         assert(!!localContext, 0x15f /* "Could not find unbound context to bind" */);
 
@@ -331,7 +331,7 @@ export class DataStores implements IDisposable {
                 id,
                 { type: CreateSummarizerNodeSource.Local },
             ),
-            makeVisibleFn: () => this.makeDataStoreVisible(id),
+            makeLocallyVisibleFn: () => this.makeDataStoreLocallyVisible(id),
             snapshotTree: undefined,
             isRootDataStore: isRoot,
             writeGCDataAtRoot: this.writeGCDataAtRoot,
@@ -352,7 +352,7 @@ export class DataStores implements IDisposable {
                 id,
                 { type: CreateSummarizerNodeSource.Local },
             ),
-            makeVisibleFn: () => this.makeDataStoreVisible(id),
+            makeLocallyVisibleFn: () => this.makeDataStoreLocallyVisible(id),
             snapshotTree: undefined,
             isRootDataStore: isRoot,
             writeGCDataAtRoot: this.writeGCDataAtRoot,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -47,7 +47,7 @@ describe("Data Store Context Tests", () => {
         let localDataStoreContext: LocalFluidDataStoreContext;
         let storage: IDocumentStorageService;
         let scope: FluidObject;
-        const makeVisibleFn = () => {};
+        const makeLocallyVisibleFn = () => {};
         let containerRuntime: ContainerRuntime;
         let summarizerNode: IRootSummarizerNodeWithGC;
 
@@ -99,7 +99,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    makeVisibleFn,
+                    makeLocallyVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: true,
                     writeGCDataAtRoot: true,
@@ -141,7 +141,7 @@ describe("Data Store Context Tests", () => {
                         storage,
                         scope,
                         createSummarizerNodeFn,
-                        makeVisibleFn,
+                        makeLocallyVisibleFn,
                         snapshotTree: undefined,
                         isRootDataStore: false,
                         writeGCDataAtRoot: true,
@@ -176,7 +176,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    makeVisibleFn,
+                    makeLocallyVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: false,
                     writeGCDataAtRoot: true,
@@ -216,7 +216,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    makeVisibleFn,
+                    makeLocallyVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: true,
                     writeGCDataAtRoot: true,
@@ -235,7 +235,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    makeVisibleFn,
+                    makeLocallyVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: false,
                     writeGCDataAtRoot: true,
@@ -256,7 +256,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    makeVisibleFn,
+                    makeLocallyVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: true,
                     writeGCDataAtRoot: true,
@@ -275,7 +275,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    makeVisibleFn,
+                    makeLocallyVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: false,
                     writeGCDataAtRoot: true,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -14,7 +14,6 @@ import {
     SummaryType,
 } from "@fluidframework/protocol-definitions";
 import {
-    IFluidDataStoreChannel,
     IFluidDataStoreContext,
     IFluidDataStoreFactory,
     IFluidDataStoreRegistry,
@@ -48,7 +47,7 @@ describe("Data Store Context Tests", () => {
         let localDataStoreContext: LocalFluidDataStoreContext;
         let storage: IDocumentStorageService;
         let scope: FluidObject;
-        const attachCb = (mR: IFluidDataStoreChannel) => { };
+        const makeVisibleFn = () => {};
         let containerRuntime: ContainerRuntime;
         let summarizerNode: IRootSummarizerNodeWithGC;
 
@@ -100,7 +99,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    bindChannelFn: attachCb,
+                    makeVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: true,
                     writeGCDataAtRoot: true,
@@ -142,7 +141,7 @@ describe("Data Store Context Tests", () => {
                         storage,
                         scope,
                         createSummarizerNodeFn,
-                        bindChannelFn: attachCb,
+                        makeVisibleFn,
                         snapshotTree: undefined,
                         isRootDataStore: false,
                         writeGCDataAtRoot: true,
@@ -177,7 +176,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    bindChannelFn: attachCb,
+                    makeVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: false,
                     writeGCDataAtRoot: true,
@@ -217,7 +216,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    bindChannelFn: attachCb,
+                    makeVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: true,
                     writeGCDataAtRoot: true,
@@ -236,7 +235,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    bindChannelFn: attachCb,
+                    makeVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: false,
                     writeGCDataAtRoot: true,
@@ -257,7 +256,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    bindChannelFn: attachCb,
+                    makeVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: true,
                     writeGCDataAtRoot: true,
@@ -276,7 +275,7 @@ describe("Data Store Context Tests", () => {
                     storage,
                     scope,
                     createSummarizerNodeFn,
-                    bindChannelFn: attachCb,
+                    makeVisibleFn,
                     snapshotTree: undefined,
                     isRootDataStore: false,
                     writeGCDataAtRoot: true,

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -38,7 +38,7 @@ describe("Data Store Creation Tests", () => {
 
         let storage: IDocumentStorageService;
         let scope: FluidObject;
-        const makeVisibleFn = () => {};
+        const makeLocallyVisibleFn = () => {};
         let containerRuntime: ContainerRuntime;
         const defaultName = "default";
         const dataStoreAName = "dataStoreA";
@@ -118,7 +118,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -145,7 +145,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -172,7 +172,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -199,7 +199,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -226,7 +226,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreBId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -250,7 +250,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreCId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -277,7 +277,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -304,7 +304,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -331,7 +331,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                makeVisibleFn,
+                makeLocallyVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -4,7 +4,6 @@
  */
 import { strict as assert } from "assert";
 import {
-    IFluidDataStoreChannel,
     IFluidDataStoreContext,
     IFluidDataStoreFactory,
     IFluidDataStoreRegistry,
@@ -39,7 +38,7 @@ describe("Data Store Creation Tests", () => {
 
         let storage: IDocumentStorageService;
         let scope: FluidObject;
-        const attachCb = (mR: IFluidDataStoreChannel) => { };
+        const makeVisibleFn = () => {};
         let containerRuntime: ContainerRuntime;
         const defaultName = "default";
         const dataStoreAName = "dataStoreA";
@@ -119,7 +118,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -146,7 +145,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -173,7 +172,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -200,7 +199,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -227,7 +226,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreBId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -251,7 +250,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreCId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -278,7 +277,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -305,7 +304,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,
@@ -332,7 +331,7 @@ describe("Data Store Creation Tests", () => {
                 storage,
                 scope,
                 createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
-                bindChannelFn: attachCb,
+                makeVisibleFn,
                 snapshotTree: undefined,
                 isRootDataStore: false,
                 writeGCDataAtRoot: true,

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -107,7 +107,13 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.59.1000",
-    "broken": {}
+    "version": "0.58.3000",
+    "broken": {
+      "0.58.2000": {
+        "ClassDeclaration_FluidDataStoreRuntime": {
+          "forwardCompat": false
+        }
+      }
+    }
   }
 }

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -107,9 +107,9 @@
     "typescript-formatter": "7.1.0"
   },
   "typeValidation": {
-    "version": "0.58.3000",
+    "version": "0.59.1000",
     "broken": {
-      "0.58.2000": {
+      "0.58.2002": {
         "ClassDeclaration_FluidDataStoreRuntime": {
           "forwardCompat": false
         }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -157,7 +157,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private readonly localChannelContextQueue = new Map<string, LocalChannelContextBase>();
     private readonly notBoundedChannelContextSet = new Set<string>();
     private _attachState: AttachState;
-    private visibilityState: VisibilityState = VisibilityState.NotVisible;
+    private visibilityState: VisibilityState;
     // A list of handles that are bound when the data store is not visible. We have to make them visible when the data
     // store becomes visible.
     private readonly pendingHandlesToMakeVisible: Set<IFluidHandle> = new Set();
@@ -267,7 +267,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         /**
          * back-compat 0.58.2000 - visibility state was added in this version. For older versions, get the visibility
          * state similar to the data store context:
-         * The existing flag can be true in two conditions:
+         * If existing flag is false, this is a new data store and is not visible.  The existing flag can be true in two
+         * conditions:
          * 1. It's a local data store that is created when a detached container is rehydrated. In this case, the data
          *    store is locally visible because the snapshot it is loaded from contains locally visible data stores only.
          * 2. It's a remote data store that is created when an attached container is loaded is loaded from snapshot or
@@ -278,6 +279,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         } else if (existing) {
             this.visibilityState = dataStoreContext.attachState === AttachState.Detached
                 ? VisibilityState.LocallyVisible : VisibilityState.GloballyVisible;
+        } else {
+            this.visibilityState = VisibilityState.NotVisible;
         }
 
         // If it's existing we know it has been attached.

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -157,7 +157,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private readonly localChannelContextQueue = new Map<string, LocalChannelContextBase>();
     private readonly notBoundedChannelContextSet = new Set<string>();
     private _attachState: AttachState;
-    private visibilityState: VisibilityState;
+    public visibilityState: VisibilityState;
     // A list of handles that are bound when the data store is not visible. We have to make them visible when the data
     // store becomes visible.
     private readonly pendingHandlesToMakeVisible: Set<IFluidHandle> = new Set();
@@ -265,18 +265,14 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         this._attachState = dataStoreContext.attachState;
 
         /**
-         * back-compat 0.58.3000 - visibility state was added in this version. For older versions, get the visibility
-         * state similar to the data store context:
-         * If existing flag is false, this is a new data store and is not visible.  The existing flag can be true in two
+         * If existing flag is false, this is a new data store and is not visible. The existing flag can be true in two
          * conditions:
          * 1. It's a local data store that is created when a detached container is rehydrated. In this case, the data
          *    store is locally visible because the snapshot it is loaded from contains locally visible data stores only.
          * 2. It's a remote data store that is created when an attached container is loaded is loaded from snapshot or
          *    when an attach op comes in. In both these cases, the data store is already globally visible.
          */
-        if (dataStoreContext.visibilityState !== undefined) {
-            this.visibilityState = dataStoreContext.visibilityState;
-        } else if (existing) {
+        if (existing) {
             this.visibilityState = dataStoreContext.attachState === AttachState.Detached
                 ? VisibilityState.LocallyVisible : VisibilityState.GloballyVisible;
         } else {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -729,6 +729,10 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
          */
         this.attachGraph();
 
+        assert(this.visibilityState === VisibilityState.LocallyVisible,
+            "The data store should be locally visible when generating attach summary",
+        );
+
         const summaryBuilder = new SummaryTreeBuilder();
 
         // Craft the .attributes file for each shared object
@@ -788,6 +792,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         channel.handle.attachGraph();
 
         assert(this.isAttached, 0x182 /* "Data store should be attached to attach the channel." */);
+        assert(this.visibilityState === VisibilityState.GloballyVisible,
+            "Data store should be globally visible to attach channels.");
 
         const summarizeResult = summarizeChannel(channel, true /* fullTree */, false /* trackState */);
         // Attach message needs the summary in ITree format. Convert the ISummaryTree into an ITree.
@@ -894,7 +900,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
             this._attachState = AttachState.Attaching;
 
             assert(this.visibilityState === VisibilityState.LocallyVisible,
-                `Data store should be locally visible before it can become globally visible.`);
+                "Data store should be locally visible before it can become globally visible.");
 
             // Mark the data store globally visible and make its child channels visible as well.
             this.visibilityState = VisibilityState.GloballyVisible;
@@ -908,6 +914,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
             this.emit("attaching");
         });
         this.dataStoreContext.once("attached", () => {
+            assert(this.visibilityState === VisibilityState.GloballyVisible,
+                "Data store should be globally visible when its attached.");
             this._attachState = AttachState.Attached;
             this.emit("attached");
         });

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -265,7 +265,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         this._attachState = dataStoreContext.attachState;
 
         /**
-         * back-compat 0.58.2000 - visibility state was added in this version. For older versions, get the visibility
+         * back-compat 0.58.3000 - visibility state was added in this version. For older versions, get the visibility
          * state similar to the data store context:
          * If existing flag is false, this is a new data store and is not visible.  The existing flag can be true in two
          * conditions:
@@ -722,7 +722,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
 
     public getAttachSummary(): ISummaryTreeWithStats {
         /**
-         * back-compat 0.58.2000 - getAttachSummary() is called when making a data store globally visible (previously
+         * back-compat 0.58.3000 - getAttachSummary() is called when making a data store globally visible (previously
          * attaching state). Ideally, attachGraph() should have already be called making it locally visible. However,
          * before visibility state was added, this may not have been the case and getAttachSummary() could be called:
          * 1) Before attaching the data store - When a detached container is attached.
@@ -732,9 +732,14 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
          */
         this.attachGraph();
 
-        // assert(this.visibilityState === VisibilityState.LocallyVisible,
-        //     "The data store should be locally visible when generating attach summary",
-        // );
+        /**
+         * This assert cannot be added now due to back-compat. To be uncommented when the following issue is fixed -
+         * https://github.com/microsoft/FluidFramework/issues/9688.
+         *
+         * assert(this.visibilityState === VisibilityState.LocallyVisible,
+         *   "The data store should be locally visible when generating attach summary",
+         * );
+         */
 
         const summaryBuilder = new SummaryTreeBuilder();
 
@@ -890,7 +895,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         this.setMaxListeners(Number.MAX_SAFE_INTEGER);
         this.dataStoreContext.once("attaching", () => {
             /**
-             * back-compat 0.58.2000 - Ideally, attachGraph() should have already been called making the data store
+             * back-compat 0.58.3000 - Ideally, attachGraph() should have already been called making the data store
              * locally visible. However, before visibility state was added, this may not have been the case and data
              * store can move to "attaching" state in 2 scenarios:
              * 1) Before attachGraph() is called - When a data store is created and bound in an attached container.

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -732,9 +732,9 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
          */
         this.attachGraph();
 
-        assert(this.visibilityState === VisibilityState.LocallyVisible,
-            "The data store should be locally visible when generating attach summary",
-        );
+        // assert(this.visibilityState === VisibilityState.LocallyVisible,
+        //     "The data store should be locally visible when generating attach summary",
+        // );
 
         const summaryBuilder = new SummaryTreeBuilder();
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -49,6 +49,7 @@ import {
     IGarbageCollectionDetailsBase,
     IInboundSignalMessage,
     ISummaryTreeWithStats,
+    VisibilityState,
 } from "@fluidframework/runtime-definitions";
 import {
     convertSnapshotTreeToSummaryTree,
@@ -152,15 +153,12 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private readonly pendingAttach = new Map<string, IAttachMessage>();
 
     private bindState: BindState;
-    // For new data stores, this is used to break the recursion while attaching the graph. The graph must be attached
-    // before the data store can move to Attached state (see _attachState) and become live.
-    // For existing data stores, the graph is always attached.
-    private graphAttachState: AttachState = AttachState.Detached;
     private readonly deferredAttached = new Deferred<void>();
     private readonly localChannelContextQueue = new Map<string, LocalChannelContextBase>();
     private readonly notBoundedChannelContextSet = new Set<string>();
     private boundhandles: Set<IFluidHandle> | undefined;
     private _attachState: AttachState;
+    private visibilityState: VisibilityState = VisibilityState.NotVisible;
 
     public readonly id: string;
     public readonly options: ILoaderOptions;
@@ -224,11 +222,11 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                             this.addedGCOutboundReference(srcHandle, outboundHandle),
                         tree.trees[path]);
                     // This is the case of rehydrating a detached container from snapshot. Now due to delay loading of
-                    // data store, if the data store is loaded after the container is attached, then we missed marking
-                    // the channel as attached. So mark it now. Otherwise add it to local channel context queue, so
-                    // that it can be mark attached later with the data store.
+                    // data store, if the data store is loaded after the container is attached, then we missed making
+                    // the channel visible. So do it now. Otherwise, add it to local channel context queue, so
+                    // that it can be make it visible later with the data store.
                     if (dataStoreContext.attachState !== AttachState.Detached) {
-                        (channelContext as LocalChannelContextBase).markAttached();
+                        (channelContext as LocalChannelContextBase).makeVisible();
                     } else {
                         this.localChannelContextQueue.set(path, channelContext as LocalChannelContextBase);
                     }
@@ -263,6 +261,22 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         // If exists on storage or loaded from a snapshot, it should already be binded.
         this.bindState = existing ? BindState.Bound : BindState.NotBound;
         this._attachState = dataStoreContext.attachState;
+
+        /**
+         * back-compat 0.58.2000 - visibility state was added in this version. For older versions, get the visibility
+         * state similar to the data store context:
+         * The existing flag can be true in two conditions:
+         * 1. It's a local data store that is created when a detached container is rehydrated. In this case, the data
+         *    store is locally visible because the snapshot it is loaded from contains locally visible data stores only.
+         * 2. It's a remote data store that is created when an attached container is loaded is loaded from snapshot or
+         *    when an attach op comes in. In both these cases, the data store is already globally visible.
+         */
+        if (dataStoreContext.visibilityState !== undefined) {
+            this.visibilityState = dataStoreContext.visibilityState;
+        } else if (existing) {
+            this.visibilityState = dataStoreContext.attachState === AttachState.Detached
+                ? VisibilityState.LocallyVisible : VisibilityState.GloballyVisible;
+        }
 
         // If it's existing we know it has been attached.
         if (existing) {
@@ -387,28 +401,55 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         }
     }
 
-    public attachGraph() {
-        if (this.graphAttachState !== AttachState.Detached) {
+    /**
+     * This function is called when a data store becomes root. It does the following:
+     * 1. Marks the data store locally visible in the container.
+     * 2. Attaches the graph of all the handles bound to it.
+     * 3. Calls into the data store context to mark it visible in the container too. If the container is globally
+     *    visible, it will mark us globally visible. Otherwise, it will mark us globally visible when it becomes
+     *    globally visible.
+     */
+    public makeVisibleAndAttachGraph() {
+        if (this.visibilityState !== VisibilityState.NotVisible) {
             return;
         }
-        this.graphAttachState = AttachState.Attaching;
+        this.visibilityState = VisibilityState.LocallyVisible;
+
         if (this.boundhandles !== undefined) {
             this.boundhandles.forEach((handle) => {
                 handle.attachGraph();
             });
             this.boundhandles = undefined;
         }
+        this.dataStoreContext.makeVisible?.();
+    }
 
-        // Flush the queue to set any pre-existing channels to local
-        this.localChannelContextQueue.forEach((channel) => {
-            // When we are attaching the data store we don't need to send attach for the registered services.
-            // This is because they will be captured as part of the Attach data store snapshot
-            channel.markAttached();
-        });
+    /**
+     * This function is called when a handle to this data store is added to a visible DDS.
+     */
+    public attachGraph() {
+        this.makeVisibleAndAttachGraph();
 
-        this.localChannelContextQueue.clear();
-        this.bindToContext();
-        this.graphAttachState = AttachState.Attached;
+        /**
+         * back-compat 0.58.2000 - Older versions of data store context will call attachGraph() at the time of attaching
+         * the data store in getAttachSummary(). So, we have to mark each of its child channels visible. Note that we
+         * cannot do this on getting the "attaching" event like we do for current version. This is because it may
+         * happen before attachGraph() is called and we cannot make channels visible before attaching their graph.
+         */
+        if (this.dataStoreContext.makeVisible === undefined) {
+            // Flush the queue to set any pre-existing channels to local
+            this.localChannelContextQueue.forEach((channel) => {
+                // When we are attaching the data store we don't need to send attach for the registered services.
+                // This is because they will be captured as part of the Attach data store snapshot
+                channel.makeVisible();
+            });
+
+            this.localChannelContextQueue.clear();
+            this.bindToContext();
+            // This is needed so we don't send out attach ops for child channels that are attached while attaching the
+            // data store. This is possible because attachGraph() may be called after the "attaching" event is emitted.
+            this.visibilityState = VisibilityState.CompatGraphAttached;
+        }
     }
 
     /**
@@ -417,7 +458,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
      * 1. Sending an Attach op that includes all existing state
      * 2. Attaching the graph if the data store becomes attached.
      */
-     public bindToContext() {
+    public bindToContext() {
         if (this.bindState !== BindState.NotBound) {
             return;
         }
@@ -427,9 +468,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public bind(handle: IFluidHandle): void {
-        // If the data store is already attached or its graph is already in attaching or attached state,
-        // then attach the incoming handle too.
-        if (this.isAttached || this.graphAttachState !== AttachState.Detached) {
+        // If visible, attach the incoming handle's graph. Else, this will be done when we become visible.
+        if (this.visibilityState !== VisibilityState.NotVisible) {
             handle.attachGraph();
             return;
         }
@@ -587,8 +627,8 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
      * including any of its child channel contexts. Each node has a set of outbound routes to other GC nodes in the
      * document. It does the following:
      * 1. Calls into each child context to get its GC data.
-     * 2. Prefixs the child context's id to the GC nodes in the child's GC data. This makes sure that the node can be
-     *    idenfied as belonging to the child.
+     * 2. Prefixes the child context's id to the GC nodes in the child's GC data. This makes sure that the node can be
+     *    identified as belonging to the child.
      * 3. Adds a GC node for this channel to the nodes received from the children. All these nodes together represent
      *    the GC data of this channel.
      * @param fullGC - true to bypass optimizations and force full generation of GC data.
@@ -695,7 +735,15 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     }
 
     public getAttachSummary(): ISummaryTreeWithStats {
-        this.attachGraph();
+        /**
+         * back-compat 0.58.2000 - getAttachSummary() is called when making a data store globally visible (previously
+         * attached state). Ideally, attachGraph() should have already be called which happens when making it locally
+         * visible. However, before visibility state was added, attachGraph() was called here and we have to keep this
+         * around for backwards compatibility.
+         */
+        if (this.dataStoreContext.visibilityState === undefined) {
+            this.attachGraph();
+        }
 
         const summaryBuilder = new SummaryTreeBuilder();
 
@@ -756,9 +804,20 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         channel.handle.attachGraph();
 
         assert(this.isAttached, 0x182 /* "Data store should be attached to attach the channel." */);
-        // Get the object snapshot only if the data store is Bound and its graph is attached too,
-        // because if the graph is attaching, then it would get included in the data store snapshot.
-        if (this.bindState === BindState.Bound && this.graphAttachState === AttachState.Attached) {
+        /**
+         * back-compat 0.58.2000 - Ideally, attachChannel should only be called when the data store is globally
+         * visible (previously attached). However, before visibilityState was added, this could have been called while
+         * attaching a data store via the following sequence of events:
+         * 1. In an attached container, a root data store is created with a DDS.
+         * 2. The create API on container runtime calls bindToContext on the data store runtime.
+         * 3. This calls DataStores::bindFluidDataStore which moves the data store runtime to "attaching" state.
+         * 4. bindFluidDataStore then calls getAttachSummary on data store runtime to generates the initial summary.
+         * 5. getAttachSummary calls attachGraph which attaches the DDS and attachChannel is called.
+         * In this case, we don't want to generate an attach message for this DDS because its summary will be part of
+         * the data store's summary in its attach message.
+         */
+        if (this.dataStoreContext.visibilityState !== undefined
+            || (this.bindState === BindState.Bound && this.visibilityState === VisibilityState.CompatGraphAttached)) {
             const summarizeResult = summarizeChannel(channel, true /* fullTree */, false /* trackState */);
             // Attach message needs the summary in ITree format. Convert the ISummaryTree into an ITree.
             const snapshot = convertSummaryTreeToITree(summarizeResult.summary);
@@ -773,7 +832,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         }
 
         const context = this.contexts.get(channel.id) as LocalChannelContextBase;
-        context.markAttached();
+        context.makeVisible();
     }
 
     private submitChannelOp(address: string, contents: any, localOpMetadata: unknown) {
@@ -851,16 +910,31 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
     private attachListener() {
         this.setMaxListeners(Number.MAX_SAFE_INTEGER);
         this.dataStoreContext.once("attaching", () => {
-            assert(this.bindState !== BindState.NotBound,
-                0x186 /* "Data store attaching should not occur if it is not bound" */);
             this._attachState = AttachState.Attaching;
+
+            /**
+             * back-compat 0.58.2000 - Before visibilityState was added, data store may move to "attaching" state before
+             * attachGraph() is called from getAttachSummary(). In those cases, we cannot make the channels visible
+             * without first attaching their graphs.
+             */
+            if (this.dataStoreContext.visibilityState === undefined) {
+                this.attachGraph();
+            } else {
+                assert(this.visibilityState === VisibilityState.LocallyVisible,
+                    "Data store should not attach if is not locally visible");
+            }
+
+            // Mark the data store globally visible and make its child channels visible as well.
+            this.visibilityState = VisibilityState.GloballyVisible;
+            this.localChannelContextQueue.forEach((channel) => {
+                channel.makeVisible();
+            });
+
             // This promise resolution will be moved to attached event once we fix the scheduler.
             this.deferredAttached.resolve();
             this.emit("attaching");
         });
         this.dataStoreContext.once("attached", () => {
-            assert(this.bindState === BindState.Bound,
-                0x187 /* "Data store should only be attached after it is bound" */);
             this._attachState = AttachState.Attached;
             this.emit("attached");
         });

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -11,7 +11,7 @@ import {
 import { generateHandleContextPath } from "@fluidframework/runtime-utils";
 
 export class FluidObjectHandle<T extends FluidObject = FluidObject> implements IFluidHandle {
-    private boundHandles: Set<IFluidHandle> | undefined;
+    private readonly pendingHandlesToMakeVisible: Set<IFluidHandle> = new Set();
     public readonly absolutePath: string;
 
     public get IFluidHandle(): IFluidHandle { return this; }
@@ -63,13 +63,10 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
         }
 
         this._visible = true;
-        if (this.boundHandles !== undefined) {
-            for (const handle of this.boundHandles) {
-                handle.attachGraph();
-            }
-
-            this.boundHandles = undefined;
-        }
+        this.pendingHandlesToMakeVisible.forEach((handle) => {
+            handle.attachGraph();
+        });
+        this.pendingHandlesToMakeVisible.clear();
         this.routeContext.attachGraph();
     }
 
@@ -79,10 +76,6 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> implements I
             handle.attachGraph();
             return;
         }
-
-        if (this.boundHandles === undefined) {
-            this.boundHandles = new Set<IFluidHandle>();
-        }
-        this.boundHandles.add(handle);
+        this.pendingHandlesToMakeVisible.add(handle);
     }
 }

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -38,7 +38,7 @@ import { ChannelStorageService } from "./channelStorageService";
  */
 export abstract class LocalChannelContextBase implements IChannelContext {
     public channel: IChannel | undefined;
-    private attached = false;
+    private globallyVisible = false;
     protected readonly pending: ISequencedDocumentMessage[] = [];
     protected factory: IChannelFactory | undefined;
     constructor(
@@ -62,14 +62,14 @@ export abstract class LocalChannelContextBase implements IChannelContext {
     }
 
     public setConnectionState(connected: boolean, clientId?: string) {
-        // Connection events are ignored if the data store is not yet attached or loaded
-        if (this.attached && this.isLoaded) {
+        // Connection events are ignored if the data store is not yet globallyVisible or loaded
+        if (this.globallyVisible && this.isLoaded) {
             this.servicesGetter().value.deltaConnection.setConnectionState(connected);
         }
     }
 
     public processOp(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void {
-        assert(this.attached, 0x188 /* "Local channel must be attached when processing op" */);
+        assert(this.globallyVisible, "Local channel must be globally visible when processing op");
 
         // A local channel may not be loaded in case where we rehydrate the container from a snapshot because of
         // delay loading. So after the container is attached and some other client joins which start generating
@@ -85,7 +85,7 @@ export abstract class LocalChannelContextBase implements IChannelContext {
 
     public reSubmit(content: any, localOpMetadata: unknown) {
         assert(this.isLoaded, 0x18a /* "Channel should be loaded to resubmit ops" */);
-        assert(this.attached, 0x18b /* "Local channel must be attached when resubmitting op" */);
+        assert(this.globallyVisible, "Local channel must be globally visible when resubmitting op");
         this.servicesGetter().value.deltaConnection.reSubmit(content, localOpMetadata);
     }
 
@@ -108,16 +108,16 @@ export abstract class LocalChannelContextBase implements IChannelContext {
         return summarizeChannel(this.channel, true /* fullTree */, false /* trackState */);
     }
 
-    public markAttached(): void {
-        if (this.attached) {
-            throw new Error("Channel is already attached");
+    public makeVisible(): void {
+        if (this.globallyVisible) {
+            throw new Error("Channel is already globally visible");
         }
 
         if (this.isLoaded) {
             assert(!!this.channel, 0x192 /* "Channel should be there if loaded!!" */);
             this.channel.connect(this.servicesGetter().value);
         }
-        this.attached = true;
+        this.globallyVisible = true;
     }
 
     /**

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.ts
@@ -48,6 +48,7 @@ declare function get_old_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<current.FluidDataStoreRuntime>);
 use_current_ClassDeclaration_FluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -80,13 +80,6 @@ export enum VisibilityState {
      *    visible.
      */
     GloballyVisible = "GloballyVisible",
-
-    /**
-     * back-compat - In older versions, this state is used to track the state of an object when it is transitioning from
-     * not visible to locally visible. See FluidDataStoreRuntime::attachChannel for more details of the scenario that
-     * requires this.
-     */
-    CompatGraphAttached = "CompatGraphAttached",
 }
 
 export interface IContainerRuntimeBaseEvents extends IEvent{

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -57,6 +57,38 @@ export enum FlushMode {
     TurnBased,
 }
 
+/**
+ * This tells the visibility state of a Fluid object. It basically tracks whether the object is not visible, visible
+ * locally within the container only or visible globally to all clients.
+ */
+export enum VisibilityState {
+    /** Indicates that the object is not visible. This is the state when an object is first created. */
+    NotVisible = "NotVisible",
+
+    /**
+     * Indicates that the object is visible locally within the container. This is the state when an object is attached
+     * to the container's graph but the container itself isn't globally visible. The object's state goes from not
+     * visible to locally visible.
+     */
+    LocallyVisible = "LocallyVisible",
+
+    /**
+     * Indicates that the object is visible globally to all clients. This is the state of an object in 2 scenarios:
+     * 1. It is attached to the container's graph when the container is globally visible. The object's state goes from
+     *    not visible to globally visible.
+     * 2. When a container becomes globally visible, all locally visible objects go from locally visible to globally
+     *    visible.
+     */
+    GloballyVisible = "GloballyVisible",
+
+    /**
+     * back-compat - In older versions, this state is used to track the state of an object when it is transitioning from
+     * not visible to locally visible. See FluidDataStoreRuntime::attachChannel for more details of the scenario that
+     * requires this.
+     */
+    CompatGraphAttached = "CompatGraphAttached",
+}
+
 export interface IContainerRuntimeBaseEvents extends IEvent{
     (event: "batchBegin" | "op", listener: (op: ISequencedDocumentMessage) => void);
     (event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void);
@@ -185,12 +217,19 @@ export interface IFluidDataStoreChannel extends
      * Called to bind the runtime to the container.
      * If the container is not attached to storage, then this would also be unknown to other clients.
      */
-     bindToContext(): void;
+    bindToContext(): void;
 
     /**
+     * @deprecated - This will be removed in favor of makeVisibleAndAttachGraph.
      * Runs through the graph and attaches the bound handles. Then binds this runtime to the container.
      */
     attachGraph(): void;
+
+    /**
+     * Makes the data store channel visible in the container. Also, runs through its graph and attaches all
+     * bound handles that represent its dependencies in the container's graph.
+     */
+    makeVisibleAndAttachGraph?(): void;
 
     /**
      * Retrieves the summary used as part of the initial summary message
@@ -295,6 +334,8 @@ export interface IFluidDataStoreContext extends
      */
     readonly attachState: AttachState;
 
+    readonly visibilityState?: VisibilityState;
+
     readonly containerRuntime: IContainerRuntimeBase;
 
     /**
@@ -335,13 +376,20 @@ export interface IFluidDataStoreContext extends
     submitSignal(type: string, content: any): void;
 
     /**
+     * @deprecated - To be removed in favor of makeVisible.
      * Register the runtime to the container
      */
     bindToContext(): void;
 
     /**
+     * Makes the data store visible in the container. This happens automatically for root data stores when they are
+     * marked as root. For non-root data stores, this happens when their handle is added to a visible DDS.
+     */
+    makeVisible?(): void;
+
+    /**
      * Call by IFluidDataStoreChannel, indicates that a channel is dirty and needs to be part of the summary.
-     * @param address - The address of the channe that is dirty.
+     * @param address - The address of the channel that is dirty.
      */
     setChannelDirty(address: string): void;
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -206,6 +206,8 @@ export interface IFluidDataStoreChannel extends
      */
     readonly attachState: AttachState;
 
+    readonly visibilityState?: VisibilityState;
+
     /**
      * @deprecated - This is an internal method that should not be exposed.
      * Called to bind the runtime to the container.
@@ -327,8 +329,6 @@ export interface IFluidDataStoreContext extends
      * Indicates the attachment state of the data store to a host service.
      */
     readonly attachState: AttachState;
-
-    readonly visibilityState?: VisibilityState;
 
     readonly containerRuntime: IContainerRuntimeBase;
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -375,10 +375,10 @@ export interface IFluidDataStoreContext extends
     bindToContext(): void;
 
     /**
-     * Makes the data store visible in the container. This happens automatically for root data stores when they are
-     * marked as root. For non-root data stores, this happens when their handle is added to a visible DDS.
+     * Called to make the data store locally visible in the container. This happens automatically for root data stores
+     * when they are marked as root. For non-root data stores, this happens when their handle is added to a visible DDS.
      */
-    makeVisible?(): void;
+    makeLocallyVisible?(): void;
 
     /**
      * Call by IFluidDataStoreChannel, indicates that a channel is dirty and needs to be part of the summary.

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -61,16 +61,16 @@ export enum FlushMode {
  * This tells the visibility state of a Fluid object. It basically tracks whether the object is not visible, visible
  * locally within the container only or visible globally to all clients.
  */
-export enum VisibilityState {
+export const VisibilityState = {
     /** Indicates that the object is not visible. This is the state when an object is first created. */
-    NotVisible = "NotVisible",
+    NotVisible: "NotVisible",
 
     /**
      * Indicates that the object is visible locally within the container. This is the state when an object is attached
      * to the container's graph but the container itself isn't globally visible. The object's state goes from not
      * visible to locally visible.
      */
-    LocallyVisible = "LocallyVisible",
+    LocallyVisible: "LocallyVisible",
 
     /**
      * Indicates that the object is visible globally to all clients. This is the state of an object in 2 scenarios:
@@ -79,8 +79,9 @@ export enum VisibilityState {
      * 2. When a container becomes globally visible, all locally visible objects go from locally visible to globally
      *    visible.
      */
-    GloballyVisible = "GloballyVisible",
-}
+    GloballyVisible: "GloballyVisible",
+};
+export type VisibilityState = typeof VisibilityState[keyof typeof VisibilityState];
 
 export interface IContainerRuntimeBaseEvents extends IEvent{
     (event: "batchBegin" | "op", listener: (op: ISequencedDocumentMessage) => void);

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -686,4 +686,24 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
         assert.strictEqual(dataStore2.root.get("attachKey").absolutePath, subDataStore1.handle.absolutePath,
             "Stored handle should match!!");
     });
+
+    /**
+     * Fixed in 0.58.2000. Move to full compat once this is the last supported version.
+     */
+    it("Requesting non-root data stores in detached container", async () => {
+        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+        // Get the root dataStore from the detached container.
+        const rootDataStore = await requestFluidObject<ITestFluidObject>(container, "/");
+
+        // Create another data store and bind it by adding its handle in the root data store's DDS.
+        const dataStore2 = await createFluidObject(rootDataStore.context, "default");
+        rootDataStore.root.set("dataStore2", dataStore2.handle);
+
+        // Request the new data store via the request API on the container.
+        const dataStore2Response = await container.request({ url: dataStore2.handle.absolutePath });
+        assert(
+            dataStore2Response.mimeType === "fluid/object" && dataStore2Response.status === 200,
+            "Unable to load bound data store in detached container",
+        );
+    });
 });

--- a/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
@@ -114,14 +114,6 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
          * Also, they are visible in remote clients and can send ops.
          */
         it("validates that non-root data stores become visible correctly", async function() {
-            /**
-             * This test fails in detached container because of https://github.com/microsoft/FluidFramework/issues/9127.
-             * To be enabled once the bug is fixed.
-             */
-            if (detachedMode) {
-                this.skip();
-            }
-
             const dataObject2 = await createNonRootDataObject(container1, containerRuntime1);
             dataObject1._root.set("dataObject2", dataObject2.handle);
 
@@ -155,14 +147,6 @@ describeNoCompat("New Fluid objects visibility", (getTestObjectProvider) => {
          * until the parent data store is visible. Also, they are visible in remote clients and can send ops.
          */
         it("validates that non-root data store and its dependencies become visible correctly", async function() {
-            /**
-             * This test fails in detached container because of https://github.com/microsoft/FluidFramework/issues/9127.
-             * To be enabled once the bug is fixed.
-             */
-            if (detachedMode) {
-                this.skip();
-            }
-
             const dataObject2 = await createNonRootDataObject(container1, containerRuntime1);
             const dataObject3 = await createNonRootDataObject(container1, containerRuntime1);
 


### PR DESCRIPTION
Fixes #9127. Note that this bug will still happen when using these bits with older bits of container runtime of data store runtime. Only when the versions of both of these are current or newer, this bug won't happen.

Added `VisibilityState` to data store runtime. It has 3 values:
1. not visible - Created for the first time.
2. locally visible - Visible and reachable within the container locally.
3. globally visible - Visible and reachable to all clients connected to the document.

A local data store transitions from not visible -> locally visible -> globally visible without exception. A remote data store is globally visible by default.

Here is when the state transition happens:
- In detached container
  - A root data store becomes immediately locally visible by calling `makeVisibleAndAttachGraph` on its runtime. All its bound handles also recursively become locally visible.
  - Non-root data stores become locally visible when their handles are added to a locally visible DDS. This calls `attachGraph` on the runtime. All their bound handles also recursively become locally visible.
  - When the container attaches, it makes all its locally visible data stores globally visible by emitting "attaching" event. The data store marks all its DDS channels globally visible as well.
- In attached container
  - A root data store becomes immediately locally visible by calling `makeVisibleAndAttachGraph` on its runtime. All its bound handles also recursively become locally visible. All the data stores in this graph are made globally visible as well by emitting "attaching" event on them and sending an attach op.
  - Non-root data stores become locally visible when their handles are added to a locally visible DDS. This calls `attachGraph` on the runtime. All their bound handles also recursively become locally visible. All the data stores in this graph are made globally visible as well by emitting "attaching" event on them and sending an attach op.