### PR TITLE
Pipeline changes to enable publishin GitRest npm packages

### DIFF
--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -13,6 +13,16 @@ parameters:
   values:
     - none
     - release
+
+- name: releaseKind
+  displayName: Release Kind
+  type: string
+  default: both
+  values:
+    - both
+    - npm
+    - docker
+
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
   type: string
@@ -35,9 +45,12 @@ trigger:
     - tools/pipelines/templates/build-docker-service.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-generate-notice-steps.yml
+    - tools/pipelines/templates/include-publish-npm-package.yml
+    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-publish-docker-service.yml
     - tools/pipelines/templates/include-publish-docker-service-steps.yml
-    - tools/pipelines/templates/include-generate-notice-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
 
 pr:
@@ -61,7 +74,9 @@ extends:
     releaseImage: true
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    releaseKind: ${{ parameters.releaseKind }}
     buildDirectory: server/gitrest
     containerName: fluidframework/routerlicious/gitrest
     test: test
     tagName: gitrest
+    pack: true


### PR DESCRIPTION
Following up on #9550 and making pipeline changes in order to be able to publish both npm packages and docker images for GitRest.