### PR TITLE
correctly handle simultaneous upload of identical blob

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -147,9 +147,12 @@ export class BlobManager {
     }
 
     public processBlobAttachOp(blobId: string, local: boolean) {
-        assert(!local || this.pendingBlobIds.has(blobId), 0x1f8 /* "local BlobAttach op with no pending blob" */);
-        this.pendingBlobIds.get(blobId)?.resolve();
-        this.pendingBlobIds.delete(blobId);
+        if (local) {
+            const pendingBlobP = this.pendingBlobIds.get(blobId);
+            assert(pendingBlobP !== undefined, 0x1f8 /* "local BlobAttach op with no pending blob" */);
+            pendingBlobP.resolve();
+            this.pendingBlobIds.delete(blobId);
+        }
         this.blobIds.add(blobId);
     }
 


### PR DESCRIPTION
Fix #9702
Correctly handle the case where multiple containers upload the same blob and submit blobAttach ops with identical blob IDs due to blob de-duping. In this case, BlobManager should only resolve the deferred promise when it sees its own op.