### PR TITLE
Account for gaps in the LocalReference array when packing segments

### DIFF
--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "console";
+import { assert } from "@fluidframework/common-utils";
 import { Client } from "./client";
 import {
     ISegment,

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -132,6 +132,10 @@ export class LocalReferenceCollection {
         if (seg2.localRefs && !seg2.localRefs.empty) {
             if (!seg1.localRefs) {
                 seg1.localRefs = new LocalReferenceCollection(seg1);
+            } else if (seg1.cachedLength > seg1.localRefs.refsByOffset.length) {
+                // Since creating the LocalReferenceCollection, we may have appended
+                // segments that had no local references. Account for them now by padding the array.
+                seg1.localRefs.refsByOffset.length = seg1.cachedLength;
             }
             seg1.localRefs.append(seg2.localRefs);
         }

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "console";
 import { Client } from "./client";
 import {
     ISegment,
@@ -132,12 +133,14 @@ export class LocalReferenceCollection {
         if (seg2.localRefs && !seg2.localRefs.empty) {
             if (!seg1.localRefs) {
                 seg1.localRefs = new LocalReferenceCollection(seg1);
-            } else if (seg1.cachedLength > seg1.localRefs.refsByOffset.length) {
-                // Since creating the LocalReferenceCollection, we may have appended
-                // segments that had no local references. Account for them now by padding the array.
-                seg1.localRefs.refsByOffset.length = seg1.cachedLength;
             }
+            assert(seg1.localRefs.refsByOffset.length === seg1.cachedLength, "LocalReferences array contains a gap");
             seg1.localRefs.append(seg2.localRefs);
+        }
+        else if (seg1.localRefs) {
+            // Since creating the LocalReferenceCollection, we may have appended
+            // segments that had no local references. Account for them now by padding the array.
+            seg1.localRefs.refsByOffset.length += seg2.cachedLength;
         }
     }
 


### PR DESCRIPTION
When Zamboni combines TextSegment's, it needs to update LocalReference's that refer to the segments. It wasn't doing this correctly in the case where, say, a reference is found at position 0, then some number of segments without references were appended, then a segment containing a reference was appended. The text corresponding to the segments without references wasn't accounted in the final segment. A gap needs to be introduced in the LocalReference array to make the references correct.