### PR TITLE
Release 0.55 - Adding nonSysOps count to the treeSnapshot (#9622)

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -16,6 +16,7 @@ import {
     InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { isSystemMessage } from "@fluidframework/protocol-base";
 import { IOdspSnapshot, ISnapshotCachedEntry, IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts";
 import { getQueryString } from "./getQueryString";
 import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth";
@@ -290,6 +291,7 @@ async function fetchLatestSnapshotCore(
                     encodedBlobsSize,
                     sequenceNumber,
                     ops: snapshot.ops?.length ?? 0,
+                    nonSysOps:  snapshot.ops?.filter((op) => !isSystemMessage(op)).length ?? 0,
                     headers: Object.keys(response.requestHeaders).length !== 0 ? true : undefined,
                     redirecttime: redirectTime,
                     dnsLookuptime: dnstime,


### PR DESCRIPTION
Porting Main Fix for #9621 to log the number of ops that are not system ops to help us understand how much user content is there.