### PR TITLE
[t9s] Avoiding setting up Lumberjack twice

### DIFF
--- a/server/tinylicious/src/index.ts
+++ b/server/tinylicious/src/index.ts
@@ -9,8 +9,7 @@ import http from "http";
 import Axios from "axios";
 import winston from "winston";
 import { runService } from "@fluidframework/server-services-shared";
-import { configureLogging, WinstonLumberjackEngine } from "@fluidframework/server-services-utils";
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { configureLogging } from "@fluidframework/server-services-utils";
 import { TinyliciousResourcesFactory } from "./resourcesFactory";
 import { TinyliciousRunnerFactory } from "./runnerFactory";
 
@@ -26,8 +25,6 @@ Axios.defaults.httpAgent = new http.Agent({ keepAlive: true });
 const configPath = path.join(__dirname, "../config.json");
 
 configureLogging(configPath);
-const lumberjackEngine = new WinstonLumberjackEngine();
-Lumberjack.setup([lumberjackEngine]);
 
 runService(
     new TinyliciousResourcesFactory(),


### PR DESCRIPTION
Tinylicious was printing a non-blocking (but confusing) error message to the console due to duplicate `Lumberjack` setup. That is because `configureLogging()` already sets it up, but we were doing it again in `index.ts`. This PR fixes that, leaving only the `configureLogging()` setup.

Testing/Validation: confirmed that the log message `This Lumberjack was already setup with a list of engines and optional schema validator.` does not show up anymore after the fix, and confirmed no unexpected issues happen by running Clicker against t9s.