### PR TITLE
[GitRest] Allowing customization of git directory through settings

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -19,7 +19,10 @@ data:
             "timestamp": false
         },
         "requestSizeLimit": "1gb",
-        "storageDir": "/home/node/documents",
+        "storageDir": {
+            "baseDir": "/home/node/documents",
+            "useRepoOwner": true
+        },
         "externalStorage": {
           "enabled": false,
           "endpoint": "http://externalStorage:3005"

--- a/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
@@ -15,6 +15,7 @@ import {
     IsomorphicGitManagerFactory,
     NodegitRepositoryManagerFactory,
     NodeFsManagerFactory,
+    IStorageDirectoryConfig,
 } from "./utils";
 
 export class GitrestResources implements core.IResources {
@@ -38,18 +39,18 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
         const port = normalizePort(process.env.PORT || "3000");
         const fileSystemManagerFactory = new NodeFsManagerFactory();
         const externalStorageManager = new ExternalStorageManager(config);
-        const storageDirectory = config.get("storageDir");
+        const storageDirectoryConfig: IStorageDirectoryConfig = config.get("storageDir") as IStorageDirectoryConfig;
         const gitLibrary: string | undefined = config.get("git:lib:name");
         const getRepositoryManagerFactory = () => {
             if (!gitLibrary || gitLibrary === "nodegit") {
                 return new NodegitRepositoryManagerFactory(
-                    storageDirectory,
+                    storageDirectoryConfig,
                     fileSystemManagerFactory,
                     externalStorageManager,
                 );
             } else if (gitLibrary === "isomorphic-git") {
                 return new IsomorphicGitManagerFactory(
-                    storageDirectory,
+                    storageDirectoryConfig,
                     fileSystemManagerFactory,
                 );
             }

--- a/server/gitrest/packages/gitrest-base/src/test/treebuilder.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/treebuilder.spec.ts
@@ -7,6 +7,7 @@ import * as async from "async";
 import sillyname from "sillyname";
 import git from "nodegit";
 import * as testUtils from "./utils";
+import { IStorageDirectoryConfig } from "../utils";
 
 async function mockTree(repository: git.Repository, entries: number) {
     const builder = await git.Treebuilder.create(repository, null);
@@ -31,8 +32,9 @@ describe("Treebuilder", () => {
         const treeCount = 100;
 
         const isBare: any = 1;
+        const storageDirConfig: IStorageDirectoryConfig = testUtils.defaultProvider.get("storageDir");
         const repository = await git.Repository.init(
-            `${testUtils.defaultProvider.get("storageDir")}/test`,
+            `${storageDirConfig.baseDir}/test`,
             isBare);
 
         const buffer = Buffer.from("Hello, World!", "utf-8");

--- a/server/gitrest/packages/gitrest-base/src/test/utils.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/utils.ts
@@ -6,6 +6,7 @@
 import * as util from "util";
 import nconf from "nconf";
 import rimrafCallback from "rimraf";
+import { IStorageDirectoryConfig } from "../utils";
 
 export const defaultProvider = new nconf.Provider({}).defaults({
     logger: {
@@ -15,7 +16,10 @@ export const defaultProvider = new nconf.Provider({}).defaults({
         morganFormat: "dev",
         timestamp: true,
     },
-    storageDir: "/tmp/historian",
+    storageDir: {
+        baseDir: "/tmp/historian",
+        useRepoOwner: true,
+    },
     externalStorage: {
         enabled: false,
         endpoint: "http://localhost:3005",
@@ -26,6 +30,7 @@ const rimraf = util.promisify(rimrafCallback);
 
 export function initializeBeforeAfterTestHooks(provider: nconf.Provider) {
     afterEach(async () => {
-        return rimraf(provider.get("storageDir"));
+        const storageDirConfig: IStorageDirectoryConfig = provider.get("storageDir");
+        return rimraf(storageDirConfig.baseDir);
     });
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -11,6 +11,11 @@ export enum Constants {
     StorageNameHeader = "Storage-Name",
 }
 
+export interface IStorageDirectoryConfig {
+    useRepoOwner: boolean;
+    baseDir?: string;
+}
+
 export interface IExternalWriterConfig {
     enabled: boolean;
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -119,5 +119,5 @@ export function getRepoPath(name: string, owner?: string): string {
 }
 
 export function getGitDirectory(repoPath: string, baseDir?: string): string {
-    return baseDir && baseDir !== "" ? `${baseDir}/${repoPath}` : repoPath;
+    return baseDir ? `${baseDir}/${repoPath}` : repoPath;
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -104,23 +104,20 @@ export async function retrieveLatestFullSummaryFromStorage(
 /**
  * Retrieves the full repository path. Or throws an error if not valid.
  */
-export function getRepoPath(owner: string, name: string) {
-    if (!owner || owner === "") {
-        throw new NetworkError(400, `Invalid arguments. A repo owner must be provided.`);
+export function getRepoPath(name: string, owner?: string): string {
+    // `name` needs to be always present and valid.
+    if (!name || name === "" || path.parse(name).dir !== "") {
+        throw new NetworkError(400, `Invalid repo name provided.`);
     }
 
-    if (!name || name === "") {
-        throw new NetworkError(400, `Invalid arguments. A repo name must be provided.`);
+    // When `owner` is present, it needs to be valid.
+    if (owner && (owner === "" || path.parse(owner).dir !== "")) {
+        throw new NetworkError(400, `Invalid repo owner provided.`);
     }
 
-    // Verify that both inputs are valid folder names
-    const parsedOwner = path.parse(owner);
-    const parsedName = path.parse(name);
-    const repoPath = `${owner}/${name}`;
+    return owner ? `${owner}/${name}` : name;
+}
 
-    if (parsedName.dir !== "" || parsedOwner.dir !== "") {
-        throw new NetworkError(400, `Invalid repo name ${repoPath}`);
-    }
-
-    return repoPath;
+export function getGitDirectory(repoPath: string, baseDir?: string): string {
+    return baseDir && baseDir !== "" ? `${baseDir}/${repoPath}` : repoPath;
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -106,12 +106,12 @@ export async function retrieveLatestFullSummaryFromStorage(
  */
 export function getRepoPath(name: string, owner?: string): string {
     // `name` needs to be always present and valid.
-    if (!name || name === "" || path.parse(name).dir !== "") {
+    if (!name || path.parse(name).dir !== "") {
         throw new NetworkError(400, `Invalid repo name provided.`);
     }
 
     // When `owner` is present, it needs to be valid.
-    if (owner && (owner === "" || path.parse(owner).dir !== "")) {
+    if (owner && path.parse(owner).dir !== "") {
         throw new NetworkError(400, `Invalid repo owner provided.`);
     }
 

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -18,6 +18,7 @@ import {
     IRepositoryManager,
     IFileSystemManagerFactory,
     IRepoManagerParams,
+    IStorageDirectoryConfig,
 } from "./definitions";
 
 export class NodegitRepositoryManager implements IRepositoryManager {
@@ -332,7 +333,7 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
     private repositoryPCache: { [key: string]: Promise<nodegit.Repository> } = {};
 
     constructor(
-        private readonly baseDir: string,
+        private readonly storageDirectoryConfig: IStorageDirectoryConfig,
         private readonly fileSystemManagerFactory: IFileSystemManagerFactory,
         private readonly externalStorageManager: IExternalStorageManager,
     ) {
@@ -340,10 +341,17 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
 
     public async create(params: IRepoManagerParams): Promise<NodegitRepositoryManager> {
         // Verify that both inputs are valid folder names
-        const repoPath = helpers.getRepoPath(params.repoOwner, params.repoName);
+        const repoPath = helpers.getRepoPath(
+            params.repoName,
+            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
         // Create and then cache the repository
         const isBare = 1;
-        const repositoryP = nodegit.Repository.init(`${this.baseDir}/${repoPath}`, isBare);
+
+        const repositoryP = nodegit.Repository.init(
+            helpers.getGitDirectory(
+                repoPath,
+                this.storageDirectoryConfig.baseDir),
+            isBare);
         this.repositoryPCache[repoPath] = repositoryP;
 
         const repository = await this.repositoryPCache[repoPath];
@@ -358,10 +366,14 @@ export class NodegitRepositoryManagerFactory implements IRepositoryManagerFactor
     }
 
     public async open(params: IRepoManagerParams): Promise<NodegitRepositoryManager> {
-        const repoPath = helpers.getRepoPath(params.repoOwner, params.repoName);
+        const repoPath = helpers.getRepoPath(
+            params.repoName,
+            this.storageDirectoryConfig.useRepoOwner ? params.repoOwner : undefined);
 
         if (!(repoPath in this.repositoryPCache)) {
-            const directory = `${this.baseDir}/${repoPath}`;
+            const directory = helpers.getGitDirectory(
+                repoPath,
+                this.storageDirectoryConfig.baseDir);
 
             const repoExists = await helpers.exists(
                 this.fileSystemManagerFactory.create(params.fileSystemManagerParams), directory);

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -7,7 +7,10 @@
         "timestamp": true
     },
     "requestSizeLimit": "1gb",
-    "storageDir": "/home/node/documents",
+    "storageDir": {
+        "baseDir": "/home/node/documents",
+        "useRepoOwner": true
+    },
     "externalStorage": {
         "enabled": false,
         "endpoint": "http://externalStorage:3005"


### PR DESCRIPTION
Allowing for the directory used by the Git RepositoryManagers to be customizable in 2 ways:
* Allowing to either use or ignore the `owner` parameter. That's because `owner` currently never changes. `name` currently maps to the tenantId, while `owner` is hardcoded. Therefore, the Git directory can be simplified by omitting `owner`.
* Allowing to not use a `baseDir` for the Git repo path. `baseDir` makes sense when we are mapping a volume in Docker, for example, where we will store Git data. But with `isomorphic-git` and custom filesystem implementations, that `baseDir` is not needed.