### PR TITLE
Add better tracking of Collab window

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -250,6 +250,8 @@ export interface IAckSummaryResult {
 // @public
 export interface IBaseSummarizeResult {
     readonly error: any;
+    // (undocumented)
+    readonly minimumSequenceNumber: number;
     readonly referenceSequenceNumber: number;
     // (undocumented)
     readonly stage: "base";

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -62,6 +62,29 @@
   },
   "typeValidation": {
     "version": "0.58.3000",
-    "broken": {}
+    "broken": {
+      "0.58.2000": {
+        "InterfaceDeclaration_IBaseSummarizeResult": {
+          "forwardCompat": false,
+          "backCompat": true
+        },
+        "InterfaceDeclaration_IGenerateSummaryTreeResult": {
+          "forwardCompat": false,
+          "backCompat": true
+        },
+        "InterfaceDeclaration_ISubmitSummaryOpResult": {
+          "forwardCompat": false,
+          "backCompat": true
+        },
+        "InterfaceDeclaration_IUploadSummaryResult": {
+          "forwardCompat": false,
+          "backCompat": true
+        },
+        "InterfaceDeclaration_SubmitSummaryResult": {
+          "forwardCompat": false,
+          "backCompat": true
+        }
+      }
+    }
   }
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -62,29 +62,6 @@
   },
   "typeValidation": {
     "version": "0.58.3000",
-    "broken": {
-      "0.58.2000": {
-        "InterfaceDeclaration_IBaseSummarizeResult": {
-          "forwardCompat": false,
-          "backCompat": true
-        },
-        "InterfaceDeclaration_IGenerateSummaryTreeResult": {
-          "forwardCompat": false,
-          "backCompat": true
-        },
-        "InterfaceDeclaration_ISubmitSummaryOpResult": {
-          "forwardCompat": false,
-          "backCompat": true
-        },
-        "InterfaceDeclaration_IUploadSummaryResult": {
-          "forwardCompat": false,
-          "backCompat": true
-        },
-        "InterfaceDeclaration_SubmitSummaryResult": {
-          "forwardCompat": false,
-          "backCompat": true
-        }
-      }
-    }
+    "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -112,6 +112,27 @@
   },
   "typeValidation": {
     "version": "0.58.3000",
-    "broken": {}
+    "broken": {
+      "0.58.2000": {
+        "InterfaceDeclaration_IBaseSummarizeResult": {
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IGenerateSummaryTreeResult": {
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_ISubmitSummaryOpResult": {
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_IUploadSummaryResult": {
+          "forwardCompat": false
+        },
+        "InterfaceDeclaration_SubmitSummaryResult": {
+          "forwardCompat": false
+        },
+        "TypeAliasDeclaration_SubmitSummaryResult": {
+          "forwardCompat": false
+        }
+      }
+    }
   }
 }

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -156,6 +156,7 @@ export interface IBaseSummarizeResult {
     readonly error: any;
     /** Reference sequence number as of the generate summary attempt. */
     readonly referenceSequenceNumber: number;
+    readonly minimumSequenceNumber: number;
 }
 
 /** Results of submitSummary after generating the summary tree. */

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -65,6 +65,8 @@ type SummaryGeneratorRequiredTelemetryProperties =
 type SummaryGeneratorOptionalTelemetryProperties =
     /** Reference sequence number as of the generate summary attempt. */
     "referenceSequenceNumber" |
+    /** minimum sequence number (at the reference sequence number) */
+    "minimumSequenceNumber" |
     /** Delta between the current reference sequence number and the reference sequence number of the last attempt */
     "opsSinceLastAttempt" |
     /** Delta between the current reference sequence number and the reference sequence number of the last summary */
@@ -298,6 +300,7 @@ export class SummaryGenerator {
             summarizeTelemetryProps = {
                 ...summarizeTelemetryProps,
                 referenceSequenceNumber,
+                minimumSequenceNumber: summaryData.minimumSequenceNumber,
                 opsSinceLastAttempt: referenceSequenceNumber - this.heuristicData.lastAttempt.refSequenceNumber,
                 opsSinceLastSummary,
             };

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -155,6 +155,7 @@ describe("Runtime", () => {
                         return {
                             stage: "submit",
                             referenceSequenceNumber: lastRefSeq,
+                            minimumSequenceNumber: 0,
                             generateDuration: 0,
                             uploadDuration: 0,
                             submitOpDuration: 0,

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -288,6 +288,7 @@ declare function get_old_InterfaceDeclaration_IBaseSummarizeResult():
 declare function use_current_InterfaceDeclaration_IBaseSummarizeResult(
     use: TypeOnly<current.IBaseSummarizeResult>);
 use_current_InterfaceDeclaration_IBaseSummarizeResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IBaseSummarizeResult());
 
 /*
@@ -600,6 +601,7 @@ declare function get_old_InterfaceDeclaration_IGenerateSummaryTreeResult():
 declare function use_current_InterfaceDeclaration_IGenerateSummaryTreeResult(
     use: TypeOnly<current.IGenerateSummaryTreeResult>);
 use_current_InterfaceDeclaration_IGenerateSummaryTreeResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IGenerateSummaryTreeResult());
 
 /*
@@ -864,6 +866,7 @@ declare function get_old_InterfaceDeclaration_ISubmitSummaryOpResult():
 declare function use_current_InterfaceDeclaration_ISubmitSummaryOpResult(
     use: TypeOnly<current.ISubmitSummaryOpResult>);
 use_current_InterfaceDeclaration_ISubmitSummaryOpResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISubmitSummaryOpResult());
 
 /*
@@ -1296,6 +1299,7 @@ declare function get_old_InterfaceDeclaration_IUploadSummaryResult():
 declare function use_current_InterfaceDeclaration_IUploadSummaryResult(
     use: TypeOnly<current.IUploadSummaryResult>);
 use_current_InterfaceDeclaration_IUploadSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IUploadSummaryResult());
 
 /*
@@ -1464,6 +1468,7 @@ declare function get_old_TypeAliasDeclaration_SubmitSummaryResult():
 declare function use_current_TypeAliasDeclaration_SubmitSummaryResult(
     use: TypeOnly<current.SubmitSummaryResult>);
 use_current_TypeAliasDeclaration_SubmitSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_SubmitSummaryResult());
 
 /*


### PR DESCRIPTION
Fixes #9683: Duration in "MsnStatistics" event is tracking garbage
Helps better understand #9682: MSN window is too large!

This change adds
- tracking of collab window at summarization, to better understand impact on quality of summary (search, size of catchup blobs).
- tracking of batch sizes, time to inbound and msn size at that time
   - I expect to see msn size correlating with batch sizes, as collab window grows to at least the size of batch at the moment when batch is sent
- Correct tracking of how long it takes for a sequence number to fall out of collab window.
