### PR TITLE
Fix 8947

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -301,6 +301,6 @@
             "runtimeArgs": ["--unhandled-rejections=strict"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
-        },
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -302,21 +302,5 @@
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Mocha Tests PackageRuntime",
-            "cwd": "${workspaceFolder}/packages/runtime/container-runtime",
-            "program": "${workspaceFolder}/packages/runtime/container-runtime/node_modules/.bin/_mocha",
-            "args": [
-                "--recursive",
-                "dist/test"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/packages/runtime/container-runtime/dist/test/*.js"
-            ],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-        },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -301,6 +301,22 @@
             "runtimeArgs": ["--unhandled-rejections=strict"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
-        }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests PackageRuntime",
+            "cwd": "${workspaceFolder}/packages/runtime/container-runtime",
+            "program": "${workspaceFolder}/packages/runtime/container-runtime/node_modules/.bin/_mocha",
+            "args": [
+                "--recursive",
+                "dist/test"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/packages/runtime/container-runtime/dist/test/*.js"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
     ]
 }

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger, ITelemetryProperties } from "@fluidframework/common-definitions";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ChildLogger, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import {
@@ -18,19 +18,16 @@ import { assert, performance } from "@fluidframework/common-utils";
  */
 export const latencyThreshold = 5000;
 
-type IOpPerfTelemetryRequiredProperties =
+interface IOpPerfTelemetryProperties {
     /** Track how long op is sitting in inbound queue until it is processed */
-    "durationInboundQueue" |
+    durationInboundQueue: number | undefined;
     /** Measure time outbound op is sitting in queue due to active batch */
-    "durationOutboundQueue" |
+    durationOutboundQueue: number | undefined;
     /** Time spent between DeltaManager's inbound "push" event until the DeltaManager "op" event */
-    "durationInboundToProcessing" |
+    durationInboundToProcessing: number | undefined;
     /** Length of the DeltaManager's inbound queue at the time of the processing */
-    "lenghtInboundQueue";
-
-type IOpPerfTelemetryProperties =
-    Pick<ITelemetryProperties, IOpPerfTelemetryRequiredProperties>;
-
+    lenghtInboundQueue: number | undefined;
+}
 /**
  * We collect the timing at various moments in time during the op processing.
  */

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -32,7 +32,7 @@ type IOpPerfTelemetryProperties =
     Pick<ITelemetryProperties, IOpPerfTelemetryRequiredProperties>;
 
 /**
- * We report various latency-related errors when waiting for op roundtrip takes longer than that amout of time.
+ * We collect the timing at various moments in time during the op processing.
  */
 enum OpTimings {
     opSendTimeForLatencyStatistics,


### PR DESCRIPTION
Initial Fix for #8947  - create a property bag for the performance data we will submit in the opPerfRoundtripTime event.
+ Addressing part of the 8912 (excluding the tracking or pauses and resumes). 
