### PR TITLE
Fix order of dirtiness cleaning when reporting the change

### DIFF
--- a/experimental/PropertyDDS/packages/property-binder/src/test/data_binder.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/data_binder.spec.js
@@ -2990,6 +2990,30 @@ describe('DataBinder', function() {
       expect(callbackSpyRegistered).toHaveBeenCalledTimes(1);
     });
 
+    it.only('should be possible to modify property and inside requestChangesetPostProcessing and get notified on the changes', function () {
+      const callbackSpyRegistered = jest.fn();
+      const callbackNestedSpyRegistered = jest.fn();
+
+      dataBinder.attachTo(workspace);
+
+      dataBinder.registerOnPath('mypath.aString', ['modify'], () => {
+        callbackNestedSpyRegistered();
+      });
+
+      dataBinder.registerOnPath('mypath', ['insert'], () => {
+        callbackSpyRegistered();
+        dataBinder.requestChangesetPostProcessing(() => {
+          const prop = workspace.root.get('mypath');
+          prop.get('aString').setValue('modified');
+        });
+      });
+
+      workspace.root.insert('mypath', PropertyFactory.create(PrimitiveChildrenTemplate.typeid));
+
+      expect(callbackSpyRegistered).toHaveBeenCalledTimes(1);
+      expect(callbackNestedSpyRegistered).toHaveBeenCalledTimes(1);
+    });
+
     it('should be possible to unregister before attaching to a workspace', function() {
       var callbackSpyRegistered = jest.fn();
       var callbackSpyUnregistered = jest.fn();

--- a/experimental/PropertyDDS/packages/property-binder/src/test/data_binder.spec.js
+++ b/experimental/PropertyDDS/packages/property-binder/src/test/data_binder.spec.js
@@ -2990,7 +2990,7 @@ describe('DataBinder', function() {
       expect(callbackSpyRegistered).toHaveBeenCalledTimes(1);
     });
 
-    it.only('should be possible to modify property and inside requestChangesetPostProcessing and get notified on the changes', function () {
+    it.only('should be possible to modify property and inside requestChangesetPostProcessing and get notified on the changes', function() {
       const callbackSpyRegistered = jest.fn();
       const callbackNestedSpyRegistered = jest.fn();
 

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -169,12 +169,14 @@ export class SharedPropertyTree extends SharedObject {
 		// for the serialization of the data structure
 		if (this.listenerCount("localModification") > 0) {
 			const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
+            this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
 			const _changeSet = new ChangeSet(changes);
 			if (!isEmpty(_changeSet.getSerializedChangeSet())) {
 				this.emit("localModification", _changeSet);
 			}
-		}
-		this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
+		} else {
+            this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
+        }
 	}
 
 	public get changeSet(): SerializedChangeSet {


### PR DESCRIPTION
A fix to PropertyDDS dirtiness reporting, it should clean the changes before reporting the changes to the client. Otherwise, changes made to the tree in `DataBinder.requestChangesetPostProcessing` will be ignored. 

@ruiterr FYI