### PR TITLE
[GitRest] Refactoring APIs to support storage name header

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/app.ts
+++ b/server/gitrest/packages/gitrest-base/src/app.ts
@@ -12,7 +12,7 @@ import split from "split";
 import winston from "winston";
 import { bindCorrelationId } from "@fluidframework/server-services-utils";
 import * as routes from "./routes";
-import { IFileSystemManager, IRepositoryManagerFactory } from "./utils";
+import { IFileSystemManagerFactory, IRepositoryManagerFactory } from "./utils";
 
 /**
  * Basic stream logging interface for libraries that require a stream to pipe output to
@@ -23,7 +23,7 @@ const stream = split().on("data", (message) => {
 
 export function create(
     store: nconf.Provider,
-    fileSystemManager: IFileSystemManager,
+    fileSystemManagerFactory: IFileSystemManagerFactory,
     repositoryManagerFactory: IRepositoryManagerFactory,
 ) {
     // Express app configuration
@@ -56,7 +56,7 @@ export function create(
 
     app.use(cors());
 
-    const apiRoutes = routes.create(store, fileSystemManager, repositoryManagerFactory);
+    const apiRoutes = routes.create(store, fileSystemManagerFactory, repositoryManagerFactory);
     app.use(apiRoutes.git.blobs);
     app.use(apiRoutes.git.refs);
     app.use(apiRoutes.git.repos);

--- a/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
@@ -6,23 +6,16 @@
 import { ICreateBlobParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { Constants, IRepositoryManagerFactory } from "../../utils";
+import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
-
     router.post("/repos/:owner/:repo/git/blobs", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.createBlob(
-            request.body as ICreateBlobParams,
-        ));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.createBlob(
+                request.body as ICreateBlobParams,
+            ));
 
         handleResponse(resultP, response, 201);
     });
@@ -31,16 +24,10 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
      * Retrieves the given blob from the repository
      */
     router.get("/repos/:owner/:repo/git/blobs/:sha", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getBlob(
-            request.params.sha,
-        ));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getBlob(
+                request.params.sha,
+            ));
 
         handleResponse(resultP, response);
     });

--- a/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/blobs.ts
@@ -6,17 +6,21 @@
 import { ICreateBlobParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { IRepositoryManagerFactory } from "../../utils";
+import { Constants, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
 
     router.post("/repos/:owner/:repo/git/blobs", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.createBlob(
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.createBlob(
             request.body as ICreateBlobParams,
         ));
 
@@ -27,10 +31,14 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
      * Retrieves the given blob from the repository
      */
     router.get("/repos/:owner/:repo/git/blobs/:sha", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getBlob(
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getBlob(
             request.params.sha,
         ));
 

--- a/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
@@ -6,7 +6,7 @@
 import { ICreateCommitParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { Constants, IRepositoryManagerFactory } from "../../utils";
+import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
@@ -15,27 +15,15 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
     // * https://developer.github.com/v3/git/commits/
 
     router.post("/repos/:owner/:repo/git/commits", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.createCommit(request.body as ICreateCommitParams));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.createCommit(request.body as ICreateCommitParams));
 
         handleResponse(resultP, response, 201);
     });
 
     router.get("/repos/:owner/:repo/git/commits/:sha", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getCommit(request.params.sha));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getCommit(request.params.sha));
 
         handleResponse(resultP, response);
     });

--- a/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/commits.ts
@@ -6,7 +6,7 @@
 import { ICreateCommitParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { IRepositoryManagerFactory } from "../../utils";
+import { Constants, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
@@ -15,19 +15,27 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
     // * https://developer.github.com/v3/git/commits/
 
     router.post("/repos/:owner/:repo/git/commits", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.createCommit(request.body as ICreateCommitParams));
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.createCommit(request.body as ICreateCommitParams));
 
         handleResponse(resultP, response, 201);
     });
 
     router.get("/repos/:owner/:repo/git/commits/:sha", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getCommit(request.params.sha));
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getCommit(request.params.sha));
 
         handleResponse(resultP, response);
     });

--- a/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
@@ -8,7 +8,7 @@ import {
     IPatchRefParamsExternal } from "@fluidframework/server-services-client";
 import { Router } from "express";
 import nconf from "nconf";
-import { Constants, getExternalWriterParams, IRepositoryManagerFactory } from "../../utils";
+import { getExternalWriterParams, getRepoManagerParamsFromRequest, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 /**
@@ -27,74 +27,46 @@ export function create(
     // https://developer.github.com/v3/git/refs/
 
     router.get("/repos/:owner/:repo/git/refs", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getRefs());
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getRefs());
+
         handleResponse(resultP, response);
     });
 
     router.get("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getRef(
-            getRefId(request.params[0]),
-            getExternalWriterParams(request.query?.config as string),
-        ));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getRef(
+                getRefId(request.params[0]),
+                getExternalWriterParams(request.query?.config as string),
+            ));
         handleResponse(resultP, response);
     });
 
     router.post("/repos/:owner/:repo/git/refs", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
         const createRefParams = request.body as ICreateRefParamsExternal;
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.createRef(
-            createRefParams,
-            createRefParams.config,
-        ));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.createRef(
+                createRefParams,
+                createRefParams.config,
+            ));
         handleResponse(resultP, response, 201);
     });
 
     router.patch("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
         const patchRefParams = request.body as IPatchRefParamsExternal;
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.patchRef(
-            getRefId(request.params[0]),
-            patchRefParams,
-            patchRefParams.config,
-        ));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.patchRef(
+                getRefId(request.params[0]),
+                patchRefParams,
+                patchRefParams.config,
+            ));
         handleResponse(resultP, response);
     });
 
     router.delete("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.deleteRef(getRefId(request.params[0])));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.deleteRef(getRefId(request.params[0])));
+
         handleResponse(resultP, response, 204);
     });
     return router;

--- a/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/refs.ts
@@ -8,7 +8,7 @@ import {
     IPatchRefParamsExternal } from "@fluidframework/server-services-client";
 import { Router } from "express";
 import nconf from "nconf";
-import { getExternalWriterParams, IRepositoryManagerFactory } from "../../utils";
+import { Constants, getExternalWriterParams, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 /**
@@ -27,18 +27,26 @@ export function create(
     // https://developer.github.com/v3/git/refs/
 
     router.get("/repos/:owner/:repo/git/refs", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getRefs());
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getRefs());
         handleResponse(resultP, response);
     });
 
     router.get("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getRef(
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getRef(
             getRefId(request.params[0]),
             getExternalWriterParams(request.query?.config as string),
         ));
@@ -46,11 +54,15 @@ export function create(
     });
 
     router.post("/repos/:owner/:repo/git/refs", async (request, response, next) => {
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
         const createRefParams = request.body as ICreateRefParamsExternal;
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.createRef(
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.createRef(
             createRefParams,
             createRefParams.config,
         ));
@@ -58,11 +70,15 @@ export function create(
     });
 
     router.patch("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
         const patchRefParams = request.body as IPatchRefParamsExternal;
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.patchRef(
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.patchRef(
             getRefId(request.params[0]),
             patchRefParams,
             patchRefParams.config,
@@ -71,10 +87,14 @@ export function create(
     });
 
     router.delete("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.deleteRef(getRefId(request.params[0])));
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.deleteRef(getRefId(request.params[0])));
         handleResponse(resultP, response, 204);
     });
     return router;

--- a/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
@@ -6,7 +6,7 @@
 import { ICreateTagParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { Constants, IRepositoryManagerFactory } from "../../utils";
+import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
@@ -15,27 +15,15 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
     // https://developer.github.com/v3/git/tags/
 
     router.post("/repos/:owner/:repo/git/tags", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.createTag(request.body as ICreateTagParams));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.createTag(request.body as ICreateTagParams));
 
         handleResponse(resultP, response, 201);
     });
 
     router.get("/repos/:owner/:repo/git/tags/*", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getTag(request.params[0]));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getTag(request.params[0]));
 
         handleResponse(resultP, response);
     });

--- a/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/tags.ts
@@ -6,7 +6,7 @@
 import { ICreateTagParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { IRepositoryManagerFactory } from "../../utils";
+import { Constants, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
@@ -15,19 +15,27 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
     // https://developer.github.com/v3/git/tags/
 
     router.post("/repos/:owner/:repo/git/tags", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.createTag(request.body as ICreateTagParams));
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.createTag(request.body as ICreateTagParams));
 
         handleResponse(resultP, response, 201);
     });
 
     router.get("/repos/:owner/:repo/git/tags/*", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getTag(request.params[0]));
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getTag(request.params[0]));
 
         handleResponse(resultP, response);
     });

--- a/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
@@ -6,26 +6,34 @@
 import { ICreateTreeParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { IRepositoryManagerFactory } from "../../utils";
+import { Constants, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
 
     router.post("/repos/:owner/:repo/git/trees", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.createTree(request.body as ICreateTreeParams));
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.createTree(request.body as ICreateTreeParams));
 
         handleResponse(resultP, response, 201);
     });
 
     router.get("/repos/:owner/:repo/git/trees/:sha", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getTree(request.params.sha, request.query.recursive === "1"));
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getTree(request.params.sha, request.query.recursive === "1"));
 
         handleResponse(resultP, response);
     });

--- a/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/git/trees.ts
@@ -6,34 +6,22 @@
 import { ICreateTreeParams } from "@fluidframework/gitresources";
 import { Router } from "express";
 import nconf from "nconf";
-import { Constants, IRepositoryManagerFactory } from "../../utils";
+import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
 
     router.post("/repos/:owner/:repo/git/trees", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.createTree(request.body as ICreateTreeParams));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.createTree(request.body as ICreateTreeParams));
 
         handleResponse(resultP, response, 201);
     });
 
     router.get("/repos/:owner/:repo/git/trees/:sha", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getTree(request.params.sha, request.query.recursive === "1"));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getTree(request.params.sha, request.query.recursive === "1"));
 
         handleResponse(resultP, response);
     });

--- a/server/gitrest/packages/gitrest-base/src/routes/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/index.ts
@@ -5,7 +5,7 @@
 
 import { Router } from "express";
 import nconf from "nconf";
-import { IFileSystemManager, IRepositoryManagerFactory } from "../utils";
+import { IFileSystemManagerFactory, IRepositoryManagerFactory } from "../utils";
 /* eslint-disable import/no-internal-modules */
 import * as blobs from "./git/blobs";
 import * as commits from "./git/commits";
@@ -36,7 +36,7 @@ export interface IRoutes {
 
 export function create(
     store: nconf.Provider,
-    fileSystemManager: IFileSystemManager,
+    fileSystemManagerFactory: IFileSystemManagerFactory,
     repoManagerFactory: IRepositoryManagerFactory,
 ): IRoutes {
     return {
@@ -52,6 +52,6 @@ export function create(
             commits: repositoryCommits.create(store, repoManagerFactory),
             contents: contents.create(store, repoManagerFactory),
         },
-        summaries: summaries.create(store, fileSystemManager, repoManagerFactory),
+        summaries: summaries.create(store, fileSystemManagerFactory, repoManagerFactory),
     };
 }

--- a/server/gitrest/packages/gitrest-base/src/routes/repository/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/repository/commits.ts
@@ -5,7 +5,7 @@
 
 import { Router } from "express";
 import nconf from "nconf";
-import { getExternalWriterParams, IRepositoryManagerFactory } from "../../utils";
+import { Constants, getExternalWriterParams, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
@@ -18,10 +18,14 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
     // since
     // until
     router.get("/repos/:owner/:repo/commits", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getCommits(
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getCommits(
             request.query.sha as string,
             Number(request.query.count as string),
             getExternalWriterParams(request.query?.config as string),

--- a/server/gitrest/packages/gitrest-base/src/routes/repository/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/repository/commits.ts
@@ -5,7 +5,7 @@
 
 import { Router } from "express";
 import nconf from "nconf";
-import { Constants, getExternalWriterParams, IRepositoryManagerFactory } from "../../utils";
+import { getExternalWriterParams, getRepoManagerParamsFromRequest, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
@@ -18,18 +18,12 @@ export function create(store: nconf.Provider, repoManagerFactory: IRepositoryMan
     // since
     // until
     router.get("/repos/:owner/:repo/commits", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getCommits(
-            request.query.sha as string,
-            Number(request.query.count as string),
-            getExternalWriterParams(request.query?.config as string),
-        ));
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getCommits(
+                request.query.sha as string,
+                Number(request.query.count as string),
+                getExternalWriterParams(request.query?.config as string),
+            ));
         handleResponse(resultP, response);
     });
 

--- a/server/gitrest/packages/gitrest-base/src/routes/repository/contents.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/repository/contents.ts
@@ -5,17 +5,21 @@
 
 import { Router } from "express";
 import nconf from "nconf";
-import { IRepositoryManagerFactory } from "../../utils";
+import { Constants, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
 
     router.get("/repos/:owner/:repo/contents/*", async (request, response, next) => {
-        const resultP = repoManagerFactory.open(
-            request.params.owner,
-            request.params.repo,
-        ).then(async (repoManager) => repoManager.getContent(
+        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+        const resultP = repoManagerFactory.open({
+            repoOwner: request.params.owner,
+            repoName: request.params.repo,
+            fileSystemManagerParams: {
+                storageName,
+            },
+        }).then(async (repoManager) => repoManager.getContent(
             request.query.ref as string,
             request.params[0],
         ));

--- a/server/gitrest/packages/gitrest-base/src/routes/repository/contents.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/repository/contents.ts
@@ -5,25 +5,19 @@
 
 import { Router } from "express";
 import nconf from "nconf";
-import { Constants, IRepositoryManagerFactory } from "../../utils";
+import { getRepoManagerParamsFromRequest, IRepositoryManagerFactory } from "../../utils";
 import { handleResponse } from "../utils";
 
 export function create(store: nconf.Provider, repoManagerFactory: IRepositoryManagerFactory): Router {
     const router: Router = Router();
 
     router.get("/repos/:owner/:repo/contents/*", async (request, response, next) => {
-        const storageName: string | undefined = request.get(Constants.StorageNameHeader);
-        const resultP = repoManagerFactory.open({
-            repoOwner: request.params.owner,
-            repoName: request.params.repo,
-            fileSystemManagerParams: {
-                storageName,
-            },
-        }).then(async (repoManager) => repoManager.getContent(
-            request.query.ref as string,
-            request.params[0],
-        ));
-        handleResponse(resultP, response);
+        const resultP = repoManagerFactory.open(getRepoManagerParamsFromRequest(request))
+            .then(async (repoManager) => repoManager.getContent(
+                request.query.ref as string,
+                request.params[0],
+            ));
+            handleResponse(resultP, response);
     });
 
     return router;

--- a/server/gitrest/packages/gitrest-base/src/runner.ts
+++ b/server/gitrest/packages/gitrest-base/src/runner.ts
@@ -8,7 +8,7 @@ import { IWebServer, IWebServerFactory, IRunner } from "@fluidframework/server-s
 import { Provider } from "nconf";
 import * as winston from "winston";
 import * as app from "./app";
-import { IFileSystemManager, IRepositoryManagerFactory } from "./utils";
+import { IFileSystemManagerFactory, IRepositoryManagerFactory } from "./utils";
 
 export class GitrestRunner implements IRunner {
     private server: IWebServer;
@@ -18,14 +18,14 @@ export class GitrestRunner implements IRunner {
         private readonly serverFactory: IWebServerFactory,
         private readonly config: Provider,
         private readonly port: string | number,
-        private readonly fileSystemManager: IFileSystemManager,
+        private readonly fileSystemManagerFactory: IFileSystemManagerFactory,
         private readonly repositoryManagerFactory: IRepositoryManagerFactory) {
     }
 
     public async start(): Promise<void> {
         this.runningDeferred = new Deferred<void>();
         // Create the gitrest app
-        const gitrest = app.create(this.config, this.fileSystemManager, this.repositoryManagerFactory);
+        const gitrest = app.create(this.config, this.fileSystemManagerFactory, this.repositoryManagerFactory);
         gitrest.set("port", this.port);
 
         this.server = this.serverFactory.create(gitrest);

--- a/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import assert from "assert";
-import fs from "fs";
 import {
     ICreateBlobParams,
     ICreateBlobResponse,
@@ -22,7 +21,7 @@ import sillyname from "sillyname";
 import request from "supertest";
 import * as app from "../app";
 import { ExternalStorageManager } from "../externalStorageManager";
-import { NodegitRepositoryManagerFactory } from "../utils";
+import { NodeFsManagerFactory, NodegitRepositoryManagerFactory } from "../utils";
 import * as testUtils from "./utils";
 
 // TODO: (issue logged): replace email & name
@@ -147,10 +146,11 @@ describe("GitRest", () => {
             sha: "cf0b592907d683143b28edd64d274ca70f68998e",
         };
 
+        const fileSystemManagerFactory = new NodeFsManagerFactory();
         const externalStorageManager = new ExternalStorageManager(testUtils.defaultProvider);
         const getRepoManagerFactory = () => new NodegitRepositoryManagerFactory(
             testUtils.defaultProvider.get("storageDir"),
-            fs,
+            fileSystemManagerFactory,
             externalStorageManager,
         );
 
@@ -160,7 +160,7 @@ describe("GitRest", () => {
         let supertest: request.SuperTest<request.Test>;
         beforeEach(() => {
             const repoManagerFactory = getRepoManagerFactory();
-            const testApp = app.create(testUtils.defaultProvider, fs, repoManagerFactory);
+            const testApp = app.create(testUtils.defaultProvider, fileSystemManagerFactory, repoManagerFactory);
             supertest = request(testApp);
         });
 
@@ -424,7 +424,10 @@ describe("GitRest", () => {
 
                 await initBaseRepo(supertest, testOwnerName, testRepoName, testBlob, testTree, testCommit, testRef);
                 const repoManagerFactory = getRepoManagerFactory();
-                const repoManager = await repoManagerFactory.open(testOwnerName, testRepoName);
+                const repoManager = await repoManagerFactory.open({
+                    repoOwner: testOwnerName,
+                    repoName: testRepoName,
+                });
 
                 let lastCommit;
 

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -6,6 +6,11 @@
 import fsPromises from "fs/promises";
 import * as git from "@fluidframework/gitresources";
 
+export enum Constants {
+    StorageRoutingIdHeader = "Storage-Routing-Id",
+    StorageNameHeader = "Storage-Name",
+}
+
 export interface IExternalWriterConfig {
     enabled: boolean;
 }
@@ -55,15 +60,29 @@ export interface IFileSystemManager {
     promises: IFileSystemPromises;
 }
 
+export interface IFileSystemManagerParams {
+    storageName?: string;
+}
+
+export interface IFileSystemManagerFactory {
+    create(fileSystemManagerParams?: IFileSystemManagerParams): IFileSystemManager;
+}
+
+export interface IRepoManagerParams {
+    repoOwner: string;
+    repoName: string;
+    fileSystemManagerParams?: IFileSystemManagerParams;
+}
+
 export interface IRepositoryManagerFactory {
     /**
      * Create a new repository and return its manager instance.
      */
-    create(repoOwner: string, repoName: string): Promise<IRepositoryManager>;
+    create(params: IRepoManagerParams): Promise<IRepositoryManager>;
     /**
      * Open an existing repository and return its manager instance.
      */
-    open(repoOwner: string, repoName: string): Promise<IRepositoryManager>;
+    open(params: IRepoManagerParams): Promise<IRepositoryManager>;
 }
 
 // 100644 for file (blob)

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -5,8 +5,9 @@
 
 import { PathLike, Stats } from "fs";
 import * as path from "path";
+import { Request } from "express";
 import { IGetRefParamsExternal, IWholeFlatSummary, NetworkError } from "@fluidframework/server-services-client";
-import { IExternalWriterConfig, IFileSystemManager } from "./definitions";
+import { Constants, IExternalWriterConfig, IFileSystemManager, IRepoManagerParams } from "./definitions";
 
 /**
  * Validates that the input encoding is valid
@@ -31,6 +32,17 @@ export function getExternalWriterParams(params: string | undefined): IExternalWr
         return getRefParams.config;
     }
     return undefined;
+}
+
+export function getRepoManagerParamsFromRequest(request: Request): IRepoManagerParams {
+    const storageName: string | undefined = request.get(Constants.StorageNameHeader);
+    return {
+        repoOwner: request.params.owner,
+        repoName: request.params.repo,
+        fileSystemManagerParams: {
+            storageName,
+        },
+    };
 }
 
 export async function exists(

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -93,6 +93,14 @@ export async function retrieveLatestFullSummaryFromStorage(
  * Retrieves the full repository path. Or throws an error if not valid.
  */
 export function getRepoPath(owner: string, name: string) {
+    if (!owner || owner === "") {
+        throw new NetworkError(400, `Invalid arguments. A repo owner must be provided.`);
+    }
+
+    if (!name || name === "") {
+        throw new NetworkError(400, `Invalid arguments. A repo name must be provided.`);
+    }
+
     // Verify that both inputs are valid folder names
     const parsedOwner = path.parse(owner);
     const parsedName = path.parse(name);

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -4,7 +4,8 @@
  */
 
 export * from "./definitions";
+export * from "./gitWholeSummaryManager";
 export * from "./helpers";
 export * from "./isomorphicgitManager";
+export * from "./nodeFsManagerFactory";
 export * from "./nodegitManager";
-export * from "./gitWholeSummaryManager";

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -15,6 +15,8 @@ import {
     IExternalWriterConfig,
     IRepositoryManager,
     IFileSystemManager,
+    IFileSystemManagerFactory,
+    IRepoManagerParams,
 } from "./definitions";
 
 export class IsomorphicGitRepositoryManager implements IRepositoryManager {
@@ -343,38 +345,40 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
 
     constructor(
         private readonly baseDir: string,
-        private readonly fileSystemManager: IFileSystemManager,
+        private readonly fileSystemManagerFactory: IFileSystemManagerFactory,
     ) { }
 
-    public async create(owner: string, name: string): Promise<IsomorphicGitRepositoryManager> {
+    public async create(params: IRepoManagerParams): Promise<IsomorphicGitRepositoryManager> {
         // Verify that both inputs are valid folder names
-        const repoPath = helpers.getRepoPath(owner, name);
+        const repoPath = helpers.getRepoPath(params.repoOwner, params.repoName);
+        const fileSystemManager = this.fileSystemManagerFactory.create(params.fileSystemManagerParams);
         const directoryPath = `${this.baseDir}/${repoPath}`;
 
         // Create and then cache the repository
         await isomorphicGit.init({
-            fs: this.fileSystemManager,
-            gitdir: `${this.baseDir}/${repoPath}`,
+            fs: fileSystemManager,
+            gitdir: directoryPath,
             bare: true,
         });
 
         this.repositoryCache.add(repoPath);
         const repoManager = new IsomorphicGitRepositoryManager(
-            this.fileSystemManager,
-            owner,
-            name,
+            fileSystemManager,
+            params.repoOwner,
+            params.repoName,
             directoryPath);
-        winston.info(`Created a new repo for owner ${owner} reponame: ${name}`);
+        winston.info(`Created a new repo for owner ${params.repoOwner} reponame: ${params.repoName}`);
 
         return repoManager;
     }
 
-    public async open(owner: string, name: string): Promise<IsomorphicGitRepositoryManager> {
-        const repoPath = helpers.getRepoPath(owner, name);
+    public async open(params: IRepoManagerParams): Promise<IsomorphicGitRepositoryManager> {
+        const repoPath = helpers.getRepoPath(params.repoOwner, params.repoName);
         const directoryPath = `${this.baseDir}/${repoPath}`;
+        const fileSystemManager = this.fileSystemManagerFactory.create(params.fileSystemManagerParams);
 
         if (!(this.repositoryCache.has(repoPath))) {
-            const repoExists = await helpers.exists(this.fileSystemManager, directoryPath);
+            const repoExists = await helpers.exists(fileSystemManager, directoryPath);
             if (!repoExists || !repoExists.isDirectory()) {
                 winston.info(`Repo does not exist ${directoryPath}`);
                 // services-client/getOrCreateRepository depends on a 400 response code
@@ -385,9 +389,9 @@ export class IsomorphicGitManagerFactory implements IRepositoryManagerFactory {
         }
 
         const repoManager = new IsomorphicGitRepositoryManager(
-            this.fileSystemManager,
-            owner,
-            name,
+            fileSystemManager,
+            params.repoOwner,
+            params.repoName,
             directoryPath);
         return repoManager;
     }

--- a/server/gitrest/packages/gitrest-base/src/utils/nodeFsManagerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodeFsManagerFactory.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import fs from "fs";
+import { IFileSystemManager, IFileSystemManagerFactory, IFileSystemManagerParams } from "./definitions";
+
+export class NodeFsManagerFactory implements IFileSystemManagerFactory {
+    public create(params?: IFileSystemManagerParams): IFileSystemManager {
+        return fs;
+    }
+}


### PR DESCRIPTION
In  #9339, a new optional header was introduced in Historian requests coming to GitRest: `"Storage-Name"`. It specifies the storage name associated with a given tenant. In this PR, I am updating our APIs/routes to read that header from the requests, and then I refactored parts of the code to optionally use it.