### PR TITLE
Fix branch labeler config

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -18,7 +18,7 @@ jobs:
     name: Label base branches
     steps:
     - uses: srvaroa/labeler@36ad6b8842ea13d9ce2e4d22993bbf6fc0d20b5e # pin@v0.9
-      with:
+      env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   external_label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For some reason I thought `with` and `env` worked the same way