### PR TITLE
send package version from driver to service for telemetry in Historian and R11s

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -10,6 +10,7 @@ import { IAnyDriverError } from "@fluidframework/driver-utils";
 import { IClient, IConnect } from "@fluidframework/protocol-definitions";
 import type { io as SocketIOClientStatic } from "socket.io-client";
 import { errorObjectFromSocketError, IR11sSocketError } from "./errorUtils";
+import { pkgVersion as driverVersion } from "./packageVersion";
 
 const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
 
@@ -47,6 +48,7 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection
             tenantId,
             token,  // Token is going to indicate tenant level information, etc...
             versions: protocolVersions,
+            relayUserAgent: [client.details.environment, ` driverVersion:${driverVersion}`].join(";"),
         };
 
         // TODO: expose to host at factory level

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -17,6 +17,7 @@ import safeStringify from "json-stringify-safe";
 import { v4 as uuid } from "uuid";
 import { throwR11sNetworkError } from "./errorUtils";
 import { ITokenProvider } from "./tokens";
+import { pkgVersion as driverVersion } from "./packageVersion";
 
 type AuthorizationHeaderGetter = (refresh?: boolean) => Promise<string | undefined>;
 
@@ -107,8 +108,10 @@ export class RouterliciousRestWrapper extends RestWrapper {
 
         return {
             ...requestHeaders,
+            // TODO: replace header names with CorrelationIdHeaderName and DriverVersionHeaderName from services-client
             // NOTE: Can correlationId actually be number | true?
             "x-correlation-id": correlationId as string,
+            "x-driver-version": driverVersion,
             // NOTE: If this.authorizationHeader is undefined, should "Authorization" be removed entirely?
             "Authorization": this.authorizationHeader!,
         };

--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -57,6 +57,8 @@ export function create(
             const messageMetaData = {
                 method: tokens.method(req, res),
                 pathCategory: `${req.baseUrl}${req.route ? req.route.path : "PATH_UNAVAILABLE"}`,
+                // TODO: replace "x-driver-version" with DriverVersionHeaderName from services-client
+                driverVersion: tokens.req(req, res, "x-driver-version"),
                 url: tokens.url(req, res),
                 status: tokens.status(req, res),
                 contentLength: tokens.res(req, res, "content-length"),

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -47,11 +47,17 @@ export function convertSummaryTreeToWholeSummaryTree(parentHandle: string | unde
 // @public
 export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(flatSummary: IWholeFlatSummary): INormalizedWholeSummary;
 
+// @public (undocumented)
+export const CorrelationIdHeaderName = "x-correlation-id";
+
 // @public
 export function createFluidServiceNetworkError(statusCode: number, errorData?: INetworkErrorDetails | string): NetworkError;
 
 // @public (undocumented)
 export const defaultHash = "00000000";
+
+// @public (undocumented)
+export const DriverVersionHeaderName = "x-driver-version";
 
 // @public (undocumented)
 export type ExtendedSummaryObject = SummaryObject | IEmbeddedSummaryHandle;

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -20,7 +20,7 @@ import express from "express";
 import morgan from "morgan";
 import { Provider } from "nconf";
 import * as winston from "winston";
-import { IAlfredTenant } from "@fluidframework/server-services-client";
+import { DriverVersionHeaderName, IAlfredTenant } from "@fluidframework/server-services-client";
 import { bindCorrelationId } from "@fluidframework/server-services-utils";
 import { RestLessServer } from "@fluidframework/server-services";
 import { logRequestMetric, Lumberjack } from "@fluidframework/server-services-telemetry";
@@ -79,6 +79,7 @@ export function create(
                 method: tokens.method(req, res),
                 pathCategory: `${req.baseUrl}${req.route ? req.route.path : "PATH_UNAVAILABLE"}`,
                 url: tokens.url(req, res),
+                driverVersion: tokens.req(req, res, DriverVersionHeaderName),
                 status: tokens.status(req, res),
                 contentLength: tokens.res(req, res, "content-length"),
                 durationInMs: tokens["response-time"](req, res),

--- a/server/routerlicious/packages/services-client/src/constants.ts
+++ b/server/routerlicious/packages/services-client/src/constants.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const CorrelationIdHeaderName = "x-correlation-id";
+export const DriverVersionHeaderName = "x-driver-version";

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from "./auth";
+export * from "./constants";
 export * from "./error";
 export * from "./generateNames";
 export * from "./gitManager";

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -9,6 +9,7 @@ import Axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosRequestHeade
 import { v4 as uuid } from "uuid";
 import { debug } from "./debug";
 import { createFluidServiceNetworkError, INetworkErrorDetails } from "./error";
+import { CorrelationIdHeaderName } from "./constants";
 
 export abstract class RestWrapper {
     constructor(
@@ -149,7 +150,7 @@ export class BasicRestWrapper extends RestWrapper {
                     } else if (error?.response?.status === 401 && canRetry && this.refreshOnAuthError()) {
                         const retryConfig = { ...requestConfig };
                         retryConfig.headers = this.generateHeaders(
-                            retryConfig.headers, options.headers["x-correlation-id"] as string);
+                            retryConfig.headers, options.headers[CorrelationIdHeaderName] as string);
 
                         this.request<T>(retryConfig, statusCode, false)
                             .then(resolve)
@@ -190,10 +191,10 @@ export class BasicRestWrapper extends RestWrapper {
             result = { ...this.defaultHeaders, ...headers };
         }
 
-        if (result["x-correlation-id"]) {
+        if (result[CorrelationIdHeaderName]) {
             return result;
         }
-        return { "x-correlation-id": fallbackCorrelationId, ...result };
+        return { [CorrelationIdHeaderName]: fallbackCorrelationId, ...result };
     }
 
     private refreshOnAuthError(): boolean {

--- a/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/basicRestwrapper.spec.ts
@@ -7,12 +7,12 @@ import { strict as assert } from "assert";
 import Axios from "axios";
 import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { CorrelationIdHeaderName } from "../constants";
 import { BasicRestWrapper } from "../restWrapper";
 
 describe("BasicRestWrapper", () => {
     const baseurl = "https://fake.microsoft.com";
     const requestUrl = "/fakerequesturl/";
-    const correlationIdHeader = "x-correlation-id";
     const headerCount = 1;
     const maxBodyLength = 1000 * 1024 * 1024;
     const maxContentLength = 1000 * 1024 * 1024;
@@ -211,7 +211,7 @@ describe("BasicRestWrapper", () => {
             assert.strictEqual(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.strictEqual(requestUrl, requestOptions.url, "requestUrl should be the same");
             assert.strictEqual(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
-            assert.strictEqual(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
+            assert.strictEqual(CorrelationIdHeaderName, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {
@@ -330,7 +330,7 @@ describe("BasicRestWrapper", () => {
             assert.strictEqual(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.strictEqual(requestUrl, requestOptions.url, "requestUrl should be the same");
             assert.strictEqual(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
-            assert.strictEqual(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
+            assert.strictEqual(CorrelationIdHeaderName, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {
@@ -450,7 +450,7 @@ describe("BasicRestWrapper", () => {
             assert.strictEqual(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.strictEqual(requestUrl, requestOptions.url, "requestUrl should be the same");
             assert.strictEqual(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
-            assert.strictEqual(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
+            assert.strictEqual(CorrelationIdHeaderName, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {
@@ -570,7 +570,7 @@ describe("BasicRestWrapper", () => {
             assert.strictEqual(baseurl, requestOptions.baseURL, "baseURL should be the same");
             assert.strictEqual(requestUrl, requestOptions.url, "requestUrl should be the same");
             assert.strictEqual(headerCount, Object.keys(requestOptions.headers).length, "Headers should only have 1 header");
-            assert.strictEqual(correlationIdHeader, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
+            assert.strictEqual(CorrelationIdHeaderName, Object.keys(requestOptions.headers)[0], "Headers should only have x-correlation-id");
         });
 
         it("Default QueryString and Default Headers", async () => {

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -38,6 +38,7 @@ export enum CommonProperties {
     clientId = "clientId",
     clientType = "clientType",
     clientCount = "clientCount",
+    clientDriverVersion = "clientDriverVersion",
 
     // Session properties
     sessionState = "sessionState",

--- a/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncLocalStorage.ts
@@ -6,6 +6,7 @@
 import { AsyncLocalStorage } from "async_hooks";
 import * as uuid from "uuid";
 import { Request, Response, NextFunction } from "express";
+import { CorrelationIdHeaderName } from "@fluidframework/server-services-client";
 
 const defaultAsyncLocalStorage = new AsyncLocalStorage<string>();
 
@@ -18,7 +19,7 @@ export function getCorrelationId(altAsyncLocalStorage?: AsyncLocalStorage<string
 }
 
 export const bindCorrelationId =
-    (altAsyncLocalStorage?: AsyncLocalStorage<string>, headerName: string = "x-correlation-id") =>
+    (altAsyncLocalStorage?: AsyncLocalStorage<string>, headerName: string = CorrelationIdHeaderName) =>
         ((req: Request, res: Response, next: NextFunction): void => {
             const id: string = req.header(headerName) || uuid.v4();
             res.setHeader(headerName, id);


### PR DESCRIPTION
We want to know what version of the driver is being used for a given request or socket connection.
1. Use existing socket connection message property `relayUserAgent` to parse and log driver version for a socket connection
2. Add new HTTP header `x-driver-version` to all HTTP requests from the driver

Follow-ups:
Once this PR merges and the new header name constants are consumable, update Historian and Driver changes to use constants from services-client.