### PR TITLE
[r11s] Allowing getOrCreateRepository to handle headers

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -69,7 +69,7 @@ export const getAuthorizationTokenFromCredentials: (credentials: ICredentials) =
 export function getNextHash(message: ISequencedDocumentMessage, lastHash: string): string;
 
 // @public (undocumented)
-export function getOrCreateRepository(endpoint: string, owner: string, repository: string): Promise<void>;
+export function getOrCreateRepository(endpoint: string, owner: string, repository: string, headers?: AxiosRequestHeaders): Promise<void>;
 
 // @public (undocumented)
 export function getRandomName(connector?: string, capitalize?: boolean): string;

--- a/server/routerlicious/packages/services-client/src/utils.ts
+++ b/server/routerlicious/packages/services-client/src/utils.ts
@@ -4,12 +4,16 @@
  */
 
 import * as resources from "@fluidframework/gitresources";
-import Axios from "axios";
+import Axios, { AxiosRequestHeaders } from "axios";
 
-export async function getOrCreateRepository(endpoint: string, owner: string, repository: string): Promise<void> {
+export async function getOrCreateRepository(
+    endpoint: string,
+    owner: string,
+    repository: string,
+    headers?: AxiosRequestHeaders): Promise<void> {
     console.log(`Get Repo: ${endpoint}/${owner}/${repository}`);
 
-    const details = await Axios.get(`${endpoint}/repos/${owner}/${repository}`)
+    const details = await Axios.get(`${endpoint}/repos/${owner}/${repository}`, { headers })
         .catch((error) => {
             if (error.response && error.response.status === 400) {
                 return null;
@@ -24,6 +28,6 @@ export async function getOrCreateRepository(endpoint: string, owner: string, rep
             name: repository,
         };
 
-        await Axios.post(`${endpoint}/${owner}/repos`, createParams);
+        await Axios.post(`${endpoint}/${owner}/repos`, createParams, { headers });
     }
 }


### PR DESCRIPTION
`getOrCreateRepository()` in services-client is used by Riddler when it creates tenants/checks if a tenant exists. The requests sent by `getOrCreateRepository()` through `Axios` land on GitRest directly - that's different than most of the other types of requests, which are proxied through Historian. Historian is capable of reading tenant information and including a `Storage-Name` header in the requests (as introduced in this PR: #9339). To match that behavior, `getOrCreateRepository()` needs the capability of also handling headers, and that is implemented in this PR.