### PR TITLE
Fix logging in runWithRetry when aborted

### DIFF
--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -64,7 +64,6 @@
     "@fluidframework/core-interfaces": "^0.42.0",
     "@fluidframework/driver-definitions": "^0.45.2000-0",
     "@fluidframework/gitresources": "^0.1035.1000",
-    "@fluidframework/odsp-driver-definitions": "^0.58.3000",
     "@fluidframework/protocol-base": "^0.1035.1000",
     "@fluidframework/protocol-definitions": "^0.1027.1000",
     "@fluidframework/telemetry-utils": "^0.58.3000",

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -74,7 +74,7 @@ export async function runWithRetry<T>(
                 throw new NonRetryableError(
                     "runWithRetry was Aborted",
                     OdspErrorType.fetchTimeout,
-                    { driverVersion: pkgVersion },
+                    { driverVersion: pkgVersion, fetchCallName },
                 );
             }
 

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -5,10 +5,11 @@
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { delay, performance } from "@fluidframework/common-utils";
-import { OdspErrorType } from "@fluidframework/odsp-driver-definitions";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { canRetryOnError, getRetryDelayFromError } from "./network";
 import { pkgVersion } from "./packageVersion";
 import { NonRetryableError } from ".";
+
 
 /**
  * Interface describing an object passed to various network APIs.
@@ -61,6 +62,7 @@ export async function runWithRetry<T>(
                     eventName: `${fetchCallName}_cancel`,
                     retry: numRetries,
                     duration: performance.now() - startTime,
+                    fetchCallName,
                 }, err);
                 throw err;
             }
@@ -70,10 +72,11 @@ export async function runWithRetry<T>(
                     eventName: `${fetchCallName}_runWithRetryAborted`,
                     retry: numRetries,
                     duration: performance.now() - startTime,
+                    fetchCallName,
                 }, err);
                 throw new NonRetryableError(
                     "runWithRetry was Aborted",
-                    OdspErrorType.fetchTimeout,
+                    DriverErrorType.genericError,
                     { driverVersion: pkgVersion, fetchCallName },
                 );
             }
@@ -94,6 +97,7 @@ export async function runWithRetry<T>(
             eventName: `${fetchCallName}_lastError`,
             retry: numRetries,
             duration: performance.now() - startTime,
+            fetchCallName,
         },
         lastError);
     }

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -10,7 +10,6 @@ import { canRetryOnError, getRetryDelayFromError } from "./network";
 import { pkgVersion } from "./packageVersion";
 import { NonRetryableError } from ".";
 
-
 /**
  * Interface describing an object passed to various network APIs.
  * It allows caller to control cancellation, as well as learn about any delays.

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -66,10 +66,15 @@ export async function runWithRetry<T>(
             }
 
             if (progress.cancel?.aborted === true) {
+                logger.sendTelemetryEvent({
+                    eventName: `${fetchCallName}_runWithRetryAborted`,
+                    retry: numRetries,
+                    duration: performance.now() - startTime,
+                }, err);
                 throw new NonRetryableError(
-                    "runWithRetryAborted",
+                    "runWithRetry was Aborted",
                     OdspErrorType.fetchTimeout,
-                    { eventName: `runWithRetryAborted_${fetchCallName}`, driverVersion: pkgVersion },
+                    { driverVersion: pkgVersion },
                 );
             }
 


### PR DESCRIPTION
Fixes #8309 
Fixed how the error is logged and thrown in runWithRetry when it's aborted