### PR TITLE
Add missing step in readme instructions

### DIFF
--- a/examples/apps/collaborative-textarea/README.md
+++ b/examples/apps/collaborative-textarea/README.md
@@ -3,7 +3,7 @@
 **Collaborative TextArea** is a basic example that creates a SharedString and uses the react CollaborativeTextArea
 component to launch a basic collaborative HTML `<textarea>`
 
-<!-- AUTO-GENERATED-CONTENT:START (GET_STARTED) -->
+<!-- AUTO-GENERATED-CONTENT:START (GET_STARTED:tinylicious=true) -->
 <!-- The getting started instructions are automatically generated.
 To update them, edit docs/md-magic.config.js, then run 'npm run build:md-magic' -->
 
@@ -14,6 +14,7 @@ You can run this example using the following steps:
 1. Run `npm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
    a. For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/collaborative-textarea`
+1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](../../../server/tinylicious).
 1. Run `npm run start` from this directory (examples/apps/collaborative-textarea) and open <http://localhost:8080> in a web browser to see the app running.
 <!-- AUTO-GENERATED-CONTENT:END -->
 


### PR DESCRIPTION
The collab text area example requires Tinylicious.