### PR TITLE
r11s: use named imports for debug package

### DIFF
--- a/server/routerlicious/packages/memory-orderer/src/debug.ts
+++ b/server/routerlicious/packages/memory-orderer/src/debug.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug } from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:memory-orderer");

--- a/server/routerlicious/packages/services-client/src/debug.ts
+++ b/server/routerlicious/packages/services-client/src/debug.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug } from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:services-client");

--- a/server/routerlicious/packages/services-core/src/debug.ts
+++ b/server/routerlicious/packages/services-core/src/debug.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug } from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:core");

--- a/server/routerlicious/packages/services-shared/src/debug.ts
+++ b/server/routerlicious/packages/services-shared/src/debug.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug } from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:services");

--- a/server/routerlicious/packages/services-utils/src/debug.ts
+++ b/server/routerlicious/packages/services-utils/src/debug.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug } from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:utils");

--- a/server/routerlicious/packages/services/src/debug.ts
+++ b/server/routerlicious/packages/services/src/debug.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug } from "debug";
 import { pkgName, pkgVersion } from "./packageVersion";
 
 export const debug = registerDebug("fluid:services");

--- a/server/routerlicious/packages/test-utils/src/logger.ts
+++ b/server/routerlicious/packages/test-utils/src/logger.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import registerDebug from "debug";
+import { debug as registerDebug, IDebugger } from "debug";
 import { ILogger } from "@fluidframework/server-services-core";
 
 /**
@@ -29,9 +29,9 @@ export class DebugLogger implements ILogger {
     }
 
     constructor(
-        private readonly debugInfo: registerDebug.IDebugger,
-        private readonly debugErr: registerDebug.IDebugger,
-        private readonly debugWarn: registerDebug.IDebugger) {
+        private readonly debugInfo: IDebugger,
+        private readonly debugErr: IDebugger,
+        private readonly debugWarn: IDebugger) {
     }
 
     public info(message: string) {


### PR DESCRIPTION
Someone ran into an issue with Webpack 5 and the default import of `debug` in services-client package. Switching to named import is an easy enough fix.