### PR TITLE
Reenable unbound method lint rule and preemptive fixes

### DIFF
--- a/common/build/eslint-config-fluid/eslint7.js
+++ b/common/build/eslint-config-fluid/eslint7.js
@@ -139,7 +139,12 @@ module.exports = {
         "@typescript-eslint/strict-boolean-expressions": "error",
         "@typescript-eslint/triple-slash-reference": "error",
         "@typescript-eslint/type-annotation-spacing": "error",
-        "@typescript-eslint/unbound-method": "off",
+        "@typescript-eslint/unbound-method": [
+            "error",
+            {
+                "ignoreStatic": true
+            }
+        ],
         "@typescript-eslint/unified-signatures": "error",
 
         // eslint-plugin-eslint-comments

--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -927,11 +927,6 @@
         }
       }
     },
-    "eslint-plugin-no-null": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-null/-/eslint-plugin-no-null-1.0.2.tgz",
-      "integrity": "sha1-EjaoEjkTkKGHetQAfCbnRTQclR8="
-    },
     "eslint-plugin-promise": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",

--- a/experimental/PropertyDDS/packages/property-changeset/.eslintrc.js
+++ b/experimental/PropertyDDS/packages/property-changeset/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
         "@typescript-eslint/quotes": "off",
         "@typescript-eslint/restrict-plus-operands": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "@typescript-eslint/unbound-method": "off",
         "@typescript-eslint/unified-signatures": "off",
         "eqeqeq": "off",
         "import/no-internal-modules": "off",

--- a/experimental/PropertyDDS/packages/property-properties/.eslintignore
+++ b/experimental/PropertyDDS/packages/property-properties/.eslintignore
@@ -1,0 +1,1 @@
+src/index.d.ts

--- a/experimental/PropertyDDS/packages/property-properties/.eslintrc.js
+++ b/experimental/PropertyDDS/packages/property-properties/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
         "@typescript-eslint/quotes": "off",
         "@typescript-eslint/restrict-plus-operands": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "@typescript-eslint/unbound-method": "off",
         "guard-for-in": "off",
         "import/no-duplicates": "off",
         "import/no-internal-modules": "off",

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -545,6 +545,8 @@ export class Client {
             }
         }
 
+        // start and end are guaranteed to be non-null here, otherwise we throw above.
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         return { start, end } as IIntegerRange;
     }
 

--- a/packages/dds/merge-tree/src/collections.ts
+++ b/packages/dds/merge-tree/src/collections.ts
@@ -190,6 +190,7 @@ export class Heap<T> {
         this.fixup(this.count());
     }
 
+    /* eslint-disable no-bitwise */
     private fixup(k: number) {
         let _k = k;
         while (_k > 1 && (this.comp.compare(this.L[_k >> 1], this.L[_k]) > 0)) {
@@ -216,6 +217,7 @@ export class Heap<T> {
             _k = j;
         }
     }
+    /* eslint-enable no-bitwise */
 }
 
 export const enum RBColor {

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -366,12 +366,12 @@ export class PartialSequenceLengths {
             }
         }
         if (seqPartialLen === undefined) {
+            // len will be assigned below, making this assertion true.
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             seqPartialLen = {
                 clientId,
                 seglen: seqSeglen,
                 seq,
-            // len will be assigned below, making this assertion true.
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             } as PartialSequenceLength;
             partialLengths.push(seqPartialLen);
         } else {

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -370,6 +370,8 @@ export class PartialSequenceLengths {
                 clientId,
                 seglen: seqSeglen,
                 seq,
+            // len will be assigned below, making this assertion true.
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             } as PartialSequenceLength;
             partialLengths.push(seqPartialLen);
         } else {

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -81,6 +81,7 @@ export class TestClient extends Client {
             {
                 logger: client2.logger,
                 clientId: newLongClientId,
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             } as IFluidDataStoreRuntime,
             storage,
             TestClient.serializer);

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -78,10 +78,10 @@ export class TestClient extends Client {
         specToSeg: (spec: IJSONSegment) => ISegment): Promise<TestClient> {
         const client2 = new TestClient(undefined, specToSeg);
         const { catchupOpsP } = await client2.load(
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             {
                 logger: client2.logger,
                 clientId: newLongClientId,
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             } as IFluidDataStoreRuntime,
             storage,
             TestClient.serializer);

--- a/packages/dds/merge-tree/src/test/testServer.ts
+++ b/packages/dds/merge-tree/src/test/testServer.ts
@@ -89,6 +89,7 @@ export class TestServer extends TestClient {
             referenceSequenceNumber: msg.referenceSequenceNumber,
             sequenceNumber: msg.sequenceNumber,
             type: msg.type,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         } as ISequencedDocumentMessage;
     }
 

--- a/packages/dds/merge-tree/src/test/testServer.ts
+++ b/packages/dds/merge-tree/src/test/testServer.ts
@@ -81,6 +81,7 @@ export class TestServer extends TestClient {
         msg.sequenceNumber = -1;
     }
     copyMsg(msg: ISequencedDocumentMessage) {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         return {
             clientId: msg.clientId,
             clientSequenceNumber: msg.clientSequenceNumber,
@@ -89,7 +90,6 @@ export class TestServer extends TestClient {
             referenceSequenceNumber: msg.referenceSequenceNumber,
             sequenceNumber: msg.sequenceNumber,
             type: msg.type,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         } as ISequencedDocumentMessage;
     }
 

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -399,7 +399,7 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
         private readonly label: string,
         private readonly helpers: IIntervalHelpers<TInterval>,
     ) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         this.endIntervalTree = new RedBlackTree<TInterval, TInterval>(helpers.compareEnds);
     }
 

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -397,9 +397,10 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
     constructor(
         private readonly client: Client,
         private readonly label: string,
-        private readonly helpers: IIntervalHelpers<TInterval>) {
-        this.endIntervalTree =
-            new RedBlackTree<TInterval, TInterval>(helpers.compareEnds);
+        private readonly helpers: IIntervalHelpers<TInterval>,
+    ) {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        this.endIntervalTree = new RedBlackTree<TInterval, TInterval>(helpers.compareEnds);
     }
 
     public addConflictResolver(conflictResolver: IntervalConflictResolver<TInterval>) {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -388,7 +388,7 @@ export class OdspDocumentService implements IDocumentService {
         };
 
         const getResponseAndRefreshAfterDeltaMs = async () => {
-            let _response = await this.cache.sessionJoinCache.addOrGet(this.joinSessionKey, executeFetch);
+            const _response = await this.cache.sessionJoinCache.addOrGet(this.joinSessionKey, executeFetch);
             // If the response does not contain refreshSessionDurationSeconds, then treat it as old flow and let the
             // cache entry to be treated as expired after 1 hour.
             _response.joinSessionResponse.refreshSessionDurationSeconds =

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -146,7 +146,7 @@ export class DependencyContainer<TMap> implements IFluidDependencySynthesizer {
             for (const parent of this.parents) {
                 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 const sp = { [t]: t } as FluidObjectSymbolProvider<Pick<TMap, T>>;
-                const syn = parent.synthesize<Pick<TMap, T>,{}>(
+                const syn = parent.synthesize<Pick<TMap, T>, Record<string, unknown>>(
                     sp,
                     {});
                 const descriptor = Object.getOwnPropertyDescriptor(syn, t);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2042,11 +2042,12 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             gcStats = await this.collectGarbage({ logger: summaryLogger, runSweep, fullGC });
         }
 
-        const summarizeResult = await this.summarizerNode.summarize(fullTree, trackState);
-        assert(summarizeResult.summary.type === SummaryType.Tree,
+        const { stats, summary } = await this.summarizerNode.summarize(fullTree, trackState);
+
+        assert(summary.type === SummaryType.Tree,
             0x12f /* "Container Runtime's summarize should always return a tree" */);
 
-        return { ...summarizeResult, gcStats } as IRootSummaryTreeWithStats;
+        return { stats, summary, gcStats };
     }
 
     /**

--- a/packages/runtime/container-runtime/src/test/batchTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/batchTracker.spec.ts
@@ -88,6 +88,7 @@ describe("Runtime", () => {
         ]);
     });
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const batchMessage = (sequenceNumber: number): ISequencedDocumentMessage => ({
         sequenceNumber,
         referenceSequenceNumber: sequenceNumber,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -551,6 +551,7 @@ describe("Runtime", () => {
                 };
             };
             const getMockPendingStateManager = (hasPendingMessages: boolean): PendingStateManager => {
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 return {
                     replayPendingStates: () => { },
                     hasPendingMessages: () => hasPendingMessages,
@@ -560,6 +561,7 @@ describe("Runtime", () => {
                 } as PendingStateManager;
             };
             const getMockDataStores = (): DataStores => {
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 return {
                     processFluidDataStoreOp:
                         (_message: ISequencedDocumentMessage,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -83,6 +83,7 @@ describe("Data Store Context Tests", () => {
                 get IFluidDataStoreRegistry() { return registry; },
                 get: async (pkg) => Promise.resolve(factory),
             };
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             containerRuntime = {
                 IFluidDataStoreRegistry: registry,
                 on: (event, listener) => { },
@@ -164,6 +165,7 @@ describe("Data Store Context Tests", () => {
                 registryWithSubRegistries.instantiateDataStore =
                     async (context: IFluidDataStoreContext) => new MockFluidDataStoreRuntime();
 
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 containerRuntime = {
                     IFluidDataStoreRegistry: registryWithSubRegistries,
                     on: (event, listener) => { },
@@ -323,6 +325,7 @@ describe("Data Store Context Tests", () => {
             registry.IFluidDataStoreRegistry = registry;
             registry.get = async (pkg) => Promise.resolve(factory);
 
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             containerRuntime = {
                 IFluidDataStoreRegistry: registry,
                 on: (event, listener) => { },

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -90,6 +90,7 @@ describe("Data Store Creation Tests", () => {
                 get IFluidDataStoreRegistry() { return globalRegistry; },
                 get: async (pkg) => globalRegistryEntries.get(pkg),
             };
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             containerRuntime = {
                 IFluidDataStoreRegistry: globalRegistry,
                 on: (event, listener) => { },

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -47,9 +47,11 @@ export class LoaderContainerTracker implements IOpProcessingController {
                 return container;
             };
         };
+        /* eslint-disable @typescript-eslint/unbound-method */
         loader.resolve = patch(loader.resolve);
         loader.createDetachedContainer = patch(loader.createDetachedContainer);
         loader.rehydrateDetachedContainerFromSnapshot = patch(loader.rehydrateDetachedContainerFromSnapshot);
+        /* eslint-enable @typescript-eslint/unbound-method */
     }
 
     /**

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -41,6 +41,7 @@ export type QuorumClientsSnapshot = [string, ISequencedClient][];
 /**
  * Snapshot format for a QuorumProposals
  */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type QuorumProposalsSnapshot = {
     proposals: [number, ISequencedProposal, string[]][];
     values: [string, ICommittedProposal][];

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -162,7 +162,7 @@ export class Historian implements IHistorian {
         };
     }
 
-    private getQueryString(queryString?: {}): Record<string, unknown> {
+    private getQueryString(queryString?: Record<string, unknown>): Record<string, unknown> {
         if (this.cacheBust) {
             return {
                 cacheBust: Date.now(),

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -304,9 +304,11 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 					// when this happens, let's requeue the messages for later.
 					// note: send will return a new deferred. we need to hook it into
 					// the existing boxcar deferred to ensure continuity
+					/* eslint-disable @typescript-eslint/unbound-method */
 					this.send(boxcar.messages, boxcar.tenantId, boxcar.documentId, boxcar.partitionId)
 						.then(boxcar.deferred.resolve)
 						.catch(boxcar.deferred.reject);
+					/* eslint-enable @typescript-eslint/unbound-method */
 				}
 			} catch (ex) {
 				// produce can throw if the outgoing message queue is full


### PR DESCRIPTION
First part of #9082, enabling the rule in eslint7 and performing the preemptive fixes to make integration of the next release smooth.