### PR TITLE
Driver-Definitions - Updating the protocol-definitions version 

### DIFF
--- a/common/lib/driver-definitions/package-lock.json
+++ b/common/lib/driver-definitions/package-lock.json
@@ -365,9 +365,9 @@
       }
     },
     "@fluidframework/protocol-definitions": {
-      "version": "0.1027.1000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1027.1000.tgz",
-      "integrity": "sha512-6eUlOw9bOLjGmma1XtJDq7bMgSmrut+tsTA37kfokcWiUCBhlxLXq+fJkLuhjDOCVowEy5m0fRgt3vHzG/H9mg==",
+      "version": "0.1028.1000-58358",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.1000-58358.tgz",
+      "integrity": "sha512-6nrwus9JfQy/94lnhjDO0Zs9Vctv9V/Z+Iesr5drSPcUdPbke+oRlQE3OHZt61WPwF6hR09ZYDieIauuZbn/Ew==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0"
       }

--- a/common/lib/driver-definitions/package.json
+++ b/common/lib/driver-definitions/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@fluidframework/common-definitions": "^0.20.0",
     "@fluidframework/core-interfaces": "^0.42.0",
-    "@fluidframework/protocol-definitions": "^0.1027.1000"
+    "@fluidframework/protocol-definitions": "^0.1028.1000-0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^0.23.0",


### PR DESCRIPTION
After releasing a prerelease for protocol-definitions, we need to bump its version on the driver-definition @heliocliu  to confirm. 