### PR TITLE
Remove IFluidObject from IContainerContext scope

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -29,6 +29,7 @@ ICodeLoader interface was deprecated a while ago and will be removed in the next
 - [getAbsoluteUrl() argument type changed](#getAbsoluteUrl-argument-type-changed)
 - [Replace ICodeLoader with ICodeDetailsLoader interface](#Replace-ICodeLoader-with-ICodeDetailsLoader-interface)
 - [IFluidModule.fluidExport is no longer an IFluidObject](#IFluidModule.fluidExport-is-no-longer-an-IFluidObject)
+- [IContainerContext.scope is no longer an IFluidObject](#IContainerContext.scope-is-no-longer-an-IFluidObject)
 
 ### Removing Commit from TreeEntry and commits from SnapShotTree
 Cleaning up properties that are not being used in the codebase: `TreeEntry.Commit` and `ISnapshotTree.commits`.
@@ -95,7 +96,11 @@ All codeloaders are now expected to return the object including both the runtime
 You can start by returning default code details that were passed into the code loader which used to be our implementation on your behalf if code details were not passed in. Later on, this gives an opportunity to implement more sophisticated code loading where the code loader now can inform about the actual loaded module via the returned details.
 
 ### IFluidModule.fluidExport is no longer an IFluidObject
-IFluidObject is no longer part of the type of IFluidModule.fluidExport. IFluidModule.fluidExport is still a [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
+IFluidObject is no longer part of the type of IFluidModule.fluidExport. IFluidModule.fluidExport is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
+
+### IContainerContext.scope is no longer an IFluidObject
+IFluidObject is no longer part of the type of IContainerContext.scope. IContainerContext.scope is still an [FluidObject](#Deprecate-IFluidObject-and-introduce-FluidObject) which should be used instead.
+
 
 # 0.58
 

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -184,7 +184,7 @@ export interface IContainerContext extends IDisposable {
     pendingLocalState?: unknown;
     // (undocumented)
     readonly quorum: IQuorumClients;
-    readonly scope: IFluidObject & FluidObject;
+    readonly scope: FluidObject;
     // (undocumented)
     readonly serviceConfiguration: IClientConfiguration | undefined;
     // (undocumented)

--- a/common/lib/container-definitions/api-report/container-definitions.api.md
+++ b/common/lib/container-definitions/api-report/container-definitions.api.md
@@ -16,7 +16,6 @@ import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IErrorEvent } from '@fluidframework/common-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
-import { IFluidObject } from '@fluidframework/core-interfaces';
 import { IFluidResolvedUrl } from '@fluidframework/driver-definitions';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -530,31 +530,18 @@
       },
       "0.47.1000": {
         "InterfaceDeclaration_IContainerContext": {
-          "forwardCompat": false,
           "backCompat": false
         },
         "InterfaceDeclaration_ICodeDetailsLoader": {
-          "forwardCompat": false,
           "backCompat": false
         },
         "InterfaceDeclaration_ICodeLoader": {
-          "forwardCompat": false,
           "backCompat": false
         },
         "InterfaceDeclaration_IFluidModule": {
-          "forwardCompat": false,
           "backCompat": false
         },
         "InterfaceDeclaration_IFluidModuleWithDetails": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_IRuntimeFactory": {
-          "forwardCompat": false,
-          "backCompat": false
-        },
-        "InterfaceDeclaration_IProvideRuntimeFactory": {
-          "forwardCompat": false,
           "backCompat": false
         }
       }

--- a/common/lib/container-definitions/package.json
+++ b/common/lib/container-definitions/package.json
@@ -529,13 +529,11 @@
         }
       },
       "0.47.1000": {
-        "InterfaceDeclaration_IContainerContext": {"forwardCompat": false, "backCompat": false },
-        "InterfaceDeclaration_ICodeDetailsLoader": {"forwardCompat": false, "backCompat": false},
-        "InterfaceDeclaration_ICodeLoader": {"forwardCompat": false, "backCompat": false},
-        "InterfaceDeclaration_IFluidModule": {"forwardCompat": false, "backCompat": false},
-        "InterfaceDeclaration_IFluidModuleWithDetails": {"forwardCompat": false,"backCompat": false},
-        "InterfaceDeclaration_IRuntimeFactory": {"forwardCompat": false, "backCompat": false},
-        "InterfaceDeclaration_IProvideRuntimeFactory": {"forwardCompat": false, "backCompat": false}
+        "InterfaceDeclaration_IContainerContext": { "backCompat": false },
+        "InterfaceDeclaration_ICodeDetailsLoader": { "backCompat": false},
+        "InterfaceDeclaration_ICodeLoader": { "backCompat": false},
+        "InterfaceDeclaration_IFluidModule": { "backCompat": false},
+        "InterfaceDeclaration_IFluidModuleWithDetails": {"backCompat": false}
       }
     }
   }

--- a/common/lib/container-definitions/src/runtime.ts
+++ b/common/lib/container-definitions/src/runtime.ts
@@ -6,7 +6,6 @@
 import { ITelemetryBaseLogger, IDisposable } from "@fluidframework/common-definitions";
 import {
     FluidObject,
-    IFluidObject,
     IRequest,
     IResponse,
 } from "@fluidframework/core-interfaces";
@@ -144,7 +143,7 @@ export interface IContainerContext extends IDisposable {
     /**
      * Ambient services provided with the context
      */
-    readonly scope: IFluidObject & FluidObject;
+    readonly scope: FluidObject;
 
     /**
      * Get an absolute url for a provided container-relative request.

--- a/common/lib/container-definitions/src/test/types/validate0.47.1000.ts
+++ b/common/lib/container-definitions/src/test/types/validate0.47.1000.ts
@@ -259,7 +259,6 @@ declare function get_old_InterfaceDeclaration_ICodeDetailsLoader():
 declare function use_current_InterfaceDeclaration_ICodeDetailsLoader(
     use: current.ICodeDetailsLoader);
 use_current_InterfaceDeclaration_ICodeDetailsLoader(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICodeDetailsLoader());
 
 /*
@@ -285,7 +284,6 @@ declare function get_old_InterfaceDeclaration_ICodeLoader():
 declare function use_current_InterfaceDeclaration_ICodeLoader(
     use: current.ICodeLoader);
 use_current_InterfaceDeclaration_ICodeLoader(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICodeLoader());
 
 /*
@@ -359,7 +357,6 @@ declare function get_old_InterfaceDeclaration_IContainerContext():
 declare function use_current_InterfaceDeclaration_IContainerContext(
     use: current.IContainerContext);
 use_current_InterfaceDeclaration_IContainerContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerContext());
 
 /*
@@ -817,7 +814,6 @@ declare function get_old_InterfaceDeclaration_IFluidModule():
 declare function use_current_InterfaceDeclaration_IFluidModule(
     use: current.IFluidModule);
 use_current_InterfaceDeclaration_IFluidModule(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidModule());
 
 /*
@@ -843,7 +839,6 @@ declare function get_old_InterfaceDeclaration_IFluidModuleWithDetails():
 declare function use_current_InterfaceDeclaration_IFluidModuleWithDetails(
     use: current.IFluidModuleWithDetails);
 use_current_InterfaceDeclaration_IFluidModuleWithDetails(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidModuleWithDetails());
 
 /*
@@ -1205,7 +1200,6 @@ declare function get_old_InterfaceDeclaration_IProvideRuntimeFactory():
 declare function use_current_InterfaceDeclaration_IProvideRuntimeFactory(
     use: current.IProvideRuntimeFactory);
 use_current_InterfaceDeclaration_IProvideRuntimeFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProvideRuntimeFactory());
 
 /*
@@ -1218,7 +1212,6 @@ declare function get_current_InterfaceDeclaration_IProvideRuntimeFactory():
 declare function use_old_InterfaceDeclaration_IProvideRuntimeFactory(
     use: old.IProvideRuntimeFactory);
 use_old_InterfaceDeclaration_IProvideRuntimeFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IProvideRuntimeFactory());
 
 /*
@@ -1327,7 +1320,6 @@ declare function get_old_InterfaceDeclaration_IRuntimeFactory():
 declare function use_current_InterfaceDeclaration_IRuntimeFactory(
     use: current.IRuntimeFactory);
 use_current_InterfaceDeclaration_IRuntimeFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRuntimeFactory());
 
 /*
@@ -1340,7 +1332,6 @@ declare function get_current_InterfaceDeclaration_IRuntimeFactory():
 declare function use_old_InterfaceDeclaration_IRuntimeFactory(
     use: old.IRuntimeFactory);
 use_old_InterfaceDeclaration_IRuntimeFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IRuntimeFactory());
 
 /*

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -23,7 +23,6 @@ import {
     IFluidModuleWithDetails,
 } from "@fluidframework/container-definitions";
 import {
-    IFluidObject,
     IRequest,
     IResponse,
     FluidObject,
@@ -156,7 +155,7 @@ export class ContainerContext implements IContainerContext {
 
     constructor(
         private readonly container: Container,
-        public readonly scope: IFluidObject & FluidObject,
+        public readonly scope: FluidObject,
         private readonly codeLoader: ICodeDetailsLoader,
         private readonly _codeDetails: IFluidCodeDetails,
         private readonly _baseSnapshot: ISnapshotTree | undefined,


### PR DESCRIPTION
IFluidObject is no longer part of the type of IContainerContext.scope. IContainerContext.scope is still an FluidObject which should be used instead.

fixes #8941 