### PR TITLE
Remove some peer dependencies

### DIFF
--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -14,8 +14,5 @@
   "bin": {
     "gen-version": "bin/gen-version"
   },
-  "scripts": {},
-  "peerDependencies": {
-    "typescript": ">=3.7.4"
-  }
+  "scripts": {}
 }

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -26,8 +26,5 @@
   "devDependencies": {
     "eslint": ">=8.6.0",
     "typescript": ">=4.5.3"
-  },
-  "peerDependencies": {
-    "eslint": ">= 7 || >=8"
   }
 }

--- a/tools/build-tools/package.json
+++ b/tools/build-tools/package.json
@@ -72,10 +72,5 @@
     "@types/webpack": "^4.41.22",
     "mocha": "^8.4.0",
     "typescript": "~4.1.3"
-  },
-  "peerDependencies": {
-    "@rushstack/eslint-config": "^2.5.1",
-    "eslint": "~8.6.0",
-    "typescript": "~4.1.3"
   }
 }


### PR DESCRIPTION
Using peer dependencies with our build tooling is unneeded because the tools are intended only for use in our repo, and peer dependencies are a hassle for downstream consumers.

Note that we have legitimate peer dependencies declared in the azure-client and Property DDS packages. Those dependencies are not addressed in this PR. See #7913 for more details.