### PR TITLE
Implement rollback for shared string insert

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -141,7 +141,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     get options(): ILoaderOptions;
     // (undocumented)
-    orderSequentially(callback: () => void): void;
+    orderSequentially(callback: () => void, failureMode?: OrderSequentiallyFailureMode): void;
     // (undocumented)
     process(messageArg: ISequencedDocumentMessage, local: boolean): void;
     // (undocumented)
@@ -149,8 +149,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     refreshLatestSummaryAck(proposalHandle: string | undefined, ackHandle: string, summaryRefSeq: number, summaryLogger: ITelemetryLogger): Promise<void>;
     request(request: IRequest): Promise<IResponse>;
     resolveHandle(request: IRequest): Promise<IResponse>;
-    // (undocumented)
-    get reSubmitFn(): (type: ContainerMessageType, content: any, localOpMetadata: unknown, opMetadata: Record<string, unknown> | undefined) => void;
     // (undocumented)
     get scope(): IFluidObject & FluidObject;
     // (undocumented)
@@ -597,6 +595,14 @@ export type OpActionEventListener = (op: ISequencedDocumentMessage) => void;
 
 // @public (undocumented)
 export type OpActionEventName = MessageType.Summarize | MessageType.SummaryAck | MessageType.SummaryNack | "default";
+
+// @public (undocumented)
+export enum OrderSequentiallyFailureMode {
+    // (undocumented)
+    Fail = 0,
+    // (undocumented)
+    Rollback = 1
+}
 
 // @public
 export enum RuntimeHeaders {

--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -84,6 +84,8 @@ export interface IDeltaHandler {
     applyStashedOp(message: any): unknown;
     process: (message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) => void;
     reSubmit(message: any, localOpMetadata: unknown): void;
+    // (undocumented)
+    rollback?(message: any, localOpMetadata: unknown): void;
     setConnectionState(connected: boolean): void;
 }
 

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -103,6 +103,8 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     resolveHandle(request: IRequest): Promise<IResponse>;
     reSubmit(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
     // (undocumented)
+    rollback(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
+    // (undocumented)
     get rootRoutingContext(): this;
     // (undocumented)
     get routeContext(): IFluidHandleContext;

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -187,6 +187,7 @@ export class Client {
     removePendingSegmentGroup(): void;
     removeRangeLocal(start: number, end: number): IMergeTreeRemoveMsg | undefined;
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number | undefined;
+    rollbackRange(start: number, end: number): void;
     serializeGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void;
     // (undocumented)
     readonly specToSegment: (spec: IJSONSegment) => ISegment;

--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -183,6 +183,8 @@ export class Client {
     regeneratePendingOp(resetOp: IMergeTreeOp, segmentGroup: SegmentGroup | SegmentGroup[]): IMergeTreeOp;
     // (undocumented)
     removeLocalReference(lref: LocalReference): void;
+    // (undocumented)
+    removePendingSegmentGroup(): void;
     removeRangeLocal(start: number, end: number): IMergeTreeRemoveMsg | undefined;
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number | undefined;
     serializeGCData(handle: IFluidHandle, handleCollectingSerializer: IFluidSerializer): void;

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -136,6 +136,8 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processSignal(message: any, local: boolean): void;
     reSubmit(type: string, content: any, localOpMetadata: unknown): any;
+    // (undocumented)
+    rollback?(type: string, content: any, localOpMetadata: unknown): void;
     setConnectionState(connected: boolean, clientId?: string): any;
     summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[], gcTimestamp?: number): void;

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -575,7 +575,7 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     // (undocumented)
     removeLocalReference(lref: LocalReference): void;
     // (undocumented)
-    removeRange(start: number, end: number): IMergeTreeRemoveMsg;
+    removeRange(start: number, end: number, sendOp?: boolean): IMergeTreeRemoveMsg;
     protected replaceRange(start: number, end: number, segment: ISegment): void;
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number;
     // (undocumented)
@@ -639,7 +639,9 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     get ISharedString(): ISharedString;
     removeText(start: number, end: number): IMergeTreeRemoveMsg;
     replaceText(start: number, end: number, text: string, props?: PropertySet): void;
-}
+    // (undocumented)
+    protected rollback(content: any, localOpMetadata: unknown): void;
+    }
 
 // @public (undocumented)
 export class SharedStringFactory implements IChannelFactory {

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -575,7 +575,7 @@ export abstract class SharedSegmentSequence<T extends ISegment> extends SharedOb
     // (undocumented)
     removeLocalReference(lref: LocalReference): void;
     // (undocumented)
-    removeRange(start: number, end: number, sendOp?: boolean): IMergeTreeRemoveMsg;
+    removeRange(start: number, end: number): IMergeTreeRemoveMsg;
     protected replaceRange(start: number, end: number, segment: ISegment): void;
     resolveRemoteClientPosition(remoteClientPosition: number, remoteClientRefSeq: number, remoteClientId: string): number;
     // (undocumented)

--- a/api-report/shared-object-base.api.md
+++ b/api-report/shared-object-base.api.md
@@ -129,6 +129,8 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): any;
     protected reSubmitCore(content: any, localOpMetadata: unknown): void;
     // (undocumented)
+    protected rollback(content: any, localOpMetadata: unknown): void;
+    // (undocumented)
     protected runtime: IFluidDataStoreRuntime;
     protected submitLocalMessage(content: any, localOpMetadata?: unknown): void;
     abstract summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats>;

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -422,6 +422,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     reSubmit(content: any, localOpMetadata: unknown): void;
     // (undocumented)
+    rollback(message: any, localOpMetadata: unknown): void;
+    // (undocumented)
     get rootRoutingContext(): IFluidHandleContext;
     // (undocumented)
     save(message: string): void;

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -340,6 +340,18 @@ export class Client {
         return this.mergeTree.getMarkerFromId(id);
     }
 
+    public removePendingSegmentGroup() {
+        // just take the last thing off
+        const pendingSegmentGroup = this.mergeTree.pendingSegments?.dequeue();
+        if (!pendingSegmentGroup) {
+            throw new Error("No pending segments");
+        }
+        for (const segment of pendingSegmentGroup.segments) {
+            const segmentSegmentGroup = segment.segmentGroups.dequeue();
+            assert(segmentSegmentGroup === pendingSegmentGroup, "Unexpected segmentGroup in segment");
+        }
+    }
+
     /**
      * Performs the remove based on the provided op
      * @param opArgs - The ops args for the op

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -16,7 +16,6 @@ import { LoggingError } from "@fluidframework/telemetry-utils";
 import { IIntegerRange } from "./base";
 import { RedBlackTree } from "./collections";
 import {
-    LocalClientId,
     TreeMaintenanceSequenceNumber,
     UnassignedSequenceNumber,
     UniversalSequenceNumber,
@@ -364,14 +363,13 @@ export class Client {
         // fix up prior insertion pending segment group in client/mergeTree and segment
         this.removePendingSegmentGroup();
 
-        // this.removeRangeLocal(start, end);
-
+        const segWindow = this.getCollabWindow();
         const removeOp = createRemoveRangeOp(start, end);
         this.mergeTree.markRangeRemoved(
             start,
             end,
             UniversalSequenceNumber,
-            LocalClientId,
+            segWindow.clientId,
             TreeMaintenanceSequenceNumber,
             false,
             { op: removeOp });

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-/* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -230,9 +230,9 @@ export abstract class SharedSegmentSequence<T extends ISegment>
      * @param start - The inclusive start of the range to remove
      * @param end - The exclusive end of the range to remove
      */
-    public removeRange(start: number, end: number, sendOp: boolean = true) {
+    public removeRange(start: number, end: number) {
         const removeOp = this.client.removeRangeLocal(start, end);
-        if (removeOp && sendOp) {
+        if (removeOp) {
             this.submitSequenceMessage(removeOp);
         }
         return removeOp;

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -230,9 +230,9 @@ export abstract class SharedSegmentSequence<T extends ISegment>
      * @param start - The inclusive start of the range to remove
      * @param end - The exclusive end of the range to remove
      */
-    public removeRange(start: number, end: number) {
+    public removeRange(start: number, end: number, sendOp: boolean = true) {
         const removeOp = this.client.removeRangeLocal(start, end);
-        if (removeOp) {
+        if (removeOp && sendOp) {
             this.submitSequenceMessage(removeOp);
         }
         return removeOp;

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -284,14 +284,13 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     protected rollback(content: any, localOpMetadata: unknown): void {
         if (this.previousInsertsCount > 0 && content === this.previousInserts[this.previousInsertsCount - 1]) {
             // fix up insertion pending segment group in client/mergeTree and segment
-            this.client.removePendingSegmentGroup();
-
+            // this.client.removePendingSegmentGroup();
             const msg = content as IMergeTreeInsertMsg;
-            this.removeRange(msg.pos1, msg.pos1 + (msg.seg as string).length, false);
+            this.client.rollbackRange(msg.pos1, msg.pos1 + (msg.seg as string).length);
+            // this.removeRange(msg.pos1, msg.pos1 + (msg.seg as string).length);
             this.previousInsertsCount--;
-
             // fix up removal pending segment group in client/mergeTree and segment
-            this.client.removePendingSegmentGroup();
+            // this.client.removePendingSegmentGroup();
         } else {
             throw new Error("No previous insert");
         }

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -283,9 +283,15 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
 
     protected rollback(content: any, localOpMetadata: unknown): void {
         if (this.previousInsertsCount > 0 && content === this.previousInserts[this.previousInsertsCount - 1]) {
+            // fix up insertion pending segment group in client/mergeTree and segment
+            this.client.removePendingSegmentGroup();
+
             const msg = content as IMergeTreeInsertMsg;
             this.removeRange(msg.pos1, msg.pos1 + (msg.seg as string).length, false);
             this.previousInsertsCount--;
+
+            // fix up removal pending segment group in client/mergeTree and segment
+            this.client.removePendingSegmentGroup();
         } else {
             throw new Error("No previous insert");
         }

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -355,6 +355,9 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
             applyStashedOp: (content: any): unknown => {
                 return this.applyStashedOp(content);
             },
+            rollback:  (content: any, localOpMetadata: unknown) => {
+                this.rollback(content, localOpMetadata);
+            },
         });
 
         // Trigger initial state
@@ -383,7 +386,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
             // - nack could get a new msn - but might as well do it in the join?
             this.onDisconnect();
         } else {
-            // Call this for now so that DDSes like ConsensesOrderedCollection that maintain their own pending
+            // Call this for now so that DDSes like ConsensusOrderedCollection that maintain their own pending
             // messages will work.
             this.onConnect();
         }
@@ -411,6 +414,10 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
      */
     private reSubmit(content: any, localOpMetadata: unknown) {
         this.reSubmitCore(content, localOpMetadata);
+    }
+
+    protected rollback(content: any, localOpMetadata: unknown) {
+        throw new Error("rollback not supported");
     }
 
     protected abstract applyStashedOp(content: any): unknown;

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -114,6 +114,9 @@
     "version": "0.58.3000",
     "broken": {
       "0.58.2000": {
+        "ClassDeclaration_ContainerRuntime": {
+          "backCompat": false
+        },
         "InterfaceDeclaration_IBaseSummarizeResult": {
           "forwardCompat": false
         },

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -709,6 +709,13 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         this.channel.reSubmit(innerContents.type, innerContents.content, localOpMetadata);
     }
 
+    public rollback(contents: any, localOpMetadata: unknown) {
+        assert(!!this.channel,"Channel must exist when rolling back ops");
+        const innerContents = contents as FluidDataStoreMessage;
+        assert(!!this.channel.rollback, "rollback not supported");
+        this.channel.rollback(innerContents.type, innerContents.content, localOpMetadata);
+    }
+
     public async applyStashedOp(contents: any): Promise<unknown> {
         if (!this.channel) {
             await this.realize();

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -368,6 +368,13 @@ export class DataStores implements IDisposable {
         context.reSubmit(envelope.contents, localOpMetadata);
     }
 
+    public rollbackDataStoreOp(content: any, localOpMetadata: unknown) {
+        const envelope = content as IEnvelope;
+        const context = this.contexts.get(envelope.address);
+        assert(!!context, 0x160 /* "There should be a store context for the op" */);
+        context.rollback(envelope.contents, localOpMetadata);
+    }
+
     public async applyStashedOp(content: any): Promise<unknown> {
         const envelope = content as IEnvelope;
         const context = this.contexts.get(envelope.address);

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -371,7 +371,7 @@ export class DataStores implements IDisposable {
     public rollbackDataStoreOp(content: any, localOpMetadata: unknown) {
         const envelope = content as IEnvelope;
         const context = this.contexts.get(envelope.address);
-        assert(!!context, 0x160 /* "There should be a store context for the op" */);
+        assert(!!context, "There should be a store context for the op");
         context.rollback(envelope.contents, localOpMetadata);
     }
 

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -18,6 +18,7 @@ export {
     agentSchedulerId,
     ContainerRuntime,
     RuntimeHeaders,
+    OrderSequentiallyFailureMode,
 } from "./containerRuntime";
 export { DeltaScheduler } from "./deltaScheduler";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -5,13 +5,14 @@
 
 import { IDisposable } from "@fluidframework/common-definitions";
 import { assert, Lazy } from "@fluidframework/common-utils";
+import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { DataProcessingError } from "@fluidframework/container-utils";
 import {
     ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import Deque from "double-ended-queue";
-import { ContainerRuntime, ContainerMessageType, isRuntimeMessage } from "./containerRuntime";
+import { ContainerMessageType, isRuntimeMessage } from "./containerRuntime";
 
 /**
  * This represents a message that has been submitted and is added to the pending queue when `submit` is called on the
@@ -57,6 +58,34 @@ export interface IPendingLocalState {
     pendingStates: IPendingState[];
 }
 
+export interface Handler{
+    connected(): boolean,
+    clientId(): string | undefined,
+    flushMode(): FlushMode,
+    setFlushMode(mode: FlushMode),
+    close(error?: ICriticalContainerError): void,
+    applyStashedOp: (type: ContainerMessageType, content: ISequencedDocumentMessage) => Promise<unknown>,
+    flush(),
+    reSubmit(
+        type: ContainerMessageType,
+        content: any,
+        localOpMetadata: unknown,
+        opMetadata: Record<string, unknown> | undefined,
+    ),
+    rollback(
+        type: ContainerMessageType,
+        content: any,
+        localOpMetadata: unknown,
+        opMetadata: Record<string, unknown> | undefined)
+}
+
+export class RollbackError extends Error {
+    constructor(message?: string, public readonly innerError?: Error) {
+        super(message);
+        this.name = "RollbackError";
+    }
+}
+
 /**
  * PendingStateManager is responsible for maintaining the messages that have not been sent or have not yet been
  * acknowledged by the server. It also maintains the batch information for both automatically and manually flushed
@@ -95,10 +124,6 @@ export class PendingStateManager implements IDisposable {
 
     private clientId: string | undefined;
 
-    private get connected(): boolean {
-        return this.containerRuntime.connected;
-    }
-
     /**
      * Called to check if there are any pending messages in the pending state queue.
      * @returns A boolean indicating whether there are messages or not.
@@ -120,8 +145,7 @@ export class PendingStateManager implements IDisposable {
     }
 
     constructor(
-        private readonly containerRuntime: ContainerRuntime,
-        private readonly applyStashedOp: (type, content) => Promise<unknown>,
+        private readonly stateHandler: Handler,
         initialFlushMode: FlushMode,
         initialLocalState: IPendingLocalState | undefined,
     ) {
@@ -189,7 +213,7 @@ export class PendingStateManager implements IDisposable {
     public onFlush() {
         // If the FlushMode is Immediate, we don't need to track an explicit flush call because every message is
         // automatically flushed. So, flush is a no-op.
-        if (this.containerRuntime.flushMode === FlushMode.Immediate) {
+        if (this.stateHandler.flushMode() === FlushMode.Immediate) {
             return;
         }
 
@@ -219,7 +243,8 @@ export class PendingStateManager implements IDisposable {
                 }
 
                 // applyStashedOp will cause the DDS to behave as if it has sent the op but not actually send it
-                const localOpMetadata = await this.applyStashedOp(nextState.messageType, nextState.content);
+                const localOpMetadata =
+                    await this.stateHandler.applyStashedOp(nextState.messageType, nextState.content);
                 nextState.localOpMetadata = localOpMetadata;
             }
 
@@ -246,6 +271,26 @@ export class PendingStateManager implements IDisposable {
         } else {
             return this.processRemoteMessage(message);
         }
+    }
+
+    public checkpoint() {
+        const checkpointHead = this.pendingStates.peekBack();
+        return{
+            rollback:()=>{
+                try{
+                    while(this.pendingStates.peekBack() !== checkpointHead) {
+                        this.rollbackNextPendingState();
+                    }
+                } catch(err) {
+                    const error = DataProcessingError.wrapIfUnrecognized(
+                        err,
+                        "checkpointRollback",
+                    );
+                    this.stateHandler.close(error);
+                    throw new RollbackError("Rollback failure", error);  // should set original stack?
+                }
+            },
+        };
     }
 
     /**
@@ -330,7 +375,7 @@ export class PendingStateManager implements IDisposable {
                 { expectedClientSequenceNumber: pendingState.clientSequenceNumber },
             );
 
-            this.containerRuntime.closeFn(error);
+            this.stateHandler.close(error);
             return;
         }
 
@@ -455,17 +500,39 @@ export class PendingStateManager implements IDisposable {
         return nextPendingState;
     }
 
+    public rollbackNextPendingState() {
+        const pendingStatesCount = this.pendingStates.length;
+        if (pendingStatesCount === 0) {
+            return;
+        }
+
+        this.pendingMessagesCount--;
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const pendingState = this.pendingStates.pop()!;
+        switch (pendingState.type) {
+            case "message":
+                this.stateHandler.rollback(
+                    pendingState.messageType,
+                    pendingState.content,
+                    pendingState.localOpMetadata,
+                    pendingState.opMetadata);
+                break;
+            default:
+        }
+    }
+
     /**
      * Called when the Container's connection state changes. If the Container gets connected, it replays all the pending
      * states in its queue. This includes setting the FlushMode and triggering resubmission of unacked ops.
      */
     public replayPendingStates() {
-        assert(this.connected, 0x172 /* "The connection state is not consistent with the runtime" */);
+        assert(this.stateHandler.connected(), 0x172 /* "The connection state is not consistent with the runtime" */);
 
         // This assert suggests we are about to send same ops twice, which will result in data loss.
-        assert(this.clientId !== this.containerRuntime.clientId,
+        assert(this.clientId !== this.stateHandler.clientId(),
             0x173 /* "replayPendingStates called twice for same clientId!" */);
-        this.clientId = this.containerRuntime.clientId;
+        this.clientId = this.stateHandler.clientId();
 
         assert(this.initialStates.isEmpty(), 0x174 /* "initial states should be empty before replaying pending" */);
 
@@ -478,11 +545,11 @@ export class PendingStateManager implements IDisposable {
         this.pendingMessagesCount = 0;
 
         // Save the current FlushMode so that we can revert it back after replaying the states.
-        const savedFlushMode = this.containerRuntime.flushMode;
+        const savedFlushMode = this.stateHandler.flushMode();
 
         // Set the flush mode for the next message. This step is important because the flush mode may have been changed
         // after the next pending message was sent.
-        this.containerRuntime.setFlushMode(this.flushModeForNextMessage);
+        this.stateHandler.setFlushMode(this.flushModeForNextMessage);
 
         // Process exactly `pendingStatesCount` items in the queue as it represents the number of states that were
         // pending when we connected. This is important because the `reSubmitFn` might add more items in the queue
@@ -492,17 +559,17 @@ export class PendingStateManager implements IDisposable {
             const pendingState = this.pendingStates.shift()!;
             switch (pendingState.type) {
                 case "message":
-                    this.containerRuntime.reSubmitFn(
+                    this.stateHandler.reSubmit(
                         pendingState.messageType,
                         pendingState.content,
                         pendingState.localOpMetadata,
                         pendingState.opMetadata);
                     break;
                 case "flushMode":
-                    this.containerRuntime.setFlushMode(pendingState.flushMode);
+                    this.stateHandler.setFlushMode(pendingState.flushMode);
                     break;
                 case "flush":
-                    this.containerRuntime.flush();
+                    this.stateHandler.flush();
                     break;
                 default:
                     break;
@@ -511,6 +578,6 @@ export class PendingStateManager implements IDisposable {
         }
 
         // Revert the FlushMode.
-        this.containerRuntime.setFlushMode(savedFlushMode);
+        this.stateHandler.setFlushMode(savedFlushMode);
     }
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.ts
@@ -84,6 +84,7 @@ declare function get_current_ClassDeclaration_ContainerRuntime():
 declare function use_old_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<old.ContainerRuntime>);
 use_old_ClassDeclaration_ContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ContainerRuntime());
 
 /*

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -80,6 +80,8 @@ export interface IDeltaHandler {
     reSubmit(message: any, localOpMetadata: unknown): void;
 
     applyStashedOp(message: any): unknown;
+
+    rollback?(message: any, localOpMetadata: unknown): void;
 }
 
 /**

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -108,6 +108,10 @@
   },
   "typeValidation": {
     "version": "0.58.3000",
-    "broken": {}
+    "broken": {
+      "0.58.2000": {
+        "ClassDeclaration_FluidDataStoreRuntime": {"forwardCompat": false}
+      }
+    }
   }
 }

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -32,6 +32,8 @@ export interface IChannelContext {
 
     applyStashedOp(content: any): unknown;
 
+    rollback(message: any, localOpMetadata: unknown): void;
+
     /**
      * Returns the data used for garbage collection. This includes a list of GC nodes that represent this context
      * including any of its children. Each node has a set of outbound routes to other GC nodes in the document.

--- a/packages/runtime/datastore/src/channelDeltaConnection.ts
+++ b/packages/runtime/datastore/src/channelDeltaConnection.ts
@@ -52,6 +52,10 @@ export class ChannelDeltaConnection implements IDeltaConnection {
         this.handler.reSubmit(content, localOpMetadata);
     }
 
+    public rollback(content: any, localOpMetadata: unknown) {
+        this.handler.rollback?.(content, localOpMetadata);
+    }
+
     public applyStashedOp(message: ISequencedDocumentMessage): unknown {
         return this.handler.applyStashedOp(message);
     }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -827,7 +827,7 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
                     // For Operations, find the right channel and trigger resubmission on it.
                     const envelope = content as IEnvelope;
                     const channelContext = this.contexts.get(envelope.address);
-                    assert(!!channelContext, 0x183 /* "There should be a channel context for the op" */);
+                    assert(!!channelContext, "There should be a channel context for the op");
                     channelContext.rollback(envelope.contents, localOpMetadata);
                     break;
                 }

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -818,6 +818,24 @@ IFluidDataStoreChannel, IFluidDataStoreRuntime, IFluidHandleContext {
         }
     }
 
+    public rollback(type: DataStoreMessageType, content: any, localOpMetadata: unknown) {
+        this.verifyNotClosed();
+
+        switch (type) {
+            case DataStoreMessageType.ChannelOp:
+                {
+                    // For Operations, find the right channel and trigger resubmission on it.
+                    const envelope = content as IEnvelope;
+                    const channelContext = this.contexts.get(envelope.address);
+                    assert(!!channelContext, 0x183 /* "There should be a channel context for the op" */);
+                    channelContext.rollback(envelope.contents, localOpMetadata);
+                    break;
+                }
+            default:
+                unreachableCase(type as never);
+        }
+    }
+
     public async applyStashedOp(content: any): Promise<unknown> {
         const envelope = content as IEnvelope;
         const channelContext = this.contexts.get(envelope.address);

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -89,6 +89,12 @@ export abstract class LocalChannelContextBase implements IChannelContext {
         this.servicesGetter().value.deltaConnection.reSubmit(content, localOpMetadata);
     }
 
+    public rollback(content: any, localOpMetadata: unknown) {
+        assert(this.isLoaded,"Channel should be loaded to rollback ops");
+        assert(this.attached,"Local channel must be attached when rollback op");
+        this.servicesGetter().value.deltaConnection.rollback(content, localOpMetadata);
+    }
+
     public applyStashedOp() {
         throw new Error("no stashed ops on local channel");
     }

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -138,6 +138,12 @@ export class RemoteChannelContext implements IChannelContext {
         this.services.deltaConnection.reSubmit(content, localOpMetadata);
     }
 
+    public rollback(content: any, localOpMetadata: unknown) {
+        assert(this.isLoaded,"Remote channel must be loaded when rolling back op");
+
+        this.services.deltaConnection.rollback(content, localOpMetadata);
+    }
+
     /**
      * Returns a summary at the current sequence number.
      * @param fullTree - true to bypass optimizations and force a full summary tree

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.ts
@@ -48,6 +48,7 @@ declare function get_old_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<current.FluidDataStoreRuntime>);
 use_current_ClassDeclaration_FluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -247,6 +247,8 @@ export interface IFluidDataStoreChannel extends
     reSubmit(type: string, content: any, localOpMetadata: unknown);
 
     applyStashedOp(content: any): Promise<unknown>;
+
+    rollback?(type: string, content: any, localOpMetadata: unknown): void;
 }
 
 export type CreateChildSummarizerNodeFn = (

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -103,6 +103,10 @@
   },
   "typeValidation": {
     "version": "0.58.3000",
-    "broken": {}
+    "broken": {
+      "0.58.2000":{
+        "ClassDeclaration_MockFluidDataStoreContext": {"forwardCompat": false}
+      }
+    }
   }
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -105,7 +105,10 @@
     "version": "0.58.3000",
     "broken": {
       "0.58.2000":{
-        "ClassDeclaration_MockFluidDataStoreContext": {"forwardCompat": false}
+        "ClassDeclaration_MockFluidDataStoreContext": {
+          "backCompat": false,
+          "forwardCompat": false
+        }
       }
     }
   }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -105,8 +105,7 @@
     "version": "0.58.3000",
     "broken": {
       "0.58.2000":{
-        "ClassDeclaration_MockFluidDataStoreContext": {
-          "backCompat": false,
+        "ClassDeclaration_MockFluidDataStoreRuntime": {
           "forwardCompat": false
         }
       }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -555,6 +555,10 @@ export class MockFluidDataStoreRuntime extends EventEmitter
     public async applyStashedOp(content: any) {
         return;
     }
+
+    public rollback(message: any, localOpMetadata: unknown): void {
+        return;
+    }
 }
 
 /**

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.ts
@@ -264,7 +264,6 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreContext():
 declare function use_current_ClassDeclaration_MockFluidDataStoreContext(
     use: TypeOnly<current.MockFluidDataStoreContext>);
 use_current_ClassDeclaration_MockFluidDataStoreContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreContext());
 
 /*
@@ -277,7 +276,6 @@ declare function get_current_ClassDeclaration_MockFluidDataStoreContext():
 declare function use_old_ClassDeclaration_MockFluidDataStoreContext(
     use: TypeOnly<old.MockFluidDataStoreContext>);
 use_old_ClassDeclaration_MockFluidDataStoreContext(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_MockFluidDataStoreContext());
 
 /*
@@ -290,6 +288,7 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_MockFluidDataStoreRuntime(
     use: TypeOnly<current.MockFluidDataStoreRuntime>);
 use_current_ClassDeclaration_MockFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.ts
@@ -264,6 +264,7 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreContext():
 declare function use_current_ClassDeclaration_MockFluidDataStoreContext(
     use: TypeOnly<current.MockFluidDataStoreContext>);
 use_current_ClassDeclaration_MockFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreContext());
 
 /*
@@ -276,6 +277,7 @@ declare function get_current_ClassDeclaration_MockFluidDataStoreContext():
 declare function use_old_ClassDeclaration_MockFluidDataStoreContext(
     use: TypeOnly<old.MockFluidDataStoreContext>);
 use_old_ClassDeclaration_MockFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_MockFluidDataStoreContext());
 
 /*

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -196,10 +196,11 @@ describe("Document Dirty", () => {
                 checkDirtyState("after processing value set", false, 1);
             });
 
-            it("marks state as dirty when batch ops are sent and clean when acks are received", async () => {
+            it.only("marks state as dirty when batch ops are sent and clean when acks are received", async () => {
                 dataObject.context.containerRuntime.orderSequentially(() => {
                     sharedMap.set("key1", "value1");
                     sharedMap.set("key2", "value2");
+                    throw new Error("random error");
                 });
 
                 checkDirtyState("after batch value set", true, 0);

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -196,11 +196,10 @@ describe("Document Dirty", () => {
                 checkDirtyState("after processing value set", false, 1);
             });
 
-            it.only("marks state as dirty when batch ops are sent and clean when acks are received", async () => {
+            it("marks state as dirty when batch ops are sent and clean when acks are received", async () => {
                 dataObject.context.containerRuntime.orderSequentially(() => {
                     sharedMap.set("key1", "value1");
                     sharedMap.set("key2", "value2");
-                    throw new Error("random error");
                 });
 
                 checkDirtyState("after batch value set", true, 0);

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -14,7 +14,9 @@ import {
     ITestFluidObject,
     ChannelFactoryRegistry,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluidframework/test-version-utils";
+import { describeFullCompat, describeNoCompat, itExpects } from "@fluidframework/test-version-utils";
+import { Container } from "@fluidframework/container-loader";
+import { ContainerRuntime, OrderSequentiallyFailureMode } from "@fluidframework/container-runtime";
 
 const cellId = "cellKey";
 const registry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];
@@ -226,5 +228,46 @@ describeFullCompat("SharedCell", (getTestObjectProvider) => {
 
         verifyCellValue(await getCellDataStore(getCellDataStore(Promise.resolve(sharedCell2))), cellValue, 2);
         verifyCellValue(await getCellDataStore(getCellDataStore(Promise.resolve(sharedCell3))), cellValue, 3);
+    });
+});
+
+describeNoCompat("SharedCell orderSequentially", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+    beforeEach(() => {
+        provider = getTestObjectProvider();
+    });
+
+    let container: Container;
+    let dataObject: ITestFluidObject;
+    let sharedCell: SharedCell;
+    let containerRuntime: ContainerRuntime;
+
+    beforeEach(async () => {
+        container = await provider.makeTestContainer(testContainerConfig) as Container;
+        dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
+        sharedCell = await dataObject.getSharedObject<SharedCell>(cellId);
+        containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+    });
+
+    itExpects("Closes container when rollback fails",
+    [
+        {eventName: "fluid:telemetry:Container:ContainerClose", error: "rollback not supported"},
+        // {eventName: "TestException", error: "expectedFailure", errorType: ContainerErrorType.genericError},
+    ],
+    async () => {
+        const errorMessage = "callback failure";
+        let error: Error | undefined;
+        try {
+            containerRuntime.orderSequentially(() => {
+                sharedCell.set(0);
+                throw new Error(errorMessage);
+            }, OrderSequentiallyFailureMode.Rollback);
+        } catch(err) {
+            error = err as Error;
+        }
+
+        assert.notEqual(error, undefined, "No error");
+        assert.equal((error as Error).name, "RollbackError", "Unexpected error message");
+        assert.equal(containerRuntime.disposed, true);
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -99,7 +99,7 @@ describeNoCompat("SharedString orderSequentially", (getTestObjectProvider) => {
         assert.equal(containerRuntime.disposed, false);
     });
 
-    it("Segment removed when callback fails", () => {
+    it("Removes segment when callback fails", () => {
         const text = "insertion";
         const errorMessage = "callback failure";
         let error: Error | undefined;
@@ -118,7 +118,7 @@ describeNoCompat("SharedString orderSequentially", (getTestObjectProvider) => {
         assert.equal(containerRuntime.disposed, false);
     });
 
-    it("Segment removed when callback fails with multiple segments", () => {
+    it("Removes segment when callback fails with multiple segments", () => {
         const text1 = "insertion";
         const text2 = " here";
         const text3 = "The ";
@@ -141,7 +141,7 @@ describeNoCompat("SharedString orderSequentially", (getTestObjectProvider) => {
         assert.equal(containerRuntime.disposed, false);
     });
 
-    it("Split segments removed when callback fails", () => {
+    it("Removes split segments when callback fails", () => {
         const text1 = "09";
         const text2 = "1278";
         const text3 = "3456";
@@ -161,6 +161,29 @@ describeNoCompat("SharedString orderSequentially", (getTestObjectProvider) => {
         assert.notEqual(error, undefined, "No error");
         assert.equal((error as Error).message, errorMessage, "Unexpected error message");
         assert.equal(sharedString.getText(), text1, "The retrieved text should match before orderSequentially.");
+        assert.equal(containerRuntime.disposed, false);
+    });
+
+    it("Edits correctly after rollback", () => {
+        const text1 = "original text";
+        const text2 = "rollback fail";
+        const text3 = " and final";
+        sharedString.insertText(0, text1);
+        const errorMessage = "callback failure";
+        let error: Error | undefined;
+        try {
+            containerRuntime.orderSequentially(() => {
+                sharedString.insertText(1, text2);
+                throw new Error(errorMessage);
+            }, OrderSequentiallyFailureMode.Rollback);
+        } catch(err) {
+            error = err as Error;
+        }
+        sharedString.insertText(8, text3);
+
+        assert.notEqual(error, undefined, "No error");
+        assert.equal((error as Error).message, errorMessage, "Unexpected error message");
+        assert.equal(sharedString.getText(), "original and final text", "Wrong text.");
         assert.equal(containerRuntime.disposed, false);
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -140,4 +140,27 @@ describeNoCompat("SharedString orderSequentially", (getTestObjectProvider) => {
         assert.equal(sharedString.getText(), text1, "The retrieved text should match before orderSequentially.");
         assert.equal(containerRuntime.disposed, false);
     });
+
+    it("Split segments removed when callback fails", () => {
+        const text1 = "09";
+        const text2 = "1278";
+        const text3 = "3456";
+        sharedString.insertText(0, text1);
+        const errorMessage = "callback failure";
+        let error: Error | undefined;
+        try {
+            containerRuntime.orderSequentially(() => {
+                sharedString.insertText(1, text2);
+                sharedString.insertText(3, text3);
+                throw new Error(errorMessage);
+            }, OrderSequentiallyFailureMode.Rollback);
+        } catch(err) {
+            error = err as Error;
+        }
+
+        assert.notEqual(error, undefined, "No error");
+        assert.equal((error as Error).message, errorMessage, "Unexpected error message");
+        assert.equal(sharedString.getText(), text1, "The retrieved text should match before orderSequentially.");
+        assert.equal(containerRuntime.disposed, false);
+    });
 });

--- a/packages/tools/replay-tool/src/unknownChannel.ts
+++ b/packages/tools/replay-tool/src/unknownChannel.ts
@@ -34,6 +34,8 @@ class UnknownChannel implements IChannel {
             },
             applyStashedOp: (content: any) => {
             },
+            rollback: (content: any, localOpMetadata: unknown) => {
+            },
         });
     }
 


### PR DESCRIPTION
Draft building off Tony's prototype for rollback infrastructure. Added support for [hacky] rollback of shared string inserts.

This is for prototyping by partner team. Not for checking in.

Closes #9344 